### PR TITLE
test: pkg check rejects unsafe import paths

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -246,6 +246,14 @@ class CliParityTests(unittest.TestCase):
             proc = self._run_cli(["pkg", "check", str(project)], cwd=ROOT, expect_code=1)
             self.assertIn("invalid package manifest", proc.stderr)
 
+    def test_package_check_rejects_unsafe_import_path(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project = Path(td)
+            self._run_cli(["pkg", "init", str(project), "--name", "demo"], cwd=ROOT)
+            (project / "src" / "main.ax").write_text('import "../shared"\n', encoding="utf-8")
+            proc = self._run_cli(["pkg", "check", str(project)], cwd=ROOT, expect_code=1)
+            self.assertIn("parent traversal in import path", proc.stderr.lower())
+
     def test_package_init_force_rewrites_manifest(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             project = Path(td)


### PR DESCRIPTION
Add CLI regression test ensuring pkg check fails on unsafe import paths with parent-traversal segments (../...) and keeps diagnostics explicit.