### PR TITLE
Phase 3 host bridge safe-call filtering + parse diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ python -m axiom pkg run .
 
 # Inspect host bridge capabilities for tooling
 python -m axiom host list
+# Inspect only deterministic host calls for agentic tooling
+python -m axiom host list --safe-only
 
 # Run conformance tests (interpreter vs VM + expected output)
 python -m unittest discover -v
@@ -59,6 +61,7 @@ Supported:
 - `import "path"` for file-level module loading (resolved relative to importing file)
   - Import paths must be relative and may not use parent traversal (`..`).
 - host bridge calls: `host.version()`, `host.print(value)`, `host.read(prompt)`, `host.abs(value)`, `host.math.abs(value)` (gated side effects apply to `print`/`read` only)
+- deterministic host calls are available without runtime flags; side-effecting host calls require the explicit `--allow-host-side-effects` option
 - host bridge calls are registry-backed, and new `host.*` functions can be added with
   `axiom.host.register_host_builtin(name, arity, side_effecting, handler)`.
 - `+ - * /` with parentheses

--- a/axiom/__main__.py
+++ b/axiom/__main__.py
@@ -157,10 +157,12 @@ def cmd_pkg_run(path: Path, *, allow_host_side_effects: bool) -> int:
     return 0
 
 
-def cmd_host_list() -> int:
+def cmd_host_list(*, safe_only: bool = False) -> int:
     payload = []
     for name in HOST_BUILTIN_NAMES:
         arity, side_effecting = HOST_BUILTINS[name]
+        if safe_only and side_effecting:
+            continue
         payload.append(
             {"name": name, "arity": arity, "side_effecting": side_effecting}
         )
@@ -231,7 +233,12 @@ def main(argv: list[str] | None = None) -> int:
     )
     sp_host = sub.add_parser("host", help="Host bridge helpers")
     host = sp_host.add_subparsers(dest="host_cmd", required=True)
-    host.add_parser("list", help="List registered host capabilities")
+    host_list = host.add_parser("list", help="List registered host capabilities")
+    host_list.add_argument(
+        "--safe-only",
+        action="store_true",
+        help="Show only non-side-effecting host functions",
+    )
 
     args = p.parse_args(argv)
 
@@ -281,7 +288,7 @@ def main(argv: list[str] | None = None) -> int:
             raise AssertionError("unreachable")
         if args.cmd == "host":
             if args.host_cmd == "list":
-                return cmd_host_list()
+                return cmd_host_list(safe_only=args.safe_only)
             raise AssertionError("unreachable")
         raise AssertionError("unreachable")
     except AxiomError as e:

--- a/axiom/api.py
+++ b/axiom/api.py
@@ -15,9 +15,13 @@ def parse_file(path: Path) -> Program:
     return _load_program_file(Path(path).resolve(), set(), set())
 
 
-def parse_program(src: str) -> Program:
-    toks = Lexer(src).tokenize()
-    return Parser(toks).parse_program()
+def parse_program(src: str, path: Path | str | None = None) -> Program:
+    toks = Lexer(src, path=str(path) if path is not None else None).tokenize()
+    return Parser(
+        toks,
+        source=src,
+        source_path=str(path) if path is not None else None,
+    ).parse_program()
 
 
 def compile_to_bytecode(
@@ -26,7 +30,7 @@ def compile_to_bytecode(
     allow_host_side_effects: bool = False,
     allowed_host_calls: Optional[Set[str]] = None,
 ) -> Bytecode:
-    program = parse_program(src)
+    program = parse_program(src, path=None)
     return Compiler(
         allow_host_side_effects=allow_host_side_effects,
         allowed_host_calls=allowed_host_calls,
@@ -57,7 +61,7 @@ def _load_program_file(path: Path, seen: Set[Path], loading: Set[Path]) -> Progr
 
     loading.add(path)
     src = path.read_text(encoding="utf-8")
-    program = parse_program(src)
+    program = parse_program(src, path=path)
 
     stmts = []
     for stmt in program.stmts:

--- a/axiom/errors.py
+++ b/axiom/errors.py
@@ -10,15 +10,58 @@ class Span:
     end: int
 
 
+def _line_col(source: str, offset: int) -> tuple[int, int]:
+    if offset < 0:
+        offset = 0
+    line = source.count("\n", 0, min(offset, len(source))) + 1
+    line_start = source.rfind("\n", 0, min(offset, len(source))) + 1
+    return line, offset - line_start + 1
+
+
+def _line_text(source: str, offset: int) -> tuple[int, str]:
+    line, _ = _line_col(source, offset)
+    start = source.rfind("\n", 0, offset)
+    if start == -1:
+        start = 0
+    else:
+        start += 1
+    end = source.find("\n", offset)
+    if end == -1:
+        end = len(source)
+    return line, source[start:end].rstrip("\n")
+
+
 class AxiomError(Exception):
-    def __init__(self, message: str, span: Optional[Span] = None):
+    def __init__(
+        self,
+        message: str,
+        span: Optional[Span] = None,
+        source: Optional[str] = None,
+        path: Optional[str] = None,
+    ):
         super().__init__(message)
         self.message = message
         self.span = span
+        self.source = source
+        self.path = path
 
     def __str__(self) -> str:
         if self.span is None:
             return self.message
+        if self.source is not None:
+            line, col = _line_col(self.source, self.span.start)
+            if self.path is not None:
+                location = f"{self.path}:{line}:{col}"
+            else:
+                location = f"{line}:{col}"
+            line_num, text = _line_text(self.source, self.span.start)
+            width = max(1, self.span.end - self.span.start)
+            pointer = " " * (col - 1) + "^" * width
+            return (
+                f"{self.message} (at {location})\n"
+                f"  {line_num:>4} | {text}\n"
+                f"      | {pointer}"
+            )
         return f"{self.message} (span {self.span.start}:{self.span.end})"
 
 

--- a/axiom/lexer.py
+++ b/axiom/lexer.py
@@ -7,8 +7,9 @@ from .token import Token, TokenKind
 
 
 class Lexer:
-    def __init__(self, src: str):
+    def __init__(self, src: str, path: Optional[str] = None):
         self.src = src
+        self.path = path
         self.i = 0
         self.n = len(src)
 
@@ -59,7 +60,12 @@ class Lexer:
         try:
             v = int(text, 10)
         except ValueError as e:
-            raise AxiomParseError(f"invalid int literal {text!r}: {e}", Span(start, end))
+            raise AxiomParseError(
+                f"invalid int literal {text!r}: {e}",
+                Span(start, end),
+                source=self.src,
+                path=self.path,
+            )
         return Token(TokenKind.INT, Span(start, end), v)
 
     def _lex_ident_or_kw(self, start: int) -> Token:
@@ -94,14 +100,24 @@ class Lexer:
         while True:
             ch = self._peek()
             if ch is None:
-                raise AxiomParseError("unterminated string literal", Span(start, self.i))
+                raise AxiomParseError(
+                    "unterminated string literal",
+                    Span(start, self.i),
+                    source=self.src,
+                    path=self.path,
+                )
             self.i += 1
             if ch == '"':
                 break
             if ch == "\\":
                 esc = self._peek()
                 if esc is None:
-                    raise AxiomParseError("unterminated escape sequence", Span(start, self.i))
+                    raise AxiomParseError(
+                        "unterminated escape sequence",
+                        Span(start, self.i),
+                        source=self.src,
+                        path=self.path,
+                    )
                 self.i += 1
                 if esc == "n":
                     chars.append("\n")
@@ -140,7 +156,12 @@ class Lexer:
             if self._peek() == "=":
                 self.i += 1
                 return Token(TokenKind.NE, Span(start, start + 2))
-            raise AxiomParseError("unexpected character '!'", Span(start, start + 1))
+            raise AxiomParseError(
+                "unexpected character '!'",
+                Span(start, start + 1),
+                source=self.src,
+                path=self.path,
+            )
         if ch == "<":
             if self._peek() == "=":
                 self.i += 1
@@ -191,7 +212,12 @@ class Lexer:
             self.i -= 1
             return self._lex_ident_or_kw(start)
 
-        raise AxiomParseError(f"unexpected character {ch!r}", Span(start, start + 1))
+        raise AxiomParseError(
+            f"unexpected character {ch!r}",
+            Span(start, start + 1),
+            source=self.src,
+            path=self.path,
+        )
 
     def tokenize(self) -> List[Token]:
         toks: List[Token] = []

--- a/axiom/parser.py
+++ b/axiom/parser.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List
+from typing import List, Optional
 
 from .ast import (
     Program,
@@ -28,10 +28,18 @@ from .token import Token, TokenKind
 
 
 class Parser:
-    def __init__(self, toks: List[Token]):
+    def __init__(
+        self,
+        toks: List[Token],
+        *,
+        source: Optional[str] = None,
+        source_path: Optional[str] = None,
+    ):
         self.toks = toks
         self.i = 0
         self.function_depth = 0
+        self.source = source
+        self.source_path = source_path
 
     def _peek(self) -> Token:
         return self.toks[self.i]
@@ -48,7 +56,12 @@ class Parser:
     def _eat(self, kind: TokenKind) -> Token:
         t = self._peek()
         if t.kind != kind:
-            raise AxiomParseError(f"expected {kind.name}, got {t.kind.name}", t.span)
+            raise AxiomParseError(
+                f"expected {kind.name}, got {t.kind.name}",
+                t.span,
+                source=self.source,
+                path=self.source_path,
+            )
         self.i += 1
         return t
 
@@ -73,7 +86,12 @@ class Parser:
         }:
             self.i += 1
             return t.kind.name.lower()
-        raise AxiomParseError("expected identifier", t.span)
+        raise AxiomParseError(
+            "expected identifier",
+            t.span,
+            source=self.source,
+            path=self.source_path,
+        )
 
     def parse_program(self) -> Program:
         stmts = []
@@ -95,7 +113,12 @@ class Parser:
             return self._parse_print()
         if k == TokenKind.RETURN:
             if self.function_depth == 0:
-                raise AxiomParseError("return outside function", self._peek().span)
+                raise AxiomParseError(
+                    "return outside function",
+                    self._peek().span,
+                    source=self.source,
+                    path=self.source_path,
+                )
             return self._parse_return()
         if k == TokenKind.LBRACE:
             return self._parse_block()
@@ -111,9 +134,19 @@ class Parser:
         start = self._eat(TokenKind.FN).span.start
         name = self._eat(TokenKind.IDENT)
         if name.kind != TokenKind.IDENT:
-            raise AxiomParseError("expected function name", name.span)
+            raise AxiomParseError(
+                "expected function name",
+                name.span,
+                source=self.source,
+                path=self.source_path,
+            )
         if name.value == "host":
-            raise AxiomParseError("function name cannot be 'host'", name.span)
+            raise AxiomParseError(
+                "function name cannot be 'host'",
+                name.span,
+                source=self.source,
+                path=self.source_path,
+            )
         self._eat(TokenKind.LPAREN)
 
         params: List[str] = []
@@ -121,9 +154,19 @@ class Parser:
             while True:
                 ident = self._eat(TokenKind.IDENT)
                 if ident.kind != TokenKind.IDENT:
-                    raise AxiomParseError("expected parameter name", ident.span)
+                    raise AxiomParseError(
+                        "expected parameter name",
+                        ident.span,
+                        source=self.source,
+                        path=self.source_path,
+                    )
                 if ident.value == "host":
-                    raise AxiomParseError("parameter name cannot be 'host'", ident.span)
+                    raise AxiomParseError(
+                        "parameter name cannot be 'host'",
+                        ident.span,
+                        source=self.source,
+                        path=self.source_path,
+                    )
                 params.append(str(ident.value))
                 if self._peek().kind == TokenKind.COMMA:
                     self._bump()
@@ -133,7 +176,12 @@ class Parser:
 
         # allow duplicate parameter names only if source author wrote them; catch for deterministic errors.
         if len(set(params)) != len(params):
-            raise AxiomParseError("duplicate function parameter name", name.span)
+            raise AxiomParseError(
+                "duplicate function parameter name",
+                name.span,
+                source=self.source,
+                path=self.source_path,
+            )
 
         self.function_depth += 1
         try:
@@ -175,9 +223,19 @@ class Parser:
         start = self._bump().span.start
         ident = self._bump()
         if ident.kind != TokenKind.IDENT:
-            raise AxiomParseError("expected identifier after 'let'", ident.span)
+            raise AxiomParseError(
+                "expected identifier after 'let'",
+                ident.span,
+                source=self.source,
+                path=self.source_path,
+            )
         if ident.value == "host":
-            raise AxiomParseError("identifier cannot be 'host'", ident.span)
+            raise AxiomParseError(
+                "identifier cannot be 'host'",
+                ident.span,
+                source=self.source,
+                path=self.source_path,
+            )
         self._eat(TokenKind.EQ)
         expr = self._parse_expr()
         end = self._parse_terminator(default_end=expr_span(expr).end)
@@ -187,14 +245,24 @@ class Parser:
         start = self._eat(TokenKind.IMPORT).span.start
         path = self._eat(TokenKind.STRING)
         if not isinstance(path.value, str):
-            raise AxiomParseError("expected import path string", path.span)
+            raise AxiomParseError(
+                "expected import path string",
+                path.span,
+                source=self.source,
+                path=self.source_path,
+            )
         end = self._parse_terminator(default_end=path.span.end)
         return ImportStmt(path=path.value, span=Span(start, end))
 
     def _parse_assign(self) -> AssignStmt:
         ident = self._eat(TokenKind.IDENT)
         if ident.value == "host":
-            raise AxiomParseError("identifier cannot be 'host'", ident.span)
+            raise AxiomParseError(
+                "identifier cannot be 'host'",
+                ident.span,
+                source=self.source,
+                path=self.source_path,
+            )
         self._eat(TokenKind.EQ)
         expr = self._parse_expr()
         end = self._parse_terminator(default_end=expr_span(expr).end)
@@ -227,7 +295,12 @@ class Parser:
             return end
         if k in (TokenKind.EOF, TokenKind.RBRACE):
             return default_end
-        raise AxiomParseError("expected ';' or newline", self._peek().span)
+        raise AxiomParseError(
+            "expected ';' or newline",
+            self._peek().span,
+            source=self.source,
+            path=self.source_path,
+        )
 
     def _parse_expr(self) -> Expr:
         return self._parse_equality()
@@ -321,7 +394,12 @@ class Parser:
                 rparen = self._eat(TokenKind.RPAREN)
                 return CallExpr(callee=callee, args=args, span=Span(tok.span.start, rparen.span.end))
             if "." in callee:
-                raise AxiomParseError("call expected after dotted name", t.span)
+                raise AxiomParseError(
+                    "call expected after dotted name",
+                    t.span,
+                    source=self.source,
+                    path=self.source_path,
+                )
             return VarRef(str(tok.value), tok.span)
         if t.kind == TokenKind.MINUS:
             minus = self._bump()
@@ -332,7 +410,12 @@ class Parser:
             expr = self._parse_expr()
             r = self._eat(TokenKind.RPAREN)
             return _widen_span(expr, Span(l.span.start, r.span.end))
-        raise AxiomParseError("expected expression", t.span)
+        raise AxiomParseError(
+            "expected expression",
+            t.span,
+            source=self.source,
+            path=self.source_path,
+        )
 
 
 def _widen_span(expr: Expr, span: Span) -> Expr:

--- a/docs/kernel.md
+++ b/docs/kernel.md
@@ -40,6 +40,8 @@
 - functions use explicit call frames with locals + return address
 - every function returns an `int` (implicit `0` if no explicit return is reached)
 - `host.print` and `host.read` are side-effecting; they require an explicit runtime flag when enabled
+- non-side-effecting host calls can be used in deterministic tool pipelines without flags
+- `python -m axiom host list --safe-only` enumerates host calls that are safe by default
 - `host` call payloads in bytecode are name-based (string table index) starting at
   bytecode `v0.6` to preserve behavior if host registry order changes.
 - `python -m axiom host list` enumerates the currently registered host capabilities.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -108,6 +108,14 @@ class CliParityTests(unittest.TestCase):
         self.assertEqual(version_entry["arity"], 0)
         self.assertFalse(version_entry["side_effecting"])
 
+        safe_proc = self._run_cli(["host", "list", "--safe-only"], cwd=ROOT)
+        safe_payload = json.loads(safe_proc.stdout)
+        self.assertTrue(isinstance(safe_payload, list))
+        self.assertTrue(all(not entry["side_effecting"] for entry in safe_payload))
+        safe_names = {entry["name"] for entry in safe_payload}
+        self.assertIn("version", safe_names)
+        self.assertNotIn("print", safe_names)
+
     def test_imported_modules_execute(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             mod = Path(td) / "math_module.ax"

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -55,6 +55,16 @@ print x
         with self.assertRaises(AxiomParseError):
             compile_to_bytecode("return 1\n")
 
+    def test_parse_error_includes_path_and_location(self) -> None:
+        src = "let x = 1\nreturn 1\n"
+        with self.assertRaises(AxiomParseError) as cm:
+            parse_program(src, path=Path("bad-program.ax"))
+        msg = str(cm.exception)
+        self.assertIn("bad-program.ax:2:1", msg)
+        self.assertIn("return outside function", msg)
+        self.assertIn("return 1", msg)
+        self.assertIn("^", msg)
+
     def test_compile_undefined_function(self) -> None:
         with self.assertRaises(AxiomCompileError):
             compile_to_bytecode("print unknown(1)\n")


### PR DESCRIPTION
Phase 3 hardening: add host capability filtering () and phase-2/3 readiness docs/tests plus parse diagnostic source/line context plumbing.

Validation: python -m unittest discover -v (75/75).