### PR TITLE
fix: address issue #269

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
-.PHONY: test smoke stage1-test stage1-conformance stage1-smoke stage1-run
+.PHONY: test smoke docs-python-exit stage1-test stage1-conformance stage1-smoke stage1-run
 
-test: stage1-test
+test: docs-python-exit stage1-test
 
 smoke: stage1-smoke
+
+docs-python-exit:
+	bash scripts/ci/check-python-exit-docs.sh
 
 stage1-test:
 	cargo test --manifest-path stage1/Cargo.toml

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 Axiom is a small experimental programming language. The supported toolchain is
 the Rust bootstrap compiler in `stage1/`.
 
+Python `stage0` and its bytecode VM are not supported execution paths; see
+[docs/python-exit-vm-disposition.md](docs/python-exit-vm-disposition.md).
+
 ## Current Status
 
 Axiom currently supports a Rust-only `axiomc` workflow with:

--- a/docs/python-exit-vm-disposition.md
+++ b/docs/python-exit-vm-disposition.md
@@ -1,0 +1,57 @@
+# Python Exit VM Disposition
+
+Status: accepted
+
+Parent issue: [#265](https://github.com/OMT-Global/axiom/issues/265)
+
+Governing issue: [#269](https://github.com/OMT-Global/axiom/issues/269)
+
+## Decision
+
+Axiom will retire the Python `stage0` interpreter, bytecode compiler, bytecode
+format, bytecode VM, and disassembler as supported implementation surfaces.
+The Rust `stage1` `axiomc` workflow is the only supported execution path.
+
+The supported path is:
+
+1. Parse, check, lower, and build through `stage1/` Rust code.
+2. Execute through generated native artifacts produced by `axiomc`.
+3. Prove language and runtime behavior with Rust-owned crate tests,
+   `stage1/conformance`, and `axiomc test` package fixtures.
+
+There will be no Rust port of the Python bytecode interpreter or VM as part of
+the Python exit.
+
+## Component Disposition
+
+| Component | Disposition |
+| --- | --- |
+| Python interpreter | Retire. It is not a supported execution mode after Python exit. |
+| Python bytecode compiler | Retire. Rust `axiomc` owns lowering and generated-native builds. |
+| Python bytecode format | Preserve only as historical material if retained at all. It is not a compatibility target. |
+| Python bytecode VM | Retire. Runtime behavior must be owned by Rust `stage1` tests or future Rust runtime code. |
+| Python disassembler | Retire with the bytecode VM. Future inspection tools should target Rust-owned IR, generated Rust, debug maps, or a future direct backend. |
+
+## Consequences
+
+- Final Python deletion is not blocked on bytecode VM ownership.
+- Any behavior formerly protected by Python VM tests must move into Rust-owned
+  coverage before deletion, tracked by
+  [#267](https://github.com/OMT-Global/axiom/issues/267).
+- CLI, package, and user-facing workflows must stay `axiomc`-owned, tracked by
+  [#268](https://github.com/OMT-Global/axiom/issues/268).
+- Rust-only CI gates replace dual Python/Rust language gates, tracked by
+  [#270](https://github.com/OMT-Global/axiom/issues/270).
+- User-facing docs and install paths must not direct users to Python `stage0`,
+  tracked by [#271](https://github.com/OMT-Global/axiom/issues/271).
+- Source deletion remains the final cleanup, tracked by
+  [#272](https://github.com/OMT-Global/axiom/issues/272).
+- A future direct native backend remains separate longer-term work and is not
+  required for Python exit; see
+  [#105](https://github.com/OMT-Global/axiom/issues/105).
+
+## Validation Rule
+
+Docs may describe the Python interpreter and VM only as retired, historical, or
+to-be-deleted surfaces. They must not present the Python interpreter, bytecode
+VM, bytecode format, or disassembler as supported user-facing execution paths.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -3,6 +3,10 @@
 This file tracks the Rust compiler line under `stage1/`. New work should target
 the Rust-only `axiomc` workflow.
 
+The Python `stage0` interpreter and bytecode VM are retired as supported
+implementation surfaces; see
+[Python Exit VM Disposition](python-exit-vm-disposition.md).
+
 ## Completed Foundations
 
 - Package manifests with `axiom.toml` and `axiom.lock`.

--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -1,6 +1,9 @@
 # Stage1 bootstrap
 
 The Rust bootstrap compiler in `stage1/` is now the supported Axiom toolchain.
+The Python `stage0` interpreter, bytecode compiler, bytecode format, bytecode
+VM, and disassembler are not supported execution surfaces; see
+[Python Exit VM Disposition](python-exit-vm-disposition.md).
 
 ## Current bootstrap scope
 

--- a/scripts/ci/check-python-exit-docs.sh
+++ b/scripts/ci/check-python-exit-docs.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+decision_doc="docs/python-exit-vm-disposition.md"
+
+if [[ ! -f "$decision_doc" ]]; then
+  echo "missing $decision_doc" >&2
+  exit 1
+fi
+
+required_patterns=(
+  "Python interpreter | Retire"
+  "Python bytecode compiler | Retire"
+  "Python bytecode format | Preserve only as historical material"
+  "Python bytecode VM | Retire"
+  "Python disassembler | Retire"
+  "There will be no Rust port of the Python bytecode interpreter or VM"
+)
+
+for pattern in "${required_patterns[@]}"; do
+  if ! grep -Fq "$pattern" "$decision_doc"; then
+    echo "missing Python exit decision text: $pattern" >&2
+    exit 1
+  fi
+done
+
+legacy_invocation="python -m axi""om"
+
+if rg -n "$legacy_invocation" README.md docs scripts --glob '*.md' --glob '*.sh'; then
+  echo "user-facing docs still instruct users to run $legacy_invocation" >&2
+  exit 1
+fi

--- a/scripts/ci/run-fast-checks.sh
+++ b/scripts/ci/run-fast-checks.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+bash scripts/ci/check-python-exit-docs.sh
 make stage1-test
 make stage1-conformance
 make stage1-smoke


### PR DESCRIPTION
Closes #269

Implements the Ares-assigned fix for: Python exit: decide interpreter and bytecode VM disposition
