### PR TITLE
Document import path dedup rule

### DIFF
--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -29,6 +29,7 @@ while_stmt     := "while" expr block ;
 block          := "{" NEWLINE* stmt* "}" ;
 expr_stmt      := expr terminator ;
 call_expr      := IDENT ("." IDENT)* "(" args? ")" ;  # dotted call namespace: host.* or imported module.*
+                  # each import path may appear at most once per file, and alias names must be unique.
 args           := expr ("," expr)* ;
 
 terminator     := ";" | NEWLINE | EOF ;

--- a/docs/kernel.md
+++ b/docs/kernel.md
@@ -16,6 +16,7 @@
 - `return <expr>`
 - `import "<path>"` for file module inclusion (resolved relative to file path; loaded at compile time)
   - Import paths must be relative and must not use parent traversal (`..`).
+  - A single file may import each module path at most once.
   - Imported modules are namespaced by file stem by default (for example `import "math_utils"` exposes `math_utils.fn_name`).
   - Optional aliasing is supported: `import "math_utils" as mu` exposes `mu.fn_name`.
 - function calls: `<name>(<arg1>, ... )`


### PR DESCRIPTION
Updates grammar/kernel docs to state that a file cannot import the same module path more than once, matching parser behavior introduced in namespace hardening.