### PR TITLE
Phase4 host capability registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Supported:
 - function calls: `name(arg, ...)`
 - `import "path"` for file-level module loading (resolved relative to importing file)
 - host bridge calls: `host.version()`, `host.print(value)`, `host.read(prompt)`, `host.abs(value)`, `host.math.abs(value)` (gated side effects apply to `print`/`read` only)
+- host bridge calls are registry-backed, and new `host.*` functions can be added with
+  `axiom.host.register_host_builtin(name, arity, side_effecting, handler)`.
 - `+ - * /` with parentheses
 - comparisons: `== != < <= > >=` (results are `0` or `1`)
 - unary `-`

--- a/axiom/host.py
+++ b/axiom/host.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import builtins as py_builtins
 from dataclasses import dataclass
-from typing import Dict, List
+from typing import Callable, Dict, List, TextIO, Tuple
 
 from .bytecode import VERSION_MINOR
+
+
+Handler = Callable[[List[int], TextIO], int]
 
 
 @dataclass(frozen=True)
@@ -11,18 +15,89 @@ class HostBuiltin:
     name: str
     arity: int
     side_effecting: bool
+    handler: Handler
 
 
-_HOST_BUILTINS_LIST: List[HostBuiltin] = [
-    HostBuiltin("version", 0, False),
-    HostBuiltin("print", 1, True),
-    HostBuiltin("read", 1, True),
-    HostBuiltin("abs", 1, False),
-    HostBuiltin("math.abs", 1, False),
+def _builtin_version(_args: List[int], _out: TextIO) -> int:
+    return HOST_VERSION
+
+
+def _builtin_print(args: List[int], out: TextIO) -> int:
+    out.write(f"{args[0]}\n")
+    return 0
+
+
+def _builtin_read(args: List[int], _out: TextIO) -> int:
+    prompt = str(args[0])
+    try:
+        line = py_builtins.input(prompt)
+    except EOFError:
+        return 0
+    try:
+        return int(line.strip())
+    except ValueError as e:
+        raise ValueError(f"host.read expected integer input: {line!r}") from e
+
+
+def _builtin_abs(args: List[int], _out: TextIO) -> int:
+    return abs(args[0])
+
+
+HOST_VERSION = VERSION_MINOR
+
+_DEFAULT_HOST_BUILTINS: List[HostBuiltin] = [
+    HostBuiltin("version", 0, False, _builtin_version),
+    HostBuiltin("print", 1, True, _builtin_print),
+    HostBuiltin("read", 1, True, _builtin_read),
+    HostBuiltin("abs", 1, False, _builtin_abs),
+    HostBuiltin("math.abs", 1, False, _builtin_abs),
 ]
 
-HOST_BUILTINS = {entry.name: (entry.arity, entry.side_effecting) for entry in _HOST_BUILTINS_LIST}
-HOST_BUILTIN_NAMES = [entry.name for entry in _HOST_BUILTINS_LIST]
-HOST_BUILTIN_IDS = {entry.name: idx for idx, entry in enumerate(_HOST_BUILTINS_LIST)}
-HOST_BUILTIN_BY_ID = {idx: entry for idx, entry in enumerate(_HOST_BUILTINS_LIST)}
-HOST_VERSION = VERSION_MINOR
+_HOST_BUILTINS_LIST: List[HostBuiltin] = list(_DEFAULT_HOST_BUILTINS)
+
+HOST_BUILTINS: Dict[str, Tuple[int, bool]] = {}
+HOST_BUILTIN_NAMES: List[str] = []
+HOST_BUILTIN_IDS: Dict[str, int] = {}
+HOST_BUILTIN_BY_ID: Dict[int, HostBuiltin] = {}
+
+
+def _rebuild_host_tables() -> None:
+    HOST_BUILTINS.clear()
+    HOST_BUILTIN_NAMES.clear()
+    HOST_BUILTIN_IDS.clear()
+    HOST_BUILTIN_BY_ID.clear()
+    for idx, entry in enumerate(_HOST_BUILTINS_LIST):
+        if entry.name in HOST_BUILTIN_IDS:
+            raise ValueError(f"duplicate host builtin name {entry.name!r}")
+        HOST_BUILTINS[entry.name] = (entry.arity, entry.side_effecting)
+        HOST_BUILTIN_NAMES.append(entry.name)
+        HOST_BUILTIN_IDS[entry.name] = idx
+        HOST_BUILTIN_BY_ID[idx] = entry
+
+
+def register_host_builtin(name: str, arity: int, side_effecting: bool, handler: Handler) -> None:
+    if name in HOST_BUILTINS:
+        raise ValueError(f"host builtin {name!r} already exists")
+    if arity < 0:
+        raise ValueError(f"host builtin arity must be non-negative, got {arity}")
+    _HOST_BUILTINS_LIST.append(HostBuiltin(name=name, arity=arity, side_effecting=side_effecting, handler=handler))
+    _rebuild_host_tables()
+
+
+def reset_host_builtins() -> None:
+    del _HOST_BUILTINS_LIST[:]
+    _HOST_BUILTINS_LIST.extend(_DEFAULT_HOST_BUILTINS)
+    _rebuild_host_tables()
+
+
+def call_host_builtin(name: str, args: List[int], out: TextIO) -> int:
+    if name not in HOST_BUILTIN_IDS:
+        raise KeyError(f"undefined host function {name!r}")
+    return call_host_builtin_id(HOST_BUILTIN_IDS[name], args, out)
+
+
+def call_host_builtin_id(host_fn_id: int, args: List[int], out: TextIO) -> int:
+    return HOST_BUILTIN_BY_ID[host_fn_id].handler(args, out)
+
+
+_rebuild_host_tables()

--- a/axiom/interpreter.py
+++ b/axiom/interpreter.py
@@ -25,7 +25,7 @@ from .ast import (
 )
 from .errors import AxiomCompileError, AxiomRuntimeError
 from .intops import trunc_div, to_bool_int
-from .host import HOST_BUILTINS, HOST_VERSION
+from .host import HOST_BUILTINS, call_host_builtin
 
 
 @dataclass
@@ -157,28 +157,10 @@ class Interpreter:
             raise AxiomRuntimeError(
                 f"host call {fn_name!r} is side-effecting; enable allow_host_side_effects"
             )
-        if host_name == "version":
-            return HOST_VERSION
-        if host_name == "print":
-            out.write(f"{args[0]}\n")
-            return 0
-        if host_name == "read":
-            prompt = str(args[0])
-            try:
-                line = input(prompt)
-            except EOFError:
-                return 0
-            try:
-                return int(line.strip())
-            except ValueError as e:
-                raise AxiomRuntimeError(
-                    f"host.read expected integer input: {line!r}",
-                ) from e
-        if host_name == "abs":
-            return abs(args[0])
-        if host_name == "math.abs":
-            return abs(args[0])
-        raise AxiomRuntimeError(f"unsupported host function {fn_name!r}")
+        try:
+            return call_host_builtin(host_name, args, out)
+        except ValueError as e:
+            raise AxiomRuntimeError(str(e)) from e
 
     def _eval(self, expr: Expr, out: TextIO) -> int:
         if isinstance(expr, IntLit):

--- a/axiom/vm.py
+++ b/axiom/vm.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import List, Optional, TextIO
-import builtins
 
 from .bytecode import Bytecode, FunctionMeta, Op
 from .errors import AxiomRuntimeError
 from .intops import trunc_div, to_bool_int
-from .host import HOST_BUILTIN_BY_ID, HOST_BUILTINS, HOST_VERSION
+from .host import HOST_BUILTIN_BY_ID, call_host_builtin_id
 
 
 @dataclass
@@ -170,36 +169,7 @@ class Vm:
     def _call_host_fn(self, fn_id: int, args: List[int], out: TextIO) -> int:
         if fn_id not in HOST_BUILTIN_BY_ID:
             raise AxiomRuntimeError(f"unknown host function id {fn_id}")
-        builtin = HOST_BUILTIN_BY_ID[fn_id]
-        if builtin.name == "version":
-            return HOST_VERSION
-        if builtin.name == "print":
-            if not self.allow_host_side_effects:
-                raise AxiomRuntimeError(
-                    "host call 1 is side-effecting; enable allow_host_side_effects"
-                )
-            if len(args) != 1:
-                raise AxiomRuntimeError(f"host.call 1 expected 1 arg, got {len(args)}")
-            out.write(f"{args[0]}\n")
-            return 0
-        if builtin.name == "read":
-            if not self.allow_host_side_effects:
-                raise AxiomRuntimeError(
-                    "host call 2 is side-effecting; enable allow_host_side_effects"
-                )
-            if len(args) != 1:
-                raise AxiomRuntimeError(f"host.call 2 expected 1 arg, got {len(args)}")
-            prompt = str(args[0])
-            try:
-                line = builtins.input(prompt)
-            except EOFError:
-                return 0
-            try:
-                return int(line.strip())
-            except ValueError as e:
-                raise AxiomRuntimeError(f"host.read expected integer input: {line!r}") from e
-        if builtin.name == "abs":
-            return abs(args[0])
-        if builtin.name == "math.abs":
-            return abs(args[0])
-        raise AxiomRuntimeError(f"unknown host function id {fn_id}")
+        try:
+            return call_host_builtin_id(fn_id, args, out)
+        except ValueError as e:
+            raise AxiomRuntimeError(str(e)) from e

--- a/docs/bytecode.md
+++ b/docs/bytecode.md
@@ -56,3 +56,6 @@ Host builtin indices:
 - 2 => host.read
 - 3 => host.abs
 - 4 => host.math.abs
+
+Custom host capabilities can be appended by registering via `axiom.host.register_host_builtin`.
+Host builtin indices are assigned in registry order.

--- a/docs/kernel.md
+++ b/docs/kernel.md
@@ -17,6 +17,9 @@
 - `import "<path>"` for file module inclusion (resolved relative to file path; loaded at compile time)
 - function calls: `<name>(<arg1>, ... )`
 - `host.<name>(...)` for host bridge calls (reserved namespace)
+- Host calls are resolved from a registry. Add custom capabilities via
+  `axiom.host.register_host_builtin(name, arity, side_effecting, handler)` where
+  `handler(args: list[int], out: TextIO) -> int`.
 
 ## Expressions
 - integer literals: `123`, `-5`

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -10,6 +10,7 @@ from axiom.errors import AxiomCompileError, AxiomParseError, AxiomRuntimeError
 from axiom.interpreter import Interpreter
 from axiom.vm import Vm
 from axiom.bytecode import VERSION_MINOR
+from axiom.host import register_host_builtin, reset_host_builtins
 
 
 class ErrorTests(unittest.TestCase):
@@ -68,6 +69,31 @@ print f(1)
             compile_to_bytecode("host.abs(1, 2)\n")
         with self.assertRaises(AxiomCompileError):
             compile_to_bytecode("host.math.abs()\n")
+
+    def test_compile_custom_host_builtin(self) -> None:
+        def double(args: list[int], _out) -> int:
+            return args[0] * 2
+
+        register_host_builtin("double", 1, False, double)
+        try:
+            program = parse_program("print host.double(21)\n")
+            out = io.StringIO()
+            Interpreter().run(program, out)
+            self.assertEqual(out.getvalue(), "42\n")
+
+            bc = compile_to_bytecode("print host.double(21)\n")
+            vm_out = io.StringIO()
+            Vm(locals_count=bc.locals_count).run(bc, vm_out)
+            self.assertEqual(vm_out.getvalue(), "42\n")
+        finally:
+            reset_host_builtins()
+
+    def test_host_registry_duplicate_name(self) -> None:
+        def noop(args: list[int], _out) -> int:
+            return 0
+
+        with self.assertRaises(ValueError):
+            register_host_builtin("print", 0, False, noop)
 
     def test_compile_missing_import(self) -> None:
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
Add host callable registry and custom host builtin support for agentic interoperability.

This adds registry-backed host builtins with registration/reset APIs, routes interpreter/VM host calls through shared dispatch, and adds tests/docs updates.