### PR TITLE
Restrict imported modules to declaration-only bodies

### DIFF
--- a/axiom/api.py
+++ b/axiom/api.py
@@ -91,9 +91,8 @@ def _load_program_file(path: Path, seen: Set[Path], loading: Set[Path]) -> Progr
                     f"cannot resolve import file {import_path}", stmt.span
                 )
             imported = _load_program_file(import_path, seen, loading)
-            stmts.extend(
-                _namespace_module_program(imported, stmt.alias).stmts
-            )
+            _validate_module_file(imported, import_path)
+            stmts.extend(_namespace_module_program(imported, stmt.alias).stmts)
         else:
             stmts.append(stmt)
 
@@ -181,3 +180,14 @@ def _namespace_module_program(program: Program, module_alias: str) -> Program:
 
     stmts = [_rewrite_stmt(stmt) for stmt in program.stmts]
     return Program(stmts=stmts)
+
+
+def _validate_module_file(program: Program, import_path: Path) -> None:
+    for stmt in program.stmts:
+        if isinstance(stmt, (FunctionDefStmt, ImportStmt)):
+            continue
+        raise AxiomCompileError(
+            f"imported module {import_path} may only contain imports and function declarations",
+            stmt.span,
+            path=str(import_path),
+        )

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -18,6 +18,7 @@ stmt           := let_stmt
 
 import_stmt    := "import" STRING terminator ;      # default module namespace from path, using dots for path separators
                | "import" STRING "as" IDENT terminator ;  # explicit alias
+               # imported modules are function-only and may contain imports plus fn declarations.
 fn_stmt        := "fn" IDENT "(" params? ")" block ;  # IDENT and params may not be "host"
 params         := IDENT ("," IDENT)* ;
 return_stmt    := "return" expr terminator ;

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -189,6 +189,14 @@ print f(1)
             Vm(locals_count=bc.locals_count).run(bc, out)
             self.assertEqual(out.getvalue(), "20\n")
 
+    def test_compile_imported_module_top_level_statement_disallowed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            root.joinpath("math_module.ax").write_text("print 9\n", encoding="utf-8")
+            root.joinpath("main.ax").write_text('import "math_module"\n', encoding="utf-8")
+            with self.assertRaises(AxiomCompileError):
+                compile_file(root.joinpath("main.ax"))
+
     def test_compile_import_duplicate_namespace(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)


### PR DESCRIPTION
Reject top-level executable statements in imported modules to keep function-namespaced module semantics deterministic for agentic toolchains. Add compiler validation and regression test.