### PR TITLE
Kick off AG4.1 with synthetic std/time stdlib module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,9 @@ stage1-smoke:
 	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- check stage1/examples/outcomes --json
 	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build stage1/examples/outcomes --json
 	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- run stage1/examples/outcomes
+	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- check stage1/examples/stdlib_time --json
+	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build stage1/examples/stdlib_time --json
+	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- run stage1/examples/stdlib_time
 	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- caps stage1/examples/hello --json
 
 stage1-run:

--- a/docs/stage1-agent-grade-compiler.md
+++ b/docs/stage1-agent-grade-compiler.md
@@ -162,13 +162,29 @@ Acceptance:
 
 Goal: provide the minimum runtime and stdlib needed for agents, workers, and small services.
 
+Status: in progress. AG4.1 has been kicked off with the synthetic stdlib
+plumbing and a first module (`std/time.ax`) landing. The remaining AG4.1
+modules, AG4.2 async runtime, AG4.3 HTTP service support, and AG4.4
+capability-aware integration work are still open.
+
 Work packages:
 
 - `AG4.1`: stdlib surface
+  - Synthetic stdlib infrastructure: `import "std/<module>.ax"` is resolved by
+    the compiler against an in-crate source table under a `<stdlib>` sentinel
+    package root. Wrappers call existing intrinsics; capability enforcement
+    still runs against the **importing** package's manifest via
+    `hir::lower_with_capabilities`, so stdlib imports stay transparent to the
+    capability model.
+  - `std.time` — **landed** as `std/time.ax` exposing `now_ms(): int` on top of
+    the existing `clock_now_ms` intrinsic. Covered by
+    `stage1/examples/stdlib_time` and three Rust tests
+    (`stage1_project_imports_synthetic_stdlib_time_module`,
+    `stage1_project_rejects_stdlib_time_without_clock_capability`,
+    `stage1_project_rejects_unknown_stdlib_module`).
   - `std.io`
   - `std.fs`
   - `std.env`
-  - `std.time`
   - `std.json`
   - `std.http`
   - `std.process`

--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -13,6 +13,7 @@ The Rust compiler is intentionally small in this bootstrap slice:
 
 - `axiom.toml` and `axiom.lock` are the new manifest and lockfile pair.
 - Supported source subset is top-level `import`, `pub struct`, `struct`, `pub enum`, `enum`, `pub fn`, `fn`, `let`, `print`, `if` / `else`, `while`, statement-level `match`, `return`, variables, bare enum variants, tuple-style enum constructors, named-payload enum constructors, payload-binding match arms, named-payload match arms, `Option<T>`, `Result<T, E>`, `Some`, `None`, `Ok`, `Err`, the built-in polymorphic collection helpers `len(...)`, `first(...)`, and `last(...)`, function calls, named struct types, named enum types, tuple types, tuple literals, tuple indexing, map types, map literals, map indexing, array types, array literals, array indexing, borrowed array slice expressions, borrowed slice types, borrowed slices stored inside named structs and enum payloads, borrowed-return aggregates backed by one or more borrowed parameters, struct literals, field access, `+` on `int`/`string`, and scalar comparisons.
+- Stage1 now ships a synthetic standard library surface under the `std/` import prefix. The first module is `std/time.ax`, which exposes `now_ms(): int` on top of the existing `clock_now_ms` intrinsic. Stdlib wrappers are transparent to capability enforcement: importing `std/time.ax` still requires the importing package to declare `[capabilities] clock = true`.
 - The pipeline is already split into syntax -> HIR -> MIR -> native build.
 - `axiomc build` emits a native binary by generating a Rust file and invoking `rustc`.
 - A bootstrap ownership rule is active: non-`Copy` values move on binding and call boundaries, non-`Copy` field access, non-`Copy` tuple indexing, non-`Copy` map indexing, and non-`Copy` array indexing conservatively move the owning variable, branch-local moves conservatively propagate after `if` and `match`, statically false `if` / `while` branches are now ignored instead of poisoning later ownership state, and live borrowed slices now block moving their owned collection roots until the borrow scope ends, including when those borrows are wrapped in local tuples, named structs, enum payloads, `Option` / `Result` values, passed through sibling expression evaluation, or introduced by temporary `match` expressions.
@@ -66,8 +67,8 @@ still far from the stated 1.0 target for service and agent workloads.
 
 ### Runtime and standard library gaps
 
-- There is no stage1 standard library yet.
-- Capability enforcement now exists for a compiler-known intrinsic slice across all six manifest flags: `fs_read(...)`, `net_resolve(...)`, `process_status(...)`, `env_get(...)`, `clock_now_ms()`, and `crypto_sha256(...)`, but there is still no general stdlib module surface.
+- The AG4.1 stdlib surface has been opened with a single synthetic module (`std/time.ax` exposing `now_ms()`); the remaining AG4.1 modules (`std.io`, `std.fs`, `std.env`, `std.json`, `std.http`, `std.process`, `std.collections`, `std.sync`, `std.crypto.hash`) are still unimplemented.
+- Capability enforcement exists for a compiler-known intrinsic slice across all six manifest flags: `fs_read(...)`, `net_resolve(...)`, `process_status(...)`, `env_get(...)`, `clock_now_ms()`, and `crypto_sha256(...)`, and stdlib wrappers preserve that enforcement against the importing package's manifest, but the general stdlib module surface is still mostly empty.
 - No async runtime, channels, cancellation, timers, or service-grade I/O surface exists.
 
 ### Backend and tooling gaps
@@ -90,6 +91,7 @@ Current proof points:
 - `stage1/examples/packages` proves the local path dependency baseline and root-package lockfile validation.
 - `stage1/examples/workspace` proves the package-root workspace-member baseline and workspace-aware root lockfile validation.
 - `stage1/examples/capabilities` proves the capability-gated fs/net/env/clock/crypto path, while the Rust suite covers the remaining process intrinsic contract.
+- `stage1/examples/stdlib_time` proves the AG4.1 synthetic stdlib surface: `import "std/time.ax"` brings `now_ms()` into scope and remains subject to the importing package's `[capabilities] clock` flag.
 - `stage1/examples/arrays`, `stage1/examples/maps`, `stage1/examples/tuples`,
   and `stage1/examples/structs` cover the current structured-data floor.
 - `stage1/examples/slices`, `stage1/examples/borrowed_shapes`, `stage1/examples/enums`,

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -6,6 +6,7 @@ pub mod manifest;
 pub mod mir;
 pub mod new_project;
 pub mod project;
+pub mod stdlib;
 pub mod syntax;
 
 #[cfg(test)]
@@ -1160,6 +1161,109 @@ mod tests {
         let tests = run_project_tests(&project).expect("run tests");
         assert_eq!(tests.passed, 1);
         assert_eq!(tests.failed, 0);
+    }
+
+    #[test]
+    fn stage1_project_imports_synthetic_stdlib_time_module() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("stdlib-time-app");
+        create_project(&project, Some("stdlib-time-app")).expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            render_manifest_with_capabilities(
+                "stdlib-time-app",
+                false,
+                false,
+                false,
+                false,
+                true,
+                false,
+            ),
+        )
+        .expect("write manifest");
+        let manifest = load_manifest(&project).expect("load manifest");
+        fs::write(
+            project.join("axiom.lock"),
+            render_lockfile_for_project(&project, &manifest).expect("lockfile"),
+        )
+        .expect("write lockfile");
+        fs::write(
+            project.join("src/main.ax"),
+            "import \"std/time.ax\"\nlet now: int = now_ms()\nprint now > 0\n",
+        )
+        .expect("write source");
+        fs::write(
+            project.join("src/main_test.ax"),
+            "import \"std/time.ax\"\nlet now: int = now_ms()\nprint now > 0\n",
+        )
+        .expect("write test");
+        fs::write(project.join("src/main_test.stdout"), "true\n").expect("write golden");
+
+        let built = build_project(&project).expect("build project");
+        let output = Command::new(&built.binary)
+            .output()
+            .expect("run compiled binary");
+        assert_eq!(String::from_utf8_lossy(&output.stdout), "true\n");
+
+        let tests = run_project_tests(&project).expect("run tests");
+        assert_eq!(tests.passed, 1);
+        assert_eq!(tests.failed, 0);
+    }
+
+    #[test]
+    fn stage1_project_rejects_stdlib_time_without_clock_capability() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("stdlib-time-denied");
+        create_project(&project, Some("stdlib-time-denied")).expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            render_manifest_with_capabilities(
+                "stdlib-time-denied",
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+            ),
+        )
+        .expect("write manifest");
+        let manifest = load_manifest(&project).expect("load manifest");
+        fs::write(
+            project.join("axiom.lock"),
+            render_lockfile_for_project(&project, &manifest).expect("lockfile"),
+        )
+        .expect("write lockfile");
+        fs::write(
+            project.join("src/main.ax"),
+            "import \"std/time.ax\"\nlet now: int = now_ms()\nprint now > 0\n",
+        )
+        .expect("write source");
+
+        let err = check_project(&project).expect_err("expected capability denial");
+        assert!(
+            err.message
+                .contains("requires [capabilities].clock = true"),
+            "unexpected diagnostic: {err:?}",
+        );
+    }
+
+    #[test]
+    fn stage1_project_rejects_unknown_stdlib_module() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("stdlib-unknown");
+        create_project(&project, Some("stdlib-unknown")).expect("create project");
+        fs::write(
+            project.join("src/main.ax"),
+            "import \"std/bogus.ax\"\nprint 1\n",
+        )
+        .expect("write source");
+
+        let err = check_project(&project).expect_err("expected unknown stdlib module error");
+        assert!(
+            err.message.contains("unknown stdlib module"),
+            "unexpected diagnostic: {err:?}",
+        );
     }
 
     #[test]

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -3,11 +3,12 @@ use crate::diagnostics::Diagnostic;
 use crate::hir;
 use crate::lockfile::validate_lockfile;
 use crate::manifest::{
-    CapabilityConfig, CapabilityDescriptor, CapabilityKind, Manifest, binary_path,
-    capability_descriptors, entry_path, generated_rust_path, load_manifest, manifest_path,
-    out_dir_path,
+    BuildSection, CapabilityConfig, CapabilityDescriptor, CapabilityKind, Manifest, PackageSection,
+    binary_path, capability_descriptors, entry_path, generated_rust_path, load_manifest,
+    manifest_path, out_dir_path,
 };
 use crate::mir;
+use crate::stdlib;
 use crate::syntax;
 use serde::Serialize;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
@@ -367,7 +368,54 @@ fn load_package_graph(project_root: &Path) -> Result<PackageGraph, Diagnostic> {
     let mut graph = PackageGraph::default();
     let mut visiting = Vec::new();
     load_package_graph_recursive(project_root, &mut graph, &mut visiting)?;
+    register_stdlib_package(&mut graph);
     Ok(graph)
+}
+
+/// Registers the synthetic `<stdlib>` package in the graph. The synthetic
+/// manifest enables every capability so `validate_module_capabilities` does not
+/// reject stdlib wrappers against their own package config; actual capability
+/// enforcement still runs on the flattened program via
+/// `hir::lower_with_capabilities`, which uses the **entry** package's
+/// capabilities. That keeps stdlib wrappers transparent for capability rules:
+/// an import of `std/time.ax` does not grant clock access unless the importing
+/// package's manifest also declares `[capabilities] clock = true`.
+fn register_stdlib_package(graph: &mut PackageGraph) {
+    let root = stdlib::stdlib_root();
+    if graph.packages.contains_key(&root) {
+        return;
+    }
+    let manifest = Manifest {
+        package: PackageSection {
+            name: stdlib::STDLIB_PACKAGE_NAME.to_string(),
+            version: stdlib::STDLIB_PACKAGE_VERSION.to_string(),
+        },
+        dependencies: BTreeMap::new(),
+        workspace: None,
+        build: BuildSection {
+            entry: String::from("lib.ax"),
+            out_dir: String::from("dist"),
+        },
+        tests: Vec::new(),
+        capabilities: CapabilityConfig {
+            fs: true,
+            net: true,
+            process: true,
+            env: true,
+            clock: true,
+            crypto: true,
+        },
+    };
+    graph.packages.insert(
+        root.clone(),
+        PackageContext {
+            root: root.clone(),
+            manifest,
+            source_root: root,
+            dependencies: BTreeMap::new(),
+            workspace_members: Vec::new(),
+        },
+    );
 }
 
 fn load_package_graph_recursive(
@@ -752,13 +800,28 @@ fn load_module_recursive(
     }
     let package = graph.context(package_root)?;
 
-    let source = fs::read_to_string(&module_path).map_err(|err| {
-        Diagnostic::new(
-            "source",
-            format!("failed to read {}: {err}", module_path.display()),
-        )
-        .with_path(module_path.display().to_string())
-    })?;
+    let source = if stdlib::is_stdlib_path(&module_path) {
+        stdlib::stdlib_source_for(&module_path)
+            .map(str::to_string)
+            .ok_or_else(|| {
+                Diagnostic::new(
+                    "source",
+                    format!(
+                        "internal error: missing stdlib source for {}",
+                        module_path.display()
+                    ),
+                )
+                .with_path(module_path.display().to_string())
+            })?
+    } else {
+        fs::read_to_string(&module_path).map_err(|err| {
+            Diagnostic::new(
+                "source",
+                format!("failed to read {}: {err}", module_path.display()),
+            )
+            .with_path(module_path.display().to_string())
+        })?
+    };
     let program = syntax::parse_program(&source, &module_path)?;
     if !is_entry && !program.stmts.is_empty() {
         let stmt = &program.stmts[0];
@@ -2019,7 +2082,32 @@ fn resolve_import_path(
     }
     let mut components = relative.components();
     if let Some(Component::Normal(first)) = components.next() {
-        let dependency_name = first.to_string_lossy().to_string();
+        let first_name = first.to_string_lossy().to_string();
+        if first_name == stdlib::STDLIB_IMPORT_PREFIX {
+            let mut remainder = PathBuf::new();
+            for component in components {
+                remainder.push(component.as_os_str());
+            }
+            if remainder.as_os_str().is_empty() {
+                return Err(Diagnostic::new(
+                    "import",
+                    "stdlib import must include a module path (e.g. import \"std/time.ax\")",
+                )
+                .with_path(module_path.display().to_string())
+                .with_span(import.line, import.column));
+            }
+            if !stdlib::stdlib_has_module(&remainder) {
+                return Err(Diagnostic::new(
+                    "import",
+                    format!("unknown stdlib module {:?}", import.path),
+                )
+                .with_path(module_path.display().to_string())
+                .with_span(import.line, import.column));
+            }
+            let virtual_path = stdlib::stdlib_source_path(&remainder.to_string_lossy());
+            return Ok((stdlib::stdlib_root(), virtual_path));
+        }
+        let dependency_name = first_name;
         if let Some(dependency_root) = package.dependencies.get(&dependency_name) {
             let dependency = graph.context(dependency_root)?;
             let mut remainder = PathBuf::new();

--- a/stage1/crates/axiomc/src/stdlib.rs
+++ b/stage1/crates/axiomc/src/stdlib.rs
@@ -1,0 +1,70 @@
+//! Synthetic stage1 standard library.
+//!
+//! The AG4.1 milestone introduces a `std.*` surface exposed through the normal
+//! `import "std/<module>.ax"` syntax. The compiler materialises a synthetic
+//! package under the sentinel path [`STDLIB_ROOT`] whose sources live in a
+//! compile-time table instead of the filesystem. Each stdlib module is a thin
+//! wrapper around existing capability-gated intrinsics, so capability
+//! enforcement continues to run against the importing package's manifest via
+//! `hir::lower_with_capabilities`.
+//!
+//! Today this only provides `std/time.ax`, exposing `now_ms()` on top of the
+//! existing `clock_now_ms` intrinsic. Additional AG4.1 modules land in
+//! follow-on slices.
+
+use std::path::{Path, PathBuf};
+
+/// Sentinel path component used as the synthetic stdlib package root.
+pub(crate) const STDLIB_ROOT: &str = "<stdlib>";
+
+/// Import-prefix that selects the synthetic stdlib package.
+pub(crate) const STDLIB_IMPORT_PREFIX: &str = "std";
+
+/// Package name used for the synthetic stdlib manifest.
+pub(crate) const STDLIB_PACKAGE_NAME: &str = "std";
+
+/// Package version used for the synthetic stdlib manifest.
+pub(crate) const STDLIB_PACKAGE_VERSION: &str = "0.0.0";
+
+/// Compile-time table of stdlib module sources keyed by their path relative to
+/// the stdlib import prefix. Keeping stage1 stdlib sources in-tree as `&str`
+/// avoids any filesystem lookup and keeps the bootstrap hermetic.
+const STDLIB_SOURCES: &[(&str, &str)] = &[(
+    "time.ax",
+    "pub fn now_ms(): int {\nreturn clock_now_ms()\n}\n",
+)];
+
+pub(crate) fn stdlib_root() -> PathBuf {
+    PathBuf::from(STDLIB_ROOT)
+}
+
+pub(crate) fn is_stdlib_path(path: &Path) -> bool {
+    path.starts_with(Path::new(STDLIB_ROOT))
+}
+
+/// Returns the virtual module path for `module_relative`, e.g.
+/// `"time.ax"` -> `<stdlib>/time.ax`.
+pub(crate) fn stdlib_source_path(module_relative: &str) -> PathBuf {
+    PathBuf::from(STDLIB_ROOT).join(module_relative)
+}
+
+/// Returns the embedded source for a virtual stdlib path, or `None` if the
+/// path does not correspond to a known stdlib module.
+pub(crate) fn stdlib_source_for(path: &Path) -> Option<&'static str> {
+    let relative = path.strip_prefix(Path::new(STDLIB_ROOT)).ok()?;
+    let key = relative.to_str()?;
+    STDLIB_SOURCES
+        .iter()
+        .find(|(name, _)| *name == key)
+        .map(|(_, source)| *source)
+}
+
+/// Returns the virtual module key (e.g. `"time.ax"`) used by a stdlib import
+/// remainder. `import_remainder` is the portion of the user-visible import
+/// path that follows the `std/` prefix (e.g. `"time.ax"`).
+pub(crate) fn stdlib_has_module(import_remainder: &Path) -> bool {
+    let Some(key) = import_remainder.to_str() else {
+        return false;
+    };
+    STDLIB_SOURCES.iter().any(|(name, _)| *name == key)
+}

--- a/stage1/examples/stdlib_time/axiom.lock
+++ b/stage1/examples/stdlib_time/axiom.lock
@@ -1,0 +1,6 @@
+version = 1
+
+[[package]]
+name = "stdlib-time"
+version = "0.1.0"
+source = "path"

--- a/stage1/examples/stdlib_time/axiom.toml
+++ b/stage1/examples/stdlib_time/axiom.toml
@@ -1,0 +1,15 @@
+[package]
+name = "stdlib-time"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = true
+crypto = false

--- a/stage1/examples/stdlib_time/src/main.ax
+++ b/stage1/examples/stdlib_time/src/main.ax
@@ -1,0 +1,4 @@
+import "std/time.ax"
+
+let now: int = now_ms()
+print now > 0


### PR DESCRIPTION
## Summary

- Opens the AG4 stdlib surface by introducing a synthetic `<stdlib>` package the compiler resolves in-process.
- User code can now `import "std/time.ax"` to bring `now_ms(): int` into scope, delegating to the existing `clock_now_ms` intrinsic.
- Capability enforcement stays transparent: importing `std/time.ax` still requires `[capabilities] clock = true` in the importer's manifest (verified by a negative test). No capability bypass.

## Design notes

- `stage1/crates/axiomc/src/stdlib.rs` holds an in-crate `&str` source table keyed by module-relative path; stdlib modules never touch the filesystem.
- `project.rs::register_stdlib_package` inserts a synthetic `PackageContext` at a sentinel path (`<stdlib>`) with all capabilities enabled, so `validate_module_capabilities` passes stdlib modules trivially.
- The real enforcement runs through `hir::lower_with_capabilities` on the flattened program with the **entry** package's capabilities, so stdlib wrappers cannot widen what the importing package may do.
- `resolve_import_path` intercepts imports whose first component is `std` before dependency resolution; `load_module_recursive` reads from the embedded table when the module path lives under `<stdlib>`.
- Per the AG working rule, this PR is scoped to the synthetic stdlib plumbing plus `std.time`. The remaining AG4.1 modules (`std.io`, `std.fs`, `std.env`, `std.json`, `std.http`, `std.process`, `std.collections`, `std.sync`, `std.crypto.hash`) land in follow-up slices.

## Test plan

- [x] `cargo test --manifest-path stage1/Cargo.toml` — **121 passed** (was 118; adds `stage1_project_imports_synthetic_stdlib_time_module`, `stage1_project_rejects_stdlib_time_without_clock_capability`, `stage1_project_rejects_unknown_stdlib_module`)
- [x] `make stage1-smoke` — green, including new `stage1/examples/stdlib_time` coverage
- [x] `python -m unittest discover -v` — 128 passed (stage0 unchanged)
- [x] Manual capability-denial check on the example (`clock = false` → compiler reports `requires [capabilities].clock = true`)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)