### PR TITLE
Close #87: stabilize ownership diagnostics

### DIFF
--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -71,11 +71,11 @@ still far from the stated 1.0 target for service and agent workloads.
 
 ### Type and ownership gaps
 
-- Ownership is still bootstrap-grade even though it now covers all non-`Copy` stage1 values, conservatively handles non-`Copy` field access, and enforces immutable live-borrow checks for owned values behind borrowed slices.
+- Ownership now has a stable current-stage contract for all non-`Copy` stage1 values, including shared and mutable borrowed-slice conflicts, loop-body move rejection, and stable machine-readable ownership error codes in `--json` diagnostics, but it is still intentionally narrower than a full Rust-style borrow checker.
 - AG1.1 loop-join handling is now landed: moving an outer non-`Copy` value inside a `while` body is a compile error, and post-loop ownership state preserves the pre-loop state since the body may execute zero times. Dead-branch pruning for statically false conditions is preserved.
 - Borrowed slices can now flow through direct `&[T]` returns, named structs, enum payloads, and aggregate return types like `Option<&[T]>` or tuples when they are derived from one or more borrowed parameters, `Option` / `Result` match bindings preserve enough borrow provenance to return those borrowed payloads again, conservative call summaries now keep borrowed-return provenance alive across multiple borrowed parameters, statically false control-flow is now skipped instead of contaminating move state, and live borrowed slices now block later owner moves until their scope ends even when those borrows are stored inside local aggregate wrappers, named structs, enum payloads, or temporary `match` / call expressions, but there are still no general borrows, mutable borrows, lifetime checks, precise path-sensitive borrow narrowing beyond constant conditions, or first-class partial-move analysis for aggregates and function calls.
 - Exhaustiveness checking now exists for statement-level enum `match`, but there is still no typed error propagation and no control-flow-sensitive ownership diagnostics beyond simple branches.
-- Compile-fail coverage now exists for several bootstrap ownership failures including AG1.1 loop-body move rejection, but there is still no dedicated corpus yet for the broader future borrow rules that a Rust-like language actually needs.
+- A dedicated checked-in ownership compile-fail corpus now lives under `stage1/crates/axiomc/tests/ownership_failures`, covering move-after-use, invalid borrowed returns, conflicting borrows, and loop/control-flow hazards. The checked-in ownership-heavy proof point remains `stage1/examples/borrowed_shapes`, and it stays in `make stage1-smoke`.
 
 ### Package and build graph gaps
 
@@ -93,7 +93,7 @@ still far from the stated 1.0 target for service and agent workloads.
 
 - Native builds still work by generating Rust and invoking `rustc`; there is no Cranelift backend yet.
 - There is no stage1 formatter, benchmark harness, doc generator, publisher, or LSP server yet.
-- Diagnostics are still bootstrap-grade: useful JSON exists, but span quality, notes, and compile-fail coverage are limited.
+- Diagnostics are still intentionally minimal: useful JSON now includes stable ownership codes, but span quality and note richness are still limited.
 - There are no performance targets or regression gates yet.
 
 ## Execution plan

--- a/stage1/crates/axiomc/src/diagnostics.rs
+++ b/stage1/crates/axiomc/src/diagnostics.rs
@@ -3,6 +3,8 @@ use serde::Serialize;
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct Diagnostic {
     pub kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
     pub message: String,
     pub path: Option<String>,
     pub line: Option<usize>,
@@ -13,11 +15,17 @@ impl Diagnostic {
     pub fn new(kind: impl Into<String>, message: impl Into<String>) -> Self {
         Self {
             kind: kind.into(),
+            code: None,
             message: message.into(),
             path: None,
             line: None,
             column: None,
         }
+    }
+
+    pub fn with_code(mut self, code: impl Into<String>) -> Self {
+        self.code = Some(code.into());
+        self
     }
 
     pub fn with_path(mut self, path: impl Into<String>) -> Self {

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -249,6 +249,18 @@ struct VariantInfo {
     payload_names: Vec<String>,
 }
 
+const OWNERSHIP_LOOP_MOVE_OUTER_NON_COPY: &str = "loop_move_outer_non_copy";
+const OWNERSHIP_BORROW_RETURN_REQUIRES_PARAM_ORIGIN: &str =
+    "borrow_return_requires_param_origin";
+const OWNERSHIP_MOVE_WHILE_BORROWED: &str = "move_while_borrowed";
+const OWNERSHIP_USE_AFTER_MOVE: &str = "use_after_move";
+const OWNERSHIP_SHARED_BORROW_WHILE_MUTABLE_LIVE: &str =
+    "shared_borrow_while_mutable_live";
+const OWNERSHIP_MUTABLE_BORROW_WHILE_MUTABLE_LIVE: &str =
+    "mutable_borrow_while_mutable_live";
+const OWNERSHIP_MUTABLE_BORROW_WHILE_SHARED_LIVE: &str =
+    "mutable_borrow_while_shared_live";
+
 pub fn lower(program: &syntax::Program) -> Result<Program, Diagnostic> {
     let capabilities = CapabilityConfig::default();
     lower_with_capabilities(program, &capabilities)
@@ -294,6 +306,10 @@ pub fn lower_with_capabilities(
         functions: lowered_functions,
         stmts,
     })
+}
+
+fn ownership_error(code: &'static str, message: impl Into<String>) -> Diagnostic {
+    Diagnostic::new("ownership", message).with_code(code)
 }
 
 impl Type {
@@ -886,8 +902,8 @@ fn lower_stmt(
                     }
                     if let Some(post_binding) = body_after.get(name) {
                         if post_binding.moved {
-                            return Err(Diagnostic::new(
-                                "ownership",
+                            return Err(ownership_error(
+                                OWNERSHIP_LOOP_MOVE_OUTER_NON_COPY,
                                 format!(
                                     "cannot move non-copy value `{}` inside loop body — \
                                      value would not be available on subsequent iterations",
@@ -1144,8 +1160,8 @@ fn lower_stmt(
                     Some(BorrowOrigin::Param(origin))
                         if ctx.current_borrow_return_params.contains(&origin) => {}
                     _ => {
-                        return Err(Diagnostic::new(
-                            "ownership",
+                        return Err(ownership_error(
+                            OWNERSHIP_BORROW_RETURN_REQUIRES_PARAM_ORIGIN,
                             format!(
                                 "returning borrowed values requires data derived from one of the borrowed parameters in stage1"
                             ),
@@ -1372,11 +1388,13 @@ fn lower_expr_with_expected(
         syntax::Expr::VarRef { name, line, column } => {
             if let Some(binding) = env.get(name) {
                 if binding.moved {
-                    return Err(Diagnostic::new(
-                        "ownership",
-                        format!("use of moved value {name:?}"),
-                    )
-                    .with_span(*line, *column));
+                    return Err(
+                        ownership_error(
+                            OWNERSHIP_USE_AFTER_MOVE,
+                            format!("use of moved value {name:?}"),
+                        )
+                        .with_span(*line, *column),
+                    );
                 }
                 return Ok(Expr::VarRef {
                     name: name.clone(),
@@ -2591,14 +2609,14 @@ fn move_lowered_value(expr: &Expr, env: &mut HashMap<String, Binding>) -> Result
         )
     })?;
     if binding.active_borrow_count > 0 {
-        return Err(Diagnostic::new(
-            "ownership",
+        return Err(ownership_error(
+            OWNERSHIP_MOVE_WHILE_BORROWED,
             format!("cannot move value {name:?} while borrowed slices are still live"),
         ));
     }
     if binding.moved {
-        return Err(Diagnostic::new(
-            "ownership",
+        return Err(ownership_error(
+            OWNERSHIP_USE_AFTER_MOVE,
             format!("use of moved value {name:?}"),
         ));
     }
@@ -3172,24 +3190,24 @@ fn increment_active_borrows(
         })?;
         match borrow_kind {
             BorrowKind::Shared if binding.active_mut_borrow_count > 0 => {
-                return Err(Diagnostic::new(
-                    "ownership",
+                return Err(ownership_error(
+                    OWNERSHIP_SHARED_BORROW_WHILE_MUTABLE_LIVE,
                     format!(
                         "cannot create shared borrow of value {owner_name:?} while a mutable borrow is still live"
                     ),
                 ));
             }
             BorrowKind::Mutable if binding.active_mut_borrow_count > 0 => {
-                return Err(Diagnostic::new(
-                    "ownership",
+                return Err(ownership_error(
+                    OWNERSHIP_MUTABLE_BORROW_WHILE_MUTABLE_LIVE,
                     format!(
                         "cannot create mutable borrow of value {owner_name:?} while another mutable borrow is still live"
                     ),
                 ));
             }
             BorrowKind::Mutable if binding.active_borrow_count > 0 => {
-                return Err(Diagnostic::new(
-                    "ownership",
+                return Err(ownership_error(
+                    OWNERSHIP_MUTABLE_BORROW_WHILE_SHARED_LIVE,
                     format!(
                         "cannot create mutable borrow of value {owner_name:?} while a shared borrow is still live"
                     ),

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -81,6 +81,13 @@ mod tests {
             .expect("host target")
     }
 
+    fn ownership_failure_fixture(case: &str) -> std::path::PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("ownership_failures")
+            .join(case)
+    }
+
     #[test]
     fn new_project_writes_manifest_lockfile_and_source() {
         let dir = tempdir().expect("tempdir");
@@ -2162,6 +2169,45 @@ mod tests {
     }
 
     #[test]
+    fn ownership_compile_fail_corpus_reports_stable_codes() {
+        let cases = [
+            (
+                "use_after_move",
+                "use_after_move",
+                "use of moved value",
+            ),
+            (
+                "borrow_return_requires_param_origin",
+                "borrow_return_requires_param_origin",
+                "returning borrowed values requires data derived from one of the borrowed parameters",
+            ),
+            (
+                "mutable_borrow_while_shared_live",
+                "mutable_borrow_while_shared_live",
+                "cannot create mutable borrow of value",
+            ),
+            (
+                "loop_move_outer_non_copy",
+                "loop_move_outer_non_copy",
+                "cannot move non-copy value",
+            ),
+        ];
+
+        for (case, code, message) in cases {
+            let project = ownership_failure_fixture(case);
+            let error = check_project(&project)
+                .expect_err(&format!("ownership fixture {case} should fail"));
+            assert_eq!(error.kind, "ownership", "fixture {case}");
+            assert_eq!(error.code.as_deref(), Some(code), "fixture {case}");
+            assert!(
+                error.message.contains(message),
+                "fixture {case}: {:?}",
+                error.message
+            );
+        }
+    }
+
+    #[test]
     fn check_project_rejects_branch_move_followed_by_outer_use() {
         let dir = tempdir().expect("tempdir");
         let project = dir.path().join("branch-moves");
@@ -3676,7 +3722,8 @@ mod tests {
         assert_eq!(caps_payload["command"], "caps");
         assert_eq!(caps_payload["ok"], true);
 
-        let error = crate::diagnostics::Diagnostic::new("test", "boom");
+        let error = crate::diagnostics::Diagnostic::new("ownership", "boom")
+            .with_code("use_after_move");
         let error_payload = json_contract::error("test", &error);
         assert_eq!(
             error_payload["schema_version"],
@@ -3684,6 +3731,8 @@ mod tests {
         );
         assert_eq!(error_payload["command"], "test");
         assert_eq!(error_payload["ok"], false);
+        assert_eq!(error_payload["error"]["kind"], "ownership");
+        assert_eq!(error_payload["error"]["code"], "use_after_move");
         assert_eq!(error_payload["error"]["message"], "boom");
     }
 }

--- a/stage1/crates/axiomc/tests/ownership_failures/borrow_return_requires_param_origin/axiom.lock
+++ b/stage1/crates/axiomc/tests/ownership_failures/borrow_return_requires_param_origin/axiom.lock
@@ -1,0 +1,6 @@
+version = 1
+
+[[package]]
+name = "ownership-borrow-return-origin"
+version = "0.1.0"
+source = "path"

--- a/stage1/crates/axiomc/tests/ownership_failures/borrow_return_requires_param_origin/axiom.toml
+++ b/stage1/crates/axiomc/tests/ownership_failures/borrow_return_requires_param_origin/axiom.toml
@@ -1,0 +1,15 @@
+[package]
+name = "ownership-borrow-return-origin"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false

--- a/stage1/crates/axiomc/tests/ownership_failures/borrow_return_requires_param_origin/src/main.ax
+++ b/stage1/crates/axiomc/tests/ownership_failures/borrow_return_requires_param_origin/src/main.ax
@@ -1,0 +1,6 @@
+fn tail(values: &[int]): &[int] {
+let local: [int] = [3, 7, 9, 11]
+return local[1:]
+}
+
+print 0

--- a/stage1/crates/axiomc/tests/ownership_failures/loop_move_outer_non_copy/axiom.lock
+++ b/stage1/crates/axiomc/tests/ownership_failures/loop_move_outer_non_copy/axiom.lock
@@ -1,0 +1,6 @@
+version = 1
+
+[[package]]
+name = "ownership-loop-move"
+version = "0.1.0"
+source = "path"

--- a/stage1/crates/axiomc/tests/ownership_failures/loop_move_outer_non_copy/axiom.toml
+++ b/stage1/crates/axiomc/tests/ownership_failures/loop_move_outer_non_copy/axiom.toml
@@ -1,0 +1,15 @@
+[package]
+name = "ownership-loop-move"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false

--- a/stage1/crates/axiomc/tests/ownership_failures/loop_move_outer_non_copy/src/main.ax
+++ b/stage1/crates/axiomc/tests/ownership_failures/loop_move_outer_non_copy/src/main.ax
@@ -1,0 +1,5 @@
+let greeting: string = "hello"
+while true {
+let alias: string = greeting
+print alias
+}

--- a/stage1/crates/axiomc/tests/ownership_failures/mutable_borrow_while_shared_live/axiom.lock
+++ b/stage1/crates/axiomc/tests/ownership_failures/mutable_borrow_while_shared_live/axiom.lock
@@ -1,0 +1,6 @@
+version = 1
+
+[[package]]
+name = "ownership-borrow-conflict"
+version = "0.1.0"
+source = "path"

--- a/stage1/crates/axiomc/tests/ownership_failures/mutable_borrow_while_shared_live/axiom.toml
+++ b/stage1/crates/axiomc/tests/ownership_failures/mutable_borrow_while_shared_live/axiom.toml
@@ -1,0 +1,15 @@
+[package]
+name = "ownership-borrow-conflict"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false

--- a/stage1/crates/axiomc/tests/ownership_failures/mutable_borrow_while_shared_live/src/main.ax
+++ b/stage1/crates/axiomc/tests/ownership_failures/mutable_borrow_while_shared_live/src/main.ax
@@ -1,0 +1,5 @@
+let values: [int] = [1, 2, 3]
+let shared: &[int] = values[:]
+let mutable: &mut [int] = values[:]
+print len(shared)
+print len(mutable)

--- a/stage1/crates/axiomc/tests/ownership_failures/use_after_move/axiom.lock
+++ b/stage1/crates/axiomc/tests/ownership_failures/use_after_move/axiom.lock
@@ -1,0 +1,6 @@
+version = 1
+
+[[package]]
+name = "ownership-use-after-move"
+version = "0.1.0"
+source = "path"

--- a/stage1/crates/axiomc/tests/ownership_failures/use_after_move/axiom.toml
+++ b/stage1/crates/axiomc/tests/ownership_failures/use_after_move/axiom.toml
@@ -1,0 +1,15 @@
+[package]
+name = "ownership-use-after-move"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false

--- a/stage1/crates/axiomc/tests/ownership_failures/use_after_move/src/main.ax
+++ b/stage1/crates/axiomc/tests/ownership_failures/use_after_move/src/main.ax
@@ -1,0 +1,4 @@
+let greeting: string = "hello"
+let alias: string = greeting
+print alias
+print greeting


### PR DESCRIPTION
## Summary
- add stable ownership diagnostic codes without changing the top-level `ownership` kind
- add a checked-in ownership compile-fail corpus for move-after-use, invalid borrowed returns, conflicting borrows, and loop hazards
- update stage1 status docs to reflect the dedicated corpus and machine-readable ownership diagnostics

## Verification
- `cargo test --manifest-path stage1/Cargo.toml ownership_compile_fail_corpus_reports_stable_codes -- --nocapture`
- `cargo test --manifest-path stage1/Cargo.toml json_contract_caps_and_error_payloads_are_versioned -- --nocapture`
- `cargo test --manifest-path stage1/Cargo.toml`
- `./.venv/bin/python -m unittest discover -v`
- `make stage1-smoke`

Close #87