### PR TITLE
Reject non-host namespaced calls

### DIFF
--- a/axiom/compiler.py
+++ b/axiom/compiler.py
@@ -237,6 +237,8 @@ class Compiler:
                     self._compile_expr(arg, out)
                 out.append(Instr(Op.HOST_CALL, self._intern(host_fn)))
                 return
+            if "." in fn_name:
+                raise AxiomCompileError(f"only host namespace calls are supported: {fn_name!r}", expr.span)
             if fn_name not in self.function_ids:
                 raise AxiomCompileError(f"undefined function {fn_name!r}", expr.span)
             arity = self.function_arities[fn_name]

--- a/axiom/interpreter.py
+++ b/axiom/interpreter.py
@@ -120,6 +120,8 @@ class Interpreter:
     def _call(self, fn_name: str, args: List[int], out: TextIO) -> int:
         if fn_name.startswith("host."):
             return self._call_host(fn_name, args, out)
+        if "." in fn_name:
+            raise AxiomRuntimeError("only host namespace calls are supported for dotted call syntax")
         if fn_name not in self.functions:
             raise AxiomRuntimeError(f"undefined function {fn_name!r}")
         fn = self.functions[fn_name]

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -100,6 +100,10 @@ print f(1)
         with self.assertRaises(AxiomCompileError):
             compile_to_bytecode("host.unknown(1)\n")
 
+    def test_compile_non_host_namespace_call(self) -> None:
+        with self.assertRaises(AxiomCompileError):
+            compile_to_bytecode("foo.bar(1)\n")
+
     def test_host_registry_duplicate_name(self) -> None:
         def noop(args: list[int], _out) -> int:
             return 0
@@ -167,6 +171,11 @@ print f(1)
         out = io.StringIO()
         Vm(locals_count=bc.locals_count, allow_host_side_effects=True).run(bc, out)
         self.assertEqual(out.getvalue(), "1\n")
+
+    def test_runtime_non_host_namespace_call(self) -> None:
+        program = parse_program("foo.bar(1)\n")
+        with self.assertRaises(AxiomRuntimeError):
+            Interpreter().run(program, io.StringIO())
 
     @patch("builtins.input", return_value="41")
     def test_runtime_host_read_with_allow(self, fake_input) -> None:


### PR DESCRIPTION
Add hard error for dotted calls outside host namespace in compiler and interpreter, plus tests for dotted non-host call rejection.