### PR TITLE
fix: address issue #172

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,9 @@
-* @jmcte
+# Default ownership includes a backup human reviewer so PR review is not single-pointed.
+* @jmcte @pheidon
+
+# Security-sensitive governance and automation paths request an additional reviewer.
+/.github/workflows/ @jmcte @pheidon @scrappedcode
+/.githooks/ @jmcte @pheidon @scrappedcode
+/scripts/ @jmcte @pheidon @scrappedcode
+/project.bootstrap.yaml @jmcte @pheidon @scrappedcode
+/stage1/crates/axiomc/src/ @jmcte @pheidon @scrappedcode

--- a/project.bootstrap.yaml
+++ b/project.bootstrap.yaml
@@ -31,10 +31,38 @@ github:
   createRepo: false
   reviewers:
     - jmcte
+    - pheidon
+    - scrappedcode
   codeowners:
     - pattern: "*"
       owners:
         - "@jmcte"
+        - "@pheidon"
+    - pattern: "/.github/workflows/"
+      owners:
+        - "@jmcte"
+        - "@pheidon"
+        - "@scrappedcode"
+    - pattern: "/.githooks/"
+      owners:
+        - "@jmcte"
+        - "@pheidon"
+        - "@scrappedcode"
+    - pattern: "/scripts/"
+      owners:
+        - "@jmcte"
+        - "@pheidon"
+        - "@scrappedcode"
+    - pattern: "/project.bootstrap.yaml"
+      owners:
+        - "@jmcte"
+        - "@pheidon"
+        - "@scrappedcode"
+    - pattern: "/stage1/crates/axiomc/src/"
+      owners:
+        - "@jmcte"
+        - "@pheidon"
+        - "@scrappedcode"
   autoMerge: true
   deleteBranchOnMerge: true
   requiredApprovals: 1


### PR DESCRIPTION
Closes #172

Implements the Daedalus-assigned fix for: [Security][Low] CODEOWNERS is a single-user wildcard with no backup reviewer or security-path override
