### PR TITLE
Land AG1.2 mutable borrows

### DIFF
--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -48,6 +48,11 @@ pub fn render_rust(program: &Program) -> String {
     out.push_str("    &values[start..end]\n");
     out.push_str("}\n\n");
     out.push_str("#[allow(dead_code)]\n");
+    out.push_str("fn axiom_slice_view_mut<'a, T>(values: &'a mut [T], start: Option<i64>, end: Option<i64>) -> &'a mut [T] {\n");
+    out.push_str("    let (start, end) = axiom_array_slice_bounds(values.len(), start, end);\n");
+    out.push_str("    &mut values[start..end]\n");
+    out.push_str("}\n\n");
+    out.push_str("#[allow(dead_code)]\n");
     out.push_str("fn axiom_last_index(len: usize) -> i64 {\n");
     out.push_str("    assert!(len > 0, \"collection must not be empty\");\n");
     out.push_str("    (len - 1) as i64\n");
@@ -712,20 +717,38 @@ fn render_expr(expr: &Expr) -> String {
                 .unwrap_or_else(|| String::from("None"));
             match base.ty() {
                 Type::Array(_) => {
-                    format!(
-                        "axiom_slice_view(&{}, {}, {})",
-                        render_expr(base),
-                        start,
-                        end
-                    )
+                    if matches!(expr.ty(), Type::MutSlice(_)) {
+                        format!(
+                            "axiom_slice_view_mut(&mut {}, {}, {})",
+                            render_expr(base),
+                            start,
+                            end
+                        )
+                    } else {
+                        format!(
+                            "axiom_slice_view(&{}, {}, {})",
+                            render_expr(base),
+                            start,
+                            end
+                        )
+                    }
                 }
                 Type::Slice(_) | Type::MutSlice(_) => {
-                    format!(
-                        "axiom_slice_view({}, {}, {})",
-                        render_expr(base),
-                        start,
-                        end
-                    )
+                    if matches!(expr.ty(), Type::MutSlice(_)) {
+                        format!(
+                            "axiom_slice_view_mut({}, {}, {})",
+                            render_expr(base),
+                            start,
+                            end
+                        )
+                    } else {
+                        format!(
+                            "axiom_slice_view({}, {}, {})",
+                            render_expr(base),
+                            start,
+                            end
+                        )
+                    }
                 }
                 _ => unreachable!("type checker rejects slicing non-array values"),
             }

--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -57,7 +57,9 @@ pub fn render_rust(program: &Program) -> String {
     out.push_str("    use std::io::Write;\n");
     out.push_str("    let stderr = std::io::stderr();\n");
     out.push_str("    let mut handle = stderr.lock();\n");
-    out.push_str("    match handle.write_all(text.as_bytes()).and_then(|_| handle.write_all(b\"\\n\")) {\n");
+    out.push_str(
+        "    match handle.write_all(text.as_bytes()).and_then(|_| handle.write_all(b\"\\n\")) {\n",
+    );
     out.push_str("        Ok(()) => (text.len() as i64) + 1,\n");
     out.push_str("        Err(_) => -1,\n");
     out.push_str("    }\n");
@@ -114,7 +116,9 @@ pub fn render_rust(program: &Program) -> String {
     out.push_str("    let sep = raw.windows(4).position(|w| w == b\"\\r\\n\\r\\n\")?;\n");
     out.push_str("    let head = &raw[..sep];\n");
     out.push_str("    let body = &raw[sep + 4..];\n");
-    out.push_str("    let status_line_end = head.iter().position(|b| *b == b'\\r').unwrap_or(head.len());\n");
+    out.push_str(
+        "    let status_line_end = head.iter().position(|b| *b == b'\\r').unwrap_or(head.len());\n",
+    );
     out.push_str("    let status_line = std::str::from_utf8(&head[..status_line_end]).ok()?;\n");
     out.push_str("    let mut parts = status_line.splitn(3, ' ');\n");
     out.push_str("    let _version = parts.next()?;\n");
@@ -319,7 +323,7 @@ impl<'a> TypeContext<'a> {
     ) -> bool {
         match ty {
             Type::Int | Type::Bool | Type::String => false,
-            Type::Slice(_) => true,
+            Type::Slice(_) | Type::MutSlice(_) => true,
             Type::Struct(name) => {
                 if !visiting_structs.insert(name.clone()) {
                     return false;
@@ -617,7 +621,9 @@ fn render_expr(expr: &Expr) -> String {
             Type::Bool => unreachable!("type checker rejects bool addition"),
             Type::Struct(_) => unreachable!("type checker rejects struct addition"),
             Type::Enum(_) => unreachable!("type checker rejects enum addition"),
-            Type::Slice(_) => unreachable!("type checker rejects slice addition"),
+            Type::Slice(_) | Type::MutSlice(_) => {
+                unreachable!("type checker rejects slice addition")
+            }
             Type::Option(_) => unreachable!("type checker rejects option addition"),
             Type::Result(_, _) => unreachable!("type checker rejects result addition"),
             Type::Tuple(_) => unreachable!("type checker rejects tuple addition"),
@@ -713,7 +719,7 @@ fn render_expr(expr: &Expr) -> String {
                         end
                     )
                 }
-                Type::Slice(_) => {
+                Type::Slice(_) | Type::MutSlice(_) => {
                     format!(
                         "axiom_slice_view({}, {}, {})",
                         render_expr(base),
@@ -740,7 +746,7 @@ fn render_expr(expr: &Expr) -> String {
                     )
                 }
             }
-            Type::Slice(_) => {
+            Type::Slice(_) | Type::MutSlice(_) => {
                 format!(
                     "axiom_array_get({}, {})",
                     render_expr(base),
@@ -809,6 +815,13 @@ fn rust_type_inner(ty: &Type, lifetime: Option<&str>, type_context: &TypeContext
                 None => format!("&[{inner}]"),
             }
         }
+        Type::MutSlice(inner) => {
+            let inner = rust_type_inner(inner, lifetime, type_context);
+            match lifetime {
+                Some(lifetime) => format!("&{lifetime} mut [{inner}]"),
+                None => format!("&mut [{inner}]"),
+            }
+        }
         Type::Option(inner) => {
             format!("Option<{}>", rust_type_inner(inner, lifetime, type_context))
         }
@@ -862,7 +875,7 @@ fn render_collection_edge(collection: &Expr, result_ty: &Type, from_end: bool) -
                 )
             }
         }
-        Type::Slice(_) => format!(
+        Type::Slice(_) | Type::MutSlice(_) => format!(
             "{{ let values = {rendered}; let index = {index}; axiom_array_get(values, index) }}"
         ),
         _ => unreachable!("type checker rejects first/last on non-collection values"),

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -2254,8 +2254,11 @@ fn lower_expr_with_expected(
             } else {
                 None
             };
-            let ty = match lowered_base.ty() {
-                Type::MutSlice(_) => Type::MutSlice(Box::new(element_ty)),
+            let ty = match (expected, lowered_base.ty()) {
+                (Some(Type::MutSlice(_)), Type::Array(_) | Type::MutSlice(_)) => {
+                    Type::MutSlice(Box::new(element_ty))
+                }
+                (_, Type::MutSlice(_)) => Type::MutSlice(Box::new(element_ty)),
                 _ => Type::Slice(Box::new(element_ty)),
             };
             Ok(Expr::Slice {

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -206,9 +206,11 @@ pub struct StructFieldValue {
 struct Binding {
     ty: Type,
     moved: bool,
+    borrow_kind: Option<BorrowKind>,
     borrow_origin: Option<BorrowOrigin>,
     borrowed_owners: HashSet<String>,
     active_borrow_count: usize,
+    active_mut_borrow_count: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -222,6 +224,12 @@ struct FunctionSig {
 enum BorrowOrigin {
     Param(String),
     Local,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BorrowKind {
+    Shared,
+    Mutable,
 }
 
 struct LowerContext<'a> {
@@ -644,9 +652,11 @@ fn lower_function(
             Binding {
                 ty: ty.clone(),
                 moved: false,
+                borrow_kind: borrow_kind_for_type(&ty, structs, enums),
                 borrow_origin: binding_borrow_origin(&ty, Some(&param.name), structs, enums),
                 borrowed_owners: HashSet::new(),
                 active_borrow_count: 0,
+                active_mut_borrow_count: 0,
             },
         );
         params.push(Param {
@@ -737,7 +747,9 @@ fn lower_stmt(
             }
             let borrowed_owners =
                 binding_borrowed_owners_from_expr(&expected, &lowered_expr, env, ctx);
-            increment_active_borrows(&borrowed_owners, env)?;
+            if let Some(borrow_kind) = borrow_kind_for_type(&expected, ctx.structs, ctx.enums) {
+                increment_active_borrows(&borrowed_owners, env, borrow_kind)?;
+            }
             if !actual.is_copy() {
                 move_lowered_value(&lowered_expr, env)?;
             }
@@ -746,6 +758,7 @@ fn lower_stmt(
                 Binding {
                     ty: expected.clone(),
                     moved: false,
+                    borrow_kind: borrow_kind_for_type(&expected, ctx.structs, ctx.enums),
                     borrow_origin: binding_borrow_origin_from_expr(
                         &expected,
                         &lowered_expr,
@@ -754,6 +767,7 @@ fn lower_stmt(
                     ),
                     borrowed_owners,
                     active_borrow_count: 0,
+                    active_mut_borrow_count: 0,
                 },
             );
             Ok(Stmt::Let {
@@ -899,7 +913,10 @@ fn lower_stmt(
         } => {
             let lowered_expr = lower_expr(expr, env, ctx)?;
             let match_borrowed_owners = expr_borrowed_owners(&lowered_expr, env, ctx);
-            increment_active_borrows(&match_borrowed_owners, env)?;
+            let match_borrow_kind = borrow_kind_for_type(lowered_expr.ty(), ctx.structs, ctx.enums);
+            if let Some(borrow_kind) = match_borrow_kind {
+                increment_active_borrows(&match_borrowed_owners, env, borrow_kind)?;
+            }
             if matches!(lowered_expr, Expr::VarRef { .. }) && !lowered_expr.ty().is_copy() {
                 move_lowered_owner_value(&lowered_expr, env)?;
             }
@@ -1039,6 +1056,7 @@ fn lower_stmt(
                         Binding {
                             ty: payload_ty.clone(),
                             moved: false,
+                            borrow_kind: borrow_kind_for_type(payload_ty, ctx.structs, ctx.enums),
                             borrow_origin: match_binding_borrow_origin(
                                 &lowered_expr,
                                 &arm.variant,
@@ -1058,6 +1076,7 @@ fn lower_stmt(
                                 ctx,
                             ),
                             active_borrow_count: 0,
+                            active_mut_borrow_count: 0,
                         },
                     );
                 }
@@ -1088,7 +1107,9 @@ fn lower_stmt(
                 .with_span(*line, *column));
             }
             merge_match_state(env, &before, &arm_states);
-            release_active_borrow_owners(&match_borrowed_owners, env);
+            if let Some(borrow_kind) = match_borrow_kind {
+                release_active_borrow_owners(&match_borrowed_owners, env, borrow_kind);
+            }
             Ok(Stmt::Match {
                 expr: lowered_expr,
                 arms: lowered_arms,
@@ -1162,6 +1183,7 @@ fn merge_branch_state(
             Binding {
                 ty: binding.ty.clone(),
                 moved: then_moved || else_moved,
+                borrow_kind: binding.borrow_kind,
                 borrow_origin: binding.borrow_origin.clone(),
                 borrowed_owners: binding.borrowed_owners.clone(),
                 active_borrow_count: merge_borrow_count(
@@ -1171,6 +1193,17 @@ fn merge_branch_state(
                     else_returns,
                     else_after
                         .and_then(|branch| branch.get(name).map(|entry| entry.active_borrow_count)),
+                ),
+                active_mut_borrow_count: merge_borrow_count(
+                    binding.active_mut_borrow_count,
+                    then_returns,
+                    then_after
+                        .get(name)
+                        .map(|entry| entry.active_mut_borrow_count),
+                    else_returns,
+                    else_after.and_then(|branch| {
+                        branch.get(name).map(|entry| entry.active_mut_borrow_count)
+                    }),
                 ),
             },
         );
@@ -1196,6 +1229,7 @@ fn merge_loop_state(
             Binding {
                 ty: binding.ty.clone(),
                 moved: binding.moved,
+                borrow_kind: binding.borrow_kind,
                 borrow_origin: binding.borrow_origin.clone(),
                 borrowed_owners: binding.borrowed_owners.clone(),
                 active_borrow_count: if body_returns {
@@ -1206,6 +1240,15 @@ fn merge_loop_state(
                         .map(|entry| entry.active_borrow_count)
                         .unwrap_or(binding.active_borrow_count);
                     binding.active_borrow_count.max(body_count)
+                },
+                active_mut_borrow_count: if body_returns {
+                    binding.active_mut_borrow_count
+                } else {
+                    let body_count = body_after
+                        .get(name)
+                        .map(|entry| entry.active_mut_borrow_count)
+                        .unwrap_or(binding.active_mut_borrow_count);
+                    binding.active_mut_borrow_count.max(body_count)
                 },
             },
         );
@@ -1234,6 +1277,7 @@ fn merge_match_state(
             Binding {
                 ty: binding.ty.clone(),
                 moved,
+                borrow_kind: binding.borrow_kind,
                 borrow_origin: binding.borrow_origin.clone(),
                 borrowed_owners: binding.borrowed_owners.clone(),
                 active_borrow_count: arm_states
@@ -1247,6 +1291,17 @@ fn merge_match_state(
                     })
                     .max()
                     .unwrap_or(binding.active_borrow_count),
+                active_mut_borrow_count: arm_states
+                    .iter()
+                    .filter_map(|(after, returns)| {
+                        if *returns {
+                            Some(binding.active_mut_borrow_count)
+                        } else {
+                            after.get(name).map(|entry| entry.active_mut_borrow_count)
+                        }
+                    })
+                    .max()
+                    .unwrap_or(binding.active_mut_borrow_count),
             },
         );
     }
@@ -2827,6 +2882,20 @@ fn contains_borrowed_slice_type(
     contains_borrowed_slice_type_inner(ty, structs, enums, &mut HashSet::new(), &mut HashSet::new())
 }
 
+fn contains_mut_borrowed_slice_type(
+    ty: &Type,
+    structs: &HashMap<String, StructDef>,
+    enums: &HashMap<String, EnumDef>,
+) -> bool {
+    contains_mut_borrowed_slice_type_inner(
+        ty,
+        structs,
+        enums,
+        &mut HashSet::new(),
+        &mut HashSet::new(),
+    )
+}
+
 fn contains_borrowed_slice_type_inner(
     ty: &Type,
     structs: &HashMap<String, StructDef>,
@@ -2926,6 +2995,110 @@ fn contains_borrowed_slice_type_inner(
     }
 }
 
+fn contains_mut_borrowed_slice_type_inner(
+    ty: &Type,
+    structs: &HashMap<String, StructDef>,
+    enums: &HashMap<String, EnumDef>,
+    visiting_structs: &mut HashSet<String>,
+    visiting_enums: &mut HashSet<String>,
+) -> bool {
+    match ty {
+        Type::MutSlice(_) => true,
+        Type::Slice(_) | Type::Int | Type::Bool | Type::String => false,
+        Type::Option(inner) => contains_mut_borrowed_slice_type_inner(
+            inner,
+            structs,
+            enums,
+            visiting_structs,
+            visiting_enums,
+        ),
+        Type::Result(ok, err) => {
+            contains_mut_borrowed_slice_type_inner(
+                ok,
+                structs,
+                enums,
+                visiting_structs,
+                visiting_enums,
+            ) || contains_mut_borrowed_slice_type_inner(
+                err,
+                structs,
+                enums,
+                visiting_structs,
+                visiting_enums,
+            )
+        }
+        Type::Tuple(elements) => elements.iter().any(|element| {
+            contains_mut_borrowed_slice_type_inner(
+                element,
+                structs,
+                enums,
+                visiting_structs,
+                visiting_enums,
+            )
+        }),
+        Type::Map(key, value) => {
+            contains_mut_borrowed_slice_type_inner(
+                key,
+                structs,
+                enums,
+                visiting_structs,
+                visiting_enums,
+            ) || contains_mut_borrowed_slice_type_inner(
+                value,
+                structs,
+                enums,
+                visiting_structs,
+                visiting_enums,
+            )
+        }
+        Type::Array(inner) => contains_mut_borrowed_slice_type_inner(
+            inner,
+            structs,
+            enums,
+            visiting_structs,
+            visiting_enums,
+        ),
+        Type::Struct(name) => {
+            if !visiting_structs.insert(name.clone()) {
+                return false;
+            }
+            let contains = structs.get(name).is_some_and(|struct_def| {
+                struct_def.fields.iter().any(|field| {
+                    contains_mut_borrowed_slice_type_inner(
+                        &field.ty,
+                        structs,
+                        enums,
+                        visiting_structs,
+                        visiting_enums,
+                    )
+                })
+            });
+            visiting_structs.remove(name);
+            contains
+        }
+        Type::Enum(name) => {
+            if !visiting_enums.insert(name.clone()) {
+                return false;
+            }
+            let contains = enums.get(name).is_some_and(|enum_def| {
+                enum_def.variants.iter().any(|variant| {
+                    variant.payload_tys.iter().any(|payload_ty| {
+                        contains_mut_borrowed_slice_type_inner(
+                            payload_ty,
+                            structs,
+                            enums,
+                            visiting_structs,
+                            visiting_enums,
+                        )
+                    })
+                })
+            });
+            visiting_enums.remove(name);
+            contains
+        }
+    }
+}
+
 fn classify_borrow_return(
     params: &[Type],
     return_ty: &Type,
@@ -2952,9 +3125,24 @@ fn classify_borrow_return(
     Ok(matches)
 }
 
+fn borrow_kind_for_type(
+    ty: &Type,
+    structs: &HashMap<String, StructDef>,
+    enums: &HashMap<String, EnumDef>,
+) -> Option<BorrowKind> {
+    if contains_mut_borrowed_slice_type(ty, structs, enums) {
+        Some(BorrowKind::Mutable)
+    } else if contains_borrowed_slice_type(ty, structs, enums) {
+        Some(BorrowKind::Shared)
+    } else {
+        None
+    }
+}
+
 fn increment_active_borrows(
     owner_names: &HashSet<String>,
     env: &mut HashMap<String, Binding>,
+    borrow_kind: BorrowKind,
 ) -> Result<(), Diagnostic> {
     for owner_name in owner_names {
         let binding = env.get_mut(owner_name).ok_or_else(|| {
@@ -2963,7 +3151,37 @@ fn increment_active_borrows(
                 format!("internal error: missing borrow owner {owner_name:?}"),
             )
         })?;
+        match borrow_kind {
+            BorrowKind::Shared if binding.active_mut_borrow_count > 0 => {
+                return Err(Diagnostic::new(
+                    "ownership",
+                    format!(
+                        "cannot create shared borrow of value {owner_name:?} while a mutable borrow is still live"
+                    ),
+                ));
+            }
+            BorrowKind::Mutable if binding.active_mut_borrow_count > 0 => {
+                return Err(Diagnostic::new(
+                    "ownership",
+                    format!(
+                        "cannot create mutable borrow of value {owner_name:?} while another mutable borrow is still live"
+                    ),
+                ));
+            }
+            BorrowKind::Mutable if binding.active_borrow_count > 0 => {
+                return Err(Diagnostic::new(
+                    "ownership",
+                    format!(
+                        "cannot create mutable borrow of value {owner_name:?} while a shared borrow is still live"
+                    ),
+                ));
+            }
+            _ => {}
+        }
         binding.active_borrow_count += 1;
+        if matches!(borrow_kind, BorrowKind::Mutable) {
+            binding.active_mut_borrow_count += 1;
+        }
     }
     Ok(())
 }
@@ -2972,34 +3190,48 @@ fn record_temporary_borrows(
     expr: &Expr,
     env: &mut HashMap<String, Binding>,
     ctx: &LowerContext<'_>,
-    temporary_borrows: &mut Vec<HashSet<String>>,
+    temporary_borrows: &mut Vec<(HashSet<String>, BorrowKind)>,
 ) -> Result<(), Diagnostic> {
     let owners = expr_borrowed_owners(expr, env, ctx);
-    increment_active_borrows(&owners, env)?;
-    temporary_borrows.push(owners);
+    let Some(borrow_kind) = borrow_kind_for_type(expr.ty(), ctx.structs, ctx.enums) else {
+        return Ok(());
+    };
+    increment_active_borrows(&owners, env, borrow_kind)?;
+    temporary_borrows.push((owners, borrow_kind));
     Ok(())
 }
 
 fn release_temporary_borrows(
-    temporary_borrows: &[HashSet<String>],
+    temporary_borrows: &[(HashSet<String>, BorrowKind)],
     env: &mut HashMap<String, Binding>,
 ) {
-    for owner_names in temporary_borrows.iter().rev() {
-        release_active_borrow_owners(owner_names, env);
+    for (owner_names, borrow_kind) in temporary_borrows.iter().rev() {
+        release_active_borrow_owners(owner_names, env, *borrow_kind);
     }
 }
 
-fn release_active_borrow_owners(owner_names: &HashSet<String>, env: &mut HashMap<String, Binding>) {
+fn release_active_borrow_owners(
+    owner_names: &HashSet<String>,
+    env: &mut HashMap<String, Binding>,
+    borrow_kind: BorrowKind,
+) {
     for owner_name in owner_names {
-        decrement_active_borrow(owner_name, env);
+        decrement_active_borrow(owner_name, env, borrow_kind);
     }
 }
 
-fn decrement_active_borrow(owner_name: &str, env: &mut HashMap<String, Binding>) {
+fn decrement_active_borrow(
+    owner_name: &str,
+    env: &mut HashMap<String, Binding>,
+    borrow_kind: BorrowKind,
+) {
     let Some(binding) = env.get_mut(owner_name) else {
         return;
     };
     binding.active_borrow_count = binding.active_borrow_count.saturating_sub(1);
+    if matches!(borrow_kind, BorrowKind::Mutable) {
+        binding.active_mut_borrow_count = binding.active_mut_borrow_count.saturating_sub(1);
+    }
 }
 
 fn release_scope_borrows(env: &mut HashMap<String, Binding>, scope_names: &HashSet<String>) {
@@ -3009,12 +3241,20 @@ fn release_scope_borrows(env: &mut HashMap<String, Binding>, scope_names: &HashS
         .cloned()
         .collect::<Vec<_>>();
     for name in &released {
-        let owner_names = env
+        let (owner_names, borrow_kind) = env
             .get(name)
-            .map(|binding| binding.borrowed_owners.iter().cloned().collect::<Vec<_>>())
+            .map(|binding| {
+                (
+                    binding.borrowed_owners.iter().cloned().collect::<Vec<_>>(),
+                    binding.borrow_kind,
+                )
+            })
             .unwrap_or_default();
+        let Some(borrow_kind) = borrow_kind else {
+            continue;
+        };
         for owner_name in owner_names {
-            decrement_active_borrow(&owner_name, env);
+            decrement_active_borrow(&owner_name, env, borrow_kind);
         }
     }
     for name in released {

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -2027,11 +2027,24 @@ fn lower_expr_with_expected(
             line,
             column,
         } => {
+            let expected_elements = match expected {
+                Some(Type::Tuple(expected_elements))
+                    if expected_elements.len() == elements.len() =>
+                {
+                    Some(expected_elements)
+                }
+                _ => None,
+            };
             let mut lowered_elements = Vec::new();
             let mut element_tys = Vec::new();
             let mut temporary_borrows = Vec::new();
-            for element in elements {
-                let lowered = lower_expr(element, env, ctx)?;
+            for (index, element) in elements.iter().enumerate() {
+                let lowered = lower_expr_with_expected(
+                    element,
+                    expected_elements.and_then(|expected| expected.get(index)),
+                    env,
+                    ctx,
+                )?;
                 record_temporary_borrows(&lowered, env, ctx, &mut temporary_borrows)?;
                 if !lowered.ty().is_copy() {
                     move_lowered_owner_value(&lowered, env)?;

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -171,6 +171,7 @@ pub enum Type {
     Struct(String),
     Enum(String),
     Slice(Box<Type>),
+    MutSlice(Box<Type>),
     Option(Box<Type>),
     Result(Box<Type>, Box<Type>),
     Tuple(Vec<Type>),
@@ -291,6 +292,7 @@ impl Type {
     pub fn is_copy(&self) -> bool {
         match self {
             Type::Int | Type::Bool | Type::Slice(_) => true,
+            Type::MutSlice(_) => false,
             Type::Option(inner) => inner.is_copy(),
             Type::Result(ok, err) => ok.is_copy() && err.is_copy(),
             Type::Tuple(elements) => elements.iter().all(Type::is_copy),
@@ -307,6 +309,7 @@ impl Type {
             Type::Struct(_)
             | Type::Enum(_)
             | Type::Slice(_)
+            | Type::MutSlice(_)
             | Type::Option(_)
             | Type::Result(_, _)
             | Type::Map(_, _)
@@ -1373,7 +1376,10 @@ fn lower_expr_with_expected(
                     .with_span(*line, *column));
                 }
                 let lowered = lower_expr(&args[0], env, ctx)?;
-                if !matches!(lowered.ty(), Type::Array(_) | Type::Slice(_)) {
+                if !matches!(
+                    lowered.ty(),
+                    Type::Array(_) | Type::Slice(_) | Type::MutSlice(_)
+                ) {
                     return Err(Diagnostic::new(
                         "type",
                         format!("len expects an array or slice value, got {}", lowered.ty()),
@@ -1400,7 +1406,10 @@ fn lower_expr_with_expected(
                 if lowered.ty() != &Type::String {
                     return Err(Diagnostic::new(
                         "type",
-                        format!("io_eprintln expects a string argument, got {}", lowered.ty()),
+                        format!(
+                            "io_eprintln expects a string argument, got {}",
+                            lowered.ty()
+                        ),
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }
@@ -1611,9 +1620,9 @@ fn lower_expr_with_expected(
                 }
                 let lowered = lower_expr(&args[0], env, ctx)?;
                 let element_ty = match lowered.ty() {
-                    Type::Array(element_ty) | Type::Slice(element_ty) => {
-                        (*element_ty.clone()).clone()
-                    }
+                    Type::Array(element_ty)
+                    | Type::Slice(element_ty)
+                    | Type::MutSlice(element_ty) => (*element_ty.clone()).clone(),
                     _ => {
                         return Err(Diagnostic::new(
                             "type",
@@ -1625,7 +1634,9 @@ fn lower_expr_with_expected(
                         .with_span(args[0].line(), args[0].column()));
                     }
                 };
-                if matches!(lowered.ty(), Type::Slice(_)) && !element_ty.is_copy() {
+                if matches!(lowered.ty(), Type::Slice(_) | Type::MutSlice(_))
+                    && !element_ty.is_copy()
+                {
                     return Err(Diagnostic::new(
                         "type",
                         format!(
@@ -2196,7 +2207,9 @@ fn lower_expr_with_expected(
         } => {
             let lowered_base = lower_expr(base, env, ctx)?;
             let element_ty = match lowered_base.ty() {
-                Type::Array(element_ty) | Type::Slice(element_ty) => (*element_ty.clone()).clone(),
+                Type::Array(element_ty) | Type::Slice(element_ty) | Type::MutSlice(element_ty) => {
+                    (*element_ty.clone()).clone()
+                }
                 _ => {
                     return Err(Diagnostic::new(
                         "type",
@@ -2241,11 +2254,15 @@ fn lower_expr_with_expected(
             } else {
                 None
             };
+            let ty = match lowered_base.ty() {
+                Type::MutSlice(_) => Type::MutSlice(Box::new(element_ty)),
+                _ => Type::Slice(Box::new(element_ty)),
+            };
             Ok(Expr::Slice {
                 base: Box::new(lowered_base),
                 start: lowered_start,
                 end: lowered_end,
-                ty: Type::Slice(Box::new(element_ty)),
+                ty,
             })
         }
         syntax::Expr::Index {
@@ -2271,7 +2288,7 @@ fn lower_expr_with_expected(
                     }
                     element_ty
                 }
-                Type::Slice(element_ty) => {
+                Type::Slice(element_ty) | Type::MutSlice(element_ty) => {
                     if lowered_index.ty() != &Type::Int {
                         return Err(Diagnostic::new(
                             "type",
@@ -2587,7 +2604,7 @@ fn expr_borrow_origin(
             .get(name)
             .and_then(|binding| binding.borrow_origin.clone()),
         Expr::Slice { base, .. } => match base.ty() {
-            Type::Slice(_) => expr_borrow_origin(base, env, ctx),
+            Type::Slice(_) | Type::MutSlice(_) => expr_borrow_origin(base, env, ctx),
             Type::Array(_) => Some(BorrowOrigin::Local),
             _ => Some(BorrowOrigin::Local),
         },
@@ -2734,7 +2751,7 @@ fn expr_borrowed_owners(
             .map(|binding| binding.borrowed_owners.clone())
             .unwrap_or_default(),
         Expr::Slice { base, .. } => match base.ty() {
-            Type::Slice(_) => expr_borrowed_owners(base, env, ctx),
+            Type::Slice(_) | Type::MutSlice(_) => expr_borrowed_owners(base, env, ctx),
             Type::Array(_) => owned_borrow_root(base).into_iter().collect(),
             _ => HashSet::new(),
         },
@@ -2790,7 +2807,9 @@ fn collect_expr_borrowed_owners(
 
 fn owned_borrow_root(expr: &Expr) -> Option<String> {
     match expr {
-        Expr::VarRef { name, ty } if !matches!(ty, Type::Slice(_)) => Some(name.clone()),
+        Expr::VarRef { name, ty } if !matches!(ty, Type::Slice(_) | Type::MutSlice(_)) => {
+            Some(name.clone())
+        }
         Expr::FieldAccess { base, .. } => owned_borrow_root(base),
         Expr::TupleIndex { base, .. } => owned_borrow_root(base),
         _ => None,
@@ -2813,7 +2832,7 @@ fn contains_borrowed_slice_type_inner(
     visiting_enums: &mut HashSet<String>,
 ) -> bool {
     match ty {
-        Type::Slice(_) => true,
+        Type::Slice(_) | Type::MutSlice(_) => true,
         Type::Option(inner) => contains_borrowed_slice_type_inner(
             inner,
             structs,
@@ -3060,6 +3079,9 @@ fn lower_type<T, U>(
         syntax::TypeName::Slice(inner) => Ok(Type::Slice(Box::new(lower_type(
             inner, structs, enums, line, column,
         )?))),
+        syntax::TypeName::MutSlice(inner) => Ok(Type::MutSlice(Box::new(lower_type(
+            inner, structs, enums, line, column,
+        )?))),
         syntax::TypeName::Option(inner) => Ok(Type::Option(Box::new(lower_type(
             inner, structs, enums, line, column,
         )?))),
@@ -3282,6 +3304,7 @@ impl std::fmt::Display for Type {
             Type::Struct(name) => write!(f, "{name}"),
             Type::Enum(name) => write!(f, "{name}"),
             Type::Slice(inner) => write!(f, "&[{inner}]"),
+            Type::MutSlice(inner) => write!(f, "&mut [{inner}]"),
             Type::Option(inner) => write!(f, "Option<{inner}>"),
             Type::Result(ok, err) => write!(f, "Result<{ok}, {err}>"),
             Type::Tuple(elements) => write!(

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -914,7 +914,11 @@ fn lower_stmt(
             let lowered_expr = lower_expr(expr, env, ctx)?;
             let match_borrowed_owners = expr_borrowed_owners(&lowered_expr, env, ctx);
             let match_borrow_kind = borrow_kind_for_type(lowered_expr.ty(), ctx.structs, ctx.enums);
-            if let Some(borrow_kind) = match_borrow_kind {
+            let reuse_existing_match_binding =
+                matches!(lowered_expr, Expr::VarRef { .. }) && !match_borrowed_owners.is_empty();
+            if let Some(borrow_kind) = match_borrow_kind
+                && !reuse_existing_match_binding
+            {
                 increment_active_borrows(&match_borrowed_owners, env, borrow_kind)?;
             }
             if matches!(lowered_expr, Expr::VarRef { .. }) && !lowered_expr.ty().is_copy() {
@@ -1107,7 +1111,9 @@ fn lower_stmt(
                 .with_span(*line, *column));
             }
             merge_match_state(env, &before, &arm_states);
-            if let Some(borrow_kind) = match_borrow_kind {
+            if let Some(borrow_kind) = match_borrow_kind
+                && !reuse_existing_match_binding
+            {
                 release_active_borrow_owners(&match_borrowed_owners, env, borrow_kind);
             }
             Ok(Stmt::Match {

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -2729,6 +2729,60 @@ mod tests {
     }
 
     #[test]
+    fn check_project_rejects_mutable_borrow_while_shared_borrow_is_live() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("shared-then-mutable-borrow");
+        create_project(&project, Some("shared-then-mutable-borrow-app")).expect("create project");
+        fs::write(
+            project.join("src/main.ax"),
+            "let values: [int] = [1, 2, 3]\nlet shared: &[int] = values[:]\nlet mutable: &mut [int] = values[:]\nprint len(shared)\nprint len(mutable)\n",
+        )
+        .expect("write source");
+        let error = check_project(&project)
+            .expect_err("mutable borrow should fail while a shared borrow is live");
+        assert!(error.message.contains(
+            "cannot create mutable borrow of value \"values\" while a shared borrow is still live"
+        ));
+        assert_eq!(error.kind, "ownership");
+    }
+
+    #[test]
+    fn check_project_rejects_shared_borrow_while_mutable_borrow_is_live() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("mutable-then-shared-borrow");
+        create_project(&project, Some("mutable-then-shared-borrow-app")).expect("create project");
+        fs::write(
+            project.join("src/main.ax"),
+            "let values: [int] = [1, 2, 3]\nlet mutable: &mut [int] = values[:]\nlet shared: &[int] = values[:]\nprint len(mutable)\nprint len(shared)\n",
+        )
+        .expect("write source");
+        let error = check_project(&project)
+            .expect_err("shared borrow should fail while a mutable borrow is live");
+        assert!(error.message.contains(
+            "cannot create shared borrow of value \"values\" while a mutable borrow is still live"
+        ));
+        assert_eq!(error.kind, "ownership");
+    }
+
+    #[test]
+    fn check_project_rejects_double_mutable_borrow() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("double-mutable-borrow");
+        create_project(&project, Some("double-mutable-borrow-app")).expect("create project");
+        fs::write(
+            project.join("src/main.ax"),
+            "let values: [int] = [1, 2, 3]\nlet first: &mut [int] = values[:]\nlet second: &mut [int] = values[:]\nprint len(first)\nprint len(second)\n",
+        )
+        .expect("write source");
+        let error = check_project(&project)
+            .expect_err("second mutable borrow should fail while the first is live");
+        assert!(error.message.contains(
+            "cannot create mutable borrow of value \"values\" while another mutable borrow is still live"
+        ));
+        assert_eq!(error.kind, "ownership");
+    }
+
+    #[test]
     fn check_project_rejects_moving_owner_while_tuple_wrapped_slice_is_live() {
         let dir = tempdir().expect("tempdir");
         let project = dir.path().join("tuple-wrapped-live-borrow");

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -2783,6 +2783,47 @@ mod tests {
     }
 
     #[test]
+    fn check_project_rejects_moving_owned_array_while_mutable_slice_borrow_is_live() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("live-mut-borrow-move");
+        create_project(&project, Some("live-mut-borrow-move-app")).expect("create project");
+        fs::write(
+            project.join("src/main.ax"),
+            "let values: [string] = [\"alpha\", \"beta\"]\nlet view: &mut [string] = values[:]\nprint len(view)\nprint first(values)\n",
+        )
+        .expect("write source");
+        let error =
+            check_project(&project).expect_err("moving a mutably borrowed owner should fail");
+        assert!(
+            error
+                .message
+                .contains("cannot move value \"values\" while borrowed slices are still live")
+        );
+        assert_eq!(error.kind, "ownership");
+    }
+
+    #[test]
+    fn check_project_rejects_moving_owner_while_tuple_wrapped_mut_slice_is_live() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("tuple-wrapped-live-mut-borrow");
+        create_project(&project, Some("tuple-wrapped-live-mut-borrow-app"))
+            .expect("create project");
+        fs::write(
+            project.join("src/main.ax"),
+            "let values: [string] = [\"alpha\", \"beta\"]\nlet wrapped: (&mut [string], int) = (values[:], 1)\nprint len(wrapped.0)\nprint first(values)\n",
+        )
+        .expect("write source");
+        let error = check_project(&project)
+            .expect_err("tuple-wrapped mutable borrow should block owner move");
+        assert!(
+            error
+                .message
+                .contains("cannot move value \"values\" while borrowed slices are still live")
+        );
+        assert_eq!(error.kind, "ownership");
+    }
+
+    #[test]
     fn check_project_rejects_moving_owner_while_tuple_wrapped_slice_is_live() {
         let dir = tempdir().expect("tempdir");
         let project = dir.path().join("tuple-wrapped-live-borrow");

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -172,6 +172,25 @@ mod tests {
     }
 
     #[test]
+    fn parser_lowers_mutable_slice_views() {
+        let source = "fn tail(values: &mut [int]): &mut [int] {\nlet rest: &mut [int] = values[1:]\nreturn rest\n}\n\nfn local_tail_len(): int {\nlet values: [int] = [3, 7, 9, 11]\nlet rest: &mut [int] = values[1:]\nreturn len(rest)\n}\n\nprint 0\n";
+        let parsed = parse_program(source, Path::new("main.ax")).expect("parse");
+        let hir = hir::lower(&parsed).expect("lower");
+        let mir = mir::lower(&hir);
+        let rendered = render_rust(&mir);
+        assert!(
+            rendered
+                .contains("let rest: &mut [i64] = axiom_slice_view_mut(values, Some(1), None);")
+        );
+        assert!(
+            rendered.contains(
+                "let rest: &mut [i64] = axiom_slice_view_mut(&mut values, Some(1), None);"
+            )
+        );
+        assert!(rendered.contains("fn axiom_slice_view_mut<'a, T>(values: &'a mut [T], start: Option<i64>, end: Option<i64>) -> &'a mut [T] {"));
+    }
+
+    #[test]
     fn parser_lowers_borrowed_structs_and_enums() {
         let source = "struct Window {\nview: &[int]\n}\n\nenum Snapshot {\nWindow(Window)\nNamed { window: Window }\n}\n\nfn tail(values: &[int]): Window {\nreturn Window { view: values[1:] }\n}\n\nfn read(snapshot: Snapshot): int {\nmatch snapshot {\nWindow(window) {\nreturn first(window.view)\n}\nNamed { window } {\nreturn last(window.view)\n}\n}\n}\n\nlet numbers: [int] = [3, 7, 9, 11]\nlet window: Window = tail(numbers[:])\nprint first(window.view)\nprint read(Named { window: tail(numbers[:]) })\n";
         let parsed = parse_program(source, Path::new("main.ax")).expect("parse");

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -2824,6 +2824,48 @@ mod tests {
     }
 
     #[test]
+    fn check_project_rejects_moving_owner_while_option_wrapped_mut_slice_is_live() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("option-wrapped-live-mut-borrow");
+        create_project(&project, Some("option-wrapped-live-mut-borrow-app"))
+            .expect("create project");
+        fs::write(
+            project.join("src/main.ax"),
+            "let values: [string] = [\"alpha\", \"beta\"]\nlet wrapped: Option<&mut [string]> = Some(values[:])\nmatch wrapped {\nSome(view) {\nprint len(view)\n}\nNone {\nprint 0\n}\n}\nprint first(values)\n",
+        )
+        .expect("write source");
+        let error = check_project(&project)
+            .expect_err("option-wrapped mutable borrow should block owner move");
+        assert!(
+            error
+                .message
+                .contains("cannot move value \"values\" while borrowed slices are still live")
+        );
+        assert_eq!(error.kind, "ownership");
+    }
+
+    #[test]
+    fn check_project_rejects_moving_owner_while_struct_wrapped_mut_slice_is_live() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("struct-wrapped-live-mut-borrow");
+        create_project(&project, Some("struct-wrapped-live-mut-borrow-app"))
+            .expect("create project");
+        fs::write(
+            project.join("src/main.ax"),
+            "struct Window {\nview: &mut [string]\n}\n\nlet values: [string] = [\"alpha\", \"beta\"]\nlet window: Window = Window { view: values[:] }\nprint len(window.view)\nprint first(values)\n",
+        )
+        .expect("write source");
+        let error = check_project(&project)
+            .expect_err("struct-wrapped mutable borrow should block owner move");
+        assert!(
+            error
+                .message
+                .contains("cannot move value \"values\" while borrowed slices are still live")
+        );
+        assert_eq!(error.kind, "ownership");
+    }
+
+    #[test]
     fn check_project_rejects_moving_owner_while_tuple_wrapped_slice_is_live() {
         let dir = tempdir().expect("tempdir");
         let project = dir.path().join("tuple-wrapped-live-borrow");

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -159,6 +159,19 @@ mod tests {
     }
 
     #[test]
+    fn parser_lowers_mutable_slice_signatures() {
+        let source = "fn passthrough(values: &mut [int]): &mut [int] {\nreturn values\n}\n\nfn count(values: &mut [string]): int {\nreturn len(values)\n}\n\nprint 0\n";
+        let parsed = parse_program(source, Path::new("main.ax")).expect("parse");
+        let hir = hir::lower(&parsed).expect("lower");
+        let mir = mir::lower(&hir);
+        let rendered = render_rust(&mir);
+        assert!(rendered.contains("fn passthrough<'a>(values: &'a mut [i64]) -> &'a mut [i64] {"));
+        assert!(rendered.contains("return values;"));
+        assert!(rendered.contains("fn count<'a>(values: &'a mut [String]) -> i64 {"));
+        assert!(rendered.contains("return (values).len() as i64;"));
+    }
+
+    #[test]
     fn parser_lowers_borrowed_structs_and_enums() {
         let source = "struct Window {\nview: &[int]\n}\n\nenum Snapshot {\nWindow(Window)\nNamed { window: Window }\n}\n\nfn tail(values: &[int]): Window {\nreturn Window { view: values[1:] }\n}\n\nfn read(snapshot: Snapshot): int {\nmatch snapshot {\nWindow(window) {\nreturn first(window.view)\n}\nNamed { window } {\nreturn last(window.view)\n}\n}\n}\n\nlet numbers: [int] = [3, 7, 9, 11]\nlet window: Window = tail(numbers[:])\nprint first(window.view)\nprint read(Named { window: tail(numbers[:]) })\n";
         let parsed = parse_program(source, Path::new("main.ax")).expect("parse");
@@ -1242,8 +1255,7 @@ mod tests {
 
         let err = check_project(&project).expect_err("expected capability denial");
         assert!(
-            err.message
-                .contains("requires [capabilities].clock = true"),
+            err.message.contains("requires [capabilities].clock = true"),
             "unexpected diagnostic: {err:?}",
         );
     }
@@ -1484,7 +1496,8 @@ mod tests {
 
         let err = check_project(&project).expect_err("expected capability denial");
         assert!(
-            err.message.contains("requires [capabilities].process = true"),
+            err.message
+                .contains("requires [capabilities].process = true"),
             "unexpected diagnostic: {err:?}",
         );
     }
@@ -1568,7 +1581,8 @@ mod tests {
 
         let err = check_project(&project).expect_err("expected capability denial");
         assert!(
-            err.message.contains("requires [capabilities].crypto = true"),
+            err.message
+                .contains("requires [capabilities].crypto = true"),
             "unexpected diagnostic: {err:?}",
         );
     }
@@ -1676,8 +1690,7 @@ mod tests {
             render_lockfile_for_project(&project, &manifest).expect("lockfile"),
         )
         .expect("write lockfile");
-        let source =
-            "import \"std/io.ax\"\nlet n: int = eprintln(\"hello stderr\")\nprint n > 0\n";
+        let source = "import \"std/io.ax\"\nlet n: int = eprintln(\"hello stderr\")\nprint n > 0\n";
         fs::write(project.join("src/main.ax"), source).expect("write source");
         fs::write(project.join("src/main_test.ax"), source).expect("write test");
         fs::write(project.join("src/main_test.stdout"), "true\n").expect("write golden");
@@ -3204,7 +3217,6 @@ mod tests {
             "let running: bool = true\nwhile running {\nlet inner: string = \"fresh\"\nlet sink: string = inner\nprint sink\n}\n",
         )
         .expect("write source");
-        check_project(&project)
-            .expect("moving loop-local values should be allowed");
+        check_project(&project).expect("moving loop-local values should be allowed");
     }
 }

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -2866,6 +2866,26 @@ mod tests {
     }
 
     #[test]
+    fn check_project_rejects_moving_owner_while_enum_wrapped_mut_slice_is_live() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("enum-wrapped-live-mut-borrow");
+        create_project(&project, Some("enum-wrapped-live-mut-borrow-app")).expect("create project");
+        fs::write(
+            project.join("src/main.ax"),
+            "enum Snapshot {\nWindow(&mut [string])\n}\n\nlet values: [string] = [\"alpha\", \"beta\"]\nlet snapshot: Snapshot = Window(values[:])\nmatch snapshot {\nWindow(view) {\nprint len(view)\n}\n}\nprint first(values)\n",
+        )
+        .expect("write source");
+        let error = check_project(&project)
+            .expect_err("enum-wrapped mutable borrow should block owner move");
+        assert!(
+            error
+                .message
+                .contains("cannot move value \"values\" while borrowed slices are still live")
+        );
+        assert_eq!(error.kind, "ownership");
+    }
+
+    #[test]
     fn check_project_rejects_moving_owner_while_tuple_wrapped_slice_is_live() {
         let dir = tempdir().expect("tempdir");
         let project = dir.path().join("tuple-wrapped-live-borrow");

--- a/stage1/crates/axiomc/src/mir.rs
+++ b/stage1/crates/axiomc/src/mir.rs
@@ -182,6 +182,7 @@ pub enum Type {
     Struct(String),
     Enum(String),
     Slice(Box<Type>),
+    MutSlice(Box<Type>),
     Option(Box<Type>),
     Result(Box<Type>, Box<Type>),
     Tuple(Vec<Type>),
@@ -193,6 +194,7 @@ impl Type {
     pub fn is_copy(&self) -> bool {
         match self {
             Type::Int | Type::Bool | Type::Slice(_) => true,
+            Type::MutSlice(_) => false,
             Type::Option(inner) => inner.is_copy(),
             Type::Result(ok, err) => ok.is_copy() && err.is_copy(),
             Type::Tuple(elements) => elements.iter().all(Type::is_copy),
@@ -466,6 +468,7 @@ fn lower_type(ty: &hir::Type) -> Type {
         hir::Type::Struct(name) => Type::Struct(name.clone()),
         hir::Type::Enum(name) => Type::Enum(name.clone()),
         hir::Type::Slice(inner) => Type::Slice(Box::new(lower_type(inner))),
+        hir::Type::MutSlice(inner) => Type::MutSlice(Box::new(lower_type(inner))),
         hir::Type::Option(inner) => Type::Option(Box::new(lower_type(inner))),
         hir::Type::Result(ok, err) => {
             Type::Result(Box::new(lower_type(ok)), Box::new(lower_type(err)))

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -1974,6 +1974,16 @@ fn rewrite_type_name(
             line,
             column,
         )?))),
+        syntax::TypeName::MutSlice(inner) => {
+            Ok(syntax::TypeName::MutSlice(Box::new(rewrite_type_name(
+                inner,
+                visible_types,
+                private_imported_types,
+                module_path,
+                line,
+                column,
+            )?)))
+        }
         syntax::TypeName::Result(ok, err) => Ok(syntax::TypeName::Result(
             Box::new(rewrite_type_name(
                 ok,

--- a/stage1/crates/axiomc/src/syntax.rs
+++ b/stage1/crates/axiomc/src/syntax.rs
@@ -129,6 +129,7 @@ pub enum TypeName {
     String,
     Named(String),
     Slice(Box<TypeName>),
+    MutSlice(Box<TypeName>),
     Option(Box<TypeName>),
     Result(Box<TypeName>, Box<TypeName>),
     Tuple(Vec<TypeName>),
@@ -944,6 +945,25 @@ fn parse_type_name(
     line_no: usize,
     column: usize,
 ) -> Result<TypeName, Diagnostic> {
+    if raw.starts_with("&mut [")
+        && raw.ends_with(']')
+        && matches!(find_matching_square(raw, 5), Some(close) if close == raw.len() - 1)
+    {
+        let inner = raw[6..raw.len() - 1].trim();
+        if inner.is_empty() {
+            return Err(
+                Diagnostic::new("parse", "mutable slice type is missing an inner type")
+                    .with_path(path.display().to_string())
+                    .with_span(line_no, column),
+            );
+        }
+        return Ok(TypeName::MutSlice(Box::new(parse_type_name(
+            inner,
+            path,
+            line_no,
+            column + 6,
+        )?)));
+    }
     if raw.starts_with("&[")
         && raw.ends_with(']')
         && matches!(find_matching_square(raw, 1), Some(close) if close == raw.len() - 1)


### PR DESCRIPTION
## Summary
- add stage1 mutable slice type and lowering support
- enforce mutable-vs-shared aliasing and double-mutable-borrow rejection
- preserve mutable borrow provenance through tuples, matches, and wrapped aggregates
- cover mutable borrow liveness and wrapper cases with compiler tests

## Validation
- `cargo test --manifest-path /home/pheidon/.openclaw/workspace/repos/omt-global/axiom/stage1/Cargo.toml -p axiomc mutable_slice`
- `make -C /home/pheidon/.openclaw/workspace/repos/omt-global/axiom stage1-test`
- `make -C /home/pheidon/.openclaw/workspace/repos/omt-global/axiom stage1-smoke`

Closes #85