### PR TITLE
fix: address issue #169

### DIFF
--- a/axiom/vm.py
+++ b/axiom/vm.py
@@ -166,7 +166,7 @@ class Vm:
                 self._locals = new_locals
                 self._upvalues = new_upvalues
                 self._current_function = call_idx
-                self.ip = fn.entry
+                self._set_ip(fn.entry, len(ins), f"call target {call_idx} entry")
             elif i.op == Op.HOST_CALL:
                 if i.arg is None:
                     raise AxiomRuntimeError("host call missing arg")
@@ -216,17 +216,17 @@ class Vm:
                 self._locals = frame.locals
                 self._upvalues = frame.upvalues
                 self._current_function = frame.function_index
-                self.ip = frame.ret_ip
+                self._set_ip(frame.ret_ip, len(ins), "return address")
                 self.stack.append(result)
             elif i.op == Op.JMP:
-                self.ip = int(i.arg)
+                self._set_ip(int(i.arg), len(ins), "jump target")
             elif i.op == Op.JMP_IF_FALSE:
                 if not self.stack:
                     raise AxiomRuntimeError("stack underflow on JMP_IF_FALSE")
                 cond = self.stack.pop()
                 try:
                     if not require_condition_bool(cond):
-                        self.ip = int(i.arg)
+                        self._set_ip(int(i.arg), len(ins), "conditional jump target")
                 except ValueError as e:
                     raise AxiomRuntimeError(str(e)) from e
             elif i.op == Op.PRINT:
@@ -303,7 +303,11 @@ class Vm:
                 self._locals = new_locals
                 self._upvalues = new_upvalues
                 self._current_function = fn_idx
-                self.ip = fn.entry
+                self._set_ip(
+                    fn.entry,
+                    len(ins),
+                    f"indirect call target {fn_idx} entry",
+                )
             else:
                 raise AxiomRuntimeError(f"unknown opcode {i.op}")
 
@@ -315,6 +319,14 @@ class Vm:
         b = self.stack.pop()
         a = self.stack.pop()
         return b, a
+
+    def _set_ip(self, target: int, instruction_count: int, context: str) -> None:
+        if target < 0 or target >= instruction_count:
+            raise AxiomRuntimeError(
+                f"{context} {target} out of bounds "
+                f"(instruction count {instruction_count})"
+            )
+        self.ip = target
 
     def _call_host_fn(self, fn_id: int, args: List[Value], out: TextIO) -> Value:
         if fn_id not in HOST_BUILTIN_BY_ID:

--- a/tests/test_errors_runtime.py
+++ b/tests/test_errors_runtime.py
@@ -16,7 +16,7 @@ from axiom.ast import (
     TypeRef,
     VarRef,
 )
-from axiom.bytecode import Bytecode, Instr, Op, VERSION_MINOR
+from axiom.bytecode import Bytecode, FunctionMeta, Instr, Op, VERSION_MINOR
 from axiom.errors import AxiomCompileError, AxiomParseError, AxiomRuntimeError
 from axiom.host import (
     MAX_POW_BASE,
@@ -159,6 +159,94 @@ class RuntimeErrorTests(unittest.TestCase):
         out = io.StringIO()
         Vm(locals_count=decoded.locals_count).run(decoded, out)
         self.assertEqual(out.getvalue(), "hi\n")
+
+    def test_vm_rejects_jump_target_past_instruction_end(self) -> None:
+        bc = Bytecode(
+            strings=[],
+            instructions=[Instr(Op.JMP, 2), Instr(Op.HALT)],
+            locals_count=0,
+            functions=[],
+        )
+
+        with self.assertRaises(AxiomRuntimeError) as cm:
+            Vm(locals_count=bc.locals_count).run(bc, io.StringIO())
+
+        self.assertIn(
+            "jump target 2 out of bounds (instruction count 2)",
+            str(cm.exception),
+        )
+
+    def test_vm_rejects_negative_jump_target(self) -> None:
+        bc = Bytecode(
+            strings=[],
+            instructions=[Instr(Op.JMP, -1), Instr(Op.HALT)],
+            locals_count=0,
+            functions=[],
+        )
+
+        with self.assertRaises(AxiomRuntimeError) as cm:
+            Vm(locals_count=bc.locals_count).run(bc, io.StringIO())
+
+        self.assertIn(
+            "jump target -1 out of bounds (instruction count 2)",
+            str(cm.exception),
+        )
+
+    def test_vm_rejects_conditional_jump_target_past_instruction_end(self) -> None:
+        bc = Bytecode(
+            strings=[],
+            instructions=[
+                Instr(Op.CONST_BOOL, 0),
+                Instr(Op.JMP_IF_FALSE, 3),
+                Instr(Op.HALT),
+            ],
+            locals_count=0,
+            functions=[],
+        )
+
+        with self.assertRaises(AxiomRuntimeError) as cm:
+            Vm(locals_count=bc.locals_count).run(bc, io.StringIO())
+
+        self.assertIn(
+            "conditional jump target 3 out of bounds (instruction count 3)",
+            str(cm.exception),
+        )
+
+    def test_vm_rejects_call_entry_past_instruction_end(self) -> None:
+        bc = Bytecode(
+            strings=["f"],
+            instructions=[Instr(Op.CALL, 0), Instr(Op.HALT)],
+            locals_count=0,
+            functions=[FunctionMeta(name_index=0, entry=2, arity=0, locals_count=0)],
+        )
+
+        with self.assertRaises(AxiomRuntimeError) as cm:
+            Vm(locals_count=bc.locals_count).run(bc, io.StringIO())
+
+        self.assertIn(
+            "call target 0 entry 2 out of bounds (instruction count 2)",
+            str(cm.exception),
+        )
+
+    def test_vm_rejects_indirect_call_entry_past_instruction_end(self) -> None:
+        bc = Bytecode(
+            strings=["f"],
+            instructions=[
+                Instr(Op.LOAD_FN, 0),
+                Instr(Op.CALL_INDIRECT, 0),
+                Instr(Op.HALT),
+            ],
+            locals_count=0,
+            functions=[FunctionMeta(name_index=0, entry=3, arity=0, locals_count=0)],
+        )
+
+        with self.assertRaises(AxiomRuntimeError) as cm:
+            Vm(locals_count=bc.locals_count).run(bc, io.StringIO())
+
+        self.assertIn(
+            "indirect call target 0 entry 3 out of bounds (instruction count 3)",
+            str(cm.exception),
+        )
 
     def test_runtime_host_print_requires_explicit_allow(self) -> None:
         with self.assertRaises(AxiomRuntimeError):


### PR DESCRIPTION
Closes #169

Implements the Hephaestus-assigned fix for: [Security][High] VM instruction pointer assignments not bounds-checked against instruction array length
