### PR TITLE
Guard package manifest size before parsing

### DIFF
--- a/axiom/packaging.py
+++ b/axiom/packaging.py
@@ -18,6 +18,7 @@ DEFAULT_NAME = "axiom-app"
 DEFAULT_VERSION = "0.1.0"
 DEFAULT_MAIN = "src/main.ax"
 DEFAULT_OUT_DIR = "dist"
+MAX_MANIFEST_BYTES = 1 * 1024 * 1024
 
 
 @dataclass(frozen=True)
@@ -166,6 +167,12 @@ def load_manifest(project_root: Path) -> PackageManifest:
     path = manifest_path(project_root)
     if not path.exists():
         raise AxiomCompileError(f"missing package manifest at {path}")
+    manifest_size = path.stat().st_size
+    if manifest_size > MAX_MANIFEST_BYTES:
+        raise AxiomCompileError(
+            f"package manifest {path} is too large "
+            f"({manifest_size} bytes, max {MAX_MANIFEST_BYTES})"
+        )
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as e:

--- a/tests/test_cli_packages.py
+++ b/tests/test_cli_packages.py
@@ -6,7 +6,9 @@ import shutil
 import tempfile
 import unittest
 
+from axiom.errors import AxiomCompileError
 from axiom.host import host_contract_metadata
+from axiom.packaging import MAX_MANIFEST_BYTES, load_manifest
 from tests.helpers import ROOT, init_temp_package, read_json, run_cli, write_json
 
 
@@ -41,6 +43,30 @@ class CliPackageTests(unittest.TestCase):
             proc = run_cli(self, ["pkg", "manifest", str(project)], cwd=ROOT)
             payload = json.loads(proc.stdout)
             self.assertEqual(payload["name"], "demo")
+
+    def test_load_manifest_allows_small_valid_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project = Path(td)
+            init_temp_package(self, project)
+
+            manifest = load_manifest(project)
+
+            self.assertEqual(manifest.name, "demo")
+
+    def test_load_manifest_rejects_manifest_above_size_limit(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project = Path(td)
+            project.mkdir(parents=True, exist_ok=True)
+            manifest = project / "axiom.pkg"
+            manifest.write_text("x" * (MAX_MANIFEST_BYTES + 1), encoding="utf-8")
+
+            with self.assertRaises(AxiomCompileError) as cm:
+                load_manifest(project)
+
+            message = str(cm.exception)
+            self.assertIn("too large", message)
+            self.assertIn(str(MAX_MANIFEST_BYTES + 1), message)
+            self.assertIn(str(MAX_MANIFEST_BYTES), message)
 
     def test_package_run_executes_main(self) -> None:
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
## Summary
- add a module-level package manifest size ceiling before JSON parsing
- report oversized manifests with actual and maximum byte counts
- cover valid small manifests and oversized manifest rejection in package loader tests

Closes #155

## Verification
- .venv/bin/python -m unittest tests.test_cli_packages
- .venv/bin/python -m unittest discover -v
- git diff --check