### PR TITLE
Pin ruff dev dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,10 @@ license = {file = "LICENSE"}
 authors = [{name = "JT"}]
 
 [project.optional-dependencies]
-dev = ["ruff>=0.11,<1"]
+dev = [
+    # Keep dev tooling pinned; Dependabot opens update PRs via .github/dependabot.yml.
+    "ruff==0.15.11",
+]
 
 [project.scripts]
 axiom = "axiom.__main__:main"


### PR DESCRIPTION
## Summary
- pin the ruff dev dependency to the exact installed version, 0.15.11
- add Dependabot pip updates so future ruff bumps happen through explicit PRs

Closes #157

## Verification
- grep 'ruff' pyproject.toml
- /tmp/axiom-issue-157.BuAtf1/verify-venv/bin/python -m pip install -e ".[dev]"
- /tmp/axiom-issue-157.BuAtf1/verify-venv/bin/python -m pip show ruff
- /tmp/axiom-issue-157.BuAtf1/verify-venv/bin/python -m ruff check .
- /tmp/axiom-issue-157.BuAtf1/verify-venv/bin/python -m unittest discover -v
- git diff --check