### PR TITLE
Secure secret scan temp files

### DIFF
--- a/scripts/check-detect-secrets.sh
+++ b/scripts/check-detect-secrets.sh
@@ -1,5 +1,6 @@
     #!/usr/bin/env bash
     set -euo pipefail
+    umask 0077
 
     mode="${1:-"--all-files"}"
     ignore_globs=("scripts/check-detect-secrets.sh")


### PR DESCRIPTION
## Summary
- set umask 0077 before check-detect-secrets creates its mktemp file
- preserve the existing cleanup trap and scan behavior

Closes #154

## Verification
- grep -n 'umask\|mktemp' scripts/check-detect-secrets.sh
- bash scripts/check-detect-secrets.sh --all-files
- git show HEAD:scripts/check-detect-secrets.sh | bash -s -- --all-files
- PATH=/tmp/axiom-issue-154.q7Pl5u/bin:$PATH AXIOM_MKTEMP_MARKER=/tmp/axiom-issue-154.q7Pl5u/mktemp-path.txt AXIOM_MKTEMP_SLEEP=8 bash scripts/check-detect-secrets.sh --all-files, then stat before cleanup showed: 600 -rw-------
- cleanup check confirmed the temp file was removed after script exit
- git diff --check