### PR TITLE
Add host builtin arity mismatch regression tests

### DIFF
--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -61,6 +61,12 @@ print f(1)
     def test_compile_host_side_effect_allowed(self) -> None:
         compile_to_bytecode("host.print(1)\n", allow_host_side_effects=True)
 
+    def test_compile_host_arity_mismatch(self) -> None:
+        with self.assertRaises(AxiomCompileError):
+            compile_to_bytecode("host.abs(1, 2)\n")
+        with self.assertRaises(AxiomCompileError):
+            compile_to_bytecode("host.math.abs()\n")
+
     def test_runtime_host_version(self) -> None:
         program = parse_program("print host.version()\n")
         out = io.StringIO()


### PR DESCRIPTION
Adds regression coverage for compile-time arity validation on host builtins (host.abs and host.math.abs) to complement host capability registry behavior.