### PR TITLE
Phase 2 module system scaffold with file imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Supported:
 - integer literals
 - variables
 - function calls: `name(arg, ...)`
+- `import "path"` for file-level module loading (resolved relative to importing file)
 - host bridge calls: `host.version()`, `host.print(value)`, `host.read(prompt)`, `host.abs(value)`, `host.math.abs(value)` (gated side effects apply to `print`/`read` only)
 - `+ - * /` with parentheses
 - comparisons: `== != < <= > >=` (results are `0` or `1`)

--- a/axiom/__main__.py
+++ b/axiom/__main__.py
@@ -4,7 +4,7 @@ import argparse
 import sys
 from pathlib import Path
 
-from .api import parse_program, compile_to_bytecode
+from .api import parse_file, compile_file
 from .bytecode import Bytecode, Op
 from .interpreter import Interpreter
 from .vm import Vm
@@ -12,15 +12,13 @@ from .errors import AxiomError
 
 
 def cmd_interp(path: Path, *, allow_host_side_effects: bool) -> int:
-    src = path.read_text(encoding="utf-8")
-    program = parse_program(src)
+    program = parse_file(path)
     Interpreter(allow_host_side_effects=allow_host_side_effects).run(program, sys.stdout)
     return 0
 
 
 def cmd_compile(path: Path, out_path: Path, *, allow_host_side_effects: bool) -> int:
-    src = path.read_text(encoding="utf-8")
-    bc = compile_to_bytecode(src, allow_host_side_effects=allow_host_side_effects)
+    bc = compile_file(path, allow_host_side_effects=allow_host_side_effects)
     out_path.write_bytes(bc.encode())
     print(f"wrote {out_path} ({out_path.stat().st_size} bytes)", file=sys.stderr)
     return 0
@@ -35,8 +33,7 @@ def cmd_vm(path: Path, *, allow_host_side_effects: bool) -> int:
 
 
 def cmd_run(path: Path, *, allow_host_side_effects: bool) -> int:
-    src = path.read_text(encoding="utf-8")
-    bc = compile_to_bytecode(src, allow_host_side_effects=allow_host_side_effects)
+    bc = compile_file(path, allow_host_side_effects=allow_host_side_effects)
     Vm(locals_count=bc.locals_count, allow_host_side_effects=allow_host_side_effects).run(
         bc, sys.stdout
     )
@@ -56,8 +53,7 @@ def cmd_disasm(path: Path) -> int:
 
 
 def cmd_check(path: Path, *, allow_host_side_effects: bool) -> int:
-    src = path.read_text(encoding="utf-8")
-    _ = compile_to_bytecode(src, allow_host_side_effects=allow_host_side_effects)
+    _ = compile_file(path, allow_host_side_effects=allow_host_side_effects)
     print("OK", file=sys.stderr)
     return 0
 

--- a/axiom/api.py
+++ b/axiom/api.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
+from pathlib import Path
+from typing import Set
+
 from .lexer import Lexer
 from .parser import Parser
-from .ast import Program
+from .ast import ImportStmt, Program
 from .compiler import Compiler
 from .bytecode import Bytecode
+from .errors import AxiomCompileError
+
+
+def parse_file(path: Path) -> Program:
+    return _load_program_file(Path(path).resolve(), set(), set())
 
 
 def parse_program(src: str) -> Program:
@@ -15,3 +23,52 @@ def parse_program(src: str) -> Program:
 def compile_to_bytecode(src: str, *, allow_host_side_effects: bool = False) -> Bytecode:
     program = parse_program(src)
     return Compiler(allow_host_side_effects=allow_host_side_effects).compile(program)
+
+
+def compile_file(path: Path, *, allow_host_side_effects: bool = False) -> Bytecode:
+    return Compiler(allow_host_side_effects=allow_host_side_effects).compile(
+        parse_file(path)
+    )
+
+
+def _load_program_file(path: Path, seen: Set[Path], loading: Set[Path]) -> Program:
+    if path in seen:
+        return Program(stmts=[])
+
+    if path in loading:
+        raise AxiomCompileError(f"circular import of {path}")
+
+    if not path.exists():
+        raise AxiomCompileError(f"cannot resolve import file {path}")
+
+    loading.add(path)
+    src = path.read_text(encoding="utf-8")
+    program = parse_program(src)
+
+    stmts = []
+    for stmt in program.stmts:
+        if isinstance(stmt, ImportStmt):
+            import_path = _resolve_import_path(stmt.path, path)
+            if not import_path.exists():
+                raise AxiomCompileError(
+                    f"cannot resolve import file {import_path}", stmt.span
+                )
+            stmts.extend(_load_program_file(import_path, seen, loading).stmts)
+        else:
+            stmts.append(stmt)
+
+    loading.remove(path)
+    seen.add(path)
+    return Program(stmts=stmts)
+
+
+def _resolve_import_path(raw: str, base_path: Path) -> Path:
+    candidate = Path(raw)
+    if candidate.suffix == "":
+        candidate = candidate.with_suffix(".ax")
+    if candidate.suffix not in (".ax", ".AX"):
+        # preserve prior behavior for module names that may include dots
+        candidate = Path(str(candidate) + ".ax")
+    if not candidate.is_absolute():
+        candidate = base_path.parent / candidate
+    return candidate

--- a/axiom/ast.py
+++ b/axiom/ast.py
@@ -54,6 +54,12 @@ class ExprStmt:
 
 
 @dataclass(frozen=True)
+class ImportStmt:
+    path: str
+    span: Span
+
+
+@dataclass(frozen=True)
 class BlockStmt:
     stmts: List["Stmt"]
     span: Span
@@ -77,6 +83,7 @@ class WhileStmt:
 Stmt = Union[
     LetStmt,
     AssignStmt,
+    ImportStmt,
     PrintStmt,
     ReturnStmt,
     ExprStmt,

--- a/axiom/compiler.py
+++ b/axiom/compiler.py
@@ -6,6 +6,7 @@ from typing import Dict, List
 from .ast import (
     Program,
     LetStmt,
+    ImportStmt,
     AssignStmt,
     PrintStmt,
     ExprStmt,
@@ -167,6 +168,11 @@ class Compiler:
             self._compile_expr(stmt.expr, out)
             out.append(Instr(Op.POP))
             return
+        if isinstance(stmt, ImportStmt):
+            raise AxiomCompileError(
+                "import statements are only supported in file-based compilation",
+                stmt.span,
+            )
         if isinstance(stmt, BlockStmt):
             self.scope_stack.append({})
             try:

--- a/axiom/interpreter.py
+++ b/axiom/interpreter.py
@@ -6,6 +6,7 @@ from typing import Dict, List, TextIO, Tuple
 from .ast import (
     Program,
     LetStmt,
+    ImportStmt,
     AssignStmt,
     PrintStmt,
     ReturnStmt,
@@ -77,6 +78,8 @@ class Interpreter:
         if isinstance(stmt, ExprStmt):
             self._eval(stmt.expr, out)
             return
+        if isinstance(stmt, ImportStmt):
+            raise AxiomRuntimeError("import statements are only supported in file-based parsing")
         if isinstance(stmt, BlockStmt):
             self.scopes.append({})
             try:

--- a/axiom/lexer.py
+++ b/axiom/lexer.py
@@ -73,6 +73,8 @@ class Lexer:
         text = self.src[start:end]
         if text == "let":
             return Token(TokenKind.LET, Span(start, end))
+        if text == "import":
+            return Token(TokenKind.IMPORT, Span(start, end))
         if text == "fn":
             return Token(TokenKind.FN, Span(start, end))
         if text == "print":
@@ -86,6 +88,37 @@ class Lexer:
         if text == "while":
             return Token(TokenKind.WHILE, Span(start, end))
         return Token(TokenKind.IDENT, Span(start, end), text)
+
+    def _lex_string(self, start: int) -> Token:
+        chars: List[str] = []
+        while True:
+            ch = self._peek()
+            if ch is None:
+                raise AxiomParseError("unterminated string literal", Span(start, self.i))
+            self.i += 1
+            if ch == '"':
+                break
+            if ch == "\\":
+                esc = self._peek()
+                if esc is None:
+                    raise AxiomParseError("unterminated escape sequence", Span(start, self.i))
+                self.i += 1
+                if esc == "n":
+                    chars.append("\n")
+                elif esc == "r":
+                    chars.append("\r")
+                elif esc == "t":
+                    chars.append("\t")
+                elif esc == "\\":
+                    chars.append("\\")
+                elif esc == '"':
+                    chars.append('"')
+                else:
+                    chars.append(esc)
+            else:
+                chars.append(ch)
+        end = self.i
+        return Token(TokenKind.STRING, Span(start, end), "".join(chars))
 
     def next_token(self) -> Token:
         self._skip_spaces()
@@ -130,6 +163,8 @@ class Lexer:
             return Token(TokenKind.DOT, Span(start, start + 1))
         if ch == ",":
             return Token(TokenKind.COMMA, Span(start, start + 1))
+        if ch == '"':
+            return self._lex_string(start)
         if ch == "(":
             return Token(TokenKind.LPAREN, Span(start, start + 1))
         if ch == ")":

--- a/axiom/parser.py
+++ b/axiom/parser.py
@@ -9,6 +9,7 @@ from .ast import (
     PrintStmt,
     ReturnStmt,
     FunctionDefStmt,
+    ImportStmt,
     ExprStmt,
     BlockStmt,
     IfStmt,
@@ -62,6 +63,7 @@ class Parser:
             return str(t.value)
         if t.kind in {
             TokenKind.LET,
+            TokenKind.IMPORT,
             TokenKind.FN,
             TokenKind.PRINT,
             TokenKind.RETURN,
@@ -85,6 +87,8 @@ class Parser:
         k = self._peek().kind
         if k == TokenKind.LET:
             return self._parse_let()
+        if k == TokenKind.IMPORT:
+            return self._parse_import()
         if k == TokenKind.FN:
             return self._parse_function_def()
         if k == TokenKind.PRINT:
@@ -172,6 +176,14 @@ class Parser:
         expr = self._parse_expr()
         end = self._parse_terminator(default_end=expr_span(expr).end)
         return LetStmt(name=str(ident.value), expr=expr, span=Span(start, end))
+
+    def _parse_import(self) -> ImportStmt:
+        start = self._eat(TokenKind.IMPORT).span.start
+        path = self._eat(TokenKind.STRING)
+        if not isinstance(path.value, str):
+            raise AxiomParseError("expected import path string", path.span)
+        end = self._parse_terminator(default_end=path.span.end)
+        return ImportStmt(path=path.value, span=Span(start, end))
 
     def _parse_assign(self) -> AssignStmt:
         ident = self._eat(TokenKind.IDENT)

--- a/axiom/token.py
+++ b/axiom/token.py
@@ -8,6 +8,7 @@ from .errors import Span
 
 
 class TokenKind(Enum):
+    IMPORT = auto()
     LET = auto()
     FN = auto()
     PRINT = auto()
@@ -24,6 +25,7 @@ class TokenKind(Enum):
     LE = auto()
     GT = auto()
     GE = auto()
+    STRING = auto()
     SEMI = auto()
     NEWLINE = auto()
     PLUS = auto()

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -7,6 +7,7 @@ program        := stmt* EOF ;
 
 stmt           := let_stmt
                | assign_stmt
+               | import_stmt
                | fn_stmt
                | return_stmt
                | print_stmt
@@ -15,6 +16,7 @@ stmt           := let_stmt
                | block
                | expr_stmt ;
 
+import_stmt    := "import" STRING terminator ;
 fn_stmt        := "fn" IDENT "(" params? ")" block ;
 params         := IDENT ("," IDENT)* ;
 return_stmt    := "return" expr terminator ;
@@ -37,6 +39,7 @@ term           := factor (("+" | "-") factor)* ;
 factor         := unary (("*" | "/") unary)* ;
 unary          := "-" unary | primary ;
 primary        := INT | IDENT | call_expr | "(" expr ")" ;
+STRING         := double-quoted UTF-8 string ;
 ```
 
 Comments start with `#` and run to end-of-line.

--- a/docs/kernel.md
+++ b/docs/kernel.md
@@ -14,6 +14,7 @@
 - `while <expr> { ... }`
 - `fn <name>(<params>) { ... }`
 - `return <expr>`
+- `import "<path>"` for file module inclusion (resolved relative to file path; loaded at compile time)
 - function calls: `<name>(<arg1>, ... )`
 - `host.<name>(...)` for host bridge calls (reserved namespace)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,6 +13,7 @@
 ## Phase 2
 - Functions + call frames
 - Module system
+  - file-based `import` (prototype: compile-time inlining)
 - Package/build tool skeleton
 
 ## Phase 3

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -96,6 +96,19 @@ class CliParityTests(unittest.TestCase):
             proc = self._run_cli(["run", str(src), "--allow-host-side-effects"], cwd=ROOT)
             self.assertEqual(proc.stdout, "9\n")
 
+    def test_imported_modules_execute(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            mod = Path(td) / "math_module.ax"
+            mod.write_text("fn add(a, b) {\n  return a + b\n}\n", encoding="utf-8")
+
+            main = Path(td) / "main.ax"
+            main.write_text('import "math_module"\nprint add(6, 7)\n', encoding="utf-8")
+
+            proc = self._run_cli(["interp", str(main)], cwd=ROOT)
+            self.assertEqual(proc.stdout, "13\n")
+            proc = self._run_cli(["run", str(main)], cwd=ROOT)
+            self.assertEqual(proc.stdout, "13\n")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,8 +1,10 @@
 import unittest
 import io
 from unittest.mock import patch
+from pathlib import Path
+import tempfile
 
-from axiom.api import compile_to_bytecode
+from axiom.api import compile_to_bytecode, compile_file
 from axiom.api import parse_program
 from axiom.errors import AxiomCompileError, AxiomParseError, AxiomRuntimeError
 from axiom.interpreter import Interpreter
@@ -66,6 +68,13 @@ print f(1)
             compile_to_bytecode("host.abs(1, 2)\n")
         with self.assertRaises(AxiomCompileError):
             compile_to_bytecode("host.math.abs()\n")
+
+    def test_compile_missing_import(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            root.joinpath("main.ax").write_text('import "missing.ax"\n', encoding="utf-8")
+            with self.assertRaises(AxiomCompileError):
+                compile_file(root.joinpath("main.ax"))
 
     def test_runtime_host_version(self) -> None:
         program = parse_program("print host.version()\n")


### PR DESCRIPTION
Add compile-time file module loading via :

- add ImportStmt, IMPORT + STRING lexing/parsing
- add file-based parse/compile APIs (, ) with recursive include, extension inference, dedupe, and cycle checks
- route CLI (, , , ) through file-based module-aware loading
- guard compile/runtime against leftover ImportStmt outside file-based context
- add docs updates and test coverage for import execution and missing import errors