### PR TITLE
Implement #128: richer axiomc test framework

### DIFF
--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -41,11 +41,17 @@ cargo run --manifest-path stage1/Cargo.toml -p axiomc -- caps stage1/examples/he
 
 `axiomc test` discovers `src/**/*_test.ax` entrypoints by default, builds each test
 as a native artifact, executes it, and compares stdout against a sibling
-`*.stdout` golden file when present. Projects that need explicit naming or inline
-expectations can still declare `[[tests]]` entries in `axiom.toml`. The command
-now also accepts `--filter <pattern>` to run a subset of discovered tests by
-test name or entry path. Workspace-only roots are now supported as long as
-build/run commands select a concrete member package with `-p/--package`.
+`*.stdout` golden file when present. Tests can also use the built-in assertion
+helpers `assert_eq`, `assert_ne`, `assert_true`, and `assert_contains`; they
+return `0` on success so they fit in the current statement-only bootstrap
+surface via ordinary `let` bindings, and they abort the test with a source
+location plus expected/actual detail on failure. Projects that need explicit
+naming or inline expectations can still declare `[[tests]]` entries in
+`axiom.toml`. The command now also accepts `--filter <pattern>` to run a subset
+of discovered tests by test name or entry path, and the default CLI summary now
+prints `passed` / `failed` / `skipped` counts. Workspace-only roots are now
+supported as long as build/run commands select a concrete member package with
+`-p/--package`.
 
 ## JSON contract
 
@@ -53,8 +59,8 @@ build/run commands select a concrete member package with `-p/--package`.
 emit the versioned schema envelope `schema_version = "axiom.stage1.v1"`.
 Successful payloads always include `ok`, `command`, and `project`, while
 `axiomc test --json` additionally reports `filter` and per-run/per-case
-`duration_ms`. Build payloads report the requested Rust target triple when
-`--target <triple>` is used.
+`duration_ms` plus `passed` / `failed` / `skipped`. Build payloads report the
+requested Rust target triple when `--target <triple>` is used.
 
 ## Current gaps
 

--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -70,6 +70,11 @@ pub fn render_rust(program: &Program) -> String {
     out.push_str("    }\n");
     out.push_str("}\n\n");
     out.push_str("#[allow(dead_code)]\n");
+    out.push_str("fn axiom_assert_fail(message: String, line: i64, column: i64) -> i64 {\n");
+    out.push_str("    eprintln!(\"assertion failed at {}:{}: {}\", line, column, message);\n");
+    out.push_str("    std::process::exit(1)\n");
+    out.push_str("}\n\n");
+    out.push_str("#[allow(dead_code)]\n");
     out.push_str("fn axiom_json_parse_int(text: String) -> Option<i64> {\n");
     out.push_str("    text.trim().parse::<i64>().ok()\n");
     out.push_str("}\n\n");
@@ -658,6 +663,41 @@ fn render_expr(expr: &Expr) -> String {
         Expr::Literal(LiteralValue::Bool(value)) => value.to_string(),
         Expr::Literal(LiteralValue::String(value)) => format!("String::from({value:?})"),
         Expr::VarRef { name, .. } => name.clone(),
+        Expr::Call { name, args, .. } if name == "assert_true" => {
+            format!(
+                "{{ let condition = {}; if condition {{ 0i64 }} else {{ axiom_assert_fail(String::from(\"expected condition to be true\"), {}, {}) }} }}",
+                render_expr(&args[0]),
+                render_expr(&args[1]),
+                render_expr(&args[2])
+            )
+        }
+        Expr::Call { name, args, .. } if name == "assert_contains" => {
+            format!(
+                "{{ let haystack = {}; let needle = {}; if haystack.contains(&needle) {{ 0i64 }} else {{ axiom_assert_fail(format!(\"expected {{:?}} to contain {{:?}}\", haystack, needle), {}, {}) }} }}",
+                render_expr(&args[0]),
+                render_expr(&args[1]),
+                render_expr(&args[2]),
+                render_expr(&args[3])
+            )
+        }
+        Expr::Call { name, args, .. } if name == "assert_eq" => {
+            format!(
+                "{{ let left = {}; let right = {}; if left == right {{ 0i64 }} else {{ axiom_assert_fail(format!(\"expected left == right, left={{:?}}, right={{:?}}\", left, right), {}, {}) }} }}",
+                render_expr(&args[0]),
+                render_expr(&args[1]),
+                render_expr(&args[2]),
+                render_expr(&args[3])
+            )
+        }
+        Expr::Call { name, args, .. } if name == "assert_ne" => {
+            format!(
+                "{{ let left = {}; let right = {}; if left != right {{ 0i64 }} else {{ axiom_assert_fail(format!(\"expected left != right, both were {{:?}}\", left), {}, {}) }} }}",
+                render_expr(&args[0]),
+                render_expr(&args[1]),
+                render_expr(&args[2]),
+                render_expr(&args[3])
+            )
+        }
         Expr::Call { name, args, .. } if name == "len" => {
             format!("({}).len() as i64", render_expr(&args[0]))
         }

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -1500,6 +1500,103 @@ fn lower_expr_with_expected(
             line,
             column,
         } => {
+            if name == "assert_true" {
+                if args.len() != 1 {
+                    return Err(Diagnostic::new(
+                        "type",
+                        format!("assert_true expects 1 argument, got {}", args.len()),
+                    )
+                    .with_span(*line, *column));
+                }
+                let lowered = lower_expr_with_expected(&args[0], Some(&Type::Bool), env, ctx)?;
+                if lowered.ty() != &Type::Bool {
+                    return Err(Diagnostic::new(
+                        "type",
+                        format!("assert_true expects a bool argument, got {}", lowered.ty()),
+                    )
+                    .with_span(args[0].line(), args[0].column()));
+                }
+                move_lowered_value(&lowered, env)?;
+                return Ok(Expr::Call {
+                    name: name.clone(),
+                    args: with_assert_location(vec![lowered], *line, *column),
+                    ty: Type::Int,
+                });
+            }
+            if name == "assert_contains" {
+                if args.len() != 2 {
+                    return Err(Diagnostic::new(
+                        "type",
+                        format!("assert_contains expects 2 arguments, got {}", args.len()),
+                    )
+                    .with_span(*line, *column));
+                }
+                let haystack =
+                    lower_expr_with_expected(&args[0], Some(&Type::String), env, ctx)?;
+                if haystack.ty() != &Type::String {
+                    return Err(Diagnostic::new(
+                        "type",
+                        format!(
+                            "assert_contains expects a string haystack, got {}",
+                            haystack.ty()
+                        ),
+                    )
+                    .with_span(args[0].line(), args[0].column()));
+                }
+                let needle = lower_expr_with_expected(&args[1], Some(&Type::String), env, ctx)?;
+                if needle.ty() != &Type::String {
+                    return Err(Diagnostic::new(
+                        "type",
+                        format!(
+                            "assert_contains expects a string needle, got {}",
+                            needle.ty()
+                        ),
+                    )
+                    .with_span(args[1].line(), args[1].column()));
+                }
+                move_lowered_value(&haystack, env)?;
+                move_lowered_value(&needle, env)?;
+                return Ok(Expr::Call {
+                    name: name.clone(),
+                    args: with_assert_location(vec![haystack, needle], *line, *column),
+                    ty: Type::Int,
+                });
+            }
+            if name == "assert_eq" || name == "assert_ne" {
+                if args.len() != 2 {
+                    return Err(Diagnostic::new(
+                        "type",
+                        format!("{name} expects 2 arguments, got {}", args.len()),
+                    )
+                    .with_span(*line, *column));
+                }
+                let lhs = lower_expr(&args[0], env, ctx)?;
+                if !matches!(lhs.ty(), Type::Int | Type::Bool | Type::String) {
+                    return Err(Diagnostic::new(
+                        "type",
+                        format!(
+                            "{name} expects int, bool, or string arguments, got {}",
+                            lhs.ty()
+                        ),
+                    )
+                    .with_span(args[0].line(), args[0].column()));
+                }
+                let rhs = lower_expr_with_expected(&args[1], Some(lhs.ty()), env, ctx)?;
+                if rhs.ty() != lhs.ty() {
+                    return Err(Diagnostic::new(
+                        "type",
+                        format!("{name} requires both arguments to share one type"),
+                    )
+                    .with_span(args[1].line(), args[1].column()));
+                }
+                move_lowered_value(&lhs, env)?;
+                move_lowered_value(&rhs, env)?;
+                return Ok(Expr::Call {
+                    name: name.clone(),
+                    args: with_assert_location(vec![lhs, rhs], *line, *column),
+                    ty: Type::Int,
+                });
+            }
             if name == "len" {
                 if args.len() != 1 {
                     return Err(Diagnostic::new(
@@ -3656,6 +3753,19 @@ fn lower_compare_op(op: syntax::CompareOp) -> CompareOp {
         syntax::CompareOp::Gt => CompareOp::Gt,
         syntax::CompareOp::Ge => CompareOp::Ge,
     }
+}
+
+fn with_assert_location(args: Vec<Expr>, line: usize, column: usize) -> Vec<Expr> {
+    let mut args = args;
+    args.push(Expr::Literal {
+        ty: Type::Int,
+        value: LiteralValue::Int(line as i64),
+    });
+    args.push(Expr::Literal {
+        ty: Type::Int,
+        value: LiteralValue::Int(column as i64),
+    });
+    args
 }
 
 fn static_bool_value(expr: &Expr) -> Option<bool> {

--- a/stage1/crates/axiomc/src/json_contract.rs
+++ b/stage1/crates/axiomc/src/json_contract.rs
@@ -47,6 +47,7 @@ pub fn test_success(project: &Path, filter: Option<&str>, output: &TestOutput) -
         "filter": filter,
         "passed": output.passed,
         "failed": output.failed,
+        "skipped": output.skipped,
         "duration_ms": output.duration_ms,
         "cases": output.cases,
     })

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -2199,7 +2199,59 @@ mod tests {
                 .as_ref()
                 .expect("error")
                 .message
-                .contains("stdout did not match")
+                .contains("expected \"99\\n\", got \"42\\n\"")
+        );
+    }
+
+    #[test]
+    fn run_project_tests_supports_builtin_assertions() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("runner-assertions");
+        create_project(&project, Some("runner-assertions-app")).expect("create project");
+        fs::write(
+            project.join("src/main_test.ax"),
+            "let eq_ok: int = assert_eq(40 + 2, 42)\nlet true_ok: int = assert_true(42 == 42)\nlet ne_ok: int = assert_ne(\"alpha\", \"beta\")\nlet contains_ok: int = assert_contains(\"axiom stage1\", \"stage1\")\nprint eq_ok + true_ok + ne_ok + contains_ok\n",
+        )
+        .expect("write assertion test");
+        fs::write(project.join("src/main_test.stdout"), "0\n").expect("write assertion golden");
+
+        let output = run_project_tests(&project).expect("run tests");
+        assert_eq!(output.passed, 1);
+        assert_eq!(output.failed, 0);
+        assert_eq!(output.skipped, 0);
+        let case = output.cases.first().expect("test case");
+        assert_eq!(case.stdout, "0\n");
+        assert!(case.ok);
+    }
+
+    #[test]
+    fn run_project_tests_reports_assertion_failure_details() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("runner-assertion-fail");
+        create_project(&project, Some("runner-assertion-fail-app")).expect("create project");
+        fs::write(
+            project.join("src/main_test.ax"),
+            "let failed: int = assert_eq(41, 42)\nprint failed\n",
+        )
+        .expect("write failing assertion test");
+        fs::remove_file(project.join("src/main_test.stdout")).expect("remove default golden");
+
+        let output = run_project_tests(&project).expect("run tests");
+        assert_eq!(output.passed, 0);
+        assert_eq!(output.failed, 1);
+        assert_eq!(output.skipped, 0);
+        let case = output.cases.first().expect("test case");
+        assert!(!case.ok);
+        assert!(
+            case.stderr
+                .contains("assertion failed at 1:14: expected left == right, left=41, right=42")
+        );
+        assert!(
+            case.error
+                .as_ref()
+                .expect("error")
+                .message
+                .contains("expected left == right, left=41, right=42")
         );
     }
 
@@ -3875,6 +3927,7 @@ mod tests {
         );
         assert_eq!(payload["command"], "test");
         assert_eq!(payload["filter"], "main");
+        assert_eq!(payload["skipped"], 0);
         assert!(payload["duration_ms"].is_u64());
     }
 

--- a/stage1/crates/axiomc/src/main.rs
+++ b/stage1/crates/axiomc/src/main.rs
@@ -152,8 +152,8 @@ fn main() {
                         eprintln!("  duration: {} ms", case.duration_ms);
                     }
                     eprintln!(
-                        "passed: {} failed: {} duration: {} ms",
-                        output.passed, output.failed, output.duration_ms
+                        "passed: {} failed: {} skipped: {} duration: {} ms",
+                        output.passed, output.failed, output.skipped, output.duration_ms
                     );
                 }
                 if ok { 0 } else { 1 }

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -80,6 +80,7 @@ pub struct TestOutput {
     pub cases: Vec<TestCaseResult>,
     pub passed: usize,
     pub failed: usize,
+    pub skipped: usize,
     pub duration_ms: u64,
 }
 
@@ -267,6 +268,7 @@ pub fn run_project_tests_with_options(
         cases,
         passed,
         failed,
+        skipped: 0,
         duration_ms: started.elapsed().as_millis() as u64,
     })
 }
@@ -750,14 +752,24 @@ fn run_test_case(
             let stderr = String::from_utf8_lossy(&output.stderr).to_string();
             let exit_code = output.status.code();
             let error = if !output.status.success() {
+                let detail = stderr.trim();
                 Some(
                     Diagnostic::new(
                         "test",
-                        format!(
-                            "test {:?} exited with status {}",
-                            test.name,
-                            exit_code.unwrap_or(1)
-                        ),
+                        if detail.is_empty() {
+                            format!(
+                                "test {:?} exited with status {}",
+                                test.name,
+                                exit_code.unwrap_or(1)
+                            )
+                        } else {
+                            format!(
+                                "test {:?} exited with status {}: {}",
+                                test.name,
+                                exit_code.unwrap_or(1),
+                                detail
+                            )
+                        },
                     )
                     .with_path(entry_path.display().to_string()),
                 )
@@ -766,7 +778,10 @@ fn run_test_case(
                     Some(
                         Diagnostic::new(
                             "test",
-                            format!("test {:?} stdout did not match expected output", test.name),
+                            format!(
+                                "test {:?} stdout did not match expected output: expected {:?}, got {:?}",
+                                test.name, expected_stdout, stdout
+                            ),
                         )
                         .with_path(entry_path.display().to_string()),
                     )


### PR DESCRIPTION
Implements #128.

Summary:
- expand the stage1 test framework with richer assertions and reporting
- improve failure output and skipped test accounting
- add coverage for the new testing behavior

Verification:
- cargo test --manifest-path stage1/Cargo.toml -p axiomc
- make stage1-test stage1-smoke