### PR TITLE
fix: address issue #147

### DIFF
--- a/axiom/packaging.py
+++ b/axiom/packaging.py
@@ -44,18 +44,38 @@ def manifest_path(project_root: Path) -> Path:
     return project_root / MANIFEST_FILENAME
 
 
-def _validate_output(output: str, path: Path) -> str:
+def _ensure_within_resolved_root(
+    root: Path,
+    candidate: Path,
+    *,
+    message: str,
+) -> None:
+    resolved_root = root.resolve()
+    resolved = (root / candidate).resolve()
+    if resolved != resolved_root and not resolved.is_relative_to(resolved_root):
+        raise AxiomCompileError(message)
+
+
+def _validate_output(output: str, path: Path, *, root: Optional[Path] = None) -> str:
     if not output:
         raise AxiomCompileError(f"package manifest {path} has invalid output")
 
-    if Path(output).is_absolute():
+    candidate = Path(output)
+    if candidate.is_absolute():
         raise AxiomCompileError(
             f"package manifest {path} has invalid output path: absolute paths are not allowed"
         )
 
-    if any(part == ".." for part in Path(output).parts):
+    if any(part == ".." for part in candidate.parts):
         raise AxiomCompileError(
             f"package manifest {path} has invalid output path: parent traversal is not allowed"
+        )
+
+    if root is not None:
+        _ensure_within_resolved_root(
+            root,
+            candidate,
+            message=f"package manifest {path} has invalid output path: escapes the package root",
         )
 
     return output
@@ -75,6 +95,12 @@ def _validate_relative_path(value: str, path: Path, field_name: str) -> str:
         raise AxiomCompileError(
             f"package manifest {path} has invalid {field_name}: parent traversal is not allowed"
         )
+
+    _ensure_within_resolved_root(
+        path.parent,
+        candidate,
+        message=f"package manifest {path} has invalid {field_name}: escapes the package root",
+    )
 
     return value
 
@@ -137,7 +163,7 @@ def _as_manifest(data: dict[str, object], path: Path) -> PackageManifest:
     if output is not None:
         if not isinstance(output, str):
             raise AxiomCompileError(f"package manifest {path} has invalid output")
-        output = _validate_output(output, path)
+        output = _validate_output(output, path, root=path.parent / out_dir)
 
     return PackageManifest(
         name=str(data["name"]),
@@ -264,7 +290,11 @@ def init_package(
     if output is not None and not isinstance(output, str):
         raise AxiomCompileError("package output must be a non-empty string when provided")
     if output is not None:
-        output = _validate_output(output, project_root / MANIFEST_FILENAME)
+        output = _validate_output(
+            output,
+            project_root / MANIFEST_FILENAME,
+            root=project_root / out_dir,
+        )
     if host_contract_signature is None:
         host_contract_signature = str(host_contract_metadata()["capabilities_signature"])
     host_contract_signature = _validate_host_contract_signature(
@@ -310,14 +340,16 @@ def build_package(
         if output is not None
         else prepared.manifest.output or prepared.manifest.name
     )
-    validated_output = _validate_output(
-        selected_output, manifest_path(prepared.project_root)
-    )
-
-    if validated_output.endswith(".axb"):
-        output_name = validated_output
+    if selected_output.endswith(".axb"):
+        selected_output_name = selected_output
     else:
-        output_name = f"{validated_output}.axb"
+        selected_output_name = f"{selected_output}.axb"
+
+    output_name = _validate_output(
+        selected_output_name,
+        manifest_path(prepared.project_root),
+        root=out_dir,
+    )
 
     out_path = out_dir / output_name
     out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_cli_packages.py
+++ b/tests/test_cli_packages.py
@@ -8,7 +8,12 @@ import unittest
 
 from axiom.errors import AxiomCompileError
 from axiom.host import host_contract_metadata
-from axiom.packaging import MAX_MANIFEST_BYTES, load_manifest
+from axiom.packaging import (
+    MAX_MANIFEST_BYTES,
+    _validate_output,
+    _validate_relative_path,
+    load_manifest,
+)
 from tests.helpers import ROOT, init_temp_package, read_json, run_cli, write_json
 
 
@@ -52,6 +57,74 @@ class CliPackageTests(unittest.TestCase):
             manifest = load_manifest(project)
 
             self.assertEqual(manifest.name, "demo")
+
+    def test_validate_relative_path_allows_legitimate_path(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project = Path(td)
+            manifest_path = project / "axiom.pkg"
+
+            self.assertEqual(
+                _validate_relative_path("dist/output.axm", manifest_path, "main"),
+                "dist/output.axm",
+            )
+
+    def test_validate_relative_path_rejects_literal_parent_traversal(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project = Path(td)
+            (project / "subdir").mkdir()
+            link = project / "link"
+            try:
+                link.symlink_to(project / "subdir", target_is_directory=True)
+            except OSError as e:
+                self.skipTest(f"symlinks unavailable: {e}")
+
+            with self.assertRaises(AxiomCompileError):
+                _validate_relative_path(
+                    "link/../../secret",
+                    project / "axiom.pkg",
+                    "main",
+                )
+
+    def test_validate_relative_path_rejects_symlink_escape(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            project = base / "project"
+            outside = base / "outside"
+            project.mkdir()
+            outside.mkdir()
+            link = project / "link"
+            try:
+                link.symlink_to(outside, target_is_directory=True)
+            except OSError as e:
+                self.skipTest(f"symlinks unavailable: {e}")
+
+            with self.assertRaises(AxiomCompileError) as cm:
+                _validate_relative_path("link/secret.ax", project / "axiom.pkg", "main")
+
+            self.assertIn("escapes the package root", str(cm.exception))
+
+    def test_validate_output_rejects_symlink_escape(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            project = base / "project"
+            out_dir = project / "dist"
+            outside = base / "outside"
+            out_dir.mkdir(parents=True)
+            outside.mkdir()
+            link = out_dir / "link"
+            try:
+                link.symlink_to(outside, target_is_directory=True)
+            except OSError as e:
+                self.skipTest(f"symlinks unavailable: {e}")
+
+            with self.assertRaises(AxiomCompileError) as cm:
+                _validate_output(
+                    "link/artifact.axb",
+                    project / "axiom.pkg",
+                    root=out_dir,
+                )
+
+            self.assertIn("escapes the package root", str(cm.exception))
 
     def test_load_manifest_rejects_manifest_above_size_limit(self) -> None:
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
Closes #147

Implements the Hephaestus-assigned fix for: [Security][High] Path traversal: add symlink-aware canonicalization in packaging.py
