### PR TITLE
Add host contract describe command for tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ python -m axiom pkg run .
 
 # Inspect host bridge capabilities for tooling
 python -m axiom host list
+# Inspect the full host contract (schema + runtime version + capabilities) for tooling
+python -m axiom host describe
 # Inspect only deterministic host calls for agentic tooling
 python -m axiom host list --safe-only
 

--- a/axiom/__main__.py
+++ b/axiom/__main__.py
@@ -10,7 +10,7 @@ from .bytecode import Bytecode, Op
 from .interpreter import Interpreter
 from .vm import Vm
 from .errors import AxiomError
-from .host import HOST_BUILTINS, HOST_BUILTIN_NAMES
+from .host import host_capabilities, host_contract_metadata
 from .packaging import (
     build_package,
     clean_package,
@@ -158,14 +158,13 @@ def cmd_pkg_run(path: Path, *, allow_host_side_effects: bool) -> int:
 
 
 def cmd_host_list(*, safe_only: bool = False) -> int:
-    payload = []
-    for name in sorted(HOST_BUILTIN_NAMES):
-        arity, side_effecting = HOST_BUILTINS[name]
-        if safe_only and side_effecting:
-            continue
-        payload.append(
-            {"name": name, "arity": arity, "side_effecting": side_effecting}
-        )
+    payload = host_capabilities(safe_only=safe_only)
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+def cmd_host_describe(*, safe_only: bool = False) -> int:
+    payload = host_contract_metadata(safe_only=safe_only)
     print(json.dumps(payload, indent=2))
     return 0
 
@@ -239,6 +238,12 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Show only non-side-effecting host functions",
     )
+    host_desc = host.add_parser("describe", help="Describe host contract for tooling")
+    host_desc.add_argument(
+        "--safe-only",
+        action="store_true",
+        help="Include only non-side-effecting host functions",
+    )
 
     args = p.parse_args(argv)
 
@@ -289,6 +294,8 @@ def main(argv: list[str] | None = None) -> int:
         if args.cmd == "host":
             if args.host_cmd == "list":
                 return cmd_host_list(safe_only=args.safe_only)
+            if args.host_cmd == "describe":
+                return cmd_host_describe(safe_only=args.safe_only)
             raise AssertionError("unreachable")
         raise AssertionError("unreachable")
     except AxiomError as e:

--- a/axiom/host.py
+++ b/axiom/host.py
@@ -113,4 +113,28 @@ def call_host_builtin_id(host_fn_id: int, args: List[int], out: TextIO) -> int:
     return HOST_BUILTIN_BY_ID[host_fn_id].handler(args, out)
 
 
+def host_capabilities(safe_only: bool = False) -> List[Dict[str, object]]:
+    payload: List[Dict[str, object]] = []
+    for name in sorted(HOST_BUILTIN_NAMES):
+        arity, side_effecting = HOST_BUILTINS[name]
+        if safe_only and side_effecting:
+            continue
+        payload.append(
+            {
+                "name": name,
+                "arity": arity,
+                "side_effecting": side_effecting,
+            }
+        )
+    return payload
+
+
+def host_contract_metadata(safe_only: bool = False) -> Dict[str, object]:
+    return {
+        "schema_version": 1,
+        "runtime_version_minor": VERSION_MINOR,
+        "capabilities": host_capabilities(safe_only=safe_only),
+    }
+
+
 _rebuild_host_tables()

--- a/docs/kernel.md
+++ b/docs/kernel.md
@@ -47,6 +47,7 @@
 - `host.print` and `host.read` are side-effecting; they require an explicit runtime flag when enabled
 - non-side-effecting host calls can be used in deterministic tool pipelines without flags
 - `python -m axiom host list --safe-only` enumerates host calls that are safe by default
+- `python -m axiom host describe` returns machine-readable host contract metadata for deterministic agents
 - `host` call payloads in bytecode are name-based (string table index) starting at
   bytecode `v0.6` to preserve behavior if host registry order changes.
 - `python -m axiom host list` enumerates the currently registered host capabilities.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -27,6 +27,6 @@
 - Package/build tooling skeleton (`axiom.pkg`, `axiom pkg init`, `axiom pkg build`)
 - Package command coverage (`check`, `host` side-effect gating, CLI checks)
 
-## Phase 6
+## Phase 6 ✅
 - Stable host-tooling contracts for long-running agentic workflows
 - Module namespace strategy for future large-language agent compositions

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -117,6 +117,25 @@ class CliParityTests(unittest.TestCase):
         self.assertIn("version", safe_names)
         self.assertNotIn("print", safe_names)
 
+    def test_host_describe_command(self) -> None:
+        proc = self._run_cli(["host", "describe"], cwd=ROOT)
+        payload = json.loads(proc.stdout)
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertIn("runtime_version_minor", payload)
+        self.assertIn("capabilities", payload)
+        caps = payload["capabilities"]
+        self.assertTrue(isinstance(caps, list))
+        names = {entry["name"] for entry in caps}
+        self.assertIn("version", names)
+        self.assertIn("print", names)
+
+        safe_proc = self._run_cli(["host", "describe", "--safe-only"], cwd=ROOT)
+        safe_payload = json.loads(safe_proc.stdout)
+        self.assertEqual(safe_payload["schema_version"], 1)
+        safe_caps = safe_payload["capabilities"]
+        self.assertTrue(isinstance(safe_caps, list))
+        self.assertTrue(all(not entry["side_effecting"] for entry in safe_caps))
+
     def test_imported_modules_execute(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             mod = Path(td) / "math_module.ax"


### PR DESCRIPTION
Expose host capabilities + contract metadata via new CLI endpoint (Host describe not found: 3(NXDOMAIN)) and document it.