### PR TITLE
Add host list CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ python -m axiom vm /tmp/arith.axb
 # Run package main from manifest (stage3 planning)
 python -m axiom pkg run .
 
+# Inspect host bridge capabilities for tooling
+python -m axiom host list
+
 # Run conformance tests (interpreter vs VM + expected output)
 python -m unittest discover -v
 

--- a/axiom/__main__.py
+++ b/axiom/__main__.py
@@ -10,6 +10,7 @@ from .bytecode import Bytecode, Op
 from .interpreter import Interpreter
 from .vm import Vm
 from .errors import AxiomError
+from .host import HOST_BUILTINS, HOST_BUILTIN_NAMES
 from .packaging import (
     build_package,
     clean_package,
@@ -122,6 +123,17 @@ def cmd_pkg_run(path: Path, *, allow_host_side_effects: bool) -> int:
     return 0
 
 
+def cmd_host_list() -> int:
+    payload = []
+    for name in HOST_BUILTIN_NAMES:
+        arity, side_effecting = HOST_BUILTINS[name]
+        payload.append(
+            {"name": name, "arity": arity, "side_effecting": side_effecting}
+        )
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(prog="axiom", description="Axiom language tool (stage0 interpreter + stage1 compiler/VM)")
     sub = p.add_subparsers(dest="cmd", required=True)
@@ -172,6 +184,9 @@ def main(argv: list[str] | None = None) -> int:
     pkg.add_parser("clean", help="Delete package artifacts").add_argument(
         "path", type=Path, default=Path("."), nargs="?"
     )
+    sp_host = sub.add_parser("host", help="Host bridge helpers")
+    host = sp_host.add_subparsers(dest="host_cmd", required=True)
+    host.add_parser("list", help="List registered host capabilities")
 
     args = p.parse_args(argv)
 
@@ -211,6 +226,10 @@ def main(argv: list[str] | None = None) -> int:
                 return cmd_pkg_clean(args.path)
             if args.pkg_cmd == "run":
                 return cmd_pkg_run(args.path, allow_host_side_effects=args.allow_host_side_effects)
+            raise AssertionError("unreachable")
+        if args.cmd == "host":
+            if args.host_cmd == "list":
+                return cmd_host_list()
             raise AssertionError("unreachable")
         raise AssertionError("unreachable")
     except AxiomError as e:

--- a/docs/kernel.md
+++ b/docs/kernel.md
@@ -40,3 +40,4 @@
 - `host.print` and `host.read` are side-effecting; they require an explicit runtime flag when enabled
 - `host` call payloads in bytecode are name-based (string table index) starting at
   bytecode `v0.6` to preserve behavior if host registry order changes.
+- `python -m axiom host list` enumerates the currently registered host capabilities.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -97,6 +97,17 @@ class CliParityTests(unittest.TestCase):
             proc = self._run_cli(["run", str(src), "--allow-host-side-effects"], cwd=ROOT)
             self.assertEqual(proc.stdout, "9\n")
 
+    def test_host_list_command(self) -> None:
+        proc = self._run_cli(["host", "list"], cwd=ROOT)
+        payload = json.loads(proc.stdout)
+        self.assertTrue(isinstance(payload, list))
+        names = {entry["name"] for entry in payload}
+        self.assertIn("version", names)
+        self.assertIn("print", names)
+        version_entry = next(e for e in payload if e["name"] == "version")
+        self.assertEqual(version_entry["arity"], 0)
+        self.assertFalse(version_entry["side_effecting"])
+
     def test_imported_modules_execute(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             mod = Path(td) / "math_module.ax"


### PR DESCRIPTION
Expose registered host capabilities via CLI for tool interoperability.

Changes:
- Added  top-level command with  subcommand.
-  prints JSON array of host capabilities in registry order.
- Included CLI parity test for stable names, arity, and side-effect flags.
- Updated README and kernel docs to document host capability introspection.,max_output_tokens:12000,