### PR TITLE
fix: address issue #167

### DIFF
--- a/axiom/bytecode.py
+++ b/axiom/bytecode.py
@@ -9,6 +9,7 @@ from .errors import AxiomCompileError
 MAGIC = b"AXBC"
 VERSION_MAJOR = 0
 VERSION_MINOR = 11
+MAX_STRING_BYTES = 64 * 1024 * 1024
 
 
 class Op:
@@ -101,6 +102,10 @@ class Bytecode:
         out += struct.pack("<I", len(self.strings))
         for s in self.strings:
             b = s.encode("utf-8")
+            if len(b) > MAX_STRING_BYTES:
+                raise AxiomCompileError(
+                    f"bytecode string exceeds {MAX_STRING_BYTES} byte limit"
+                )
             out += struct.pack("<I", len(b))
             out += b
 
@@ -204,6 +209,10 @@ class Bytecode:
         strings: List[str] = []
         for _ in range(n_strings):
             (blen,) = struct.unpack("<I", take(4))
+            if blen > MAX_STRING_BYTES:
+                raise ValueError(
+                    f"bytecode string exceeds {MAX_STRING_BYTES} byte limit"
+                )
             strings.append(take(blen).decode("utf-8"))
 
         (n_ins,) = struct.unpack("<I", take(4))

--- a/docs/bytecode.md
+++ b/docs/bytecode.md
@@ -23,7 +23,7 @@ All integers are little-endian.
       - u32: upvalue index (local slot or outer upvalue slot)
 - u32: string_table_count (N)
 - N times:
-  - u32: byte_len
+  - u32: byte_len (must be <= 64 MiB)
   - bytes: UTF-8 string
 - u32: instruction_count (M)
 - M times:

--- a/tests/test_bytecode.py
+++ b/tests/test_bytecode.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import struct
+import unittest
+from unittest.mock import patch
+
+import axiom.bytecode as bytecode_module
+from axiom.bytecode import MAGIC, VERSION_MAJOR, VERSION_MINOR, Bytecode
+from axiom.errors import AxiomCompileError
+
+
+class BytecodeTests(unittest.TestCase):
+    def test_decode_rejects_oversized_string_length_before_payload_read(self) -> None:
+        data = bytearray()
+        data += MAGIC
+        data += struct.pack("<HH", VERSION_MAJOR, VERSION_MINOR)
+        data += struct.pack("<I", 0)
+        data += struct.pack("<I", 0)
+        data += struct.pack("<I", 1)
+        data += struct.pack("<I", 9)
+
+        with patch.object(bytecode_module, "MAX_STRING_BYTES", 8):
+            with self.assertRaises(ValueError) as cm:
+                Bytecode.decode(bytes(data))
+
+        self.assertIn("bytecode string exceeds", str(cm.exception))
+
+    def test_encode_rejects_oversized_string(self) -> None:
+        oversized = "x" * 9
+        bytecode = Bytecode(
+            strings=[oversized],
+            instructions=[],
+            locals_count=0,
+            functions=[],
+        )
+
+        with patch.object(bytecode_module, "MAX_STRING_BYTES", 8):
+            with self.assertRaises(AxiomCompileError) as cm:
+                bytecode.encode()
+
+        self.assertIn("bytecode string exceeds", cm.exception.message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #167

Implements the Hephaestus-assigned fix for: [Security][High] Bytecode string length field is unbounded: crafted .axb allocates 4 GiB per string
