### PR TITLE
Harden host identifier reservation at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Supported:
   - `while <expr> { ... }`
 - integer literals
 - variables
+- identifiers named `host` are reserved (`let host`, function parameters, and function names)
 - function calls: `name(arg, ...)`
 - `import "path"` for file-level module loading (resolved relative to importing file)
 - host bridge calls: `host.version()`, `host.print(value)`, `host.read(prompt)`, `host.abs(value)`, `host.math.abs(value)` (gated side effects apply to `print`/`read` only)

--- a/axiom/compiler.py
+++ b/axiom/compiler.py
@@ -40,6 +40,7 @@ class Compiler:
     function_locals: Dict[str, int] = field(default_factory=dict)
     allow_host_side_effects: bool = False
     RESERVED_FUNCTION_NAMES: ClassVar[set[str]] = {"host"}
+    RESERVED_IDENTIFIER_NAMES: ClassVar[set[str]] = {"host"}
 
     def compile(self, program: Program) -> Bytecode:
         self.scope_stack = [{}]
@@ -126,6 +127,8 @@ class Compiler:
         raise AxiomCompileError(f"undefined variable {name!r}", span)
 
     def _slot_for_let(self, name: str, span) -> int:
+        if name in self.RESERVED_IDENTIFIER_NAMES:
+            raise AxiomCompileError(f"reserved identifier {name!r}", span)
         current = self.scope_stack[-1]
         if name in current:
             return current[name]
@@ -136,6 +139,8 @@ class Compiler:
         return slot
 
     def _slot_for_param(self, name: str, span) -> None:
+        if name in self.RESERVED_IDENTIFIER_NAMES:
+            raise AxiomCompileError(f"reserved identifier {name!r}", span)
         current = self.scope_stack[-1]
         if name in current:
             raise AxiomCompileError(f"duplicate parameter {name!r}", span)

--- a/axiom/interpreter.py
+++ b/axiom/interpreter.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List, TextIO, Tuple
+from typing import ClassVar, Dict, List, TextIO, Tuple
 
 from .ast import (
     Program,
@@ -35,6 +35,8 @@ class _FunctionReturn(Exception):
 
 @dataclass
 class Interpreter:
+    RESERVED_IDENTIFIER_NAMES: ClassVar[set[str]] = {"host"}
+
     scopes: List[Dict[str, int]] = field(default_factory=lambda: [{}])
     global_scope: Dict[str, int] = field(default_factory=dict)
     functions: Dict[str, FunctionDefStmt] = field(default_factory=dict)
@@ -51,6 +53,11 @@ class Interpreter:
 
         for stmt in program.stmts:
             if isinstance(stmt, FunctionDefStmt):
+                for name in stmt.params:
+                    if name in self.RESERVED_IDENTIFIER_NAMES:
+                        raise AxiomRuntimeError(f"reserved identifier {name!r}")
+                if stmt.name in self.RESERVED_IDENTIFIER_NAMES:
+                    raise AxiomRuntimeError(f"reserved function name {stmt.name!r}")
                 if stmt.name in self.functions:
                     raise AxiomCompileError(f"duplicate function {stmt.name!r}", stmt.span)
                 self.functions[stmt.name] = stmt
@@ -62,6 +69,8 @@ class Interpreter:
 
     def _exec_stmt(self, stmt, out: TextIO) -> None:
         if isinstance(stmt, LetStmt):
+            if stmt.name in self.RESERVED_IDENTIFIER_NAMES:
+                raise AxiomRuntimeError(f"reserved identifier {stmt.name!r}")
             self.scopes[-1][stmt.name] = self._eval(stmt.expr, out)
             return
         if isinstance(stmt, AssignStmt):
@@ -111,6 +120,8 @@ class Interpreter:
         raise AxiomRuntimeError(f"undefined variable {name!r}", span)
 
     def _assign(self, name: str, value: int, span) -> None:
+        if name in self.RESERVED_IDENTIFIER_NAMES:
+            raise AxiomRuntimeError(f"reserved identifier {name!r}")
         for scope in reversed(self.scopes):
             if name in scope:
                 scope[name] = value
@@ -134,6 +145,8 @@ class Interpreter:
 
         param_scope: Dict[str, int] = {}
         for index, name in enumerate(fn.params):
+            if name in self.RESERVED_IDENTIFIER_NAMES:
+                raise AxiomRuntimeError(f"reserved identifier {name!r}")
             param_scope[name] = args[index]
         self.scopes = [param_scope, self.global_scope]
         self.function_depth += 1

--- a/axiom/parser.py
+++ b/axiom/parser.py
@@ -112,6 +112,8 @@ class Parser:
         name = self._eat(TokenKind.IDENT)
         if name.kind != TokenKind.IDENT:
             raise AxiomParseError("expected function name", name.span)
+        if name.value == "host":
+            raise AxiomParseError("function name cannot be 'host'", name.span)
         self._eat(TokenKind.LPAREN)
 
         params: List[str] = []
@@ -120,6 +122,8 @@ class Parser:
                 ident = self._eat(TokenKind.IDENT)
                 if ident.kind != TokenKind.IDENT:
                     raise AxiomParseError("expected parameter name", ident.span)
+                if ident.value == "host":
+                    raise AxiomParseError("parameter name cannot be 'host'", ident.span)
                 params.append(str(ident.value))
                 if self._peek().kind == TokenKind.COMMA:
                     self._bump()
@@ -172,6 +176,8 @@ class Parser:
         ident = self._bump()
         if ident.kind != TokenKind.IDENT:
             raise AxiomParseError("expected identifier after 'let'", ident.span)
+        if ident.value == "host":
+            raise AxiomParseError("identifier cannot be 'host'", ident.span)
         self._eat(TokenKind.EQ)
         expr = self._parse_expr()
         end = self._parse_terminator(default_end=expr_span(expr).end)
@@ -187,6 +193,8 @@ class Parser:
 
     def _parse_assign(self) -> AssignStmt:
         ident = self._eat(TokenKind.IDENT)
+        if ident.value == "host":
+            raise AxiomParseError("identifier cannot be 'host'", ident.span)
         self._eat(TokenKind.EQ)
         expr = self._parse_expr()
         end = self._parse_terminator(default_end=expr_span(expr).end)

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -17,7 +17,7 @@ stmt           := let_stmt
                | expr_stmt ;
 
 import_stmt    := "import" STRING terminator ;
-fn_stmt        := "fn" IDENT "(" params? ")" block ;  # IDENT may not be "host"
+fn_stmt        := "fn" IDENT "(" params? ")" block ;  # IDENT and params may not be "host"
 params         := IDENT ("," IDENT)* ;
 return_stmt    := "return" expr terminator ;
 let_stmt       := "let" IDENT "=" expr terminator ;

--- a/docs/kernel.md
+++ b/docs/kernel.md
@@ -16,7 +16,7 @@
 - `return <expr>`
 - `import "<path>"` for file module inclusion (resolved relative to file path; loaded at compile time)
 - function calls: `<name>(<arg1>, ... )`
-- function names cannot be `host` (reserved for host namespace)
+- identifiers named `host` are reserved for host namespace (`let host`, parameters, and function names are rejected)
 - `host.<name>(...)` for host bridge calls (reserved namespace)
 - Host calls are resolved from a registry. Add custom capabilities via
   `axiom.host.register_host_builtin(name, arity, side_effecting, handler)` where

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -6,6 +6,17 @@ import tempfile
 
 from axiom.api import compile_to_bytecode, compile_file
 from axiom.api import parse_program
+from axiom.ast import (
+    AssignStmt,
+    BlockStmt,
+    FunctionDefStmt,
+    IntLit,
+    LetStmt,
+    Program,
+    ReturnStmt,
+    Span,
+    VarRef,
+)
 from axiom.errors import AxiomCompileError, AxiomParseError, AxiomRuntimeError
 from axiom.interpreter import Interpreter
 from axiom.vm import Vm
@@ -48,11 +59,23 @@ print x
         with self.assertRaises(AxiomCompileError):
             compile_to_bytecode("print unknown(1)\n")
 
-    def test_compile_reserved_host_function_name(self) -> None:
-        with self.assertRaises(AxiomCompileError):
+    def test_parse_reserved_host_function_name(self) -> None:
+        with self.assertRaises(AxiomParseError):
             compile_to_bytecode("""
 fn host() {
   return 1
+}
+""")
+
+    def test_parse_reserved_host_identifier(self) -> None:
+        with self.assertRaises(AxiomParseError):
+            compile_to_bytecode("let host = 1\n")
+        with self.assertRaises(AxiomParseError):
+            compile_to_bytecode("host = 1\n")
+        with self.assertRaises(AxiomParseError):
+            compile_to_bytecode("""
+fn f(host) {
+  return host
 }
 """)
 
@@ -174,6 +197,59 @@ print f(1)
 
     def test_runtime_non_host_namespace_call(self) -> None:
         program = parse_program("foo.bar(1)\n")
+        with self.assertRaises(AxiomRuntimeError):
+            Interpreter().run(program, io.StringIO())
+
+    def test_runtime_reserved_host_identifier_let(self) -> None:
+        program = Program(
+            [LetStmt(name="host", expr=IntLit(1, Span(0, 1)), span=Span(0, 1))]
+        )
+        with self.assertRaises(AxiomRuntimeError):
+            Interpreter().run(program, io.StringIO())
+
+    def test_runtime_reserved_host_identifier_param(self) -> None:
+        program = Program(
+            [
+                FunctionDefStmt(
+                    name="f",
+                    params=["host"],
+                    body=BlockStmt(
+                        stmts=[
+                            ReturnStmt(expr=VarRef(name="host", span=Span(0, 4)), span=Span(0, 4))
+                        ],
+                        span=Span(0, 6),
+                    ),
+                    span=Span(0, 8),
+                )
+            ]
+        )
+        with self.assertRaises(AxiomRuntimeError):
+            Interpreter().run(program, io.StringIO())
+
+    def test_runtime_reserved_host_identifier_assign(self) -> None:
+        program = Program(
+            [
+                LetStmt(name="x", expr=IntLit(1, Span(0, 1)), span=Span(0, 1)),
+                AssignStmt(name="host", expr=IntLit(2, Span(2, 3)), span=Span(2, 4)),
+            ]
+        )
+        with self.assertRaises(AxiomRuntimeError):
+            Interpreter().run(program, io.StringIO())
+
+    def test_runtime_reserved_host_function_name(self) -> None:
+        program = Program(
+            [
+                FunctionDefStmt(
+                    name="host",
+                    params=[],
+                    body=BlockStmt(
+                        stmts=[ReturnStmt(expr=IntLit(0, Span(0, 1)), span=Span(0, 1))],
+                        span=Span(0, 3),
+                    ),
+                    span=Span(0, 5),
+                )
+            ]
+        )
         with self.assertRaises(AxiomRuntimeError):
             Interpreter().run(program, io.StringIO())
 


### PR DESCRIPTION
Adds parser and runtime checks to reject reserved identifier 'host' in let assignments, function names, and params, with test + docs updates. Includes full parity validation: python -m unittest discover -v and python -m axiom check tests/programs/arith.ax.