### PR TITLE
Sync AG4 capability integration status docs

### DIFF
--- a/docs/stage1-agent-grade-compiler.md
+++ b/docs/stage1-agent-grade-compiler.md
@@ -188,9 +188,9 @@ capability (HTTPS/TLS land in a follow-on slice). It also includes
 wraps a new ungated `io_eprintln` intrinsic and establishes the "ambient
 stdio" precedent alongside the existing `print` statement. The remaining
 AG4.1 modules (`std.json`, `std.collections`, `std.sync`) require new
-stdlib intrinsics, the AG4.2 async runtime, or AG2 generics. AG4.2 async
-runtime, AG4.3 HTTP *server* support, and AG4.4 capability-aware integration
-work are still open.
+stdlib intrinsics, the AG4.2 async runtime, or AG2 generics. AG4.4
+capability-aware integration for the currently landed stdlib/runtime surface is
+now complete; AG4.2 async runtime and AG4.3 HTTP *server* support remain open.
 
 Work packages:
 
@@ -272,7 +272,12 @@ Work packages:
 - `AG4.3`: HTTP service support
   - HTTP server support is required at this milestone, not just client support.
 - `AG4.4`: capability-aware integration
-  - Stdlib operations must be capability-gated instead of acting like implicit host access.
+  - **landed for the current stdlib/runtime surface**: compiler-known
+    intrinsics enforce all six manifest flags, stdlib wrappers preserve that
+    enforcement against the importing package's manifest, capability-denied
+    programs fail before native execution, and the Rust suite covers both
+    per-wrapper denial paths and cross-package capability interactions
+    (`dependency_package_must_enable_its_own_capabilities`).
 
 Acceptance:
 

--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -86,7 +86,7 @@ still far from the stated 1.0 target for service and agent workloads.
 ### Runtime and standard library gaps
 
 - The AG4.1 stdlib surface now covers every stage1 capability-gated intrinsic with a thin wrapper module (`std/time.ax`, `std/env.ax`, `std/fs.ax`, `std/net.ax`, `std/process.ax`, `std/crypto_hash.ax`), plus `std/http.ax` (first stdlib module with a brand-new capability-gated intrinsic `http_get` sharing the existing `net` surface) and `std/io.ax` (first ungated stdlib module, `eprintln` on top of the new `io_eprintln` intrinsic). The remaining AG4.1 modules (`std.json`, `std.collections`, `std.sync`) require new stdlib intrinsics, the AG4.2 async runtime, or AG2 generics and stay as follow-on work.
-- Capability enforcement exists for a compiler-known intrinsic slice across all six manifest flags: `fs_read(...)`, `net_resolve(...)`, `process_status(...)`, `env_get(...)`, `clock_now_ms()`, and `crypto_sha256(...)`, and stdlib wrappers preserve that enforcement against the importing package's manifest, but the general stdlib module surface is still mostly empty.
+- Capability-aware integration is now in place for the current stage1 runtime surface: compiler-known intrinsics enforce all six manifest flags, stdlib wrappers preserve that enforcement against the importing package's manifest, capability-denied programs fail before native execution, and the Rust suite covers cross-package capability interactions (`dependency_package_must_enable_its_own_capabilities`) plus per-wrapper denial paths.
 - No async runtime, channels, cancellation, timers, or service-grade I/O surface exists.
 
 ### Backend and tooling gaps


### PR DESCRIPTION
## Summary
- update the stage1 status docs to reflect that capability-aware integration is already landed for the current stdlib/runtime surface
- keep AG4 overall marked in progress because async runtime, HTTP server support, and blocked stdlib modules are still open

## Verification
- docs-only change; no compiler behavior changed

Closes #98