### PR TITLE
Upgrade GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - shell-only
       - public
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Verify Python 3.12
         run: python3.12 --version
       - name: Run tests
@@ -29,8 +29,8 @@ jobs:
       matrix:
         python-version: ["3.11", "3.13"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run tests
@@ -45,8 +45,8 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run tests


### PR DESCRIPTION
## Summary
- upgrade checkout to v6
- upgrade setup-python to v6
- remove the Node 20 deprecation warnings from CI

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'\n- source .venv/bin/activate && python -m unittest discover -v