### PR TITLE
Disallow duplicate import paths

### DIFF
--- a/axiom/parser.py
+++ b/axiom/parser.py
@@ -40,6 +40,7 @@ class Parser:
         self.i = 0
         self.function_depth = 0
         self.imported_modules: set[str] = set()
+        self.imported_paths: set[str] = set()
         self.source = source
         self.source_path = source_path
 
@@ -253,6 +254,14 @@ class Parser:
                 source=self.source,
                 path=self.source_path,
             )
+        if path.value in self.imported_paths:
+            raise AxiomParseError(
+                "duplicate import path",
+                path.span,
+                source=self.source,
+                path=self.source_path,
+            )
+        self.imported_paths.add(path.value)
         default_alias = Path(path.value).stem
         if not default_alias:
             raise AxiomParseError(

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -205,6 +205,19 @@ print f(1)
             with self.assertRaises(AxiomParseError):
                 compile_file(root.joinpath("main.ax"))
 
+    def test_compile_import_duplicate_path(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            root.joinpath("math_module.ax").write_text(
+                "fn add(a, b) { return a + b }\n", encoding="utf-8"
+            )
+            root.joinpath("main.ax").write_text(
+                'import "math_module" as one\nimport "math_module" as two\n',
+                encoding="utf-8",
+            )
+            with self.assertRaises(AxiomParseError):
+                compile_file(root.joinpath("main.ax"))
+
     def test_compile_import_transitive_namespace_collision(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)


### PR DESCRIPTION
Parser now tracks imported module paths and raises a parse error when the same module is imported multiple times, preventing ambiguous namespacing after `import ... as ...` and transitive flattening.