### PR TITLE
Route Python 3.12 CI lane to self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,40 @@ on:
   pull_request:
 
 jobs:
-  test:
+  test_self_hosted_py312_trusted:
+    name: test (python 3.12 self-hosted)
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on:
+      - self-hosted
+      - synology
+      - shell-only
+      - public
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify Python 3.12
+        run: python3.12 --version
+      - name: Run tests
+        run: python3.12 -m unittest discover -v
+
+  test_hosted_matrix_trusted:
+    name: test (python ${{ matrix.python-version }} hosted)
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Run tests
+        run: python -m unittest discover -v
+
+  test_hosted_matrix_fork_pr:
+    name: test (python ${{ matrix.python-version }} hosted)
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
## What changed
- route the trusted Python 3.12 lane to the public shell-only self-hosted runners
- keep Python 3.11 and 3.13 on GitHub-hosted runners
- keep fork PRs fully on GitHub-hosted runners

## Why
- use the Synology shell-only runner pool where it is compatible
- preserve the broader version matrix and fork safety on hosted runners

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'
- . .venv/bin/activate && python -m unittest discover -v
- docker run --rm --platform linux/amd64 --entrypoint /bin/bash -v "$PWD:/workspace" -w /workspace ghcr.io/omt-global/synology-github-runner:0.1.6 -lc 'python3.12 --version && python3.12 -m unittest discover -v'