### PR TITLE
ci: trigger fast checks for code changes

### DIFF
--- a/.github/workflows/pr-fast-ci.yml
+++ b/.github/workflows/pr-fast-ci.yml
@@ -43,6 +43,11 @@ jobs:
               - 'docs/bootstrap/**'
               - 'README.md'
               - 'docs/**'
+              - 'axiom/**'
+              - 'tests/**'
+              - 'stage1/**'
+              - 'pyproject.toml'
+              - 'Makefile'
             ci:
               - 'project.bootstrap.yaml'
               - 'AGENTS.md'
@@ -54,6 +59,9 @@ jobs:
               - 'docs/bootstrap/**'
               - '.env.example'
               - 'CODEOWNERS'
+              - 'pyproject.toml'
+              - 'Makefile'
+              - '.github/dependabot.yml'
 
   fast-checks:
     name: Fast Checks


### PR DESCRIPTION
## Summary
- expand PR Fast CI path filters to catch normal code changes
- trigger fast checks for axiom, tests, stage1, pyproject, Makefile, and dependabot config changes
- reduce misleading skipped fast-check runs on real implementation PRs

## Why
Recent PRs were showing skipped fast-check jobs because the paths filter was too narrow and did not include normal application and stage1 code paths. The main CI still ran, but the fast-path workflow looked incorrectly idle.

## Testing
- workflow filter logic reviewed against recent PR change paths
- branch pushed for GitHub Actions validation on PR
