### PR TITLE
Improve stage0 diagnostics and import ergonomics

### DIFF
--- a/axiom/checker.py
+++ b/axiom/checker.py
@@ -40,6 +40,7 @@ from .semantic_plan import (
     SemanticPlan,
     build_semantic_plan,
 )
+from .suggestions import suggestion_suffix
 from .values import ValueKind
 
 
@@ -270,7 +271,11 @@ class Checker:
         result = self._try_resolve_var_type(name)
         if result is not None:
             return result
-        raise AxiomCompileError(f"undefined variable {name!r}", span)
+        raise AxiomCompileError(
+            f"undefined variable {name!r}"
+            f"{suggestion_suffix(name, self._visible_types().keys())}",
+            span,
+        )
 
     def _try_resolve_function(self, fn_name: str) -> Optional[str]:
         if fn_name.startswith("host."):
@@ -285,7 +290,18 @@ class Checker:
         resolved = self._try_resolve_function(fn_name)
         if resolved is not None:
             return resolved
-        raise AxiomCompileError(f"undefined function {fn_name!r}", span)
+        raise AxiomCompileError(
+            f"undefined function {fn_name!r}"
+            f"{suggestion_suffix(fn_name, self._visible_functions())}",
+            span,
+        )
+
+    def _visible_functions(self) -> List[str]:
+        visible: set[str] = set()
+        for scope in self.function_scope_stack:
+            visible.update(scope.keys())
+        visible.update(self.function_defs.keys())
+        return sorted(visible)
 
     def _check_expr_expecting(self, expr: Expr, expected: TypeName) -> TypeName:
         """Check expr, using expected as a hint for empty array literals."""
@@ -401,7 +417,11 @@ class Checker:
         host_fn = fn_name[len("host.") :]
         builtin = HOST_BUILTINS.get(host_fn)
         if builtin is None:
-            raise AxiomCompileError(f"undefined host function {fn_name!r}", expr.span)
+            raise AxiomCompileError(
+                f"undefined host function {fn_name!r}"
+                f"{suggestion_suffix(host_fn, HOST_BUILTINS.keys())}",
+                expr.span,
+            )
         if self.allowed_host_calls is not None and host_fn not in self.allowed_host_calls:
             raise AxiomCompileError(
                 f"host call {fn_name!r} is not permitted by package policy",
@@ -454,7 +474,13 @@ class Checker:
                 # Try resolving as a first-class function reference.
                 fn_name = self._try_resolve_function(expr.name)
                 if fn_name is None:
-                    raise AxiomCompileError(f"undefined variable {expr.name!r}", expr.span)
+                    candidates = set(self._visible_types().keys())
+                    candidates.update(self._visible_functions())
+                    raise AxiomCompileError(
+                        f"undefined variable {expr.name!r}"
+                        f"{suggestion_suffix(expr.name, candidates)}",
+                        expr.span,
+                    )
                 if fn_name not in self.function_signatures:
                     raise AxiomCompileError(
                         f"function {expr.name!r} used before its signature was resolved",

--- a/axiom/compiler.py
+++ b/axiom/compiler.py
@@ -36,6 +36,7 @@ from .semantic_plan import (
     SemanticPlan,
     build_semantic_plan,
 )
+from .suggestions import suggestion_suffix
 
 
 @dataclass(frozen=True)
@@ -249,7 +250,12 @@ class Compiler:
                 return scope[name], True
         source = self._parent_bindings.get(name)
         if source is None:
-            raise AxiomCompileError(f"undefined variable {name!r}", span)
+            candidates = set(self._visible_bindings().keys())
+            candidates.update(self._visible_functions())
+            raise AxiomCompileError(
+                f"undefined variable {name!r}{suggestion_suffix(name, candidates)}",
+                span,
+            )
         return source.index, False
 
     def _alloc_temp_slot(self) -> int:
@@ -418,8 +424,12 @@ class Compiler:
                 # Function reference — push a FunctionValue onto the stack.
                 fn_name = self._try_resolve_function(expr.name)
                 if fn_name is None or fn_name not in self.function_ids:
+                    candidates = set(self._visible_bindings().keys())
+                    candidates.update(self._visible_functions())
                     raise AxiomCompileError(
-                        f"undefined variable or function {expr.name!r}", expr.span
+                        f"undefined variable or function {expr.name!r}"
+                        f"{suggestion_suffix(expr.name, candidates)}",
+                        expr.span,
                     )
                 out.append(Instr(Op.LOAD_FN, self.function_ids[fn_name]))
             return
@@ -509,4 +519,15 @@ class Compiler:
         resolved = self._try_resolve_function(fn_name)
         if resolved is not None:
             return resolved
-        raise AxiomCompileError(f"undefined function {fn_name!r}", span)
+        raise AxiomCompileError(
+            f"undefined function {fn_name!r}"
+            f"{suggestion_suffix(fn_name, self._visible_functions())}",
+            span,
+        )
+
+    def _visible_functions(self) -> List[str]:
+        visible: set[str] = set()
+        for scope in self.function_scope_stack:
+            visible.update(scope.keys())
+        visible.update(self.function_defs.keys())
+        return sorted(visible)

--- a/axiom/interpreter.py
+++ b/axiom/interpreter.py
@@ -35,6 +35,7 @@ from .semantic_plan import (
     SemanticPlan,
     build_semantic_plan,
 )
+from .suggestions import suggestion_suffix
 from .values import (
     FunctionValue,
     Value,
@@ -96,7 +97,23 @@ class Interpreter:
             resolved = self.semantic_plan.resolve_function(name, self.function_scope_stack)
             if resolved is not None:
                 return resolved
-        raise AxiomRuntimeError(f"undefined function {name!r}")
+        raise AxiomRuntimeError(
+            f"undefined function {name!r}"
+            f"{suggestion_suffix(name, self._visible_functions())}"
+        )
+
+    def _visible_functions(self) -> List[str]:
+        visible: set[str] = set()
+        for scope in self.function_scope_stack:
+            visible.update(scope.keys())
+        visible.update(self.functions.keys())
+        return sorted(visible)
+
+    def _visible_variables(self) -> List[str]:
+        visible: set[str] = set()
+        for scope in self.scopes:
+            visible.update(scope.keys())
+        return sorted(visible)
 
     def _exec_stmt(self, stmt, out: TextIO) -> None:
         if isinstance(stmt, LetStmt):
@@ -170,7 +187,11 @@ class Interpreter:
         for scope in reversed(self.scopes):
             if name in scope:
                 return scope[name]
-        raise AxiomRuntimeError(f"undefined variable {name!r}", span)
+        raise AxiomRuntimeError(
+            f"undefined variable {name!r}"
+            f"{suggestion_suffix(name, self._visible_variables())}",
+            span,
+        )
 
     def _assign(self, name: str, value: Value, span) -> None:
         if name in RESERVED_IDENTIFIER_NAMES:
@@ -179,7 +200,11 @@ class Interpreter:
             if name in scope:
                 scope[name] = value
                 return
-        raise AxiomRuntimeError(f"undefined variable {name!r}", span)
+        raise AxiomRuntimeError(
+            f"undefined variable {name!r}"
+            f"{suggestion_suffix(name, self._visible_variables())}",
+            span,
+        )
 
     def _call(self, fn_name: str, args: List[Value], out: TextIO) -> Value:
         if fn_name.startswith("host."):
@@ -230,7 +255,10 @@ class Interpreter:
         host_name = fn_name[len("host.") :]
         builtin = HOST_BUILTINS.get(host_name)
         if builtin is None:
-            raise AxiomRuntimeError(f"undefined host function {fn_name!r}")
+            raise AxiomRuntimeError(
+                f"undefined host function {fn_name!r}"
+                f"{suggestion_suffix(host_name, HOST_BUILTINS.keys())}"
+            )
         if builtin.arity != len(args):
             raise AxiomRuntimeError(
                 f"host function {fn_name!r} expects {builtin.arity} args, got {len(args)}"
@@ -260,7 +288,13 @@ class Interpreter:
                 fn_name = self._resolve_function(expr.name)
                 return FunctionValue(fn_name)
             except AxiomRuntimeError:
-                raise AxiomRuntimeError(f"undefined variable {expr.name!r}", expr.span)
+                candidates = set(self._visible_variables())
+                candidates.update(self._visible_functions())
+                raise AxiomRuntimeError(
+                    f"undefined variable {expr.name!r}"
+                    f"{suggestion_suffix(expr.name, candidates)}",
+                    expr.span,
+                )
         if isinstance(expr, CallExpr):
             args = [self._eval(arg, out) for arg in expr.args]
             # If callee is a fn-typed local variable, call through it.

--- a/axiom/loader.py
+++ b/axiom/loader.py
@@ -29,6 +29,7 @@ from .ast import (
 from .errors import AxiomCompileError, AxiomError, Span
 from .lexer import Lexer
 from .parser import Parser
+from .suggestions import import_path_candidates, suggestion_suffix
 
 
 def parse_program(src: str, path: Path | str | None = None) -> Program:
@@ -56,6 +57,7 @@ class ModuleLoader:
     module_search_paths: Optional[Sequence[Path]] = None
     seen: Set[Path] = field(default_factory=set)
     loading: Set[Path] = field(default_factory=set)
+    loading_stack: List[Path] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         self.module_search_paths = normalize_module_search_paths(self.module_search_paths)
@@ -75,26 +77,29 @@ class ModuleLoader:
             return Program(stmts=[])
 
         if path in self.loading:
+            message = self._circular_import_message(path)
             if import_span is not None and import_source is not None and importer_path is not None:
                 raise AxiomCompileError(
-                    f"circular import of {path}",
+                    message,
                     import_span,
                     source=import_source,
                     path=str(importer_path),
                 )
-            raise AxiomCompileError(f"circular import of {path}")
+            raise AxiomCompileError(message)
 
         if not path.exists():
+            message = self._missing_import_message(path)
             if import_span is not None and import_source is not None and importer_path is not None:
                 raise AxiomCompileError(
-                    f"cannot resolve import file {path}",
+                    message,
                     import_span,
                     source=import_source,
                     path=str(importer_path),
                 )
-            raise AxiomCompileError(f"cannot resolve import file {path}")
+            raise AxiomCompileError(message)
 
         self.loading.add(path)
+        self.loading_stack.append(path)
         try:
             src = path.read_text(encoding="utf-8")
             program = parse_program(src, path=path)
@@ -147,6 +152,10 @@ class ModuleLoader:
             )
             raise
         finally:
+            if self.loading_stack and self.loading_stack[-1] == path:
+                self.loading_stack.pop()
+            else:
+                self.loading_stack = [item for item in self.loading_stack if item != path]
             self.loading.discard(path)
 
         self.seen.add(path)
@@ -166,12 +175,42 @@ class ModuleLoader:
 
         search_paths = [base_path.parent]
         search_paths.extend(self.module_search_paths or [])
+        searched_locations: List[str] = []
 
         for root in search_paths:
             candidate_path = root / candidate
+            searched_locations.append(str(candidate_path))
             if candidate_path.exists():
                 return candidate_path
-        raise AxiomCompileError(f"cannot resolve import file {candidate}")
+        raise AxiomCompileError(
+            self._missing_import_message(
+                candidate,
+                searched_locations=searched_locations,
+                search_paths=search_paths,
+            )
+        )
+
+    def _circular_import_message(self, path: Path) -> str:
+        cycle_start = 0
+        if path in self.loading_stack:
+            cycle_start = self.loading_stack.index(path)
+        chain = self.loading_stack[cycle_start:] + [path]
+        rendered = " -> ".join(item.name for item in chain)
+        return f"circular import of {path}; cycle: {rendered}"
+
+    def _missing_import_message(
+        self,
+        path: Path,
+        *,
+        searched_locations: Optional[Sequence[str]] = None,
+        search_paths: Optional[Sequence[Path]] = None,
+    ) -> str:
+        message = f"cannot resolve import file {path}"
+        if searched_locations:
+            message += f"; searched: {', '.join(searched_locations)}"
+        if search_paths:
+            message += suggestion_suffix(path.stem, import_path_candidates(search_paths))
+        return message
 
 
 def load_program_file(

--- a/axiom/parser.py
+++ b/axiom/parser.py
@@ -33,6 +33,7 @@ from .ast import (
     expr_span,
 )
 from .errors import Span, AxiomParseError
+from .suggestions import suggestion_suffix
 from .token import Token, TokenKind
 
 
@@ -453,7 +454,8 @@ class Parser:
         raw_name = str(token.value)
         if raw_name not in {"int", "string", "bool"}:
             raise AxiomParseError(
-                f"unknown type {raw_name!r}",
+                f"unknown type {raw_name!r}"
+                f"{suggestion_suffix(raw_name, ('int', 'string', 'bool'))}",
                 token.span,
                 source=self.source,
                 path=self.source_path,

--- a/axiom/suggestions.py
+++ b/axiom/suggestions.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from difflib import get_close_matches
+from pathlib import Path
+from typing import Iterable, Sequence
+
+
+def best_match(name: str, candidates: Iterable[str], *, cutoff: float = 0.6) -> str | None:
+    unique = sorted({candidate for candidate in candidates if candidate and candidate != name})
+    matches = get_close_matches(name, unique, n=1, cutoff=cutoff)
+    if not matches:
+        return None
+    return matches[0]
+
+
+def suggestion_suffix(name: str, candidates: Iterable[str], *, cutoff: float = 0.6) -> str:
+    match = best_match(name, candidates, cutoff=cutoff)
+    if match is None:
+        return ""
+    return f"; did you mean {match!r}?"
+
+
+def import_path_candidates(search_paths: Sequence[Path]) -> list[str]:
+    candidates: set[str] = set()
+    for root in search_paths:
+        if not root.exists() or not root.is_dir():
+            continue
+        for entry in root.iterdir():
+            if not entry.is_file() or entry.suffix.lower() != ".ax":
+                continue
+            candidates.add(entry.name)
+            candidates.add(entry.stem)
+    return sorted(candidates)

--- a/tests/test_errors_core.py
+++ b/tests/test_errors_core.py
@@ -54,6 +54,18 @@ print x
         with self.assertRaises(AxiomCompileError):
             compile_to_bytecode("print unknown(1)\n")
 
+    def test_compile_undefined_function_suggests_close_match(self) -> None:
+        src = """
+fn answer(value: int): int {
+  return value + 1
+}
+
+print anser(41)
+"""
+        with self.assertRaises(AxiomCompileError) as cm:
+            compile_to_bytecode(src)
+        self.assertIn("did you mean 'answer'?", str(cm.exception))
+
     def test_parse_reserved_host_function_name(self) -> None:
         with self.assertRaises(AxiomParseError):
             compile_to_bytecode(
@@ -220,6 +232,29 @@ print counter()
     def test_compile_unknown_host_function(self) -> None:
         with self.assertRaises(AxiomCompileError):
             compile_to_bytecode("host.unknown(1)\n")
+
+    def test_compile_unknown_host_function_suggests_close_match(self) -> None:
+        with self.assertRaises(AxiomCompileError) as cm:
+            compile_to_bytecode("print host.abx(-5)\n")
+        self.assertIn("did you mean 'abs'?", str(cm.exception))
+
+    def test_compile_unknown_type_suggests_close_match(self) -> None:
+        with self.assertRaises(AxiomParseError) as cm:
+            compile_to_bytecode("let ready: boool = true\n")
+        self.assertIn("did you mean 'bool'?", str(cm.exception))
+
+    def test_compile_undefined_variable_suggests_close_match(self) -> None:
+        src = """
+fn main(): int {
+  let answer: int = 41
+  return asnwer + 1
+}
+
+print main()
+"""
+        with self.assertRaises(AxiomCompileError) as cm:
+            compile_to_bytecode(src)
+        self.assertIn("did you mean 'answer'?", str(cm.exception))
 
     def test_host_registry_duplicate_name(self) -> None:
         def noop(args: list[int], _out) -> int:

--- a/tests/test_errors_imports.py
+++ b/tests/test_errors_imports.py
@@ -153,6 +153,19 @@ class ImportErrorTests(unittest.TestCase):
             self.assertIn("main.ax:1", msg)
             self.assertIn('import "missing.ax"', msg)
             self.assertIn("^", msg)
+            self.assertIn("searched:", msg)
+
+    def test_compile_missing_import_suggests_close_match(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            root.joinpath("metrics.ax").write_text(
+                "fn ready(): int { return 1 }\n",
+                encoding="utf-8",
+            )
+            root.joinpath("main.ax").write_text('import "metric"\n', encoding="utf-8")
+            with self.assertRaises(AxiomCompileError) as cm:
+                compile_file(root / "main.ax")
+            self.assertIn("did you mean 'metrics'?", str(cm.exception))
 
     def test_compile_circular_import(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -163,6 +176,7 @@ class ImportErrorTests(unittest.TestCase):
                 compile_file(root / "a.ax")
             msg = str(cm.exception)
             self.assertIn("circular import", msg)
+            self.assertIn("cycle: a.ax -> b.ax -> a.ax", msg)
             self.assertIn("b.ax:1", msg)
             self.assertIn('import "a"', msg)
             self.assertIn("^", msg)


### PR DESCRIPTION
## Summary
- add did-you-mean suggestions for undefined variables, functions, host calls, and type names
- make missing-import diagnostics list searched paths and suggest close module names
- include explicit import-cycle chains in circular-import errors with new regression coverage

## Testing
- .venv/bin/python -m unittest tests.test_errors_core tests.test_errors_imports -v
- .venv/bin/python -m ruff check axiom tests
- .venv/bin/python -m unittest discover -v

Closes #103
Closes #104