### PR TITLE
Phase 3 host side-effect CLI hardening

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,9 @@ PROGRAMS_DIR = ROOT / "tests" / "programs"
 
 
 class CliParityTests(unittest.TestCase):
-    def _run_cli(self, args: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    def _run_cli(
+        self, args: list[str], *, cwd: Path, expect_code: int = 0
+    ) -> subprocess.CompletedProcess[str]:
         proc = subprocess.run(
             [sys.executable, "-m", "axiom", *args],
             capture_output=True,
@@ -21,8 +23,8 @@ class CliParityTests(unittest.TestCase):
         )
         self.assertEqual(
             proc.returncode,
-            0,
-            msg=f"{' '.join(args)} failed: {proc.stdout}\n{proc.stderr}",
+            expect_code,
+            msg=f"{' '.join(args)} failed (expected {expect_code}): {proc.stdout}\n{proc.stderr}",
         )
         return proc
 
@@ -45,6 +47,43 @@ class CliParityTests(unittest.TestCase):
         path = PROGRAMS_DIR / "arith.ax"
         proc = self._run_cli(["check", str(path)], cwd=ROOT)
         self.assertIn("OK", proc.stderr)
+
+    def test_host_bridge_side_effects_require_flag(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            src = Path(td) / "host_print.ax"
+            bc = Path(td) / "host_print.axb"
+            src.write_text("host.print(9)\n", encoding="utf-8")
+
+            proc = self._run_cli(["interp", str(src)], cwd=ROOT, expect_code=1)
+            self.assertIn("side-effecting", proc.stderr)
+
+            proc = self._run_cli(
+                ["interp", str(src), "--allow-host-side-effects"], cwd=ROOT
+            )
+            self.assertEqual(proc.stdout, "9\n")
+
+            proc = self._run_cli(
+                ["compile", str(src), "-o", str(bc)], cwd=ROOT, expect_code=1
+            )
+            self.assertIn("side-effecting", proc.stderr)
+
+            proc = self._run_cli(
+                ["compile", str(src), "-o", str(bc), "--allow-host-side-effects"],
+                cwd=ROOT,
+            )
+            self.assertIn("wrote", proc.stderr)
+
+            proc = self._run_cli(["vm", str(bc)], cwd=ROOT, expect_code=1)
+            self.assertIn("side-effecting", proc.stderr)
+
+            proc = self._run_cli(["vm", str(bc), "--allow-host-side-effects"], cwd=ROOT)
+            self.assertEqual(proc.stdout, "9\n")
+
+            proc = self._run_cli(["run", str(src)], cwd=ROOT, expect_code=1)
+            self.assertIn("side-effecting", proc.stderr)
+
+            proc = self._run_cli(["run", str(src), "--allow-host-side-effects"], cwd=ROOT)
+            self.assertEqual(proc.stdout, "9\n")
 
 
 if __name__ == "__main__":

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -56,16 +56,42 @@ print f(1)
         with self.assertRaises(AxiomCompileError):
             compile_to_bytecode("host.print(1)\n")
 
+    def test_compile_host_side_effect_allowed(self) -> None:
+        compile_to_bytecode("host.print(1)\n", allow_host_side_effects=True)
+
     def test_runtime_host_version(self) -> None:
         program = parse_program("print host.version()\n")
         out = io.StringIO()
         Interpreter().run(program, out)
         self.assertEqual(out.getvalue(), "4\n")
 
+    def test_vm_host_version(self) -> None:
+        bc = compile_to_bytecode("print host.version()\n")
+        out = io.StringIO()
+        Vm(locals_count=bc.locals_count).run(bc, out)
+        self.assertEqual(out.getvalue(), "4\n")
+
     def test_runtime_host_print_requires_explicit_allow(self) -> None:
         program = parse_program("host.print(1)\n")
         with self.assertRaises(AxiomRuntimeError):
             Interpreter().run(program, io.StringIO())
+
+    def test_runtime_host_print_requires_explicit_allow_vm(self) -> None:
+        bc = compile_to_bytecode("host.print(1)\n", allow_host_side_effects=True)
+        with self.assertRaises(AxiomRuntimeError):
+            Vm(locals_count=bc.locals_count).run(bc, io.StringIO())
+
+    def test_runtime_host_print_with_allow(self) -> None:
+        program = parse_program("host.print(1)\n")
+        out = io.StringIO()
+        Interpreter(allow_host_side_effects=True).run(program, out)
+        self.assertEqual(out.getvalue(), "1\n")
+
+    def test_runtime_host_print_with_allow_vm(self) -> None:
+        bc = compile_to_bytecode("host.print(1)\n", allow_host_side_effects=True)
+        out = io.StringIO()
+        Vm(locals_count=bc.locals_count, allow_host_side_effects=True).run(bc, out)
+        self.assertEqual(out.getvalue(), "1\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds Phase 3 hardening tests for host bridge gating: confirms interpreter/vm/compile/run reject side-effect host calls unless --allow-host-side-effects is passed, and verifies allow-flag behavior. Also adds interpreter/VM runtime parity tests for host.version and host.print. No runtime semantics changed.