### PR TITLE
fix: address issue #145

### DIFF
--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -11,90 +11,54 @@ pub fn render_rust(program: &Program) -> String {
     let type_context = TypeContext::new(program);
     let mut out = String::new();
     out.push_str("#[allow(unused_imports)]\n");
-    out.push_str("use std::cell::RefCell;\n");
     out.push_str("use std::collections::HashMap;\n");
-    out.push_str("use std::panic::{self, PanicHookInfo};\n");
+    out.push_str("use std::panic;\n");
     out.push_str("use std::sync::Once;\n\n");
-    out.push_str("thread_local! {\n");
-    out.push_str(
-        "    static AXIOM_STACK: RefCell<Vec<AxiomStackFrame>> = const { RefCell::new(Vec::new()) };\n",
-    );
-    out.push_str("}\n\n");
-    out.push_str("#[derive(Clone)]\n");
-    out.push_str("struct AxiomStackFrame {\n");
-    out.push_str("    function: &'static str,\n");
-    out.push_str("    file: &'static str,\n");
-    out.push_str("    line: usize,\n");
-    out.push_str("    column: usize,\n");
-    out.push_str("}\n\n");
-    out.push_str("struct AxiomFrameGuard;\n\n");
-    out.push_str("impl AxiomFrameGuard {\n");
-    out.push_str(
-        "    fn new(function: &'static str, file: &'static str, line: usize, column: usize) -> Self {\n",
-    );
-    out.push_str("        AXIOM_STACK.with(|stack| {\n");
-    out.push_str("            stack.borrow_mut().push(AxiomStackFrame {\n");
-    out.push_str("                function,\n");
-    out.push_str("                file,\n");
-    out.push_str("                line,\n");
-    out.push_str("                column,\n");
-    out.push_str("            });\n");
-    out.push_str("        });\n");
-    out.push_str("        Self\n");
-    out.push_str("    }\n");
-    out.push_str("}\n\n");
-    out.push_str("impl Drop for AxiomFrameGuard {\n");
-    out.push_str("    fn drop(&mut self) {\n");
-    out.push_str("        AXIOM_STACK.with(|stack| {\n");
-    out.push_str("            stack.borrow_mut().pop();\n");
-    out.push_str("        });\n");
-    out.push_str("    }\n");
-    out.push_str("}\n\n");
-    out.push_str("fn axiom_panic_message(info: &PanicHookInfo<'_>) -> String {\n");
-    out.push_str("    if let Some(message) = info.payload().downcast_ref::<&str>() {\n");
-    out.push_str("        (*message).to_string()\n");
-    out.push_str("    } else if let Some(message) = info.payload().downcast_ref::<String>() {\n");
-    out.push_str("        message.clone()\n");
-    out.push_str("    } else {\n");
-    out.push_str("        String::from(\"panic\")\n");
-    out.push_str("    }\n");
-    out.push_str("}\n\n");
+    out.push_str("struct AxiomRuntimeAbort;\n\n");
     out.push_str("fn axiom_install_panic_hook() {\n");
     out.push_str("    static AXIOM_PANIC_HOOK: Once = Once::new();\n");
     out.push_str("    AXIOM_PANIC_HOOK.call_once(|| {\n");
-    out.push_str("        panic::set_hook(Box::new(|info| {\n");
-    out.push_str("            eprintln!(\"panic: {}\", axiom_panic_message(info));\n");
-    out.push_str("            let frames = AXIOM_STACK.with(|stack| stack.borrow().clone());\n");
-    out.push_str("            if frames.is_empty() {\n");
-    out.push_str("                eprintln!(\"Axiom stack trace: <empty>\");\n");
-    out.push_str("                return;\n");
-    out.push_str("            }\n");
-    out.push_str("            eprintln!(\"Axiom stack trace (most recent call last):\");\n");
-    out.push_str("            for frame in frames.iter().rev() {\n");
-    out.push_str("                eprintln!(\n");
-    out.push_str("                    \"  at {} ({}:{}:{})\",\n");
-    out.push_str("                    frame.function,\n");
-    out.push_str("                    frame.file,\n");
-    out.push_str("                    frame.line,\n");
-    out.push_str("                    frame.column\n");
-    out.push_str("                );\n");
-    out.push_str("            }\n");
-    out.push_str("        }));\n");
+    out.push_str("        panic::set_hook(Box::new(|_| {}));\n");
     out.push_str("    });\n");
+    out.push_str("}\n\n");
+    out.push_str("fn axiom_runtime_report(kind: &str, message: &str) {\n");
+    out.push_str("    eprintln!(\n");
+    out.push_str("        \"{{\\\"kind\\\":\\\"{}\\\",\\\"message\\\":{}}}\",\n");
+    out.push_str("        kind,\n");
+    out.push_str("        axiom_json_escape_string(message)\n");
+    out.push_str("    );\n");
+    out.push_str("}\n\n");
+    out.push_str("fn axiom_runtime_error(kind: &str, message: &str) -> ! {\n");
+    out.push_str("    axiom_runtime_report(kind, message);\n");
+    out.push_str("    panic::panic_any(AxiomRuntimeAbort)\n");
     out.push_str("}\n\n");
     out.push_str("#[allow(dead_code)]\n");
     out.push_str("fn axiom_array_get<T: Copy>(values: &[T], index: i64) -> T {\n");
+    out.push_str("    if index < 0 {\n");
     out.push_str(
-        "    let index = usize::try_from(index).expect(\"array index must be non-negative\");\n",
+        "        axiom_runtime_error(\"runtime\", \"array index must be non-negative\");\n",
     );
-    out.push_str("    values[index]\n");
+    out.push_str("    }\n");
+    out.push_str("    match values.get(index as usize) {\n");
+    out.push_str("        Some(value) => *value,\n");
+    out.push_str(
+        "        None => axiom_runtime_error(\"runtime\", \"array index out of bounds\"),\n",
+    );
+    out.push_str("    }\n");
     out.push_str("}\n\n");
     out.push_str("#[allow(dead_code)]\n");
     out.push_str("fn axiom_array_take<T>(values: Vec<T>, index: i64) -> T {\n");
+    out.push_str("    if index < 0 {\n");
     out.push_str(
-        "    let index = usize::try_from(index).expect(\"array index must be non-negative\");\n",
+        "        axiom_runtime_error(\"runtime\", \"array index must be non-negative\");\n",
     );
-    out.push_str("    values.into_iter().nth(index).expect(\"array index out of bounds\")\n");
+    out.push_str("    }\n");
+    out.push_str("    match values.into_iter().nth(index as usize) {\n");
+    out.push_str("        Some(value) => value,\n");
+    out.push_str(
+        "        None => axiom_runtime_error(\"runtime\", \"array index out of bounds\"),\n",
+    );
+    out.push_str("    }\n");
     out.push_str("}\n\n");
     out.push_str("#[allow(dead_code)]\n");
     out.push_str(
@@ -102,14 +66,26 @@ pub fn render_rust(program: &Program) -> String {
     );
     out.push_str("    let start = start.unwrap_or(0);\n");
     out.push_str("    let end = end.unwrap_or(len as i64);\n");
+    out.push_str("    if start < 0 {\n");
     out.push_str(
-        "    let start = usize::try_from(start).expect(\"array slice start must be non-negative\");\n",
+        "        axiom_runtime_error(\"runtime\", \"array slice start must be non-negative\");\n",
     );
+    out.push_str("    }\n");
+    out.push_str("    if end < 0 {\n");
     out.push_str(
-        "    let end = usize::try_from(end).expect(\"array slice end must be non-negative\");\n",
+        "        axiom_runtime_error(\"runtime\", \"array slice end must be non-negative\");\n",
     );
-    out.push_str("    assert!(start <= end, \"array slice start must be <= end\");\n");
-    out.push_str("    assert!(end <= len, \"array slice end out of bounds\");\n");
+    out.push_str("    }\n");
+    out.push_str("    let start = start as usize;\n");
+    out.push_str("    let end = end as usize;\n");
+    out.push_str("    if start > end {\n");
+    out.push_str(
+        "        axiom_runtime_error(\"runtime\", \"array slice start must be <= end\");\n",
+    );
+    out.push_str("    }\n");
+    out.push_str("    if end > len {\n");
+    out.push_str("        axiom_runtime_error(\"runtime\", \"array slice end out of bounds\");\n");
+    out.push_str("    }\n");
     out.push_str("    (start, end)\n");
     out.push_str("}\n\n");
     out.push_str("#[allow(dead_code)]\n");
@@ -124,7 +100,9 @@ pub fn render_rust(program: &Program) -> String {
     out.push_str("}\n\n");
     out.push_str("#[allow(dead_code)]\n");
     out.push_str("fn axiom_last_index(len: usize) -> i64 {\n");
-    out.push_str("    assert!(len > 0, \"collection must not be empty\");\n");
+    out.push_str("    if len == 0 {\n");
+    out.push_str("        axiom_runtime_error(\"runtime\", \"collection must not be empty\");\n");
+    out.push_str("    }\n");
     out.push_str("    (len - 1) as i64\n");
     out.push_str("}\n\n");
     out.push_str("#[allow(dead_code)]\n");
@@ -140,9 +118,8 @@ pub fn render_rust(program: &Program) -> String {
     out.push_str("    }\n");
     out.push_str("}\n\n");
     out.push_str("#[allow(dead_code)]\n");
-    out.push_str("fn axiom_assert_fail(message: String, line: i64, column: i64) -> i64 {\n");
-    out.push_str("    eprintln!(\"assertion failed at {}:{}: {}\", line, column, message);\n");
-    out.push_str("    std::process::exit(1)\n");
+    out.push_str("fn axiom_assert_fail(message: String, _line: i64, _column: i64) -> i64 {\n");
+    out.push_str("    axiom_runtime_error(\"assertion\", &message)\n");
     out.push_str("}\n\n");
     out.push_str("#[allow(dead_code)]\n");
     out.push_str("fn axiom_json_parse_int(text: String) -> Option<i64> {\n");
@@ -297,9 +274,10 @@ pub fn render_rust(program: &Program) -> String {
     out.push_str("#[allow(dead_code)]\n");
     out.push_str("fn axiom_clock_now_ms() -> i64 {\n");
     out.push_str("    use std::time::{SystemTime, UNIX_EPOCH};\n");
-    out.push_str("    let now = SystemTime::now()\n");
-    out.push_str("        .duration_since(UNIX_EPOCH)\n");
-    out.push_str("        .expect(\"system clock must be after unix epoch\");\n");
+    out.push_str("    let now = match SystemTime::now().duration_since(UNIX_EPOCH) {\n");
+    out.push_str("        Ok(now) => now,\n");
+    out.push_str("        Err(_) => axiom_runtime_error(\"runtime\", \"system clock must be after unix epoch\"),\n");
+    out.push_str("    };\n");
     out.push_str("    now.as_millis() as i64\n");
     out.push_str("}\n\n");
     out.push_str("#[allow(dead_code)]\n");
@@ -411,13 +389,19 @@ pub fn render_rust(program: &Program) -> String {
     out.push_str(
         "fn axiom_map_get<K: Eq + std::hash::Hash, V: Copy>(values: &HashMap<K, V>, key: &K) -> V {\n",
     );
-    out.push_str("    *values.get(key).expect(\"map key not found\")\n");
+    out.push_str("    match values.get(key) {\n");
+    out.push_str("        Some(value) => *value,\n");
+    out.push_str("        None => axiom_runtime_error(\"runtime\", \"map key not found\"),\n");
+    out.push_str("    }\n");
     out.push_str("}\n\n");
     out.push_str("#[allow(dead_code)]\n");
     out.push_str(
         "fn axiom_map_take<K: Eq + std::hash::Hash, V>(mut values: HashMap<K, V>, key: &K) -> V {\n",
     );
-    out.push_str("    values.remove(key).expect(\"map key not found\")\n");
+    out.push_str("    match values.remove(key) {\n");
+    out.push_str("        Some(value) => value,\n");
+    out.push_str("        None => axiom_runtime_error(\"runtime\", \"map key not found\"),\n");
+    out.push_str("    }\n");
     out.push_str("}\n\n");
     for enum_def in &program.enums {
         render_enum(enum_def, &type_context, &mut out);
@@ -431,15 +415,21 @@ pub fn render_rust(program: &Program) -> String {
         render_function(function, &type_context, &mut out);
         out.push('\n');
     }
-    out.push_str("fn main() {\n");
+    out.push_str("fn main() -> std::process::ExitCode {\n");
     out.push_str("    axiom_install_panic_hook();\n");
-    out.push_str(&format!(
-        "    let _axiom_frame = AxiomFrameGuard::new(\"<main>\", {:?}, 1, 1);\n",
-        program.path
-    ));
+    out.push_str("    let result = panic::catch_unwind(|| {\n");
     for stmt in &program.stmts {
-        render_stmt(stmt, &type_context, &mut out, 1);
+        render_stmt(stmt, &type_context, &mut out, 2);
     }
+    out.push_str("    });\n");
+    out.push_str("    match result {\n");
+    out.push_str("        Ok(()) => std::process::ExitCode::SUCCESS,\n");
+    out.push_str("        Err(payload) if payload.is::<AxiomRuntimeAbort>() => std::process::ExitCode::from(1),\n");
+    out.push_str("        Err(_) => {\n");
+    out.push_str("            axiom_runtime_report(\"panic\", \"runtime panic\");\n");
+    out.push_str("            std::process::ExitCode::from(1)\n");
+    out.push_str("        }\n");
+    out.push_str("    }\n");
     out.push_str("}\n");
     out
 }
@@ -634,10 +624,6 @@ fn render_function(function: &Function, type_context: &TypeContext<'_>, out: &mu
         lifetime,
         params,
         rust_type_in_signature(&function.return_ty, uses_slice_lifetime, type_context)
-    ));
-    out.push_str(&format!(
-        "    let _axiom_frame = AxiomFrameGuard::new({:?}, {:?}, {}, {});\n",
-        function.source_name, function.path, function.line, function.column
     ));
     for stmt in &function.body {
         render_stmt(stmt, type_context, out, 1);

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -124,22 +124,20 @@ mod tests {
     }
 
     #[test]
-    fn render_rust_includes_axiom_panic_stack_frames() {
+    fn render_rust_uses_structured_runtime_error_reporting() {
         let source = "fn crash(values: [int]): int {\nreturn values[1]\n}\n\nprint crash([7])\n";
         let parsed = parse_program(source, Path::new("main.ax")).expect("parse");
         let hir = hir::lower(&parsed).expect("lower");
         let mir = mir::lower(&hir);
         let rendered = render_rust(&mir);
         assert!(rendered.contains("fn axiom_install_panic_hook() {"));
-        assert!(
-            rendered
-                .contains("let _axiom_frame = AxiomFrameGuard::new(\"crash\", \"main.ax\", 1, 1);")
-        );
-        assert!(
-            rendered.contains(
-                "let _axiom_frame = AxiomFrameGuard::new(\"<main>\", \"main.ax\", 1, 1);"
-            )
-        );
+        assert!(rendered.contains("fn axiom_runtime_report(kind: &str, message: &str) {"));
+        assert!(rendered.contains("fn axiom_runtime_error(kind: &str, message: &str) -> ! {"));
+        assert!(rendered.contains("let result = panic::catch_unwind(|| {"));
+        assert!(!rendered.contains(".expect("));
+        assert!(!rendered.contains("std::process::exit"));
+        assert!(!rendered.contains("assert!("));
+        assert!(!rendered.contains("Axiom stack trace"));
     }
 
     #[test]
@@ -2127,10 +2125,10 @@ mod tests {
     }
 
     #[test]
-    fn stage1_runtime_panics_render_axiom_stack_trace_for_index_errors() {
+    fn stage1_runtime_reports_structured_error_for_index_errors() {
         let dir = tempdir().expect("tempdir");
-        let project = dir.path().join("panic-stack-index");
-        create_project(&project, Some("panic-stack-index")).expect("create project");
+        let project = dir.path().join("runtime-error-index");
+        create_project(&project, Some("runtime-error-index")).expect("create project");
         fs::write(
             project.join("src/math.ax"),
             "pub fn explode(values: [int]): int {\nreturn values[1]\n}\n",
@@ -2147,30 +2145,29 @@ mod tests {
             .output()
             .expect("run compiled binary");
 
-        assert!(!output.status.success(), "program should panic");
+        assert!(!output.status.success(), "program should fail");
         let stderr = String::from_utf8_lossy(&output.stderr);
-        assert!(stderr.contains("panic:"), "unexpected stderr: {stderr}");
         assert!(
-            stderr.contains("Axiom stack trace (most recent call last):"),
+            stderr.contains("{\"kind\":\"runtime\",\"message\":\"array index out of bounds\"}"),
             "unexpected stderr: {stderr}"
         );
-        assert!(stderr.contains("explode"), "unexpected stderr: {stderr}");
+        assert!(!stderr.contains("panic:"), "unexpected stderr: {stderr}");
         assert!(
-            stderr.contains(&project.join("src/math.ax").display().to_string()),
+            !stderr.contains("Axiom stack trace"),
             "unexpected stderr: {stderr}"
         );
-        assert!(stderr.contains("<main>"), "unexpected stderr: {stderr}");
+        assert!(!stderr.contains("explode"), "unexpected stderr: {stderr}");
         assert!(
-            stderr.contains(&project.join("src/main.ax").display().to_string()),
+            !stderr.contains("src/math.ax"),
             "unexpected stderr: {stderr}"
         );
     }
 
     #[test]
-    fn stage1_runtime_panics_render_axiom_stack_trace_for_assert_failures() {
+    fn stage1_runtime_reports_structured_error_for_slice_failures() {
         let dir = tempdir().expect("tempdir");
-        let project = dir.path().join("panic-stack-assert");
-        create_project(&project, Some("panic-stack-assert")).expect("create project");
+        let project = dir.path().join("runtime-error-slice");
+        create_project(&project, Some("runtime-error-slice")).expect("create project");
         fs::write(
             project.join("src/math.ax"),
             "pub fn window(values: &[int]): &[int] {\nreturn values[0:2]\n}\n",
@@ -2187,22 +2184,22 @@ mod tests {
             .output()
             .expect("run compiled binary");
 
-        assert!(!output.status.success(), "program should panic");
+        assert!(!output.status.success(), "program should fail");
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(
-            stderr.contains("array slice end out of bounds"),
+            stderr.contains("{\"kind\":\"runtime\",\"message\":\"array slice end out of bounds\"}"),
             "unexpected stderr: {stderr}"
         );
+        assert!(!stderr.contains("panic:"), "unexpected stderr: {stderr}");
         assert!(
-            stderr.contains("Axiom stack trace (most recent call last):"),
+            !stderr.contains("Axiom stack trace"),
             "unexpected stderr: {stderr}"
         );
-        assert!(stderr.contains("window"), "unexpected stderr: {stderr}");
+        assert!(!stderr.contains("window"), "unexpected stderr: {stderr}");
         assert!(
-            stderr.contains(&project.join("src/math.ax").display().to_string()),
+            !stderr.contains("src/math.ax"),
             "unexpected stderr: {stderr}"
         );
-        assert!(stderr.contains("<main>"), "unexpected stderr: {stderr}");
     }
 
     #[test]
@@ -2373,10 +2370,10 @@ mod tests {
         assert_eq!(output.skipped, 0);
         let case = output.cases.first().expect("test case");
         assert!(!case.ok);
-        assert!(
-            case.stderr
-                .contains("assertion failed at 1:14: expected left == right, left=41, right=42")
-        );
+        assert!(case.stderr.contains(
+            "{\"kind\":\"assertion\",\"message\":\"expected left == right, left=41, right=42\"}"
+        ));
+        assert!(!case.stderr.contains("1:14"));
         assert!(
             case.error
                 .as_ref()


### PR DESCRIPTION
Closes #145

Implements the Hephaestus-assigned fix for: [Security][Critical] Eliminate panics from generated Rust codegen output
