### PR TITLE
fix: address issue #268

### DIFF
--- a/docs/python-exit-vm-disposition.md
+++ b/docs/python-exit-vm-disposition.md
@@ -50,6 +50,7 @@ binary.
 | `pkg build` | Use `axiomc build <package>`. |
 | `pkg check` | Use `axiomc check <package>`. |
 | `pkg run` | Use `axiomc run <package>`. |
+| package tests | Use `axiomc test <package>` for discovered package test entrypoints. |
 | `pkg clean` | Retire. Stage1 build artifacts are ordinary package output under the manifest `out_dir`; remove that directory when a clean tree is needed. |
 | `pkg manifest` | Retire as a separate command. `axiom.toml` and `axiom.lock` are the supported package metadata surfaces, and `axiomc caps <package> --json` reports capability metadata. |
 | `host list` | Retire. Python host discovery is not part of the Rust-supported execution path. |

--- a/docs/python-exit-vm-disposition.md
+++ b/docs/python-exit-vm-disposition.md
@@ -32,6 +32,29 @@ the Python exit.
 | Python bytecode VM | Retire. Runtime behavior must be owned by Rust `stage1` tests or future Rust runtime code. |
 | Python disassembler | Retire with the bytecode VM. Future inspection tools should target Rust-owned IR, generated Rust, debug maps, or a future direct backend. |
 
+## CLI Workflow Migration
+
+The legacy entries below refer to retired Python module subcommands. User-facing
+documentation must route supported workflows through `cargo run --manifest-path
+stage1/Cargo.toml -p axiomc -- ...` or an equivalent installed `axiomc`
+binary.
+
+| Legacy module command | Disposition |
+| --- | --- |
+| `check` | Use `axiomc check <package>`. The Rust command checks `axiom.toml` packages and workspace members, with `--json` for machine-readable diagnostics and `-p/--package` for member selection. |
+| `interp` | Retire. There is no supported interpreter mode after Python exit; execute programs with `axiomc run <package>`. |
+| `compile` | Use `axiomc build <package>`. The Rust command owns lowering and emits generated Rust plus a native binary. |
+| `vm` | Retire with the bytecode VM. Runtime behavior is validated by Rust-owned tests, conformance fixtures, and native `axiomc` execution. |
+| `repl` | Retire. There is no supported REPL in the stage1 workflow. |
+| `pkg init` | Use `axiomc new <path>` to create `axiom.toml`, `axiom.lock`, and starter source. |
+| `pkg build` | Use `axiomc build <package>`. |
+| `pkg check` | Use `axiomc check <package>`. |
+| `pkg run` | Use `axiomc run <package>`. |
+| `pkg clean` | Retire. Stage1 build artifacts are ordinary package output under the manifest `out_dir`; remove that directory when a clean tree is needed. |
+| `pkg manifest` | Retire as a separate command. `axiom.toml` and `axiom.lock` are the supported package metadata surfaces, and `axiomc caps <package> --json` reports capability metadata. |
+| `host list` | Retire. Python host discovery is not part of the Rust-supported execution path. |
+| `host describe` | Retire. Future host or target inspection should be Rust-owned and tied to native build targets, not Python stage0 hosts. |
+
 ## Consequences
 
 - Final Python deletion is not blocked on bytecode VM ownership.

--- a/scripts/ci/check-python-exit-docs.sh
+++ b/scripts/ci/check-python-exit-docs.sh
@@ -25,6 +25,7 @@ required_patterns=(
   '`pkg build` | Use `axiomc build <package>`'
   '`pkg check` | Use `axiomc check <package>`'
   '`pkg run` | Use `axiomc run <package>`'
+  'package tests | Use `axiomc test <package>`'
   '`pkg clean` | Retire'
   '`pkg manifest` | Retire as a separate command'
   '`host list` | Retire'

--- a/scripts/ci/check-python-exit-docs.sh
+++ b/scripts/ci/check-python-exit-docs.sh
@@ -15,6 +15,20 @@ required_patterns=(
   "Python bytecode VM | Retire"
   "Python disassembler | Retire"
   "There will be no Rust port of the Python bytecode interpreter or VM"
+  "Legacy module command | Disposition"
+  '`check` | Use `axiomc check <package>`'
+  '`compile` | Use `axiomc build <package>`'
+  '`interp` | Retire'
+  '`vm` | Retire with the bytecode VM'
+  '`repl` | Retire'
+  '`pkg init` | Use `axiomc new <path>`'
+  '`pkg build` | Use `axiomc build <package>`'
+  '`pkg check` | Use `axiomc check <package>`'
+  '`pkg run` | Use `axiomc run <package>`'
+  '`pkg clean` | Retire'
+  '`pkg manifest` | Retire as a separate command'
+  '`host list` | Retire'
+  '`host describe` | Retire'
 )
 
 for pattern in "${required_patterns[@]}"; do

--- a/stage1/crates/axiomc/src/main.rs
+++ b/stage1/crates/axiomc/src/main.rs
@@ -18,11 +18,13 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Command {
+    /// Create a new stage1 package with axiom.toml, axiom.lock, and starter source.
     New {
         path: PathBuf,
         #[arg(long)]
         name: Option<String>,
     },
+    /// Check a stage1 package or workspace member without building a binary.
     Check {
         path: PathBuf,
         #[arg(long)]
@@ -30,6 +32,7 @@ enum Command {
         #[arg(short = 'p', long = "package")]
         package: Option<String>,
     },
+    /// Build a stage1 package into generated Rust and a native binary.
     Build {
         path: PathBuf,
         #[arg(long)]
@@ -41,11 +44,13 @@ enum Command {
         #[arg(short = 'p', long = "package")]
         package: Option<String>,
     },
+    /// Build and run a stage1 package native binary.
     Run {
         path: PathBuf,
         #[arg(short = 'p', long = "package")]
         package: Option<String>,
     },
+    /// Discover, build, and run package test entrypoints.
     Test {
         path: PathBuf,
         #[arg(long)]
@@ -55,6 +60,7 @@ enum Command {
         #[arg(short = 'p', long = "package")]
         package: Option<String>,
     },
+    /// Inspect manifest capability requirements.
     Caps {
         path: Option<PathBuf>,
         #[arg(long)]
@@ -214,6 +220,18 @@ fn print_error(command: &str, error: Diagnostic, json: bool) -> i32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::CommandFactory;
+
+    #[test]
+    fn help_describes_supported_stage1_workflows() {
+        let help = Cli::command().render_long_help().to_string();
+        assert!(help.contains("Create a new stage1 package"));
+        assert!(help.contains("Check a stage1 package or workspace member"));
+        assert!(help.contains("Build a stage1 package into generated Rust"));
+        assert!(help.contains("Build and run a stage1 package native binary"));
+        assert!(help.contains("Discover, build, and run package test entrypoints"));
+        assert!(help.contains("Inspect manifest capability requirements"));
+    }
 
     fn build_output(debug_map: Option<String>) -> BuildOutput {
         BuildOutput {


### PR DESCRIPTION
Closes #268

Implements the Ares-assigned fix for: Python exit: migrate CLI and package workflows to axiomc
