### PR TITLE
Disallow nested function definitions during parse

### DIFF
--- a/axiom/parser.py
+++ b/axiom/parser.py
@@ -135,6 +135,13 @@ class Parser:
         return self._parse_expr_stmt()
 
     def _parse_function_def(self) -> FunctionDefStmt:
+        if self.function_depth > 0:
+            raise AxiomParseError(
+                "nested function definitions are not supported",
+                self._peek().span,
+                source=self.source,
+                path=self.source_path,
+            )
         start = self._eat(TokenKind.FN).span.start
         name = self._eat(TokenKind.IDENT)
         if name.kind != TokenKind.IDENT:

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -89,6 +89,21 @@ fn f(host) {
 }
 """)
 
+    def test_nested_function_definition_parse_error(self) -> None:
+        with self.assertRaises(AxiomParseError) as cm:
+            compile_to_bytecode(
+                """
+fn outer() {
+  fn inner() {
+    return 1
+  }
+  return inner()
+}
+"""
+            )
+        msg = str(cm.exception)
+        self.assertIn("nested function definitions are not supported", msg)
+
     def test_compile_arity_mismatch(self) -> None:
         with self.assertRaises(AxiomCompileError):
             compile_to_bytecode("""


### PR DESCRIPTION
Nested function declarations were previously diagnosed during compilation. This moves enforcement into the parser so users get immediate, deterministic diagnostics and adds regression coverage.