### PR TITLE
Add compact JSON output for host introspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ python -m axiom pkg run .
 
 # Inspect host bridge capabilities for tooling
 python -m axiom host list
+# Emit compact machine-readable output for scripts
+python -m axiom host list --compact
 # Inspect the full host contract (schema + runtime version + capabilities) for tooling
 python -m axiom host describe
 # Inspect only deterministic host calls for agentic tooling

--- a/axiom/__main__.py
+++ b/axiom/__main__.py
@@ -161,15 +161,21 @@ def cmd_pkg_run(path: Path, *, allow_host_side_effects: bool) -> int:
     return 0
 
 
-def cmd_host_list(*, safe_only: bool = False) -> int:
+def cmd_host_list(*, safe_only: bool = False, compact: bool = False) -> int:
     payload = host_capabilities(safe_only=safe_only)
-    print(json.dumps(payload, indent=2))
+    if compact:
+        print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+    else:
+        print(json.dumps(payload, indent=2, sort_keys=True))
     return 0
 
 
-def cmd_host_describe(*, safe_only: bool = False) -> int:
+def cmd_host_describe(*, safe_only: bool = False, compact: bool = False) -> int:
     payload = host_contract_metadata(safe_only=safe_only)
-    print(json.dumps(payload, indent=2))
+    if compact:
+        print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+    else:
+        print(json.dumps(payload, indent=2, sort_keys=True))
     return 0
 
 
@@ -242,11 +248,21 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Show only non-side-effecting host functions",
     )
+    host_list.add_argument(
+        "--compact",
+        action="store_true",
+        help="Print compact JSON for machine parsing",
+    )
     host_desc = host.add_parser("describe", help="Describe host contract for tooling")
     host_desc.add_argument(
         "--safe-only",
         action="store_true",
         help="Include only non-side-effecting host functions",
+    )
+    host_desc.add_argument(
+        "--compact",
+        action="store_true",
+        help="Print compact JSON for machine parsing",
     )
 
     args = p.parse_args(argv)
@@ -297,9 +313,9 @@ def main(argv: list[str] | None = None) -> int:
             raise AssertionError("unreachable")
         if args.cmd == "host":
             if args.host_cmd == "list":
-                return cmd_host_list(safe_only=args.safe_only)
+                return cmd_host_list(safe_only=args.safe_only, compact=args.compact)
             if args.host_cmd == "describe":
-                return cmd_host_describe(safe_only=args.safe_only)
+                return cmd_host_describe(safe_only=args.safe_only, compact=args.compact)
             raise AssertionError("unreachable")
         raise AssertionError("unreachable")
     except AxiomError as e:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -118,6 +118,9 @@ class CliParityTests(unittest.TestCase):
         safe_names = {entry["name"] for entry in safe_payload}
         self.assertIn("version", safe_names)
         self.assertNotIn("print", safe_names)
+        compact_proc = self._run_cli(["host", "list", "--compact"], cwd=ROOT)
+        compact_payload = json.loads(compact_proc.stdout)
+        self.assertEqual(payload, compact_payload)
 
     def test_host_describe_command(self) -> None:
         proc = self._run_cli(["host", "describe"], cwd=ROOT)
@@ -155,6 +158,9 @@ class CliParityTests(unittest.TestCase):
             second_payload["capabilities_signature"],
             payload["capabilities_signature"],
         )
+        compact_proc = self._run_cli(["host", "describe", "--compact"], cwd=ROOT)
+        compact_payload = json.loads(compact_proc.stdout)
+        self.assertEqual(payload, compact_payload)
 
     def test_imported_modules_execute(self) -> None:
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
## Summary\n- Add --compact output mode to  and  for deterministic machine parsing.\n- Keep default pretty JSON output unchanged for existing behavior.\n- Add CLI tests covering compact mode and README usage examples.\n\n## Verification\n- python -m unittest tests.test_cli tests.test_errors tests.test_conformance -v