### PR TITLE
Reserve host namespace in function declarations

### DIFF
--- a/axiom/compiler.py
+++ b/axiom/compiler.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List
+from typing import ClassVar, Dict, List
 
 from .ast import (
     Program,
@@ -39,6 +39,7 @@ class Compiler:
     functions: List[FunctionMeta] = field(default_factory=list)
     function_locals: Dict[str, int] = field(default_factory=dict)
     allow_host_side_effects: bool = False
+    RESERVED_FUNCTION_NAMES: ClassVar[set[str]] = {"host"}
 
     def compile(self, program: Program) -> Bytecode:
         self.scope_stack = [{}]
@@ -81,6 +82,8 @@ class Compiler:
         )
 
     def _register_function(self, fn: FunctionDefStmt) -> None:
+        if fn.name in self.RESERVED_FUNCTION_NAMES:
+            raise AxiomCompileError(f"reserved function name {fn.name!r}", fn.span)
         if fn.name in self.function_ids:
             raise AxiomCompileError(f"duplicate function {fn.name!r}", fn.span)
         self.function_ids[fn.name] = len(self.function_defs)

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -17,7 +17,7 @@ stmt           := let_stmt
                | expr_stmt ;
 
 import_stmt    := "import" STRING terminator ;
-fn_stmt        := "fn" IDENT "(" params? ")" block ;
+fn_stmt        := "fn" IDENT "(" params? ")" block ;  # IDENT may not be "host"
 params         := IDENT ("," IDENT)* ;
 return_stmt    := "return" expr terminator ;
 let_stmt       := "let" IDENT "=" expr terminator ;

--- a/docs/kernel.md
+++ b/docs/kernel.md
@@ -16,6 +16,7 @@
 - `return <expr>`
 - `import "<path>"` for file module inclusion (resolved relative to file path; loaded at compile time)
 - function calls: `<name>(<arg1>, ... )`
+- function names cannot be `host` (reserved for host namespace)
 - `host.<name>(...)` for host bridge calls (reserved namespace)
 - Host calls are resolved from a registry. Add custom capabilities via
   `axiom.host.register_host_builtin(name, arity, side_effecting, handler)` where

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -48,6 +48,14 @@ print x
         with self.assertRaises(AxiomCompileError):
             compile_to_bytecode("print unknown(1)\n")
 
+    def test_compile_reserved_host_function_name(self) -> None:
+        with self.assertRaises(AxiomCompileError):
+            compile_to_bytecode("""
+fn host() {
+  return 1
+}
+""")
+
     def test_compile_arity_mismatch(self) -> None:
         with self.assertRaises(AxiomCompileError):
             compile_to_bytecode("""
@@ -87,6 +95,10 @@ print f(1)
             self.assertEqual(vm_out.getvalue(), "42\n")
         finally:
             reset_host_builtins()
+
+    def test_compile_unknown_host_function(self) -> None:
+        with self.assertRaises(AxiomCompileError):
+            compile_to_bytecode("host.unknown(1)\n")
 
     def test_host_registry_duplicate_name(self) -> None:
         def noop(args: list[int], _out) -> int:


### PR DESCRIPTION
Phase 3 hardening: disallow function name 'host' so namespaced host calls remain deterministic; add compile-time coverage for unknown host functions and host-namespace function reservation.