### PR TITLE
Add --allow-host-side-effects to check command

### DIFF
--- a/axiom/__main__.py
+++ b/axiom/__main__.py
@@ -55,9 +55,9 @@ def cmd_disasm(path: Path) -> int:
     return 0
 
 
-def cmd_check(path: Path) -> int:
+def cmd_check(path: Path, *, allow_host_side_effects: bool) -> int:
     src = path.read_text(encoding="utf-8")
-    _ = compile_to_bytecode(src)
+    _ = compile_to_bytecode(src, allow_host_side_effects=allow_host_side_effects)
     print("OK", file=sys.stderr)
     return 0
 
@@ -88,6 +88,7 @@ def main(argv: list[str] | None = None) -> int:
 
     sp = sub.add_parser("check", help="Parse + semantic checks (currently: undefined vars via compilation)")
     sp.add_argument("file", type=Path)
+    sp.add_argument("--allow-host-side-effects", action="store_true")
 
     args = p.parse_args(argv)
 
@@ -107,7 +108,7 @@ def main(argv: list[str] | None = None) -> int:
         if args.cmd == "disasm":
             return cmd_disasm(args.file)
         if args.cmd == "check":
-            return cmd_check(args.file)
+            return cmd_check(args.file, allow_host_side_effects=args.allow_host_side_effects)
         raise AssertionError("unreachable")
     except AxiomError as e:
         print(f"error: {e}", file=sys.stderr)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,6 +48,17 @@ class CliParityTests(unittest.TestCase):
         proc = self._run_cli(["check", str(path)], cwd=ROOT)
         self.assertIn("OK", proc.stderr)
 
+    def test_check_can_allow_host_side_effects(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            src = Path(td) / "host_print.ax"
+            src.write_text("host.print(9)\n", encoding="utf-8")
+            proc = self._run_cli(["check", str(src)], cwd=ROOT, expect_code=1)
+            self.assertIn("side-effecting", proc.stderr)
+            proc = self._run_cli(
+                ["check", str(src), "--allow-host-side-effects"], cwd=ROOT
+            )
+            self.assertIn("OK", proc.stderr)
+
     def test_host_bridge_side_effects_require_flag(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             src = Path(td) / "host_print.ax"


### PR DESCRIPTION
Extends check command with --allow-host-side-effects and wires it through compile_to_bytecode so host side-effecting host calls can be validated with explicit opt-in, matching interp/compile/vm/run semantics. Adds CLI test coverage.