### PR TITLE
fix: address issue #173

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__/
 *.pyc
 *.pyo
 *.axb
+.axiom-build/
 .DS_Store
 stage1/target/
 stage1/examples/**/dist/

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+PYTHON ?= python
+AXIOM_BUILD_DIR ?= .axiom-build
+ARITH_BYTECODE ?= $(AXIOM_BUILD_DIR)/arith.axb
+
 .PHONY: test lint smoke interp compile vm stage1-test stage1-smoke stage1-run
 
 test:
@@ -16,10 +20,11 @@ interp:
 	python -m axiom interp examples/arith.ax
 
 compile:
-	python -m axiom compile examples/arith.ax -o /tmp/arith.axb
+	mkdir -p "$(AXIOM_BUILD_DIR)"
+	$(PYTHON) -m axiom compile examples/arith.ax -o "$(ARITH_BYTECODE)"
 
-vm:
-	python -m axiom vm /tmp/arith.axb
+vm: compile
+	$(PYTHON) -m axiom vm "$(ARITH_BYTECODE)"
 
 stage1-test:
 	cargo test --manifest-path stage1/Cargo.toml

--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ source .venv/bin/activate
 python -m axiom interp examples/arith.ax
 
 # Compile to bytecode
-python -m axiom compile examples/arith.ax -o /tmp/arith.axb
+python -m axiom compile examples/arith.ax -o arith.axb
 
 # Run bytecode on the VM
-python -m axiom vm /tmp/arith.axb
+python -m axiom vm arith.axb
 
 # Run the package example
 python -m axiom pkg run examples/typed_package
@@ -143,8 +143,8 @@ python -m ruff check .
 # Typecheck / compile a source file
 python -m axiom check examples/arith.ax
 python -m axiom check examples/arith.ax --json
-python -m axiom compile examples/compile_demo.ax -o /tmp/compile_demo.axb --json
-python -m axiom vm /tmp/compile_demo.axb
+python -m axiom compile examples/compile_demo.ax -o compile_demo.axb --json
+python -m axiom vm compile_demo.axb
 
 # Build and run a package
 python -m axiom pkg build examples/typed_package


### PR DESCRIPTION
Closes #173

Implements the Daedalus-assigned fix for: [Security][Low] Makefile compile/vm targets write to predictable /tmp path (symlink pre-plant)