### PR TITLE
Add Stage 1 Axiom panic stack traces

### DIFF
--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -11,7 +11,77 @@ pub fn render_rust(program: &Program) -> String {
     let type_context = TypeContext::new(program);
     let mut out = String::new();
     out.push_str("#[allow(unused_imports)]\n");
-    out.push_str("use std::collections::HashMap;\n\n");
+    out.push_str("use std::cell::RefCell;\n");
+    out.push_str("use std::collections::HashMap;\n");
+    out.push_str("use std::panic::{self, PanicHookInfo};\n");
+    out.push_str("use std::sync::Once;\n\n");
+    out.push_str("thread_local! {\n");
+    out.push_str(
+        "    static AXIOM_STACK: RefCell<Vec<AxiomStackFrame>> = const { RefCell::new(Vec::new()) };\n",
+    );
+    out.push_str("}\n\n");
+    out.push_str("#[derive(Clone)]\n");
+    out.push_str("struct AxiomStackFrame {\n");
+    out.push_str("    function: &'static str,\n");
+    out.push_str("    file: &'static str,\n");
+    out.push_str("    line: usize,\n");
+    out.push_str("    column: usize,\n");
+    out.push_str("}\n\n");
+    out.push_str("struct AxiomFrameGuard;\n\n");
+    out.push_str("impl AxiomFrameGuard {\n");
+    out.push_str(
+        "    fn new(function: &'static str, file: &'static str, line: usize, column: usize) -> Self {\n",
+    );
+    out.push_str("        AXIOM_STACK.with(|stack| {\n");
+    out.push_str("            stack.borrow_mut().push(AxiomStackFrame {\n");
+    out.push_str("                function,\n");
+    out.push_str("                file,\n");
+    out.push_str("                line,\n");
+    out.push_str("                column,\n");
+    out.push_str("            });\n");
+    out.push_str("        });\n");
+    out.push_str("        Self\n");
+    out.push_str("    }\n");
+    out.push_str("}\n\n");
+    out.push_str("impl Drop for AxiomFrameGuard {\n");
+    out.push_str("    fn drop(&mut self) {\n");
+    out.push_str("        AXIOM_STACK.with(|stack| {\n");
+    out.push_str("            stack.borrow_mut().pop();\n");
+    out.push_str("        });\n");
+    out.push_str("    }\n");
+    out.push_str("}\n\n");
+    out.push_str("fn axiom_panic_message(info: &PanicHookInfo<'_>) -> String {\n");
+    out.push_str("    if let Some(message) = info.payload().downcast_ref::<&str>() {\n");
+    out.push_str("        (*message).to_string()\n");
+    out.push_str("    } else if let Some(message) = info.payload().downcast_ref::<String>() {\n");
+    out.push_str("        message.clone()\n");
+    out.push_str("    } else {\n");
+    out.push_str("        String::from(\"panic\")\n");
+    out.push_str("    }\n");
+    out.push_str("}\n\n");
+    out.push_str("fn axiom_install_panic_hook() {\n");
+    out.push_str("    static AXIOM_PANIC_HOOK: Once = Once::new();\n");
+    out.push_str("    AXIOM_PANIC_HOOK.call_once(|| {\n");
+    out.push_str("        panic::set_hook(Box::new(|info| {\n");
+    out.push_str("            eprintln!(\"panic: {}\", axiom_panic_message(info));\n");
+    out.push_str("            let frames = AXIOM_STACK.with(|stack| stack.borrow().clone());\n");
+    out.push_str("            if frames.is_empty() {\n");
+    out.push_str("                eprintln!(\"Axiom stack trace: <empty>\");\n");
+    out.push_str("                return;\n");
+    out.push_str("            }\n");
+    out.push_str("            eprintln!(\"Axiom stack trace (most recent call last):\");\n");
+    out.push_str("            for frame in frames.iter().rev() {\n");
+    out.push_str("                eprintln!(\n");
+    out.push_str("                    \"  at {} ({}:{}:{})\",\n");
+    out.push_str("                    frame.function,\n");
+    out.push_str("                    frame.file,\n");
+    out.push_str("                    frame.line,\n");
+    out.push_str("                    frame.column\n");
+    out.push_str("                );\n");
+    out.push_str("            }\n");
+    out.push_str("        }));\n");
+    out.push_str("    });\n");
+    out.push_str("}\n\n");
     out.push_str("#[allow(dead_code)]\n");
     out.push_str("fn axiom_array_get<T: Copy>(values: &[T], index: i64) -> T {\n");
     out.push_str(
@@ -280,6 +350,11 @@ pub fn render_rust(program: &Program) -> String {
         out.push('\n');
     }
     out.push_str("fn main() {\n");
+    out.push_str("    axiom_install_panic_hook();\n");
+    out.push_str(&format!(
+        "    let _axiom_frame = AxiomFrameGuard::new(\"<main>\", {:?}, 1, 1);\n",
+        program.path
+    ));
     for stmt in &program.stmts {
         render_stmt(stmt, &type_context, &mut out, 1);
     }
@@ -477,6 +552,10 @@ fn render_function(function: &Function, type_context: &TypeContext<'_>, out: &mu
         lifetime,
         params,
         rust_type_in_signature(&function.return_ty, uses_slice_lifetime, type_context)
+    ));
+    out.push_str(&format!(
+        "    let _axiom_frame = AxiomFrameGuard::new({:?}, {:?}, {}, {});\n",
+        function.source_name, function.path, function.line, function.column
     ));
     for stmt in &function.body {
         render_stmt(stmt, type_context, out, 1);

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -6,6 +6,7 @@ use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct Program {
+    pub path: String,
     pub structs: Vec<StructDef>,
     pub enums: Vec<EnumDef>,
     pub functions: Vec<Function>,
@@ -40,9 +41,13 @@ pub struct EnumVariantDef {
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct Function {
     pub name: String,
+    pub source_name: String,
+    pub path: String,
     pub params: Vec<Param>,
     pub return_ty: Type,
     pub body: Vec<Stmt>,
+    pub line: usize,
+    pub column: usize,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -302,6 +307,7 @@ pub fn lower_with_capabilities(
     let mut env = HashMap::new();
     let (stmts, _, _) = lower_block(&program.stmts, &mut env, &ctx)?;
     Ok(Program {
+        path: program.path.clone(),
         structs: lowered_structs,
         enums: lowered_enums,
         functions: lowered_functions,
@@ -749,9 +755,13 @@ fn lower_function(
     }
     Ok(Function {
         name: function.name.clone(),
+        source_name: function.source_name.clone(),
+        path: function.path.clone(),
         params,
         return_ty,
         body,
+        line: function.line,
+        column: function.column,
     })
 }
 

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -123,6 +123,25 @@ mod tests {
     }
 
     #[test]
+    fn render_rust_includes_axiom_panic_stack_frames() {
+        let source = "fn crash(values: [int]): int {\nreturn values[1]\n}\n\nprint crash([7])\n";
+        let parsed = parse_program(source, Path::new("main.ax")).expect("parse");
+        let hir = hir::lower(&parsed).expect("lower");
+        let mir = mir::lower(&hir);
+        let rendered = render_rust(&mir);
+        assert!(rendered.contains("fn axiom_install_panic_hook() {"));
+        assert!(
+            rendered
+                .contains("let _axiom_frame = AxiomFrameGuard::new(\"crash\", \"main.ax\", 1, 1);")
+        );
+        assert!(
+            rendered.contains(
+                "let _axiom_frame = AxiomFrameGuard::new(\"<main>\", \"main.ax\", 1, 1);"
+            )
+        );
+    }
+
+    #[test]
     fn parser_lowers_struct_literals_and_field_access() {
         let source = "struct BuildInfo {\nname: string\ncount: int\n}\n\nfn count_of(info: BuildInfo): int {\nreturn info.count\n}\n\nlet info: BuildInfo = BuildInfo { name: \"stage1\", count: 42 }\nprint count_of(info)\n";
         let parsed = parse_program(source, Path::new("main.ax")).expect("parse");
@@ -1986,6 +2005,85 @@ mod tests {
             err.message.contains("requires [capabilities].net = true"),
             "unexpected diagnostic: {err:?}",
         );
+    }
+
+    #[test]
+    fn stage1_runtime_panics_render_axiom_stack_trace_for_index_errors() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("panic-stack-index");
+        create_project(&project, Some("panic-stack-index")).expect("create project");
+        fs::write(
+            project.join("src/math.ax"),
+            "pub fn explode(values: [int]): int {\nreturn values[1]\n}\n",
+        )
+        .expect("write module");
+        fs::write(
+            project.join("src/main.ax"),
+            "import \"math.ax\"\nprint explode([7])\n",
+        )
+        .expect("write source");
+
+        let built = build_project(&project).expect("build project");
+        let output = Command::new(&built.binary)
+            .output()
+            .expect("run compiled binary");
+
+        assert!(!output.status.success(), "program should panic");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(stderr.contains("panic:"), "unexpected stderr: {stderr}");
+        assert!(
+            stderr.contains("Axiom stack trace (most recent call last):"),
+            "unexpected stderr: {stderr}"
+        );
+        assert!(stderr.contains("explode"), "unexpected stderr: {stderr}");
+        assert!(
+            stderr.contains(&project.join("src/math.ax").display().to_string()),
+            "unexpected stderr: {stderr}"
+        );
+        assert!(stderr.contains("<main>"), "unexpected stderr: {stderr}");
+        assert!(
+            stderr.contains(&project.join("src/main.ax").display().to_string()),
+            "unexpected stderr: {stderr}"
+        );
+    }
+
+    #[test]
+    fn stage1_runtime_panics_render_axiom_stack_trace_for_assert_failures() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("panic-stack-assert");
+        create_project(&project, Some("panic-stack-assert")).expect("create project");
+        fs::write(
+            project.join("src/math.ax"),
+            "pub fn window(values: &[int]): &[int] {\nreturn values[0:2]\n}\n",
+        )
+        .expect("write module");
+        fs::write(
+            project.join("src/main.ax"),
+            "import \"math.ax\"\nlet values: [int] = [7]\nlet tail: &[int] = window(values[:])\nprint len(tail)\n",
+        )
+        .expect("write source");
+
+        let built = build_project(&project).expect("build project");
+        let output = Command::new(&built.binary)
+            .output()
+            .expect("run compiled binary");
+
+        assert!(!output.status.success(), "program should panic");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("array slice end out of bounds"),
+            "unexpected stderr: {stderr}"
+        );
+        assert!(
+            stderr.contains("Axiom stack trace (most recent call last):"),
+            "unexpected stderr: {stderr}"
+        );
+        assert!(stderr.contains("window"), "unexpected stderr: {stderr}");
+        assert!(
+            stderr.contains(&project.join("src/math.ax").display().to_string()),
+            "unexpected stderr: {stderr}"
+        );
+        assert!(stderr.contains("<main>"), "unexpected stderr: {stderr}");
     }
 
     #[test]

--- a/stage1/crates/axiomc/src/mir.rs
+++ b/stage1/crates/axiomc/src/mir.rs
@@ -3,6 +3,7 @@ use serde::Serialize;
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct Program {
+    pub path: String,
     pub structs: Vec<StructDef>,
     pub enums: Vec<EnumDef>,
     pub functions: Vec<Function>,
@@ -37,9 +38,13 @@ pub struct EnumVariantDef {
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct Function {
     pub name: String,
+    pub source_name: String,
+    pub path: String,
     pub params: Vec<Param>,
     pub return_ty: Type,
     pub body: Vec<Stmt>,
+    pub line: usize,
+    pub column: usize,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -213,6 +218,7 @@ pub struct StructFieldValue {
 
 pub fn lower(program: &hir::Program) -> Program {
     Program {
+        path: program.path.clone(),
         structs: program.structs.iter().map(lower_struct).collect(),
         enums: program.enums.iter().map(lower_enum).collect(),
         functions: program.functions.iter().map(lower_function).collect(),
@@ -280,9 +286,13 @@ fn count_stmt(stmt: &Stmt) -> usize {
 fn lower_function(function: &hir::Function) -> Function {
     Function {
         name: function.name.clone(),
+        source_name: function.source_name.clone(),
+        path: function.path.clone(),
         params: function.params.iter().map(lower_param).collect(),
         return_ty: lower_type(&function.return_ty),
         body: function.body.iter().map(lower_stmt).collect(),
+        line: function.line,
+        column: function.column,
     }
 }
 

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -1365,6 +1365,11 @@ fn flatten_modules(
     }
 
     Ok(syntax::Program {
+        path: modules
+            .iter()
+            .find(|module| module.is_entry)
+            .map(|module| module.path.display().to_string())
+            .unwrap_or_default(),
         imports: Vec::new(),
         type_aliases: flattened_type_aliases,
         structs: flattened_structs,

--- a/stage1/crates/axiomc/src/syntax.rs
+++ b/stage1/crates/axiomc/src/syntax.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct Program {
+    pub path: String,
     pub imports: Vec<Import>,
     pub type_aliases: Vec<TypeAliasDecl>,
     pub structs: Vec<StructDecl>,
@@ -22,6 +23,8 @@ pub struct Import {
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct Function {
     pub name: String,
+    pub source_name: String,
+    pub path: String,
     pub params: Vec<Param>,
     pub return_ty: TypeName,
     pub body: Vec<Stmt>,
@@ -320,6 +323,7 @@ pub fn parse_program(source: &str, path: &Path) -> Result<Program, Diagnostic> {
         stmts.push(parse_stmt(&lines, &mut index, path, false)?);
     }
     Ok(Program {
+        path: path.display().to_string(),
         imports,
         type_aliases,
         structs,
@@ -539,6 +543,8 @@ fn parse_function(lines: &[&str], index: &mut usize, path: &Path) -> Result<Func
     let body = parse_stmt_list(lines, index, path)?;
     Ok(Function {
         name: name.to_string(),
+        source_name: name.to_string(),
+        path: path.display().to_string(),
         params,
         return_ty,
         body,


### PR DESCRIPTION
## Summary
- thread source file, line, column, and original function names through syntax, HIR, and MIR
- install a generated Rust panic hook that renders Axiom-level stack frames
- add renderer and runtime smoke tests for index and assertion panic stack traces

Closes #122

## Verification
- git diff --check
- cargo test -p axiomc --quiet
- make stage1-test
- make stage1-smoke