### PR TITLE
Update roadmap for host namespace hardening

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -21,6 +21,8 @@
 
 ## Phase 4
 - Built-in host capability registry for agentic extensibility
+- Reserve host namespace for tool calls and reject dotted non-host calls
 
 ## Phase 5
 - Package/build tooling skeleton (`axiom.pkg`, `axiom pkg init`, `axiom pkg build`)
+- Package command coverage (`check`, `host` side-effect gating, CLI checks)


### PR DESCRIPTION
Sync roadmap bullets with current status: host namespace reservation and package command coverage in phase 4/5.