### PR TITLE
Add pkg run subcommand and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ python -m axiom compile examples/arith.ax -o /tmp/arith.axb
 # Run bytecode on the VM (stage1)
 python -m axiom vm /tmp/arith.axb
 
+# Run package main from manifest (stage3 planning)
+python -m axiom pkg run .
+
 # Run conformance tests (interpreter vs VM + expected output)
 python -m unittest discover -v
 

--- a/axiom/__main__.py
+++ b/axiom/__main__.py
@@ -110,6 +110,18 @@ def cmd_pkg_clean(path: Path) -> int:
     return 0
 
 
+def cmd_pkg_run(path: Path, *, allow_host_side_effects: bool) -> int:
+    project_root = path.resolve()
+    manifest = load_manifest(project_root)
+    entry = project_root / manifest.main
+    bytecode = compile_file(entry, allow_host_side_effects=allow_host_side_effects)
+    Vm(
+        locals_count=bytecode.locals_count,
+        allow_host_side_effects=allow_host_side_effects,
+    ).run(bytecode, sys.stdout)
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(prog="axiom", description="Axiom language tool (stage0 interpreter + stage1 compiler/VM)")
     sub = p.add_subparsers(dest="cmd", required=True)
@@ -151,6 +163,9 @@ def main(argv: list[str] | None = None) -> int:
     sp_build = pkg.add_parser("build", help="Build package bytecode")
     sp_build.add_argument("path", type=Path, default=Path("."), nargs="?")
     sp_build.add_argument("--allow-host-side-effects", action="store_true")
+    sp_run = pkg.add_parser("run", help="Run package main source via manifest")
+    sp_run.add_argument("path", type=Path, default=Path("."), nargs="?")
+    sp_run.add_argument("--allow-host-side-effects", action="store_true")
     pkg.add_parser("manifest", help="Print package manifest JSON").add_argument(
         "path", type=Path, default=Path("."), nargs="?"
     )
@@ -194,6 +209,8 @@ def main(argv: list[str] | None = None) -> int:
                 return cmd_pkg_manifest(args.path)
             if args.pkg_cmd == "clean":
                 return cmd_pkg_clean(args.path)
+            if args.pkg_cmd == "run":
+                return cmd_pkg_run(args.path, allow_host_side_effects=args.allow_host_side_effects)
             raise AssertionError("unreachable")
         raise AssertionError("unreachable")
     except AxiomError as e:

--- a/docs/package.md
+++ b/docs/package.md
@@ -32,6 +32,7 @@ Example manifest:
 python -m axiom pkg init /path/to/project --name demo --version 0.1.0
 python -m axiom pkg build /path/to/project
 python -m axiom pkg manifest /path/to/project
+python -m axiom pkg run /path/to/project
 ```
 
 `pkg init` creates:
@@ -48,6 +49,8 @@ Options:
 - `--force` to regenerate `axiom.pkg` when it already exists.
 
 `pkg build` reads `axiom.pkg`, compiles `main`, and writes `.axb` into `out_dir`.
+
+`pkg run` reads `axiom.pkg`, compiles `main`, and executes it in the VM immediately.
 
 `pkg manifest` prints normalized manifest JSON.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -138,6 +138,14 @@ class CliParityTests(unittest.TestCase):
             payload = json.loads(proc.stdout)
             self.assertEqual(payload["name"], "demo")
 
+    def test_package_run_executes_main(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project = Path(td)
+            self._run_cli(["pkg", "init", str(project), "--name", "demo"], cwd=ROOT)
+            (project / "src" / "main.ax").write_text("print 7\n", encoding="utf-8")
+            proc = self._run_cli(["pkg", "run", str(project)], cwd=ROOT)
+            self.assertEqual(proc.stdout, "7\n")
+
     def test_package_init_with_manifest_overrides(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             project = Path(td)


### PR DESCRIPTION
Implement package run command in CLI and cover with parity test.

- Add  to load manifest and execute main entry in VM.
- Add command-line argument and dispatch.
- Add test ensuring  executes source.
- Document new command in README and package docs.