### PR TITLE
Add host builtin unregistration API

### DIFF
--- a/axiom/host.py
+++ b/axiom/host.py
@@ -84,6 +84,19 @@ def register_host_builtin(name: str, arity: int, side_effecting: bool, handler: 
     _rebuild_host_tables()
 
 
+def unregister_host_builtin(name: str) -> None:
+    if any(entry.name == name for entry in _DEFAULT_HOST_BUILTINS):
+        raise ValueError(f"cannot unregister builtin {name!r}")
+
+    for idx, entry in enumerate(_HOST_BUILTINS_LIST):
+        if entry.name == name:
+            del _HOST_BUILTINS_LIST[idx]
+            _rebuild_host_tables()
+            return
+
+    raise KeyError(f"host builtin {name!r} does not exist")
+
+
 def reset_host_builtins() -> None:
     del _HOST_BUILTINS_LIST[:]
     _HOST_BUILTINS_LIST.extend(_DEFAULT_HOST_BUILTINS)

--- a/docs/kernel.md
+++ b/docs/kernel.md
@@ -21,7 +21,8 @@
 - `host.<name>(...)` for host bridge calls (reserved namespace)
 - Host calls are resolved from a registry. Add custom capabilities via
   `axiom.host.register_host_builtin(name, arity, side_effecting, handler)` where
-  `handler(args: list[int], out: TextIO) -> int`.
+  `handler(args: list[int], out: TextIO) -> int`, and remove custom capabilities via
+  `axiom.host.unregister_host_builtin(name)`.
 
 ## Expressions
 - integer literals: `123`, `-5`

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -21,7 +21,7 @@ from axiom.errors import AxiomCompileError, AxiomParseError, AxiomRuntimeError
 from axiom.interpreter import Interpreter
 from axiom.vm import Vm
 from axiom.bytecode import Op, VERSION_MINOR
-from axiom.host import register_host_builtin, reset_host_builtins
+from axiom.host import register_host_builtin, reset_host_builtins, unregister_host_builtin
 
 
 class ErrorTests(unittest.TestCase):
@@ -140,6 +140,31 @@ print f(1)
             self.assertEqual(vm_out.getvalue(), "42\n")
         finally:
             reset_host_builtins()
+
+    def test_unregister_custom_host_builtin(self) -> None:
+        def triple(args: list[int], _out) -> int:
+            return args[0] * 3
+
+        register_host_builtin("triple", 1, False, triple)
+        try:
+            program = parse_program("print host.triple(7)\n")
+            out = io.StringIO()
+            Interpreter().run(program, out)
+            self.assertEqual(out.getvalue(), "21\n")
+
+            unregister_host_builtin("triple")
+            with self.assertRaises(AxiomCompileError):
+                compile_to_bytecode("print host.triple(7)\n")
+        finally:
+            reset_host_builtins()
+
+    def test_unregister_default_host_builtin_not_allowed(self) -> None:
+        with self.assertRaises(ValueError):
+            unregister_host_builtin("print")
+
+    def test_unregister_unknown_host_builtin(self) -> None:
+        with self.assertRaises(KeyError):
+            unregister_host_builtin("missing")
 
     def test_compile_unknown_host_function(self) -> None:
         with self.assertRaises(AxiomCompileError):


### PR DESCRIPTION
Add unregister_host_builtin API plus safety checks and error-path tests for agentic tool lifecycle management.