### PR TITLE
Tighten stage1 JSON contract and tooling flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,14 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Run tests
         run: python -m unittest discover -v
+
+  test_stage1_hosted:
+    name: test (stage1 rust hosted)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Run stage1 crate tests
+        run: make stage1-test
+      - name: Run stage1 smoke tests
+        run: make stage1-smoke

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/examples/mo
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/examples/packages --json
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/examples/workspace --json
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/examples/capabilities --json
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/examples/workspace --filter core --json
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build stage1/examples/hello --target "$(rustc -vV | sed -n 's/^host: //p')"
 
 # Inspect host capabilities
 python -m axiom host list

--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -26,8 +26,10 @@ stage0/stage1 split that can build a native hello-world and carry the 1.0 packag
 ```bash
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- check stage1/examples/hello --json
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build stage1/examples/hello --json
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build stage1/examples/hello --target "$(rustc -vV | sed -n 's/^host: //p')"
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- run stage1/examples/hello
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/examples/modules --json
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/examples/workspace --filter core --json
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/examples/packages --json
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/examples/workspace --json
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/examples/capabilities --json
@@ -37,7 +39,18 @@ cargo run --manifest-path stage1/Cargo.toml -p axiomc -- caps stage1/examples/he
 `axiomc test` discovers `src/**/*_test.ax` entrypoints by default, builds each test
 as a native artifact, executes it, and compares stdout against a sibling
 `*.stdout` golden file when present. Projects that need explicit naming or inline
-expectations can still declare `[[tests]]` entries in `axiom.toml`.
+expectations can still declare `[[tests]]` entries in `axiom.toml`. The command
+now also accepts `--filter <pattern>` to run a subset of discovered tests by
+test name or entry path.
+
+## JSON contract
+
+`axiomc check --json`, `build --json`, `test --json`, and `caps --json` all now
+emit the versioned schema envelope `schema_version = "axiom.stage1.v1"`.
+Successful payloads always include `ok`, `command`, and `project`, while
+`axiomc test --json` additionally reports `filter` and per-run/per-case
+`duration_ms`. Build payloads report the requested Rust target triple when
+`--target <triple>` is used.
 
 ## Current gaps
 

--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -57,7 +57,9 @@ pub fn render_rust(program: &Program) -> String {
     out.push_str("    use std::io::Write;\n");
     out.push_str("    let stderr = std::io::stderr();\n");
     out.push_str("    let mut handle = stderr.lock();\n");
-    out.push_str("    match handle.write_all(text.as_bytes()).and_then(|_| handle.write_all(b\"\\n\")) {\n");
+    out.push_str(
+        "    match handle.write_all(text.as_bytes()).and_then(|_| handle.write_all(b\"\\n\")) {\n",
+    );
     out.push_str("        Ok(()) => (text.len() as i64) + 1,\n");
     out.push_str("        Err(_) => -1,\n");
     out.push_str("    }\n");
@@ -114,7 +116,9 @@ pub fn render_rust(program: &Program) -> String {
     out.push_str("    let sep = raw.windows(4).position(|w| w == b\"\\r\\n\\r\\n\")?;\n");
     out.push_str("    let head = &raw[..sep];\n");
     out.push_str("    let body = &raw[sep + 4..];\n");
-    out.push_str("    let status_line_end = head.iter().position(|b| *b == b'\\r').unwrap_or(head.len());\n");
+    out.push_str(
+        "    let status_line_end = head.iter().position(|b| *b == b'\\r').unwrap_or(head.len());\n",
+    );
     out.push_str("    let status_line = std::str::from_utf8(&head[..status_line_end]).ok()?;\n");
     out.push_str("    let mut parts = status_line.splitn(3, ' ');\n");
     out.push_str("    let _version = parts.next()?;\n");
@@ -882,12 +886,21 @@ impl crate::mir::CompareOp {
     }
 }
 
-pub fn compile_native(generated_rust: &Path, binary_path: &Path) -> Result<(), Diagnostic> {
-    let status = Command::new("rustc")
+pub fn compile_native(
+    generated_rust: &Path,
+    binary_path: &Path,
+    target: Option<&str>,
+) -> Result<(), Diagnostic> {
+    let mut command = Command::new("rustc");
+    command
         .arg("--crate-name")
         .arg("axiom_stage1_bootstrap")
         .arg("--edition=2024")
-        .arg("-O")
+        .arg("-O");
+    if let Some(target) = target {
+        command.arg("--target").arg(target);
+    }
+    let status = command
         .arg(generated_rust)
         .arg("-o")
         .arg(binary_path)

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -1400,7 +1400,10 @@ fn lower_expr_with_expected(
                 if lowered.ty() != &Type::String {
                     return Err(Diagnostic::new(
                         "type",
-                        format!("io_eprintln expects a string argument, got {}", lowered.ty()),
+                        format!(
+                            "io_eprintln expects a string argument, got {}",
+                            lowered.ty()
+                        ),
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }

--- a/stage1/crates/axiomc/src/json_contract.rs
+++ b/stage1/crates/axiomc/src/json_contract.rs
@@ -1,0 +1,72 @@
+use crate::diagnostics::Diagnostic;
+use crate::manifest::CapabilityDescriptor;
+use crate::project::{BuildOutput, CheckOutput, TestOutput};
+use serde_json::{Value, json};
+use std::path::Path;
+
+pub const JSON_SCHEMA_VERSION: &str = "axiom.stage1.v1";
+
+pub fn check_success(project: &Path, output: &CheckOutput) -> Value {
+    json!({
+        "schema_version": JSON_SCHEMA_VERSION,
+        "ok": true,
+        "command": "check",
+        "project": project.display().to_string(),
+        "manifest": output.manifest,
+        "entry": output.entry,
+        "statement_count": output.statement_count,
+        "capabilities": output.capabilities,
+        "packages": output.packages,
+    })
+}
+
+pub fn build_success(project: &Path, output: &BuildOutput) -> Value {
+    json!({
+        "schema_version": JSON_SCHEMA_VERSION,
+        "ok": true,
+        "command": "build",
+        "project": project.display().to_string(),
+        "manifest": output.manifest,
+        "entry": output.entry,
+        "binary": output.binary,
+        "generated_rust": output.generated_rust,
+        "statement_count": output.statement_count,
+        "target": output.target,
+        "packages": output.packages,
+    })
+}
+
+pub fn test_success(project: &Path, filter: Option<&str>, output: &TestOutput) -> Value {
+    json!({
+        "schema_version": JSON_SCHEMA_VERSION,
+        "ok": output.failed == 0,
+        "command": "test",
+        "project": project.display().to_string(),
+        "manifest": output.manifest,
+        "packages": output.packages,
+        "filter": filter,
+        "passed": output.passed,
+        "failed": output.failed,
+        "duration_ms": output.duration_ms,
+        "cases": output.cases,
+    })
+}
+
+pub fn caps_success(project: &Path, capabilities: &[CapabilityDescriptor]) -> Value {
+    json!({
+        "schema_version": JSON_SCHEMA_VERSION,
+        "ok": true,
+        "command": "caps",
+        "project": project.display().to_string(),
+        "capabilities": capabilities,
+    })
+}
+
+pub fn error(command: &str, error: &Diagnostic) -> Value {
+    json!({
+        "schema_version": JSON_SCHEMA_VERSION,
+        "ok": false,
+        "command": command,
+        "error": error,
+    })
+}

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod codegen;
 pub mod diagnostics;
 pub mod hir;
+pub mod json_contract;
 pub mod lockfile;
 pub mod manifest;
 pub mod mir;
@@ -13,11 +14,15 @@ pub mod syntax;
 mod tests {
     use crate::codegen::render_rust;
     use crate::hir;
+    use crate::json_contract;
     use crate::lockfile::{render_lockfile, render_lockfile_for_project};
     use crate::manifest::{TestTarget, capability_descriptors, load_manifest, render_manifest};
     use crate::mir;
     use crate::new_project::create_project;
-    use crate::project::{build_project, check_project, project_capabilities, run_project_tests};
+    use crate::project::{
+        BuildOptions, TestOptions, build_project, build_project_with_options, check_project,
+        project_capabilities, run_project_tests, run_project_tests_with_options,
+    };
     use crate::syntax::parse_program;
     use std::fs;
     use std::path::Path;
@@ -58,6 +63,20 @@ mod tests {
             fs::set_permissions(&path, permissions).expect("chmod process fixture");
             path.to_string_lossy().into_owned()
         }
+    }
+
+    fn rust_host_target() -> String {
+        let output = Command::new("rustc")
+            .arg("-vV")
+            .output()
+            .expect("run rustc -vV");
+        assert!(output.status.success(), "rustc -vV failed");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        stdout
+            .lines()
+            .find_map(|line| line.strip_prefix("host: "))
+            .map(str::to_string)
+            .expect("host target")
     }
 
     #[test]
@@ -1242,8 +1261,7 @@ mod tests {
 
         let err = check_project(&project).expect_err("expected capability denial");
         assert!(
-            err.message
-                .contains("requires [capabilities].clock = true"),
+            err.message.contains("requires [capabilities].clock = true"),
             "unexpected diagnostic: {err:?}",
         );
     }
@@ -1484,7 +1502,8 @@ mod tests {
 
         let err = check_project(&project).expect_err("expected capability denial");
         assert!(
-            err.message.contains("requires [capabilities].process = true"),
+            err.message
+                .contains("requires [capabilities].process = true"),
             "unexpected diagnostic: {err:?}",
         );
     }
@@ -1568,7 +1587,8 @@ mod tests {
 
         let err = check_project(&project).expect_err("expected capability denial");
         assert!(
-            err.message.contains("requires [capabilities].crypto = true"),
+            err.message
+                .contains("requires [capabilities].crypto = true"),
             "unexpected diagnostic: {err:?}",
         );
     }
@@ -1676,8 +1696,7 @@ mod tests {
             render_lockfile_for_project(&project, &manifest).expect("lockfile"),
         )
         .expect("write lockfile");
-        let source =
-            "import \"std/io.ax\"\nlet n: int = eprintln(\"hello stderr\")\nprint n > 0\n";
+        let source = "import \"std/io.ax\"\nlet n: int = eprintln(\"hello stderr\")\nprint n > 0\n";
         fs::write(project.join("src/main.ax"), source).expect("write source");
         fs::write(project.join("src/main_test.ax"), source).expect("write test");
         fs::write(project.join("src/main_test.stdout"), "true\n").expect("write golden");
@@ -3204,7 +3223,137 @@ mod tests {
             "let running: bool = true\nwhile running {\nlet inner: string = \"fresh\"\nlet sink: string = inner\nprint sink\n}\n",
         )
         .expect("write source");
-        check_project(&project)
-            .expect("moving loop-local values should be allowed");
+        check_project(&project).expect("moving loop-local values should be allowed");
+    }
+
+    #[test]
+    fn build_project_records_requested_target_triple() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("targeted-build");
+        create_project(&project, Some("targeted-build-app")).expect("create project");
+
+        let target = rust_host_target();
+        let output = build_project_with_options(
+            &project,
+            &BuildOptions {
+                target: Some(target.clone()),
+            },
+        )
+        .expect("build project with explicit target");
+
+        assert_eq!(output.target.as_deref(), Some(target.as_str()));
+        assert!(project.join("dist/targeted-build-app").exists());
+    }
+
+    #[test]
+    fn run_project_tests_supports_name_filtering() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("filtered-tests");
+        create_project(&project, Some("filtered-tests-app")).expect("create project");
+        fs::write(project.join("src/math_test.ax"), "print 42\n").expect("write filtered test");
+        fs::write(project.join("src/math_test.stdout"), "42\n").expect("write filtered stdout");
+
+        let output = run_project_tests_with_options(
+            &project,
+            &TestOptions {
+                filter: Some(String::from("math")),
+            },
+        )
+        .expect("run filtered tests");
+
+        assert_eq!(output.passed, 1);
+        assert_eq!(output.failed, 0);
+        assert_eq!(output.cases.len(), 1);
+        assert_eq!(output.cases[0].name, "src/math_test");
+        assert!(output.duration_ms > 0 || output.cases[0].duration_ms <= output.duration_ms);
+    }
+
+    #[test]
+    fn json_contract_check_payload_is_versioned() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("json-check");
+        create_project(&project, Some("json-check-app")).expect("create project");
+        let output = check_project(&project).expect("check project");
+
+        let payload = json_contract::check_success(&project, &output);
+        assert_eq!(
+            payload["schema_version"],
+            json_contract::JSON_SCHEMA_VERSION
+        );
+        assert_eq!(payload["command"], "check");
+        assert_eq!(payload["ok"], true);
+        assert!(payload["packages"].is_array());
+    }
+
+    #[test]
+    fn json_contract_build_payload_includes_target() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("json-build");
+        create_project(&project, Some("json-build-app")).expect("create project");
+        let output = build_project_with_options(
+            &project,
+            &BuildOptions {
+                target: Some(rust_host_target()),
+            },
+        )
+        .expect("build project");
+
+        let payload = json_contract::build_success(&project, &output);
+        assert_eq!(
+            payload["schema_version"],
+            json_contract::JSON_SCHEMA_VERSION
+        );
+        assert_eq!(payload["command"], "build");
+        assert!(payload["target"].is_string());
+    }
+
+    #[test]
+    fn json_contract_test_payload_includes_filter_and_duration() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("json-test");
+        create_project(&project, Some("json-test-app")).expect("create project");
+
+        let output = run_project_tests_with_options(
+            &project,
+            &TestOptions {
+                filter: Some(String::from("main")),
+            },
+        )
+        .expect("test project");
+        let payload = json_contract::test_success(&project, Some("main"), &output);
+
+        assert_eq!(
+            payload["schema_version"],
+            json_contract::JSON_SCHEMA_VERSION
+        );
+        assert_eq!(payload["command"], "test");
+        assert_eq!(payload["filter"], "main");
+        assert!(payload["duration_ms"].is_u64());
+    }
+
+    #[test]
+    fn json_contract_caps_and_error_payloads_are_versioned() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("json-caps");
+        create_project(&project, Some("json-caps-app")).expect("create project");
+        let caps = project_capabilities(&project).expect("project capabilities");
+
+        let caps_payload = json_contract::caps_success(&project, &caps);
+        assert_eq!(
+            caps_payload["schema_version"],
+            json_contract::JSON_SCHEMA_VERSION
+        );
+        assert_eq!(caps_payload["command"], "caps");
+        assert_eq!(caps_payload["ok"], true);
+
+        let error = crate::diagnostics::Diagnostic::new("test", "boom");
+        let error_payload = json_contract::error("test", &error);
+        assert_eq!(
+            error_payload["schema_version"],
+            json_contract::JSON_SCHEMA_VERSION
+        );
+        assert_eq!(error_payload["command"], "test");
+        assert_eq!(error_payload["ok"], false);
+        assert_eq!(error_payload["error"]["message"], "boom");
     }
 }

--- a/stage1/crates/axiomc/src/main.rs
+++ b/stage1/crates/axiomc/src/main.rs
@@ -1,10 +1,11 @@
 use axiomc::diagnostics::Diagnostic;
+use axiomc::json_contract;
 use axiomc::new_project::create_project;
 use axiomc::project::{
-    build_project, check_project, project_capabilities, run_project, run_project_tests,
+    BuildOptions, TestOptions, build_project_with_options, check_project, project_capabilities,
+    run_project, run_project_tests_with_options,
 };
 use clap::{Parser, Subcommand};
-use serde_json::json;
 use std::path::PathBuf;
 
 #[derive(Debug, Parser)]
@@ -30,6 +31,8 @@ enum Command {
         path: PathBuf,
         #[arg(long)]
         json: bool,
+        #[arg(long)]
+        target: Option<String>,
     },
     Run {
         path: PathBuf,
@@ -38,6 +41,8 @@ enum Command {
         path: PathBuf,
         #[arg(long)]
         json: bool,
+        #[arg(long)]
+        filter: Option<String>,
     },
     Caps {
         path: Option<PathBuf>,
@@ -54,78 +59,48 @@ fn main() {
                 println!("initialized stage1 project in {}", path.display());
                 0
             }
-            Err(error) => print_error(error, false),
+            Err(error) => print_error("new", error, false),
         },
         Command::Check { path, json } => match check_project(&path) {
             Ok(output) => {
                 if json {
-                    println!(
-                        "{}",
-                        serde_json::to_string(&json!({
-                            "ok": true,
-                            "command": "check",
-                            "project": path.display().to_string(),
-                            "manifest": output.manifest,
-                            "entry": output.entry,
-                            "statement_count": output.statement_count,
-                            "capabilities": output.capabilities,
-                            "packages": output.packages,
-                        }))
-                        .expect("json")
-                    );
+                    println!("{}", json_contract::check_success(&path, &output));
                 } else {
                     eprintln!("OK");
                 }
                 0
             }
-            Err(error) => print_error(error, json),
+            Err(error) => print_error("check", error, json),
         },
-        Command::Build { path, json } => match build_project(&path) {
-            Ok(output) => {
-                if json {
-                    println!(
-                        "{}",
-                        serde_json::to_string(&json!({
-                            "ok": true,
-                            "command": "build",
-                            "project": path.display().to_string(),
-                            "manifest": output.manifest,
-                            "entry": output.entry,
-                            "binary": output.binary,
-                            "generated_rust": output.generated_rust,
-                            "statement_count": output.statement_count,
-                            "packages": output.packages,
-                        }))
-                        .expect("json")
-                    );
-                } else {
-                    eprintln!("wrote {}", output.binary);
+        Command::Build { path, json, target } => {
+            match build_project_with_options(&path, &BuildOptions { target }) {
+                Ok(output) => {
+                    if json {
+                        println!("{}", json_contract::build_success(&path, &output));
+                    } else {
+                        eprintln!("wrote {}", output.binary);
+                    }
+                    0
                 }
-                0
+                Err(error) => print_error("build", error, json),
             }
-            Err(error) => print_error(error, json),
-        },
+        }
         Command::Run { path } => match run_project(&path) {
             Ok(code) => code,
-            Err(error) => print_error(error, false),
+            Err(error) => print_error("run", error, false),
         },
-        Command::Test { path, json } => match run_project_tests(&path) {
+        Command::Test { path, json, filter } => match run_project_tests_with_options(
+            &path,
+            &TestOptions {
+                filter: filter.clone(),
+            },
+        ) {
             Ok(output) => {
                 let ok = output.failed == 0;
                 if json {
                     println!(
                         "{}",
-                        serde_json::to_string(&json!({
-                            "ok": ok,
-                            "command": "test",
-                            "project": path.display().to_string(),
-                            "manifest": output.manifest,
-                            "packages": output.packages,
-                            "passed": output.passed,
-                            "failed": output.failed,
-                            "cases": output.cases,
-                        }))
-                        .expect("json")
+                        json_contract::test_success(&path, filter.as_deref(), &output)
                     );
                 } else {
                     for case in &output.cases {
@@ -134,47 +109,39 @@ fn main() {
                         if let Some(error) = &case.error {
                             eprintln!("  {}", error);
                         }
+                        eprintln!("  duration: {} ms", case.duration_ms);
                     }
-                    eprintln!("passed: {} failed: {}", output.passed, output.failed);
+                    eprintln!(
+                        "passed: {} failed: {} duration: {} ms",
+                        output.passed, output.failed, output.duration_ms
+                    );
                 }
                 if ok { 0 } else { 1 }
             }
-            Err(error) => print_error(error, json),
+            Err(error) => print_error("test", error, json),
         },
         Command::Caps { path, json } => {
             let project = path.unwrap_or_else(|| PathBuf::from("."));
             match project_capabilities(&project) {
                 Ok(capabilities) => {
-                    let payload = json!({
-                        "ok": true,
-                        "command": "caps",
-                        "project": project.display().to_string(),
-                        "capabilities": capabilities,
-                    });
                     if json {
-                        println!("{}", serde_json::to_string(&payload).expect("json"));
+                        println!("{}", json_contract::caps_success(&project, &capabilities));
                     } else {
+                        let payload = json_contract::caps_success(&project, &capabilities);
                         println!("{}", serde_json::to_string_pretty(&payload).expect("json"));
                     }
                     0
                 }
-                Err(error) => print_error(error, json),
+                Err(error) => print_error("caps", error, json),
             }
         }
     };
     std::process::exit(code);
 }
 
-fn print_error(error: Diagnostic, json: bool) -> i32 {
+fn print_error(command: &str, error: Diagnostic, json: bool) -> i32 {
     if json {
-        println!(
-            "{}",
-            serde_json::to_string(&json!({
-                "ok": false,
-                "error": error,
-            }))
-            .expect("json")
-        );
+        println!("{}", json_contract::error(command, &error));
     } else {
         eprintln!("{error}");
     }

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -15,6 +15,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fs;
 use std::path::{Component, Path, PathBuf};
 use std::process::Command;
+use std::time::Instant;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct CheckedPackage {
@@ -42,6 +43,7 @@ pub struct BuiltPackage {
     pub binary: String,
     pub generated_rust: String,
     pub statement_count: usize,
+    pub target: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -51,6 +53,7 @@ pub struct BuildOutput {
     pub binary: String,
     pub generated_rust: String,
     pub statement_count: usize,
+    pub target: Option<String>,
     pub packages: Vec<BuiltPackage>,
 }
 
@@ -66,6 +69,7 @@ pub struct TestCaseResult {
     pub stdout: String,
     pub stderr: String,
     pub expected_stdout: Option<String>,
+    pub duration_ms: u64,
     pub error: Option<Diagnostic>,
 }
 
@@ -76,6 +80,17 @@ pub struct TestOutput {
     pub cases: Vec<TestCaseResult>,
     pub passed: usize,
     pub failed: usize,
+    pub duration_ms: u64,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct BuildOptions {
+    pub target: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct TestOptions {
+    pub filter: Option<String>,
 }
 
 pub fn check_project(project_root: &Path) -> Result<CheckOutput, Diagnostic> {
@@ -111,6 +126,13 @@ pub fn check_project(project_root: &Path) -> Result<CheckOutput, Diagnostic> {
 }
 
 pub fn build_project(project_root: &Path) -> Result<BuildOutput, Diagnostic> {
+    build_project_with_options(project_root, &BuildOptions::default())
+}
+
+pub fn build_project_with_options(
+    project_root: &Path,
+    options: &BuildOptions,
+) -> Result<BuildOutput, Diagnostic> {
     let project_root = normalize_path(project_root);
     let graph = load_package_graph(&project_root)?;
     let mut packages = Vec::new();
@@ -118,7 +140,7 @@ pub fn build_project(project_root: &Path) -> Result<BuildOutput, Diagnostic> {
         let analyzed = analyze_package(&graph, &package_root)?;
         let generated_rust = generated_rust_path(&package_root, &analyzed.manifest);
         let binary = binary_path(&package_root, &analyzed.manifest);
-        build_artifacts(&analyzed, &generated_rust, &binary)?;
+        build_artifacts(&analyzed, &generated_rust, &binary, options)?;
         packages.push(BuiltPackage {
             package_root: package_root.display().to_string(),
             manifest: manifest_path(&package_root).display().to_string(),
@@ -126,6 +148,7 @@ pub fn build_project(project_root: &Path) -> Result<BuildOutput, Diagnostic> {
             binary: binary.display().to_string(),
             generated_rust: generated_rust.display().to_string(),
             statement_count: analyzed.mir.statement_count(),
+            target: options.target.clone(),
         });
     }
     let root = packages.first().cloned().ok_or_else(|| {
@@ -143,6 +166,7 @@ pub fn build_project(project_root: &Path) -> Result<BuildOutput, Diagnostic> {
         binary: root.binary,
         generated_rust: root.generated_rust,
         statement_count: root.statement_count,
+        target: root.target,
         packages,
     })
 }
@@ -156,15 +180,23 @@ pub fn run_project(project_root: &Path) -> Result<i32, Diagnostic> {
 }
 
 pub fn run_project_tests(project_root: &Path) -> Result<TestOutput, Diagnostic> {
+    run_project_tests_with_options(project_root, &TestOptions::default())
+}
+
+pub fn run_project_tests_with_options(
+    project_root: &Path,
+    options: &TestOptions,
+) -> Result<TestOutput, Diagnostic> {
     let project_root = normalize_path(project_root);
     let graph = load_package_graph(&project_root)?;
     let manifest_path_text = manifest_path(&project_root).display().to_string();
     let mut packages = Vec::new();
     let mut cases = Vec::new();
+    let started = Instant::now();
     for package_root in workspace_package_roots(&graph, &project_root)? {
         let manifest = graph.context(&package_root)?.manifest.clone();
         validate_lockfile(&package_root, &manifest)?;
-        let tests = collect_test_targets(&package_root, &manifest)?;
+        let tests = collect_test_targets(&package_root, &manifest, options.filter.as_deref())?;
         if tests.is_empty() {
             continue;
         }
@@ -188,12 +220,14 @@ pub fn run_project_tests(project_root: &Path) -> Result<TestOutput, Diagnostic> 
         cases,
         passed,
         failed,
+        duration_ms: started.elapsed().as_millis() as u64,
     })
 }
 
 fn collect_test_targets(
     project_root: &Path,
     manifest: &Manifest,
+    filter: Option<&str>,
 ) -> Result<Vec<crate::manifest::TestTarget>, Diagnostic> {
     let mut tests = manifest.tests.clone();
     let mut seen_entries = tests
@@ -204,6 +238,9 @@ fn collect_test_targets(
         if seen_entries.insert(discovered.entry.clone()) {
             tests.push(discovered);
         }
+    }
+    if let Some(filter) = filter {
+        tests.retain(|test| test_matches_filter(test, filter));
     }
     Ok(tests)
 }
@@ -548,6 +585,7 @@ fn build_artifacts(
     analyzed: &AnalyzedProject,
     generated_rust: &Path,
     binary: &Path,
+    options: &BuildOptions,
 ) -> Result<(), Diagnostic> {
     if let Some(parent) = generated_rust.parent() {
         fs::create_dir_all(parent).map_err(|err| {
@@ -572,7 +610,7 @@ fn build_artifacts(
             format!("failed to write {}: {err}", generated_rust.display()),
         )
     })?;
-    compile_native(generated_rust, binary)
+    compile_native(generated_rust, binary, options.target.as_deref())
 }
 
 fn run_test_case(
@@ -581,6 +619,7 @@ fn run_test_case(
     manifest: &Manifest,
     test: &crate::manifest::TestTarget,
 ) -> TestCaseResult {
+    let started = Instant::now();
     let entry_path = project_root.join(&test.entry);
     let generated_rust = test_generated_rust_path(project_root, manifest, &test.name);
     let binary = test_binary_path(project_root, manifest, &test.name);
@@ -598,11 +637,17 @@ fn run_test_case(
                 stdout: String::new(),
                 stderr: String::new(),
                 expected_stdout: test.stdout.clone(),
+                duration_ms: started.elapsed().as_millis() as u64,
                 error: Some(error),
             };
         }
     };
-    if let Err(error) = build_artifacts(&analyzed, &generated_rust, &binary) {
+    if let Err(error) = build_artifacts(
+        &analyzed,
+        &generated_rust,
+        &binary,
+        &BuildOptions::default(),
+    ) {
         return TestCaseResult {
             package_root: project_root.display().to_string(),
             name: test.name.clone(),
@@ -614,6 +659,7 @@ fn run_test_case(
             stdout: String::new(),
             stderr: String::new(),
             expected_stdout: test.stdout.clone(),
+            duration_ms: started.elapsed().as_millis() as u64,
             error: Some(error),
         };
     }
@@ -661,6 +707,7 @@ fn run_test_case(
                 stdout,
                 stderr,
                 expected_stdout: test.stdout.clone(),
+                duration_ms: started.elapsed().as_millis() as u64,
                 error,
             }
         }
@@ -675,6 +722,7 @@ fn run_test_case(
             stdout: String::new(),
             stderr: String::new(),
             expected_stdout: test.stdout.clone(),
+            duration_ms: started.elapsed().as_millis() as u64,
             error: Some(
                 Diagnostic::new(
                     "test",
@@ -756,6 +804,10 @@ fn slugify_test_name(value: &str) -> String {
     } else {
         trimmed.to_string()
     }
+}
+
+fn test_matches_filter(test: &crate::manifest::TestTarget, filter: &str) -> bool {
+    test.name.contains(filter) || test.entry.contains(filter)
 }
 
 fn load_modules(


### PR DESCRIPTION
## Summary
- version the stage1 JSON envelope and cover `check`, `build`, `test`, `caps`, and error payloads with contract tests
- add `axiomc test --filter` with per-case and per-run durations, plus `axiomc build --target <triple>` plumbing
- add a hosted Rust CI job that runs `make stage1-test` and `make stage1-smoke`, and document the new flags/contract

## Testing
- .venv/bin/python -m unittest discover -v
- make stage1-test
- make stage1-smoke

Closes #100
Refs #102
Refs #127
Refs #128