### PR TITLE
Add module namespace imports for function calls

### DIFF
--- a/axiom/api.py
+++ b/axiom/api.py
@@ -5,7 +5,26 @@ from typing import Optional, Set
 
 from .lexer import Lexer
 from .parser import Parser
-from .ast import ImportStmt, Program
+from .ast import (
+    Binary,
+    BlockStmt,
+    CallExpr,
+    Expr,
+    FunctionDefStmt,
+    ImportStmt,
+    IntLit,
+    IfStmt,
+    Program,
+    ReturnStmt,
+    UnaryNeg,
+    VarRef,
+    WhileStmt,
+    AssignStmt,
+    PrintStmt,
+    LetStmt,
+    ExprStmt,
+    Stmt,
+)
 from .compiler import Compiler
 from .bytecode import Bytecode
 from .errors import AxiomCompileError
@@ -71,7 +90,10 @@ def _load_program_file(path: Path, seen: Set[Path], loading: Set[Path]) -> Progr
                 raise AxiomCompileError(
                     f"cannot resolve import file {import_path}", stmt.span
                 )
-            stmts.extend(_load_program_file(import_path, seen, loading).stmts)
+            imported = _load_program_file(import_path, seen, loading)
+            stmts.extend(
+                _namespace_module_program(imported, _import_alias_from_path(import_path)).stmts
+            )
         else:
             stmts.append(stmt)
 
@@ -94,3 +116,72 @@ def _resolve_import_path(raw: str, base_path: Path) -> Path:
     if not candidate.is_absolute():
         candidate = base_path.parent / candidate
     return candidate
+
+
+def _import_alias_from_path(path: Path) -> str:
+    return path.stem
+
+
+def _namespace_module_program(program: Program, module_alias: str) -> Program:
+    fn_names = {
+        stmt.name: f"{module_alias}.{stmt.name}"
+        for stmt in program.stmts
+        if isinstance(stmt, FunctionDefStmt)
+    }
+
+    def _rewrite_expr(expr: Expr):
+        if isinstance(expr, IntLit):
+            return expr
+        if isinstance(expr, VarRef):
+            return expr
+        if isinstance(expr, UnaryNeg):
+            return UnaryNeg(expr=_rewrite_expr(expr.expr), span=expr.span)
+        if isinstance(expr, Binary):
+            return Binary(
+                op=expr.op,
+                lhs=_rewrite_expr(expr.lhs),
+                rhs=_rewrite_expr(expr.rhs),
+                span=expr.span,
+            )
+        if isinstance(expr, CallExpr):
+            callee = fn_names.get(expr.callee, expr.callee)
+            return CallExpr(
+                callee=callee,
+                args=[_rewrite_expr(arg) for arg in expr.args],
+                span=expr.span,
+            )
+        raise AssertionError("unknown expr")
+
+    def _rewrite_stmt(stmt: Stmt):
+        if isinstance(stmt, FunctionDefStmt):
+            return FunctionDefStmt(
+                name=fn_names[stmt.name],
+                params=stmt.params,
+                body=_rewrite_stmt(stmt.body),
+                span=stmt.span,
+            )
+        if isinstance(stmt, LetStmt):
+            return LetStmt(name=stmt.name, expr=_rewrite_expr(stmt.expr), span=stmt.span)
+        if isinstance(stmt, AssignStmt):
+            return AssignStmt(name=stmt.name, expr=_rewrite_expr(stmt.expr), span=stmt.span)
+        if isinstance(stmt, ReturnStmt):
+            return ReturnStmt(expr=_rewrite_expr(stmt.expr), span=stmt.span)
+        if isinstance(stmt, PrintStmt):
+            return PrintStmt(expr=_rewrite_expr(stmt.expr), span=stmt.span)
+        if isinstance(stmt, ExprStmt):
+            return ExprStmt(expr=_rewrite_expr(stmt.expr), span=stmt.span)
+        if isinstance(stmt, BlockStmt):
+            return BlockStmt(stmts=[_rewrite_stmt(s) for s in stmt.stmts], span=stmt.span)
+        if isinstance(stmt, IfStmt):
+            return IfStmt(
+                cond=_rewrite_expr(stmt.cond),
+                then_block=_rewrite_stmt(stmt.then_block),
+                else_block=_rewrite_stmt(stmt.else_block) if stmt.else_block else None,
+                span=stmt.span,
+            )
+        if isinstance(stmt, WhileStmt):
+            return WhileStmt(cond=_rewrite_expr(stmt.cond), body=_rewrite_stmt(stmt.body), span=stmt.span)
+        return stmt
+
+    stmts = [_rewrite_stmt(stmt) for stmt in program.stmts]
+    return Program(stmts=stmts)

--- a/axiom/compiler.py
+++ b/axiom/compiler.py
@@ -249,8 +249,12 @@ class Compiler:
                 out.append(Instr(Op.HOST_CALL, self._intern(host_fn)))
                 return
             if "." in fn_name:
-                raise AxiomCompileError(f"only host namespace calls are supported: {fn_name!r}", expr.span)
-            if fn_name not in self.function_ids:
+                # Module-qualified calls (e.g. module.fn) are supported when sourced from imports.
+                if fn_name not in self.function_ids:
+                    raise AxiomCompileError(
+                        f"undefined function {fn_name!r}", expr.span
+                    )
+            elif fn_name not in self.function_ids:
                 raise AxiomCompileError(f"undefined function {fn_name!r}", expr.span)
             arity = self.function_arities[fn_name]
             if arity != len(expr.args):

--- a/axiom/interpreter.py
+++ b/axiom/interpreter.py
@@ -131,8 +131,6 @@ class Interpreter:
     def _call(self, fn_name: str, args: List[int], out: TextIO) -> int:
         if fn_name.startswith("host."):
             return self._call_host(fn_name, args, out)
-        if "." in fn_name:
-            raise AxiomRuntimeError("only host namespace calls are supported for dotted call syntax")
         if fn_name not in self.functions:
             raise AxiomRuntimeError(f"undefined function {fn_name!r}")
         fn = self.functions[fn_name]

--- a/axiom/parser.py
+++ b/axiom/parser.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import List, Optional
 
 from .ast import (
@@ -38,6 +39,7 @@ class Parser:
         self.toks = toks
         self.i = 0
         self.function_depth = 0
+        self.imported_modules: set[str] = set()
         self.source = source
         self.source_path = source_path
 
@@ -251,6 +253,22 @@ class Parser:
                 source=self.source,
                 path=self.source_path,
             )
+        alias = Path(path.value).stem
+        if not alias:
+            raise AxiomParseError(
+                "invalid import path for namespace",
+                path.span,
+                source=self.source,
+                path=self.source_path,
+            )
+        if alias == "host":
+            raise AxiomParseError(
+                "import namespace cannot be 'host'",
+                path.span,
+                source=self.source,
+                path=self.source_path,
+            )
+        self.imported_modules.add(alias)
         end = self._parse_terminator(default_end=path.span.end)
         return ImportStmt(path=path.value, span=Span(start, end))
 
@@ -382,12 +400,13 @@ class Parser:
                 callee_parts.append(self._eat_name_token())
             callee = ".".join(callee_parts)
             if "." in callee and callee_parts[0] != "host":
-                raise AxiomParseError(
-                    "only host namespace calls are supported",
-                    tok.span,
-                    source=self.source,
-                    path=self.source_path,
-                )
+                if callee_parts[0] not in self.imported_modules:
+                    raise AxiomParseError(
+                        "only host or imported module calls are supported",
+                        tok.span,
+                        source=self.source,
+                        path=self.source_path,
+                    )
             if self._peek().kind == TokenKind.LPAREN:
                 self._bump()
                 args = []

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -27,7 +27,7 @@ if_stmt        := "if" expr block ("else" block)? ;
 while_stmt     := "while" expr block ;
 block          := "{" NEWLINE* stmt* "}" ;
 expr_stmt      := expr terminator ;
-call_expr      := IDENT ("." IDENT)* "(" args? ")" ;  # dotted call namespace restricted to host.*
+call_expr      := IDENT ("." IDENT)* "(" args? ")" ;  # dotted call namespace: host.* or imported module.*
 args           := expr ("," expr)* ;
 
 terminator     := ";" | NEWLINE | EOF ;

--- a/docs/kernel.md
+++ b/docs/kernel.md
@@ -16,7 +16,9 @@
 - `return <expr>`
 - `import "<path>"` for file module inclusion (resolved relative to file path; loaded at compile time)
   - Import paths must be relative and must not use parent traversal (`..`).
+  - Imported modules are namespaced by file stem (for example `import "math_utils"` exposes `math_utils.fn_name`).
 - function calls: `<name>(<arg1>, ... )`
+- namespaced function calls: `<module>.<name>(...)`
 - identifiers named `host` are reserved for host namespace (`let host`, parameters, and function names are rejected)
 - `host.<name>(...)` for host bridge calls (reserved namespace)
 - Host calls are resolved from a registry. Add custom capabilities via

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -123,7 +123,7 @@ class CliParityTests(unittest.TestCase):
             mod.write_text("fn add(a, b) {\n  return a + b\n}\n", encoding="utf-8")
 
             main = Path(td) / "main.ax"
-            main.write_text('import "math_module"\nprint add(6, 7)\n', encoding="utf-8")
+            main.write_text('import "math_module"\nprint math_module.add(6, 7)\n', encoding="utf-8")
 
             proc = self._run_cli(["interp", str(main)], cwd=ROOT)
             self.assertEqual(proc.stdout, "13\n")


### PR DESCRIPTION
Add module namespace support for file imports in parser/compiler/interpreter and docs/tests. Imported functions are namespaced by file stem so calls use ; host calls remain unchanged.