### PR TITLE
chore: make scrappedcode optional for axiom source reviews

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,4 +6,4 @@
 /.githooks/ @jmcte @pheidon @scrappedcode
 /scripts/ @jmcte @pheidon @scrappedcode
 /project.bootstrap.yaml @jmcte @pheidon @scrappedcode
-/stage1/crates/axiomc/src/ @jmcte @pheidon @scrappedcode
+/stage1/crates/axiomc/src/ @jmcte @pheidon


### PR DESCRIPTION
Adjust CODEOWNERS so `@scrappedcode` is no longer required for `/stage1/crates/axiomc/src/` reviews while keeping code owner review enabled for the path via `@jmcte` and `@pheidon`.