### PR TITLE
Allow dotted import aliases and host prefix reservation

### DIFF
--- a/axiom/parser.py
+++ b/axiom/parser.py
@@ -97,6 +97,13 @@ class Parser:
             path=self.source_path,
         )
 
+    def _eat_qualified_name(self) -> str:
+        parts = [self._eat_name_token()]
+        while self._peek().kind == TokenKind.DOT:
+            self._bump()
+            parts.append(self._eat_name_token())
+        return ".".join(parts)
+
     def parse_program(self) -> Program:
         stmts = []
         self._eat_newlines()
@@ -289,7 +296,7 @@ class Parser:
         alias = default_alias
         if self._peek().kind == TokenKind.AS:
             self._bump()
-            alias = self._eat_name_token()
+            alias = self._eat_qualified_name()
             if alias == "host" or alias.startswith("host."):
                 raise AxiomParseError(
                     "import namespace cannot be 'host'",

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -16,8 +16,9 @@ stmt           := let_stmt
                | block
                | expr_stmt ;
 
-import_stmt    := "import" STRING terminator ;      # default module namespace from path, using dots for path separators
-               | "import" STRING "as" IDENT terminator ;  # explicit alias
+import_stmt    := "import" STRING terminator ;                      # default module namespace from path, using dots for path separators
+               | "import" STRING "as" qualified_ident terminator ;  # explicit alias
+qualified_ident := IDENT ("." IDENT)* ;
                # imported modules are function-only and may contain imports plus fn declarations.
 fn_stmt        := "fn" IDENT "(" params? ")" block ;  # IDENT and params may not be "host"
 params         := IDENT ("," IDENT)* ;

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -280,10 +280,13 @@ print f(1)
                 compile_file(root.joinpath("main.ax"))
 
     def test_compile_import_alias_host_reserved(self) -> None:
-        with self.assertRaises(AxiomParseError):
+        with self.assertRaises(AxiomParseError) as cm:
             parse_program('import "host/foo"\n')
-        with self.assertRaises(AxiomParseError):
+        self.assertIn("import namespace cannot be 'host'", str(cm.exception))
+
+        with self.assertRaises(AxiomParseError) as cm:
             compile_to_bytecode('import "math_module" as host.tools\n')
+        self.assertIn("import namespace cannot be 'host'", str(cm.exception))
 
     def test_host_registry_duplicate_name(self) -> None:
         def noop(args: list[int], _out) -> int:


### PR DESCRIPTION
Grammar and parser now support explicit dotted import aliases via IDENT ('.' IDENT)* and enforce host namespace reservation for dotted names as well. Existing guard remains for default aliases derived from import paths. Add test coverage for default  and explicit  aliases with explicit parse-error assertions.