### PR TITLE
Add package host-call allowlist enforcement

### DIFF
--- a/axiom/__main__.py
+++ b/axiom/__main__.py
@@ -75,6 +75,7 @@ def cmd_pkg_init(
     main: str | None = None,
     out_dir: str | None = None,
     output: str | None = None,
+    allowed_host_calls: list[str] | None = None,
     force: bool = False,
 ) -> int:
     manifest = init_package(
@@ -84,6 +85,7 @@ def cmd_pkg_init(
         main=main,
         out_dir=out_dir,
         output=output,
+        allowed_host_calls=allowed_host_calls,
         force=force,
     )
     print(f"initialized package {manifest.name} in {path}", file=sys.stderr)
@@ -111,7 +113,14 @@ def cmd_pkg_manifest(path: Path) -> int:
 def cmd_pkg_check(path: Path, *, allow_host_side_effects: bool) -> int:
     manifest = load_manifest(path)
     entry = path.resolve() / manifest.main
-    _ = compile_file(entry, allow_host_side_effects=allow_host_side_effects)
+    allowed_host_calls = (
+        set(manifest.allowed_host_calls) if manifest.allowed_host_calls else None
+    )
+    _ = compile_file(
+        entry,
+        allow_host_side_effects=allow_host_side_effects,
+        allowed_host_calls=allowed_host_calls,
+    )
     print("OK", file=sys.stderr)
     return 0
 
@@ -129,7 +138,14 @@ def cmd_pkg_run(path: Path, *, allow_host_side_effects: bool) -> int:
     project_root = path.resolve()
     manifest = load_manifest(project_root)
     entry = project_root / manifest.main
-    bytecode = compile_file(entry, allow_host_side_effects=allow_host_side_effects)
+    allowed_host_calls = (
+        set(manifest.allowed_host_calls) if manifest.allowed_host_calls else None
+    )
+    bytecode = compile_file(
+        entry,
+        allow_host_side_effects=allow_host_side_effects,
+        allowed_host_calls=allowed_host_calls,
+    )
     Vm(
         locals_count=bytecode.locals_count,
         allow_host_side_effects=allow_host_side_effects,
@@ -185,6 +201,13 @@ def main(argv: list[str] | None = None) -> int:
     sp_init.add_argument("--main", default=None)
     sp_init.add_argument("--out-dir", default=None)
     sp_init.add_argument("--output", default=None)
+    sp_init.add_argument(
+        "--allowed-host-call",
+        action="append",
+        default=None,
+        metavar="HOSTCALL",
+        help="Allowlist host call (e.g. print, abs, math.abs)",
+    )
     sp_init.add_argument("--force", action="store_true")
     sp_build = pkg.add_parser("build", help="Build package bytecode")
     sp_build.add_argument("path", type=Path, default=Path("."), nargs="?")
@@ -234,6 +257,7 @@ def main(argv: list[str] | None = None) -> int:
                     main=args.main,
                     out_dir=args.out_dir,
                     output=args.output,
+                    allowed_host_calls=args.allowed_host_call,
                     force=args.force,
                 )
             if args.pkg_cmd == "build":

--- a/axiom/api.py
+++ b/axiom/api.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Set
+from typing import Optional, Set
 
 from .lexer import Lexer
 from .parser import Parser
@@ -20,15 +20,29 @@ def parse_program(src: str) -> Program:
     return Parser(toks).parse_program()
 
 
-def compile_to_bytecode(src: str, *, allow_host_side_effects: bool = False) -> Bytecode:
+def compile_to_bytecode(
+    src: str,
+    *,
+    allow_host_side_effects: bool = False,
+    allowed_host_calls: Optional[Set[str]] = None,
+) -> Bytecode:
     program = parse_program(src)
-    return Compiler(allow_host_side_effects=allow_host_side_effects).compile(program)
+    return Compiler(
+        allow_host_side_effects=allow_host_side_effects,
+        allowed_host_calls=allowed_host_calls,
+    ).compile(program)
 
 
-def compile_file(path: Path, *, allow_host_side_effects: bool = False) -> Bytecode:
-    return Compiler(allow_host_side_effects=allow_host_side_effects).compile(
-        parse_file(path)
-    )
+def compile_file(
+    path: Path,
+    *,
+    allow_host_side_effects: bool = False,
+    allowed_host_calls: Optional[Set[str]] = None,
+) -> Bytecode:
+    return Compiler(
+        allow_host_side_effects=allow_host_side_effects,
+        allowed_host_calls=allowed_host_calls,
+    ).compile(parse_file(path))
 
 
 def _load_program_file(path: Path, seen: Set[Path], loading: Set[Path]) -> Program:

--- a/axiom/compiler.py
+++ b/axiom/compiler.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import ClassVar, Dict, List
+from typing import ClassVar, Dict, List, Optional, Set
 
 from .ast import (
     Program,
@@ -39,6 +39,7 @@ class Compiler:
     functions: List[FunctionMeta] = field(default_factory=list)
     function_locals: Dict[str, int] = field(default_factory=dict)
     allow_host_side_effects: bool = False
+    allowed_host_calls: Optional[Set[str]] = None
     RESERVED_FUNCTION_NAMES: ClassVar[set[str]] = {"host"}
     RESERVED_IDENTIFIER_NAMES: ClassVar[set[str]] = {"host"}
 
@@ -227,6 +228,11 @@ class Compiler:
                 host_fn = fn_name[len("host.") :]
                 if host_fn not in HOST_BUILTINS:
                     raise AxiomCompileError(f"undefined host function {fn_name!r}", expr.span)
+                if self.allowed_host_calls is not None and host_fn not in self.allowed_host_calls:
+                    raise AxiomCompileError(
+                        f"host call {fn_name!r} is not permitted by package policy",
+                        expr.span,
+                    )
                 arity, side_effectful = HOST_BUILTINS[host_fn]
                 if side_effectful and not self.allow_host_side_effects:
                     raise AxiomCompileError(

--- a/axiom/packaging.py
+++ b/axiom/packaging.py
@@ -4,7 +4,7 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 import shutil
-from typing import Optional
+from typing import List, Optional
 
 from .api import compile_file
 from .errors import AxiomCompileError
@@ -24,6 +24,7 @@ class PackageManifest:
     main: str = DEFAULT_MAIN
     out_dir: str = DEFAULT_OUT_DIR
     output: Optional[str] = None
+    allowed_host_calls: Optional[List[str]] = None
 
 
 def manifest_path(project_root: Path) -> Path:
@@ -65,6 +66,21 @@ def _validate_relative_path(value: str, path: Path, field_name: str) -> str:
     return value
 
 
+def _validate_host_calls(value: object, path: Path) -> List[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise AxiomCompileError(f"package manifest {path} has invalid allowed_host_calls")
+    host_calls: List[str] = []
+    for item in value:
+        if not isinstance(item, str) or not item:
+            raise AxiomCompileError(
+                f"package manifest {path} has invalid allowed_host_calls entry {item!r}"
+            )
+        host_calls.append(item)
+    return host_calls
+
+
 def _as_manifest(data: dict[str, object], path: Path) -> PackageManifest:
     if not isinstance(data, dict):
         raise AxiomCompileError(f"invalid package manifest in {path}")
@@ -81,6 +97,7 @@ def _as_manifest(data: dict[str, object], path: Path) -> PackageManifest:
     if not isinstance(out_dir, str):
         raise AxiomCompileError(f"package manifest {path} has invalid out_dir")
     out_dir = _validate_relative_path(out_dir, path, "out_dir")
+    allowed_host_calls = _validate_host_calls(data.get("allowed_host_calls"), path)
     if output is not None:
         if not isinstance(output, str):
             raise AxiomCompileError(f"package manifest {path} has invalid output")
@@ -92,6 +109,7 @@ def _as_manifest(data: dict[str, object], path: Path) -> PackageManifest:
         main=main,
         out_dir=out_dir,
         output=output if isinstance(output, str) else None,
+        allowed_host_calls=allowed_host_calls,
     )
 
 
@@ -106,8 +124,8 @@ def load_manifest(project_root: Path) -> PackageManifest:
     return _as_manifest(payload, path)
 
 
-def manifest_to_dict(manifest: PackageManifest) -> dict[str, str | None]:
-    payload: dict[str, str | None] = {
+def manifest_to_dict(manifest: PackageManifest) -> dict[str, object]:
+    payload: dict[str, object] = {
         "name": manifest.name,
         "version": manifest.version,
         "main": manifest.main,
@@ -115,6 +133,8 @@ def manifest_to_dict(manifest: PackageManifest) -> dict[str, str | None]:
     }
     if manifest.output is not None:
         payload["output"] = manifest.output
+    if manifest.allowed_host_calls:
+        payload["allowed_host_calls"] = manifest.allowed_host_calls
     return payload
 
 
@@ -141,6 +161,7 @@ def init_package(
     main: Optional[str] = None,
     out_dir: Optional[str] = None,
     output: Optional[str] = None,
+    allowed_host_calls: Optional[List[str]] = None,
     force: bool = False,
 ) -> PackageManifest:
     project_root = project_root.resolve()
@@ -166,6 +187,11 @@ def init_package(
         raise AxiomCompileError("package output must be a non-empty string when provided")
     if output is not None:
         output = _validate_output(output, project_root / MANIFEST_FILENAME)
+    if allowed_host_calls is None:
+        allowed_host_calls = []
+    elif not isinstance(allowed_host_calls, list):
+        raise AxiomCompileError("package allowed_host_calls must be a list of strings when provided")
+    allowed_host_calls = _validate_host_calls(allowed_host_calls, project_root / MANIFEST_FILENAME)
     pkg_name = name if name else (project_root.name or DEFAULT_NAME)
     if not pkg_name:
         pkg_name = DEFAULT_NAME
@@ -175,6 +201,7 @@ def init_package(
         main=main,
         out_dir=out_dir,
         output=output,
+        allowed_host_calls=allowed_host_calls or None,
     )
     write_default_manifest(project_root, manifest)
     write_default_entry(project_root, manifest.main)
@@ -182,12 +209,22 @@ def init_package(
 
 
 def build_package(
-    project_root: Path, *, allow_host_side_effects: bool = False, output: Optional[str] = None
+    project_root: Path,
+    *,
+    allow_host_side_effects: bool = False,
+    output: Optional[str] = None,
 ) -> Path:
     project_root = project_root.resolve()
     manifest = load_manifest(project_root)
     entry = project_root / manifest.main
-    bytecode = compile_file(entry, allow_host_side_effects=allow_host_side_effects)
+    allowed_host_calls = (
+        set(manifest.allowed_host_calls) if manifest.allowed_host_calls else None
+    )
+    bytecode = compile_file(
+        entry,
+        allow_host_side_effects=allow_host_side_effects,
+        allowed_host_calls=allowed_host_calls,
+    )
     out_dir = project_root / manifest.out_dir
     out_dir.mkdir(parents=True, exist_ok=True)
 

--- a/docs/package.md
+++ b/docs/package.md
@@ -10,6 +10,10 @@ Current supported fields:
 - `version` (required, string): Package semantic version.
 - `main` (optional, default: `src/main.ax`): Source file entrypoint, relative to project root.
 - `out_dir` (optional, default: `dist`): Directory for compiled bytecode artifacts.
+- `allowed_host_calls` (optional): Explicit allowlist of host calls permitted in package builds.
+  - Each entry is a string matching host call suffixes without the `host.` prefix
+    (for example, `print`, `abs`, `math.abs`).
+  - When present, package compilation fails if source uses any host call not in the allowlist.
 - `main` and `out_dir` must be relative paths and may not contain `..` parent segments.
 - `output` (optional, string): Custom output filename or path inside `out_dir`.
   - Must be a relative path and may not traverse parent directories (no `..`).
@@ -24,7 +28,8 @@ Example manifest:
   "version": "0.1.0",
   "main": "src/main.ax",
   "out_dir": "dist",
-  "output": "artifact.axb"
+  "output": "artifact.axb",
+  "allowed_host_calls": ["version", "abs", "math.abs"]
 }
 ```
 
@@ -49,6 +54,7 @@ Options:
 - `--main` (default `src/main.ax`)
 - `--out-dir` (default `dist`)
 - `--output` (optional explicit artifact filename)
+- `--allowed-host-call` (repeatable; each entry is a call suffix like `print` or `math.abs`)
 - `--force` to regenerate `axiom.pkg` when it already exists.
 
 `pkg build` reads `axiom.pkg`, compiles `main`, and writes `.axb` into `out_dir`.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -186,6 +186,26 @@ class CliParityTests(unittest.TestCase):
             self.assertEqual(manifest["output"], "bundle.axb")
             self.assertTrue((project / "src" / "app" / "main.ax").exists())
 
+    def test_package_init_with_allowed_host_calls(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project = Path(td)
+            self._run_cli(
+                [
+                    "pkg",
+                    "init",
+                    str(project),
+                    "--name",
+                    "demo",
+                    "--allowed-host-call",
+                    "print",
+                    "--allowed-host-call",
+                    "math.abs",
+                ],
+                cwd=ROOT,
+            )
+            manifest = json.loads((project / "axiom.pkg").read_text(encoding="utf-8"))
+            self.assertEqual(manifest["allowed_host_calls"], ["print", "math.abs"])
+
     def test_package_check_command(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             project = Path(td)
@@ -299,6 +319,41 @@ class CliParityTests(unittest.TestCase):
 
             vm_out = self._run_cli(["vm", str(out)], cwd=ROOT).stdout
             self.assertEqual(vm_out, "88\n")
+
+    def test_package_check_rejects_disallowed_host_call(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project = Path(td)
+            self._run_cli(["pkg", "init", str(project), "--name", "demo"], cwd=ROOT)
+            manifest_path = project / "axiom.pkg"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["allowed_host_calls"] = ["abs"]
+            manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+            (project / manifest["main"]).write_text("host.print(9)\n", encoding="utf-8")
+
+            proc = self._run_cli(["pkg", "check", str(project)], cwd=ROOT, expect_code=1)
+            self.assertIn("not permitted by package policy", proc.stderr)
+
+    def test_package_check_allows_host_call_when_manifest_allows(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project = Path(td)
+            self._run_cli(["pkg", "init", str(project), "--name", "demo"], cwd=ROOT)
+            manifest_path = project / "axiom.pkg"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["allowed_host_calls"] = ["print"]
+            manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+            (project / manifest["main"]).write_text("host.print(9)\n", encoding="utf-8")
+
+            proc = self._run_cli(
+                ["pkg", "check", str(project), "--allow-host-side-effects"], cwd=ROOT
+            )
+            self.assertIn("OK", proc.stderr)
+
+            self._run_cli(["pkg", "build", str(project), "--allow-host-side-effects"], cwd=ROOT)
+            out = project / manifest["out_dir"] / f"{manifest['name']}.axb"
+            vm_out = self._run_cli(
+                ["vm", str(out), "--allow-host-side-effects"], cwd=ROOT
+            ).stdout
+            self.assertEqual(vm_out, "9\n")
 
     def test_package_build_output_override_flag(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -101,6 +101,15 @@ print f(1)
         with self.assertRaises(AxiomCompileError):
             compile_to_bytecode("host.math.abs()\n")
 
+    def test_compile_host_allowed_list_enforcement(self) -> None:
+        with self.assertRaises(AxiomCompileError):
+            compile_to_bytecode("host.abs(-5)\n", allowed_host_calls={"print"})
+
+        bc = compile_to_bytecode("print host.abs(-5)\n", allowed_host_calls={"abs"})
+        out = io.StringIO()
+        Vm(locals_count=bc.locals_count).run(bc, out)
+        self.assertEqual(out.getvalue(), "5\n")
+
     def test_compile_custom_host_builtin(self) -> None:
         def double(args: list[int], _out) -> int:
             return args[0] * 2


### PR DESCRIPTION
## Summary\n- Add optional package policy allowlist for host calls (allowed_host_calls).\n- Thread policy through API, compiler, packaging, and CLI check/run/build paths.\n- Add docs + tests for manifest persistence and compile/package enforcement.\n\n## Verification\n- python -m unittest discover -v\n- parity check over tests/programs via interp/compile/vm outputs