### PR TITLE
Phase 5 package init customization

### DIFF
--- a/axiom/__main__.py
+++ b/axiom/__main__.py
@@ -66,8 +66,25 @@ def cmd_check(path: Path, *, allow_host_side_effects: bool) -> int:
     return 0
 
 
-def cmd_pkg_init(path: Path, *, name: str | None = None, force: bool = False) -> int:
-    manifest = init_package(path, name=name, force=force)
+def cmd_pkg_init(
+    path: Path,
+    *,
+    name: str | None = None,
+    version: str | None = None,
+    main: str | None = None,
+    out_dir: str | None = None,
+    output: str | None = None,
+    force: bool = False,
+) -> int:
+    manifest = init_package(
+        path,
+        name=name,
+        version=version,
+        main=main,
+        out_dir=out_dir,
+        output=output,
+        force=force,
+    )
     print(f"initialized package {manifest.name} in {path}", file=sys.stderr)
     return 0
 
@@ -126,6 +143,10 @@ def main(argv: list[str] | None = None) -> int:
     sp_init = pkg.add_parser("init", help="Create a package manifest and default source entry")
     sp_init.add_argument("path", type=Path, default=Path("."), nargs="?")
     sp_init.add_argument("--name")
+    sp_init.add_argument("--version", default=None)
+    sp_init.add_argument("--main", default=None)
+    sp_init.add_argument("--out-dir", default=None)
+    sp_init.add_argument("--output", default=None)
     sp_init.add_argument("--force", action="store_true")
     sp_build = pkg.add_parser("build", help="Build package bytecode")
     sp_build.add_argument("path", type=Path, default=Path("."), nargs="?")
@@ -159,7 +180,13 @@ def main(argv: list[str] | None = None) -> int:
         if args.cmd == "pkg":
             if args.pkg_cmd == "init":
                 return cmd_pkg_init(
-                    args.path, name=args.name, force=args.force
+                    args.path,
+                    name=args.name,
+                    version=args.version,
+                    main=args.main,
+                    out_dir=args.out_dir,
+                    output=args.output,
+                    force=args.force,
                 )
             if args.pkg_cmd == "build":
                 return cmd_pkg_build(args.path, allow_host_side_effects=args.allow_host_side_effects)

--- a/axiom/packaging.py
+++ b/axiom/packaging.py
@@ -66,10 +66,6 @@ def load_manifest(project_root: Path) -> PackageManifest:
     return _as_manifest(payload, path)
 
 
-def default_manifest(name: str) -> PackageManifest:
-    return PackageManifest(name=name, version=DEFAULT_VERSION)
-
-
 def manifest_to_dict(manifest: PackageManifest) -> dict[str, str | None]:
     payload: dict[str, str | None] = {
         "name": manifest.name,
@@ -89,8 +85,8 @@ def write_default_manifest(project_root: Path, manifest: PackageManifest) -> Pac
     return manifest
 
 
-def write_default_entry(project_root: Path) -> Path:
-    path = project_root / DEFAULT_MAIN
+def write_default_entry(project_root: Path, main: str) -> Path:
+    path = project_root / main
     path.parent.mkdir(parents=True, exist_ok=True)
     if not path.exists():
         path.write_text("print 0\n", encoding="utf-8")
@@ -98,7 +94,14 @@ def write_default_entry(project_root: Path) -> Path:
 
 
 def init_package(
-    project_root: Path, *, name: Optional[str] = None, force: bool = False
+    project_root: Path,
+    *,
+    name: Optional[str] = None,
+    version: Optional[str] = None,
+    main: Optional[str] = None,
+    out_dir: Optional[str] = None,
+    output: Optional[str] = None,
+    force: bool = False,
 ) -> PackageManifest:
     project_root = project_root.resolve()
     project_root.mkdir(parents=True, exist_ok=True)
@@ -106,10 +109,31 @@ def init_package(
         raise AxiomCompileError(
             f"package manifest already exists at {manifest_path(project_root)}"
         )
+    if name is not None and (not isinstance(name, str) or not name):
+        raise AxiomCompileError("package name must be a non-empty string")
+    version = version if version is not None else DEFAULT_VERSION
+    main = main if main is not None else DEFAULT_MAIN
+    out_dir = out_dir if out_dir is not None else DEFAULT_OUT_DIR
+    if not isinstance(version, str) or not version:
+        raise AxiomCompileError("package version must be a non-empty string")
+    if not isinstance(main, str) or not main:
+        raise AxiomCompileError("package main must be a non-empty string")
+    if not isinstance(out_dir, str) or not out_dir:
+        raise AxiomCompileError("package out_dir must be a non-empty string")
+    if output is not None and (not isinstance(output, str) or not output):
+        raise AxiomCompileError("package output must be a non-empty string when provided")
     pkg_name = name if name else (project_root.name or DEFAULT_NAME)
-    manifest = default_manifest(pkg_name)
+    if not pkg_name:
+        pkg_name = DEFAULT_NAME
+    manifest = PackageManifest(
+        name=pkg_name,
+        version=version,
+        main=main,
+        out_dir=out_dir,
+        output=output,
+    )
     write_default_manifest(project_root, manifest)
-    write_default_entry(project_root)
+    write_default_entry(project_root, manifest.main)
     return manifest
 
 

--- a/docs/package.md
+++ b/docs/package.md
@@ -29,7 +29,7 @@ Example manifest:
 ## CLI
 
 ```bash
-python -m axiom pkg init /path/to/project --name demo
+python -m axiom pkg init /path/to/project --name demo --version 0.1.0
 python -m axiom pkg build /path/to/project
 python -m axiom pkg manifest /path/to/project
 ```
@@ -38,7 +38,14 @@ python -m axiom pkg manifest /path/to/project
 
 - `axiom.pkg` (with default values)
 - `src/main.ax` (only if missing) with `print 0` fallback body
-- Pass `--force` to regenerate `axiom.pkg` when it already exists.
+Options:
+
+- `--name`
+- `--version` (default `0.1.0`)
+- `--main` (default `src/main.ax`)
+- `--out-dir` (default `dist`)
+- `--output` (optional explicit artifact filename)
+- `--force` to regenerate `axiom.pkg` when it already exists.
 
 `pkg build` reads `axiom.pkg`, compiles `main`, and writes `.axb` into `out_dir`.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -138,6 +138,35 @@ class CliParityTests(unittest.TestCase):
             payload = json.loads(proc.stdout)
             self.assertEqual(payload["name"], "demo")
 
+    def test_package_init_with_manifest_overrides(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project = Path(td)
+            self._run_cli(
+                [
+                    "pkg",
+                    "init",
+                    str(project),
+                    "--name",
+                    "demo",
+                    "--version",
+                    "2.0.0",
+                    "--main",
+                    "src/app/main.ax",
+                    "--out-dir",
+                    "build",
+                    "--output",
+                    "bundle.axb",
+                ],
+                cwd=ROOT,
+            )
+            manifest = json.loads((project / "axiom.pkg").read_text(encoding="utf-8"))
+            self.assertEqual(manifest["name"], "demo")
+            self.assertEqual(manifest["version"], "2.0.0")
+            self.assertEqual(manifest["main"], "src/app/main.ax")
+            self.assertEqual(manifest["out_dir"], "build")
+            self.assertEqual(manifest["output"], "bundle.axb")
+            self.assertTrue((project / "src" / "app" / "main.ax").exists())
+
     def test_package_init_force_rewrites_manifest(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             project = Path(td)


### PR DESCRIPTION
Add support for pkg init manifest options: version, main, out-dir, and output; keep defaults and force overwrite behavior. Update docs and CLI coverage.