### PR TITLE
fix: address issue #163

### DIFF
--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -275,6 +275,10 @@ pub fn render_rust_with_debug(program: &Program, debug: bool) -> String {
     out.push_str("        .map(|addr| addr.ip().to_string())\n");
     out.push_str("}\n\n");
     out.push_str("#[allow(dead_code)]\n");
+    out.push_str("fn axiom_http_strip_crlf(value: &str) -> String {\n");
+    out.push_str("    value.chars().filter(|ch| *ch != '\\r' && *ch != '\\n').collect()\n");
+    out.push_str("}\n\n");
+    out.push_str("#[allow(dead_code)]\n");
     out.push_str("fn axiom_http_get(url: String) -> Option<String> {\n");
     out.push_str("    use std::io::{Read, Write};\n");
     out.push_str("    use std::net::TcpStream;\n");
@@ -304,7 +308,14 @@ pub fn render_rust_with_debug(program: &Program, debug: bool) -> String {
     out.push_str("        }\n");
     out.push_str("        None => (host_port, 80u16),\n");
     out.push_str("    };\n");
-    out.push_str("    let addrs = axiom_resolve_public_socket_addrs(host, port)?;\n");
+    out.push_str("    let clean_host = axiom_http_strip_crlf(host);\n");
+    out.push_str("    let clean_path = axiom_http_strip_crlf(path);\n");
+    out.push_str("    if clean_host.is_empty() || clean_path.is_empty() {\n");
+    out.push_str("        return None;\n");
+    out.push_str("    }\n");
+    out.push_str(
+        "    let addrs = axiom_resolve_public_socket_addrs(clean_host.as_str(), port)?;\n",
+    );
     out.push_str("    let mut stream = None;\n");
     out.push_str("    for addr in addrs {\n");
     out.push_str("        if let Ok(candidate) = TcpStream::connect_timeout(&addr, Duration::from_secs(5)) {\n");
@@ -317,7 +328,7 @@ pub fn render_rust_with_debug(program: &Program, debug: bool) -> String {
     out.push_str("    stream.set_write_timeout(Some(Duration::from_secs(5))).ok()?;\n");
     out.push_str("    let request = format!(\n");
     out.push_str("        \"GET {} HTTP/1.0\\r\\nHost: {}\\r\\nUser-Agent: axiom-stage1/0.1\\r\\nConnection: close\\r\\n\\r\\n\",\n");
-    out.push_str("        path, host\n");
+    out.push_str("        clean_path, clean_host\n");
     out.push_str("    );\n");
     out.push_str("    stream.write_all(request.as_bytes()).ok()?;\n");
     out.push_str("    let mut raw = Vec::new();\n");

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -308,6 +308,16 @@ mod tests {
         let rendered = render_rust(&mir);
         assert!(rendered.contains("const MAX_HEADER_BYTES: usize = 64 * 1024;"));
         assert!(rendered.contains("const MAX_BODY_BYTES: usize = 1024 * 1024;"));
+        assert!(rendered.contains("TcpStream::connect_timeout(&addr, Duration::from_secs(5))"));
+    }
+
+    #[test]
+    fn render_rust_strips_crlf_from_http_request_parts() {
+        let source = "print true\n";
+        let parsed = parse_program(source, Path::new("main.ax")).expect("parse");
+        let hir = hir::lower(&parsed).expect("lower");
+        let mir = mir::lower(&hir);
+        let rendered = render_rust(&mir);
         assert!(rendered.contains("fn axiom_http_strip_crlf(value: &str) -> String {"));
         assert!(rendered.contains("*ch != '\\r' && *ch != '\\n'"));
         assert!(rendered.contains("let clean_host = axiom_http_strip_crlf(host);"));
@@ -316,7 +326,6 @@ mod tests {
         assert!(rendered.contains("clean_path, clean_host"));
         assert!(!rendered.contains("axiom_resolve_public_socket_addrs(host, port)?"));
         assert!(!rendered.contains("path, host\n"));
-        assert!(rendered.contains("TcpStream::connect_timeout(&addr, Duration::from_secs(5))"));
     }
 
     #[test]

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -308,7 +308,14 @@ mod tests {
         let rendered = render_rust(&mir);
         assert!(rendered.contains("const MAX_HEADER_BYTES: usize = 64 * 1024;"));
         assert!(rendered.contains("const MAX_BODY_BYTES: usize = 1024 * 1024;"));
-        assert!(rendered.contains("axiom_resolve_public_socket_addrs(host, port)?"));
+        assert!(rendered.contains("fn axiom_http_strip_crlf(value: &str) -> String {"));
+        assert!(rendered.contains("*ch != '\\r' && *ch != '\\n'"));
+        assert!(rendered.contains("let clean_host = axiom_http_strip_crlf(host);"));
+        assert!(rendered.contains("let clean_path = axiom_http_strip_crlf(path);"));
+        assert!(rendered.contains("axiom_resolve_public_socket_addrs(clean_host.as_str(), port)?"));
+        assert!(rendered.contains("clean_path, clean_host"));
+        assert!(!rendered.contains("axiom_resolve_public_socket_addrs(host, port)?"));
+        assert!(!rendered.contains("path, host\n"));
         assert!(rendered.contains("TcpStream::connect_timeout(&addr, Duration::from_secs(5))"));
     }
 


### PR DESCRIPTION
Closes #163

Implements the Hephaestus-assigned fix for: [Security][High] HTTP header injection: http_get embeds URL path and host into request without CRLF stripping
