### PR TITLE
Treat empty allowed_host_calls as explicit deny-all policy

### DIFF
--- a/axiom/__main__.py
+++ b/axiom/__main__.py
@@ -114,7 +114,9 @@ def cmd_pkg_check(path: Path, *, allow_host_side_effects: bool) -> int:
     manifest = load_manifest(path)
     entry = path.resolve() / manifest.main
     allowed_host_calls = (
-        set(manifest.allowed_host_calls) if manifest.allowed_host_calls else None
+        set(manifest.allowed_host_calls)
+        if manifest.allowed_host_calls is not None
+        else None
     )
     _ = compile_file(
         entry,
@@ -139,7 +141,9 @@ def cmd_pkg_run(path: Path, *, allow_host_side_effects: bool) -> int:
     manifest = load_manifest(project_root)
     entry = project_root / manifest.main
     allowed_host_calls = (
-        set(manifest.allowed_host_calls) if manifest.allowed_host_calls else None
+        set(manifest.allowed_host_calls)
+        if manifest.allowed_host_calls is not None
+        else None
     )
     bytecode = compile_file(
         entry,

--- a/axiom/packaging.py
+++ b/axiom/packaging.py
@@ -66,9 +66,9 @@ def _validate_relative_path(value: str, path: Path, field_name: str) -> str:
     return value
 
 
-def _validate_host_calls(value: object, path: Path) -> List[str]:
+def _validate_host_calls(value: object, path: Path) -> Optional[List[str]]:
     if value is None:
-        return []
+        return None
     if not isinstance(value, list):
         raise AxiomCompileError(f"package manifest {path} has invalid allowed_host_calls")
     host_calls: List[str] = []
@@ -77,7 +77,12 @@ def _validate_host_calls(value: object, path: Path) -> List[str]:
             raise AxiomCompileError(
                 f"package manifest {path} has invalid allowed_host_calls entry {item!r}"
             )
-        host_calls.append(item)
+        normalized = item[5:] if item.startswith("host.") else item
+        if not normalized:
+            raise AxiomCompileError(
+                f"package manifest {path} has invalid allowed_host_calls entry {item!r}"
+            )
+        host_calls.append(normalized)
     return host_calls
 
 
@@ -133,7 +138,7 @@ def manifest_to_dict(manifest: PackageManifest) -> dict[str, object]:
     }
     if manifest.output is not None:
         payload["output"] = manifest.output
-    if manifest.allowed_host_calls:
+    if manifest.allowed_host_calls is not None:
         payload["allowed_host_calls"] = manifest.allowed_host_calls
     return payload
 
@@ -188,7 +193,7 @@ def init_package(
     if output is not None:
         output = _validate_output(output, project_root / MANIFEST_FILENAME)
     if allowed_host_calls is None:
-        allowed_host_calls = []
+        allowed_host_calls = None
     elif not isinstance(allowed_host_calls, list):
         raise AxiomCompileError("package allowed_host_calls must be a list of strings when provided")
     allowed_host_calls = _validate_host_calls(allowed_host_calls, project_root / MANIFEST_FILENAME)
@@ -201,7 +206,7 @@ def init_package(
         main=main,
         out_dir=out_dir,
         output=output,
-        allowed_host_calls=allowed_host_calls or None,
+        allowed_host_calls=allowed_host_calls,
     )
     write_default_manifest(project_root, manifest)
     write_default_entry(project_root, manifest.main)
@@ -218,7 +223,9 @@ def build_package(
     manifest = load_manifest(project_root)
     entry = project_root / manifest.main
     allowed_host_calls = (
-        set(manifest.allowed_host_calls) if manifest.allowed_host_calls else None
+        set(manifest.allowed_host_calls)
+        if manifest.allowed_host_calls is not None
+        else None
     )
     bytecode = compile_file(
         entry,

--- a/docs/package.md
+++ b/docs/package.md
@@ -13,7 +13,9 @@ Current supported fields:
 - `allowed_host_calls` (optional): Explicit allowlist of host calls permitted in package builds.
   - Each entry is a string matching host call suffixes without the `host.` prefix
     (for example, `print`, `abs`, `math.abs`).
+  - Values with an optional `host.` prefix are normalized to the suffix form.
   - When present, package compilation fails if source uses any host call not in the allowlist.
+  - An empty list denies all host calls.
 - `main` and `out_dir` must be relative paths and may not contain `..` parent segments.
 - `output` (optional, string): Custom output filename or path inside `out_dir`.
   - Must be a relative path and may not traverse parent directories (no `..`).

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -355,6 +355,19 @@ class CliParityTests(unittest.TestCase):
             ).stdout
             self.assertEqual(vm_out, "9\n")
 
+    def test_package_check_rejects_empty_host_allowlist(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project = Path(td)
+            self._run_cli(["pkg", "init", str(project), "--name", "demo"], cwd=ROOT)
+            manifest_path = project / "axiom.pkg"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["allowed_host_calls"] = []
+            manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+            (project / manifest["main"]).write_text("host.abs(-1)\n", encoding="utf-8")
+
+            proc = self._run_cli(["pkg", "check", str(project)], cwd=ROOT, expect_code=1)
+            self.assertIn("not permitted by package policy", proc.stderr)
+
     def test_package_build_output_override_flag(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             project = Path(td)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -105,6 +105,9 @@ print f(1)
         with self.assertRaises(AxiomCompileError):
             compile_to_bytecode("host.abs(-5)\n", allowed_host_calls={"print"})
 
+        with self.assertRaises(AxiomCompileError):
+            compile_to_bytecode("host.abs(-5)\n", allowed_host_calls=set())
+
         bc = compile_to_bytecode("print host.abs(-5)\n", allowed_host_calls={"abs"})
         out = io.StringIO()
         Vm(locals_count=bc.locals_count).run(bc, out)


### PR DESCRIPTION
## Summary\n- Distinguish missing  (default) from explicit empty allowlist in package manifests.\n- Normalize optional  prefixes while validating allowlist entries.\n- Preserve and persist explicit empty list to manifest and enforce it in check/run/build.\n- Add regression tests for empty allowlist rejection and compile-time deny-all enforcement.\n\n## Verification\n- python -m unittest discover -v