### PR TITLE
Add pkg check host-side-effect parity coverage

### DIFF
--- a/docs/package.md
+++ b/docs/package.md
@@ -52,6 +52,8 @@ Options:
 `pkg build` reads `axiom.pkg`, compiles `main`, and writes `.axb` into `out_dir`.
 
 `pkg check` validates `axiom.pkg` and compiles the manifest `main` entrypoint.
+Host side-effecting host calls (for example `host.print`) obey the global
+`--allow-host-side-effects` flag.
 
 `pkg run` reads `axiom.pkg`, compiles `main`, and executes it in the VM immediately.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -193,6 +193,21 @@ class CliParityTests(unittest.TestCase):
             proc = self._run_cli(["pkg", "check", str(project)], cwd=ROOT)
             self.assertIn("OK", proc.stderr)
 
+    def test_package_check_command_respects_host_effect_gating(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project = Path(td)
+            self._run_cli(["pkg", "init", str(project), "--name", "demo"], cwd=ROOT)
+            (project / "src" / "main.ax").write_text("host.print(9)\n", encoding="utf-8")
+
+            proc = self._run_cli(["pkg", "check", str(project)], cwd=ROOT, expect_code=1)
+            self.assertIn("side-effecting", proc.stderr)
+
+            proc = self._run_cli(
+                ["pkg", "check", str(project), "--allow-host-side-effects"],
+                cwd=ROOT,
+            )
+            self.assertIn("OK", proc.stderr)
+
     def test_package_init_force_rewrites_manifest(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             project = Path(td)


### PR DESCRIPTION
Add test coverage ensuring  enforces host side-effect gating and supports ; document host-call behavior in package CLI docs.