### PR TITLE
Extend AG4.1 stdlib with synthetic std/fs module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,9 @@ stage1-smoke:
 	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- check stage1/examples/stdlib_env --json
 	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build stage1/examples/stdlib_env --json
 	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- run stage1/examples/stdlib_env
+	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- check stage1/examples/stdlib_fs --json
+	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build stage1/examples/stdlib_fs --json
+	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- run stage1/examples/stdlib_fs
 	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- caps stage1/examples/hello --json
 
 stage1-run:

--- a/docs/stage1-agent-grade-compiler.md
+++ b/docs/stage1-agent-grade-compiler.md
@@ -163,9 +163,9 @@ Acceptance:
 Goal: provide the minimum runtime and stdlib needed for agents, workers, and small services.
 
 Status: in progress. AG4.1 has been kicked off with the synthetic stdlib
-plumbing, and two modules are landed (`std/time.ax` and `std/env.ax`). The
-remaining AG4.1 modules, AG4.2 async runtime, AG4.3 HTTP service support, and
-AG4.4 capability-aware integration work are still open.
+plumbing, and three modules are landed (`std/time.ax`, `std/env.ax`, and
+`std/fs.ax`). The remaining AG4.1 modules, AG4.2 async runtime, AG4.3 HTTP
+service support, and AG4.4 capability-aware integration work are still open.
 
 Work packages:
 
@@ -187,8 +187,12 @@ Work packages:
     intrinsic. Covered by `stage1/examples/stdlib_env` and two Rust tests
     (`stage1_project_imports_synthetic_stdlib_env_module`,
     `stage1_project_rejects_stdlib_env_without_env_capability`).
+  - `std.fs` — **landed** as `std/fs.ax` exposing
+    `read_file(path: string): Option<string>` on top of the existing `fs_read`
+    intrinsic. Covered by `stage1/examples/stdlib_fs` and two Rust tests
+    (`stage1_project_imports_synthetic_stdlib_fs_module`,
+    `stage1_project_rejects_stdlib_fs_without_fs_capability`).
   - `std.io`
-  - `std.fs`
   - `std.json`
   - `std.http`
   - `std.process`

--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -13,7 +13,7 @@ The Rust compiler is intentionally small in this bootstrap slice:
 
 - `axiom.toml` and `axiom.lock` are the new manifest and lockfile pair.
 - Supported source subset is top-level `import`, `pub struct`, `struct`, `pub enum`, `enum`, `pub fn`, `fn`, `let`, `print`, `if` / `else`, `while`, statement-level `match`, `return`, variables, bare enum variants, tuple-style enum constructors, named-payload enum constructors, payload-binding match arms, named-payload match arms, `Option<T>`, `Result<T, E>`, `Some`, `None`, `Ok`, `Err`, the built-in polymorphic collection helpers `len(...)`, `first(...)`, and `last(...)`, function calls, named struct types, named enum types, tuple types, tuple literals, tuple indexing, map types, map literals, map indexing, array types, array literals, array indexing, borrowed array slice expressions, borrowed slice types, borrowed slices stored inside named structs and enum payloads, borrowed-return aggregates backed by one or more borrowed parameters, struct literals, field access, `+` on `int`/`string`, and scalar comparisons.
-- Stage1 now ships a synthetic standard library surface under the `std/` import prefix. Two modules are landed: `std/time.ax` exposes `now_ms(): int` on top of the `clock_now_ms` intrinsic, and `std/env.ax` exposes `get_env(key: string): Option<string>` on top of the `env_get` intrinsic. Stdlib wrappers are transparent to capability enforcement: importing `std/time.ax` still requires the importing package to declare `[capabilities] clock = true`, and `std/env.ax` still requires `[capabilities] env = true`.
+- Stage1 now ships a synthetic standard library surface under the `std/` import prefix. Three modules are landed: `std/time.ax` exposes `now_ms(): int` on top of the `clock_now_ms` intrinsic, `std/env.ax` exposes `get_env(key: string): Option<string>` on top of the `env_get` intrinsic, and `std/fs.ax` exposes `read_file(path: string): Option<string>` on top of the `fs_read` intrinsic. Stdlib wrappers are transparent to capability enforcement: importing `std/time.ax` still requires `[capabilities] clock = true`, `std/env.ax` still requires `[capabilities] env = true`, and `std/fs.ax` still requires `[capabilities] fs = true`.
 - The pipeline is already split into syntax -> HIR -> MIR -> native build.
 - `axiomc build` emits a native binary by generating a Rust file and invoking `rustc`.
 - A bootstrap ownership rule is active: non-`Copy` values move on binding and call boundaries, non-`Copy` field access, non-`Copy` tuple indexing, non-`Copy` map indexing, and non-`Copy` array indexing conservatively move the owning variable, branch-local moves conservatively propagate after `if` and `match`, statically false `if` / `while` branches are now ignored instead of poisoning later ownership state, and live borrowed slices now block moving their owned collection roots until the borrow scope ends, including when those borrows are wrapped in local tuples, named structs, enum payloads, `Option` / `Result` values, passed through sibling expression evaluation, or introduced by temporary `match` expressions.
@@ -67,7 +67,7 @@ still far from the stated 1.0 target for service and agent workloads.
 
 ### Runtime and standard library gaps
 
-- The AG4.1 stdlib surface is being opened incrementally: `std/time.ax` (`now_ms()`) and `std/env.ax` (`get_env()`) are landed; the remaining AG4.1 modules (`std.io`, `std.fs`, `std.json`, `std.http`, `std.process`, `std.collections`, `std.sync`, `std.crypto.hash`) are still unimplemented.
+- The AG4.1 stdlib surface is being opened incrementally: `std/time.ax` (`now_ms()`), `std/env.ax` (`get_env()`), and `std/fs.ax` (`read_file()`) are landed; the remaining AG4.1 modules (`std.io`, `std.json`, `std.http`, `std.process`, `std.collections`, `std.sync`, `std.crypto.hash`) are still unimplemented.
 - Capability enforcement exists for a compiler-known intrinsic slice across all six manifest flags: `fs_read(...)`, `net_resolve(...)`, `process_status(...)`, `env_get(...)`, `clock_now_ms()`, and `crypto_sha256(...)`, and stdlib wrappers preserve that enforcement against the importing package's manifest, but the general stdlib module surface is still mostly empty.
 - No async runtime, channels, cancellation, timers, or service-grade I/O surface exists.
 
@@ -93,11 +93,12 @@ Current proof points:
 - `stage1/examples/capabilities` proves the capability-gated fs/net/env/clock/crypto path, while the Rust suite covers the remaining process intrinsic contract.
 - `stage1/examples/stdlib_time` proves the AG4.1 synthetic stdlib surface: `import "std/time.ax"` brings `now_ms()` into scope and remains subject to the importing package's `[capabilities] clock` flag.
 - `stage1/examples/stdlib_env` extends AG4.1 with `import "std/env.ax"`, bringing `get_env(key)` into scope and staying subject to the importing package's `[capabilities] env` flag.
+- `stage1/examples/stdlib_fs` extends AG4.1 with `import "std/fs.ax"`, bringing `read_file(path)` into scope and staying subject to the importing package's `[capabilities] fs` flag.
 - `stage1/examples/arrays`, `stage1/examples/maps`, `stage1/examples/tuples`,
   and `stage1/examples/structs` cover the current structured-data floor.
 - `stage1/examples/slices`, `stage1/examples/borrowed_shapes`, `stage1/examples/enums`,
   and `stage1/examples/outcomes` cover the current borrow-aware and enum/result floor.
-- `make stage1-test stage1-smoke` now covers all fourteen checked-in stage1 examples.
+- `make stage1-test stage1-smoke` now covers all fifteen checked-in stage1 examples.
 
 Agent-grade compiler milestone summary:
 

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -1327,6 +1327,92 @@ mod tests {
     }
 
     #[test]
+    fn stage1_project_imports_synthetic_stdlib_fs_module() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("stdlib-fs-app");
+        create_project(&project, Some("stdlib-fs-app")).expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            render_manifest_with_capabilities(
+                "stdlib-fs-app",
+                true,
+                false,
+                false,
+                false,
+                false,
+                false,
+            ),
+        )
+        .expect("write manifest");
+        let manifest = load_manifest(&project).expect("load manifest");
+        fs::write(
+            project.join("axiom.lock"),
+            render_lockfile_for_project(&project, &manifest).expect("lockfile"),
+        )
+        .expect("write lockfile");
+        let fixture = project.join("src/fixture.txt");
+        fs::write(&fixture, "hello stdlib fs\n").expect("write fixture");
+        let fixture_literal = fixture.to_string_lossy().replace('\\', "\\\\");
+        let source = format!(
+            "import \"std/fs.ax\"\nmatch read_file(\"{fixture_literal}\") {{\nSome(value) {{\nprint value\n}}\nNone {{\nprint \"missing\"\n}}\n}}\n"
+        );
+        fs::write(project.join("src/main.ax"), &source).expect("write source");
+        fs::write(project.join("src/main_test.ax"), &source).expect("write test");
+        fs::write(project.join("src/main_test.stdout"), "hello stdlib fs\n\n")
+            .expect("write golden");
+
+        let built = build_project(&project).expect("build project");
+        let output = Command::new(&built.binary)
+            .output()
+            .expect("run compiled binary");
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout),
+            "hello stdlib fs\n\n"
+        );
+
+        let tests = run_project_tests(&project).expect("run tests");
+        assert_eq!(tests.passed, 1);
+        assert_eq!(tests.failed, 0);
+    }
+
+    #[test]
+    fn stage1_project_rejects_stdlib_fs_without_fs_capability() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("stdlib-fs-denied");
+        create_project(&project, Some("stdlib-fs-denied")).expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            render_manifest_with_capabilities(
+                "stdlib-fs-denied",
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+            ),
+        )
+        .expect("write manifest");
+        let manifest = load_manifest(&project).expect("load manifest");
+        fs::write(
+            project.join("axiom.lock"),
+            render_lockfile_for_project(&project, &manifest).expect("lockfile"),
+        )
+        .expect("write lockfile");
+        fs::write(
+            project.join("src/main.ax"),
+            "import \"std/fs.ax\"\nmatch read_file(\"x\") {\nSome(v) {\nprint v\n}\nNone {\nprint \"missing\"\n}\n}\n",
+        )
+        .expect("write source");
+
+        let err = check_project(&project).expect_err("expected capability denial");
+        assert!(
+            err.message.contains("requires [capabilities].fs = true"),
+            "unexpected diagnostic: {err:?}",
+        );
+    }
+
+    #[test]
     fn stage1_project_rejects_unknown_stdlib_module() {
         let dir = tempdir().expect("tempdir");
         let project = dir.path().join("stdlib-unknown");

--- a/stage1/crates/axiomc/src/stdlib.rs
+++ b/stage1/crates/axiomc/src/stdlib.rs
@@ -8,9 +8,10 @@
 //! enforcement continues to run against the importing package's manifest via
 //! `hir::lower_with_capabilities`.
 //!
-//! Today this provides `std/time.ax` (`now_ms()` on top of `clock_now_ms`) and
-//! `std/env.ax` (`get_env(key)` on top of `env_get`). Additional AG4.1 modules
-//! land in follow-on slices.
+//! Today this provides `std/time.ax` (`now_ms()` on top of `clock_now_ms`),
+//! `std/env.ax` (`get_env(key)` on top of `env_get`), and `std/fs.ax`
+//! (`read_file(path)` on top of `fs_read`). Additional AG4.1 modules land in
+//! follow-on slices.
 
 use std::path::{Path, PathBuf};
 
@@ -37,6 +38,10 @@ const STDLIB_SOURCES: &[(&str, &str)] = &[
     (
         "env.ax",
         "pub fn get_env(key: string): Option<string> {\nreturn env_get(key)\n}\n",
+    ),
+    (
+        "fs.ax",
+        "pub fn read_file(path: string): Option<string> {\nreturn fs_read(path)\n}\n",
     ),
 ];
 

--- a/stage1/examples/stdlib_fs/axiom.lock
+++ b/stage1/examples/stdlib_fs/axiom.lock
@@ -1,0 +1,6 @@
+version = 1
+
+[[package]]
+name = "stdlib-fs"
+version = "0.1.0"
+source = "path"

--- a/stage1/examples/stdlib_fs/axiom.toml
+++ b/stage1/examples/stdlib_fs/axiom.toml
@@ -1,0 +1,15 @@
+[package]
+name = "stdlib-fs"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = true
+net = false
+process = false
+env = false
+clock = false
+crypto = false

--- a/stage1/examples/stdlib_fs/src/fixture.txt
+++ b/stage1/examples/stdlib_fs/src/fixture.txt
@@ -1,0 +1,1 @@
+hello stdlib_fs

--- a/stage1/examples/stdlib_fs/src/main.ax
+++ b/stage1/examples/stdlib_fs/src/main.ax
@@ -1,0 +1,10 @@
+import "std/fs.ax"
+
+match read_file("stage1/examples/stdlib_fs/src/fixture.txt") {
+Some(value) {
+print value
+}
+None {
+print "missing"
+}
+}

--- a/stage1/examples/stdlib_fs/src/main_test.ax
+++ b/stage1/examples/stdlib_fs/src/main_test.ax
@@ -1,0 +1,10 @@
+import "std/fs.ax"
+
+match read_file("stage1/examples/stdlib_fs/src/fixture.txt") {
+Some(value) {
+print value
+}
+None {
+print "missing"
+}
+}

--- a/stage1/examples/stdlib_fs/src/main_test.stdout
+++ b/stage1/examples/stdlib_fs/src/main_test.stdout
@@ -1,0 +1,2 @@
+hello stdlib_fs
+


### PR DESCRIPTION
## Summary
- Adds `std/fs.ax` as the third AG4.1 synthetic stdlib module, exposing `read_file(path: string): Option<string>` on top of the existing `fs_read` intrinsic.
- Capability enforcement is unchanged: importing `std/fs.ax` still requires the importing package to declare `[capabilities] fs = true`.
- Adds `stage1/examples/stdlib_fs` with a fixture text file as the check/build/run/test proof fixture and wires it into `make stage1-smoke`.

## Test plan
- [x] `cargo test --manifest-path stage1/Cargo.toml` — 125 passed (+2 new stdlib_fs tests)
- [x] `make stage1-smoke` — all fifteen stage1 examples green
- [x] `python3 -m unittest discover` — 128 passed (stage0 unchanged)
- [x] `axiomc test stage1/examples/stdlib_fs --json` — one golden test passes
- [x] Negative test: manifest without `fs = true` fails with `requires [capabilities].fs = true`

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)