### PR TITLE
Reject host-prefixed import namespaces

### DIFF
--- a/axiom/parser.py
+++ b/axiom/parser.py
@@ -278,7 +278,7 @@ class Parser:
                 source=self.source,
                 path=self.source_path,
             )
-        if default_alias == "host":
+        if default_alias == "host" or default_alias.startswith("host."):
             raise AxiomParseError(
                 "import namespace cannot be 'host'",
                 path.span,
@@ -290,7 +290,7 @@ class Parser:
         if self._peek().kind == TokenKind.AS:
             self._bump()
             alias = self._eat_name_token()
-            if alias == "host":
+            if alias == "host" or alias.startswith("host."):
                 raise AxiomParseError(
                     "import namespace cannot be 'host'",
                     path.span,

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -280,14 +280,10 @@ print f(1)
                 compile_file(root.joinpath("main.ax"))
 
     def test_compile_import_alias_host_reserved(self) -> None:
-        with tempfile.TemporaryDirectory() as td:
-            root = Path(td)
-            root.joinpath("math_module.ax").write_text(
-                "fn add(a, b) { return a + b }\n", encoding="utf-8"
-            )
-            root.joinpath("main.ax").write_text('import "math_module" as host\n', encoding="utf-8")
-            with self.assertRaises(AxiomParseError):
-                compile_file(root.joinpath("main.ax"))
+        with self.assertRaises(AxiomParseError):
+            parse_program('import "host/foo"\n')
+        with self.assertRaises(AxiomParseError):
+            compile_to_bytecode('import "math_module" as host.tools\n')
 
     def test_host_registry_duplicate_name(self) -> None:
         def noop(args: list[int], _out) -> int:


### PR DESCRIPTION
Fix parse-time import namespace validation so import aliases that are  or start with  (including defaults like ) are rejected, preventing namespace collisions with host bridge calls. Add tests for both default and explicit alias forms.