### PR TITLE
Add deterministic host contract signature tests and docs

### DIFF
--- a/axiom/host.py
+++ b/axiom/host.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import builtins as py_builtins
+import hashlib
+import json
 from dataclasses import dataclass
 from typing import Callable, Dict, List, TextIO, Tuple
 
@@ -130,10 +132,15 @@ def host_capabilities(safe_only: bool = False) -> List[Dict[str, object]]:
 
 
 def host_contract_metadata(safe_only: bool = False) -> Dict[str, object]:
+    caps = host_capabilities(safe_only=safe_only)
+    signature = hashlib.sha256(
+        json.dumps(caps, sort_keys=True).encode("utf-8")
+    ).hexdigest()
     return {
         "schema_version": 1,
         "runtime_version_minor": VERSION_MINOR,
-        "capabilities": host_capabilities(safe_only=safe_only),
+        "capabilities": caps,
+        "capabilities_signature": signature,
     }
 
 

--- a/docs/kernel.md
+++ b/docs/kernel.md
@@ -48,7 +48,11 @@
 - `host.print` and `host.read` are side-effecting; they require an explicit runtime flag when enabled
 - non-side-effecting host calls can be used in deterministic tool pipelines without flags
 - `python -m axiom host list --safe-only` enumerates host calls that are safe by default
-- `python -m axiom host describe` returns machine-readable host contract metadata for deterministic agents
+- `python -m axiom host describe` returns machine-readable host contract metadata for deterministic agents:
+  - `schema_version`
+  - `runtime_version_minor`
+  - `capabilities`
+  - `capabilities_signature` (`sha256` hash of sorted capabilities payload for change detection)
 - `host` call payloads in bytecode are name-based (string table index) starting at
   bytecode `v0.6` to preserve behavior if host registry order changes.
 - `python -m axiom host list` enumerates the currently registered host capabilities.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import subprocess
 import sys
 from pathlib import Path
+import hashlib
 import tempfile
 import json
 import unittest
@@ -123,11 +124,17 @@ class CliParityTests(unittest.TestCase):
         self.assertEqual(payload["schema_version"], 1)
         self.assertIn("runtime_version_minor", payload)
         self.assertIn("capabilities", payload)
+        self.assertIn("capabilities_signature", payload)
         caps = payload["capabilities"]
         self.assertTrue(isinstance(caps, list))
         names = {entry["name"] for entry in caps}
         self.assertIn("version", names)
         self.assertIn("print", names)
+        self.assertIsInstance(payload["capabilities_signature"], str)
+        self.assertEqual(
+            payload["capabilities_signature"],
+            hashlib.sha256(json.dumps(caps, sort_keys=True).encode("utf-8")).hexdigest(),
+        )
 
         safe_proc = self._run_cli(["host", "describe", "--safe-only"], cwd=ROOT)
         safe_payload = json.loads(safe_proc.stdout)
@@ -135,6 +142,18 @@ class CliParityTests(unittest.TestCase):
         safe_caps = safe_payload["capabilities"]
         self.assertTrue(isinstance(safe_caps, list))
         self.assertTrue(all(not entry["side_effecting"] for entry in safe_caps))
+        self.assertNotEqual(payload["capabilities_signature"], safe_payload["capabilities_signature"])
+        self.assertEqual(
+            safe_payload["capabilities_signature"],
+            hashlib.sha256(json.dumps(safe_caps, sort_keys=True).encode("utf-8")).hexdigest(),
+        )
+        # signature must be stable across repeated invocations with same registry state
+        second_proc = self._run_cli(["host", "describe"], cwd=ROOT)
+        second_payload = json.loads(second_proc.stdout)
+        self.assertEqual(
+            second_payload["capabilities_signature"],
+            payload["capabilities_signature"],
+        )
 
     def test_imported_modules_execute(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -21,7 +21,7 @@ from axiom.errors import AxiomCompileError, AxiomParseError, AxiomRuntimeError
 from axiom.interpreter import Interpreter
 from axiom.vm import Vm
 from axiom.bytecode import Op, VERSION_MINOR
-from axiom.host import register_host_builtin, reset_host_builtins, unregister_host_builtin
+from axiom.host import host_contract_metadata, register_host_builtin, reset_host_builtins, unregister_host_builtin
 
 
 class ErrorTests(unittest.TestCase):
@@ -429,6 +429,23 @@ print f(1)
         Vm(locals_count=bc.locals_count, allow_host_side_effects=True).run(bc, out)
         self.assertEqual(out.getvalue(), "41\n")
         fake_input.assert_called_once_with("123")
+
+    def test_host_contract_signature_tracks_capability_state(self) -> None:
+        base = host_contract_metadata()
+        base_signature = base["capabilities_signature"]
+
+        def probe(_args: list[int], _out) -> int:
+            return 7
+
+        register_host_builtin("sig_probe", 0, False, probe)
+        try:
+            with_probe = host_contract_metadata()
+            self.assertNotEqual(base_signature, with_probe["capabilities_signature"])
+            self.assertIn("capabilities_signature", with_probe)
+            self.assertEqual(with_probe["schema_version"], 1)
+            self.assertIn("sig_probe", {e["name"] for e in with_probe["capabilities"]})
+        finally:
+            reset_host_builtins()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds deterministic capabilities_signature in host contract metadata assertions, locks it with CLI/doc tests, and keeps host bridge contract stable for phase-3 tooling.