### PR TITLE
fix: address issue #94

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,10 @@ stage1-smoke:
 	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build stage1/examples/stdlib_collections --json
 	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- run stage1/examples/stdlib_collections
 	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/examples/stdlib_collections --json
+	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- check stage1/examples/stdlib_sync --json
+	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build stage1/examples/stdlib_sync --json
+	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- run stage1/examples/stdlib_sync
+	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/examples/stdlib_sync --json
 	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- check stage1/examples/stdlib_http --json
 	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build stage1/examples/stdlib_http --json
 	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- run stage1/examples/stdlib_http

--- a/docs/stage1-agent-grade-compiler.md
+++ b/docs/stage1-agent-grade-compiler.md
@@ -269,7 +269,12 @@ Work packages:
     and `window`) on top of AG2 generic functions plus existing collection
     primitives. Covered by `stage1/examples/stdlib_collections` and one Rust
     test (`stage1_project_imports_synthetic_stdlib_collections_module`).
-  - `std.sync` — blocked on the AG4.2 async runtime.
+  - `std.sync` — **landed** as `std/sync.ax` exposing ownership-shaped
+    primitives (`Mutex`, `MutexGuard`, `Once`, and `Channel`) implemented in
+    Axiom without host-thread capabilities. The stage1 channel is single-slot
+    and nonblocking; blocking, wakeups, and async-aware channels remain AG4.2
+    runtime work. Covered by `stage1/examples/stdlib_sync` and one Rust test
+    (`stage1_project_imports_synthetic_stdlib_sync_module`).
 - `AG4.2`: async runtime
   - `async fn`
   - `await`

--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -96,9 +96,9 @@ still far from the stated 1.0 target for service and agent workloads.
 
 ### Runtime and standard library gaps
 
-- The AG4.1 stdlib surface now covers every stage1 capability-gated intrinsic with a thin wrapper module (`std/time.ax`, `std/env.ax`, `std/fs.ax`, `std/net.ax`, `std/process.ax`, `std/crypto_hash.ax`), plus `std/http.ax` (first stdlib module with a brand-new capability-gated intrinsic `http_get` sharing the existing `net` surface), `std/io.ax` (first ungated stdlib module, `eprintln` on top of the new `io_eprintln` intrinsic), `std/json.ax` (ungated scalar/string JSON helpers), and `std/collections.ax` (generic borrowed-slice helpers built on AG2 generic functions). The remaining AG4.1 module (`std.sync`) requires the AG4.2 async runtime and stays as follow-on work.
+- The AG4.1 stdlib surface now covers every stage1 capability-gated intrinsic with a thin wrapper module (`std/time.ax`, `std/env.ax`, `std/fs.ax`, `std/net.ax`, `std/process.ax`, `std/crypto_hash.ax`), plus `std/http.ax` (first stdlib module with a brand-new capability-gated intrinsic `http_get` sharing the existing `net` surface), `std/io.ax` (first ungated stdlib module, `eprintln` on top of the new `io_eprintln` intrinsic), `std/json.ax` (ungated scalar/string JSON helpers), `std/collections.ax` (generic borrowed-slice helpers built on AG2 generic functions), and `std/sync.ax` (ownership-shaped mutex guards, one-shot cells, and single-slot nonblocking channels). Blocking, task wakeups, and async-aware channels remain AG4.2 runtime work.
 - Capability-aware integration is now in place for the current stage1 runtime surface: compiler-known intrinsics enforce all six manifest flags, stdlib wrappers preserve that enforcement against the importing package's manifest, capability-denied programs fail before native execution, and the Rust suite covers cross-package capability interactions (`dependency_package_must_enable_its_own_capabilities`) plus per-wrapper denial paths.
-- No async runtime, channels, cancellation, timers, or service-grade I/O surface exists.
+- No async runtime, blocking channels, cancellation, timers, or service-grade I/O surface exists.
 
 ### Backend and tooling gaps
 

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -2185,6 +2185,56 @@ mod tests {
     }
 
     #[test]
+    fn stage1_project_imports_synthetic_stdlib_sync_module() {
+        // `std/sync.ax` is ungated in stage1 because it is implemented in
+        // Axiom using ownership tokens rather than host threads or blocking
+        // runtime services. Async-aware channels and wakeups stay AG4.2 work.
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("stdlib-sync-app");
+        create_project(&project, Some("stdlib-sync-app")).expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            render_manifest_with_capabilities(
+                "stdlib-sync-app",
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+            ),
+        )
+        .expect("write manifest");
+        let manifest = load_manifest(&project).expect("load manifest");
+        fs::write(
+            project.join("axiom.lock"),
+            render_lockfile_for_project(&project, &manifest).expect("lockfile"),
+        )
+        .expect("write lockfile");
+        let source = "import \"std/sync.ax\"\nlet counter: Mutex<int> = mutex<int>(1)\nlet guard: MutexGuard<int> = lock<int>(counter)\nlet updated: Mutex<int> = replace<int>(guard, 2)\nlet final_guard: MutexGuard<int> = lock<int>(updated)\nprint into_inner<int>(final_guard)\nlet ready: Once<string> = once_with<string>(\"configured\")\nprint once_is_set<string>(ready)\nlet empty: Once<int> = once<int>(None)\nmatch once_take<int>(empty) {\nSome(value) {\nprint value\n}\nNone {\nprint \"empty\"\n}\n}\nlet channel: Channel<string> = channel<string>(None)\nlet sent: Channel<string> = send<string>(channel, \"message\")\nmatch try_recv<string>(sent) {\nSome(message) {\nprint message\n}\nNone {\nprint \"missing\"\n}\n}\n";
+        fs::write(project.join("src/main.ax"), source).expect("write source");
+        fs::write(project.join("src/main_test.ax"), source).expect("write test");
+        fs::write(
+            project.join("src/main_test.stdout"),
+            "2\ntrue\nempty\nmessage\n",
+        )
+        .expect("write golden");
+
+        let built = build_project(&project).expect("build project");
+        let output = compiled_binary_command(&built.binary)
+            .output()
+            .expect("run compiled binary");
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout),
+            "2\ntrue\nempty\nmessage\n"
+        );
+
+        let tests = run_project_tests(&project).expect("run tests");
+        assert_eq!(tests.passed, 1);
+        assert_eq!(tests.failed, 0);
+    }
+
+    #[test]
     fn stage1_project_rejects_stdlib_json_with_wrong_argument_type() {
         let dir = tempdir().expect("tempdir");
         let project = dir.path().join("stdlib-json-bad-arg");

--- a/stage1/crates/axiomc/src/stdlib.rs
+++ b/stage1/crates/axiomc/src/stdlib.rs
@@ -8,7 +8,7 @@
 //! enforcement continues to run against the importing package's manifest via
 //! `hir::lower_with_capabilities`.
 //!
-//! Today this provides ten stdlib modules. Six are thin wrappers over
+//! Today this provides eleven stdlib modules. Six are thin wrappers over
 //! single-intrinsic capability-gated surfaces, one per capability class:
 //!
 //! * `std/time.ax` — `now_ms()` on top of `clock_now_ms` (clock).
@@ -32,7 +32,7 @@
 //!   manifest flag would not add meaningful isolation in stage1. The
 //!   stage1 client is http:// only: HTTPS/TLS land in a follow-on slice.
 //!
-//! The eighth, ninth, and tenth modules are stdlib surfaces not tied to a
+//! The eighth, ninth, tenth, and eleventh modules are stdlib surfaces not tied to a
 //! capability flag, matching the ambient status of the `print` statement:
 //!
 //! * `std/io.ax` — `eprintln(text)` on top of the new ungated `io_eprintln`
@@ -41,9 +41,10 @@
 //!   top of new ungated `json_parse_*` / `json_stringify_*` intrinsics.
 //! * `std/collections.ax` — generic borrowed-slice helpers built on the
 //!   existing polymorphic collection primitives and AG2 generic functions.
-//!
-//! The remaining AG4.1 module (`std.sync`) requires the AG4.2 async runtime
-//! and lands in a follow-on slice.
+//! * `std/sync.ax` — ownership-shaped synchronization primitives implemented
+//!   in Axiom: move-only mutex guards, one-shot cells, and single-slot
+//!   nonblocking channels. Blocking, task wakeups, and async-aware channels
+//!   remain AG4.2 runtime work.
 
 use std::path::{Path, PathBuf};
 
@@ -108,6 +109,24 @@ pub fn has_items<T>(values: &[T]): bool {\nreturn len(values) > 0\n}\n\
 pub fn skip<T>(values: &[T], count: int): &[T] {\nreturn values[count:]\n}\n\
 pub fn take<T>(values: &[T], count: int): &[T] {\nreturn values[:count]\n}\n\
 pub fn window<T>(values: &[T], start: int, end: int): &[T] {\nreturn values[start:end]\n}\n",
+    ),
+    (
+        "sync.ax",
+        "pub struct Mutex<T> {\nvalue: T\n}\n\
+pub struct MutexGuard<T> {\nvalue: T\n}\n\
+pub struct Once<T> {\nvalue: Option<T>\n}\n\
+pub struct Channel<T> {\nslot: Option<T>\n}\n\
+pub fn mutex<T>(value: T): Mutex<T> {\nreturn Mutex { value: value }\n}\n\
+pub fn lock<T>(mutex: Mutex<T>): MutexGuard<T> {\nreturn MutexGuard { value: mutex.value }\n}\n\
+pub fn replace<T>(_guard: MutexGuard<T>, value: T): Mutex<T> {\nreturn Mutex { value: value }\n}\n\
+pub fn into_inner<T>(guard: MutexGuard<T>): T {\nreturn guard.value\n}\n\
+pub fn once<T>(value: Option<T>): Once<T> {\nreturn Once { value: value }\n}\n\
+pub fn once_with<T>(value: T): Once<T> {\nreturn Once { value: Some(value) }\n}\n\
+pub fn once_is_set<T>(cell: Once<T>): bool {\nmatch cell.value {\nSome(_value) {\nreturn true\n}\nNone {\nreturn false\n}\n}\n}\n\
+pub fn once_take<T>(cell: Once<T>): Option<T> {\nreturn cell.value\n}\n\
+pub fn channel<T>(slot: Option<T>): Channel<T> {\nreturn Channel { slot: slot }\n}\n\
+pub fn send<T>(_channel: Channel<T>, value: T): Channel<T> {\nreturn Channel { slot: Some(value) }\n}\n\
+pub fn try_recv<T>(channel: Channel<T>): Option<T> {\nreturn channel.slot\n}\n",
     ),
     (
         "http.ax",

--- a/stage1/examples/stdlib_sync/axiom.lock
+++ b/stage1/examples/stdlib_sync/axiom.lock
@@ -1,0 +1,6 @@
+version = 1
+
+[[package]]
+name = "stdlib-sync"
+version = "0.1.0"
+source = "path"

--- a/stage1/examples/stdlib_sync/axiom.toml
+++ b/stage1/examples/stdlib_sync/axiom.toml
@@ -1,0 +1,15 @@
+[package]
+name = "stdlib-sync"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false

--- a/stage1/examples/stdlib_sync/src/main.ax
+++ b/stage1/examples/stdlib_sync/src/main.ax
@@ -1,0 +1,31 @@
+import "std/sync.ax"
+
+let counter: Mutex<int> = mutex<int>(1)
+let guard: MutexGuard<int> = lock<int>(counter)
+let updated: Mutex<int> = replace<int>(guard, 2)
+let final_guard: MutexGuard<int> = lock<int>(updated)
+print into_inner<int>(final_guard)
+
+let ready: Once<string> = once_with<string>("configured")
+print once_is_set<string>(ready)
+
+let empty: Once<int> = once<int>(None)
+match once_take<int>(empty) {
+Some(value) {
+print value
+}
+None {
+print "empty"
+}
+}
+
+let channel: Channel<string> = channel<string>(None)
+let sent: Channel<string> = send<string>(channel, "message")
+match try_recv<string>(sent) {
+Some(message) {
+print message
+}
+None {
+print "missing"
+}
+}

--- a/stage1/examples/stdlib_sync/src/main_test.ax
+++ b/stage1/examples/stdlib_sync/src/main_test.ax
@@ -1,0 +1,31 @@
+import "std/sync.ax"
+
+let counter: Mutex<int> = mutex<int>(1)
+let guard: MutexGuard<int> = lock<int>(counter)
+let updated: Mutex<int> = replace<int>(guard, 2)
+let final_guard: MutexGuard<int> = lock<int>(updated)
+print into_inner<int>(final_guard)
+
+let ready: Once<string> = once_with<string>("configured")
+print once_is_set<string>(ready)
+
+let empty: Once<int> = once<int>(None)
+match once_take<int>(empty) {
+Some(value) {
+print value
+}
+None {
+print "empty"
+}
+}
+
+let channel: Channel<string> = channel<string>(None)
+let sent: Channel<string> = send<string>(channel, "message")
+match try_recv<string>(sent) {
+Some(message) {
+print message
+}
+None {
+print "missing"
+}
+}

--- a/stage1/examples/stdlib_sync/src/main_test.stdout
+++ b/stage1/examples/stdlib_sync/src/main_test.stdout
@@ -1,0 +1,4 @@
+2
+true
+empty
+message


### PR DESCRIPTION
Closes #94

Implements the Daedalus-assigned fix for: AG4.1: std.sync — Synchronization primitives
