### PR TITLE
Add import aliases with collision checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Supported:
 - variables
 - identifiers named `host` are reserved (`let host`, function parameters, and function names)
 - function calls: `name(arg, ...)`
-- `import "path"` for file-level module loading (resolved relative to importing file)
+- `import "path"` (or `import "path" as alias`) for file-level module loading (resolved relative to importing file)
   - Import paths must be relative and may not use parent traversal (`..`).
 - host bridge calls: `host.version()`, `host.print(value)`, `host.read(prompt)`, `host.abs(value)`, `host.math.abs(value)` (gated side effects apply to `print`/`read` only)
 - deterministic host calls are available without runtime flags; side-effecting host calls require the explicit `--allow-host-side-effects` option

--- a/axiom/api.py
+++ b/axiom/api.py
@@ -92,7 +92,7 @@ def _load_program_file(path: Path, seen: Set[Path], loading: Set[Path]) -> Progr
                 )
             imported = _load_program_file(import_path, seen, loading)
             stmts.extend(
-                _namespace_module_program(imported, _import_alias_from_path(import_path)).stmts
+                _namespace_module_program(imported, stmt.alias).stmts
             )
         else:
             stmts.append(stmt)
@@ -116,10 +116,6 @@ def _resolve_import_path(raw: str, base_path: Path) -> Path:
     if not candidate.is_absolute():
         candidate = base_path.parent / candidate
     return candidate
-
-
-def _import_alias_from_path(path: Path) -> str:
-    return path.stem
 
 
 def _namespace_module_program(program: Program, module_alias: str) -> Program:

--- a/axiom/ast.py
+++ b/axiom/ast.py
@@ -56,6 +56,7 @@ class ExprStmt:
 @dataclass(frozen=True)
 class ImportStmt:
     path: str
+    alias: str
     span: Span
 
 

--- a/axiom/lexer.py
+++ b/axiom/lexer.py
@@ -81,6 +81,8 @@ class Lexer:
             return Token(TokenKind.LET, Span(start, end))
         if text == "import":
             return Token(TokenKind.IMPORT, Span(start, end))
+        if text == "as":
+            return Token(TokenKind.AS, Span(start, end))
         if text == "fn":
             return Token(TokenKind.FN, Span(start, end))
         if text == "print":

--- a/axiom/parser.py
+++ b/axiom/parser.py
@@ -253,24 +253,43 @@ class Parser:
                 source=self.source,
                 path=self.source_path,
             )
-        alias = Path(path.value).stem
-        if not alias:
+        default_alias = Path(path.value).stem
+        if not default_alias:
             raise AxiomParseError(
                 "invalid import path for namespace",
                 path.span,
                 source=self.source,
                 path=self.source_path,
             )
-        if alias == "host":
+        if default_alias == "host":
             raise AxiomParseError(
                 "import namespace cannot be 'host'",
                 path.span,
                 source=self.source,
                 path=self.source_path,
             )
+
+        alias = default_alias
+        if self._peek().kind == TokenKind.AS:
+            self._bump()
+            alias = self._eat_name_token()
+            if alias == "host":
+                raise AxiomParseError(
+                    "import namespace cannot be 'host'",
+                    path.span,
+                    source=self.source,
+                    path=self.source_path,
+                )
+        if alias in self.imported_modules:
+            raise AxiomParseError(
+                "duplicate import namespace",
+                path.span,
+                source=self.source,
+                path=self.source_path,
+            )
         self.imported_modules.add(alias)
         end = self._parse_terminator(default_end=path.span.end)
-        return ImportStmt(path=path.value, span=Span(start, end))
+        return ImportStmt(path=path.value, alias=alias, span=Span(start, end))
 
     def _parse_assign(self) -> AssignStmt:
         ident = self._eat(TokenKind.IDENT)

--- a/axiom/token.py
+++ b/axiom/token.py
@@ -15,6 +15,7 @@ class TokenKind(Enum):
     RETURN = auto()
     IF = auto()
     ELSE = auto()
+    AS = auto()
     WHILE = auto()
     IDENT = auto()
     INT = auto()

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -17,6 +17,7 @@ stmt           := let_stmt
                | expr_stmt ;
 
 import_stmt    := "import" STRING terminator ;
+               | "import" STRING "as" IDENT terminator ;
 fn_stmt        := "fn" IDENT "(" params? ")" block ;  # IDENT and params may not be "host"
 params         := IDENT ("," IDENT)* ;
 return_stmt    := "return" expr terminator ;

--- a/docs/kernel.md
+++ b/docs/kernel.md
@@ -16,7 +16,8 @@
 - `return <expr>`
 - `import "<path>"` for file module inclusion (resolved relative to file path; loaded at compile time)
   - Import paths must be relative and must not use parent traversal (`..`).
-  - Imported modules are namespaced by file stem (for example `import "math_utils"` exposes `math_utils.fn_name`).
+  - Imported modules are namespaced by file stem by default (for example `import "math_utils"` exposes `math_utils.fn_name`).
+  - Optional aliasing is supported: `import "math_utils" as mu` exposes `mu.fn_name`.
 - function calls: `<name>(<arg1>, ... )`
 - namespaced function calls: `<module>.<name>(...)`
 - identifiers named `host` are reserved for host namespace (`let host`, parameters, and function names are rejected)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -130,6 +130,22 @@ class CliParityTests(unittest.TestCase):
             proc = self._run_cli(["run", str(main)], cwd=ROOT)
             self.assertEqual(proc.stdout, "13\n")
 
+    def test_imported_modules_execute_with_alias(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            mod = Path(td) / "math_module.ax"
+            mod.write_text("fn add(a, b) {\n  return a + b\n}\n", encoding="utf-8")
+
+            main = Path(td) / "main.ax"
+            main.write_text(
+                'import "math_module" as MATH\nprint MATH.add(9, 8)\n',
+                encoding="utf-8",
+            )
+
+            proc = self._run_cli(["interp", str(main)], cwd=ROOT)
+            self.assertEqual(proc.stdout, "17\n")
+            proc = self._run_cli(["run", str(main)], cwd=ROOT)
+            self.assertEqual(proc.stdout, "17\n")
+
     def test_package_init_and_build(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             project = Path(td)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -174,6 +174,47 @@ print f(1)
         with self.assertRaises(AxiomParseError):
             compile_to_bytecode("foo.bar(1)\n")
 
+    def test_compile_import_alias(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            root.joinpath("math_module.ax").write_text(
+                "fn add(a, b) { return a + b }\n", encoding="utf-8"
+            )
+            root.joinpath("main.ax").write_text(
+                'import "math_module" as math\nprint math.add(11, 9)\n',
+                encoding="utf-8",
+            )
+            bc = compile_file(root.joinpath("main.ax"))
+            out = io.StringIO()
+            Vm(locals_count=bc.locals_count).run(bc, out)
+            self.assertEqual(out.getvalue(), "20\n")
+
+    def test_compile_import_duplicate_namespace(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            root.joinpath("math_module.ax").write_text(
+                "fn add(a, b) { return a + b }\n", encoding="utf-8"
+            )
+            root.joinpath("other_module.ax").write_text(
+                "fn sub(a, b) { return a - b }\n", encoding="utf-8"
+            )
+            root.joinpath("main.ax").write_text(
+                'import "math_module" as shared\nimport "other_module" as shared\n',
+                encoding="utf-8",
+            )
+            with self.assertRaises(AxiomParseError):
+                compile_file(root.joinpath("main.ax"))
+
+    def test_compile_import_alias_host_reserved(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            root.joinpath("math_module.ax").write_text(
+                "fn add(a, b) { return a + b }\n", encoding="utf-8"
+            )
+            root.joinpath("main.ax").write_text('import "math_module" as host\n', encoding="utf-8")
+            with self.assertRaises(AxiomParseError):
+                compile_file(root.joinpath("main.ax"))
+
     def test_host_registry_duplicate_name(self) -> None:
         def noop(args: list[int], _out) -> int:
             return 0


### PR DESCRIPTION
Implements optional import <path> as <alias> syntax, parser validation, namespace rewrite wiring, and error-path coverage.