### PR TITLE
fix: address issue #267

### DIFF
--- a/docs/python-exit-conformance.md
+++ b/docs/python-exit-conformance.md
@@ -1,0 +1,57 @@
+# Python Exit Conformance
+
+Stage1 owns the Rust-run conformance corpus at `stage1/conformance`.
+
+Run it with:
+
+```sh
+make stage1-conformance
+```
+
+## Fixture Layout
+
+Executable fixtures live under `stage1/conformance/pass`. Each fixture is a
+complete package and includes `expected-output.txt`; the runner compiles and
+executes the generated native binary, then checks stdout.
+
+Compile-fail fixtures live under `stage1/conformance/fail`. Each fixture is a
+complete package and includes `expected-error.json`; the runner checks the
+diagnostic kind, code, exact message, relative source path, line, and column.
+
+## Python Test Module Migration
+
+| Retired Python test module | Stage1 destination or disposition |
+| --- | --- |
+| `tests/test_conformance.py` | Replaced by `make stage1-conformance` and the checked-in `stage1/conformance/{pass,fail}` corpus. |
+| `tests/test_cli_runtime.py` | Runtime execution parity moved to `axiomc test` and `axiomc run` coverage under `stage1/conformance`, `stage1/examples`, and Rust project tests. REPL, interpreter, bytecode compiler, and VM checks are retired by `docs/python-exit-vm-disposition.md`. |
+| `tests/test_cli_packages.py` | Replaced by Rust stage1 package/workspace tests and `stage1/examples/{packages,workspace,workspace_only}`. Python `pkg` subcommands are retired by `docs/python-exit-vm-disposition.md`. |
+| `tests/test_errors_core.py` | Replaced by Rust checker tests plus compile-fail conformance fixtures for stable public diagnostics. |
+| `tests/test_errors_imports.py` | Replaced by Rust import/package tests and compile-fail conformance fixtures for supported stage1 import behavior. Python import aliases and namespace-qualified calls are retired because stage1 rejects them. |
+| `tests/test_errors_runtime.py` | Runtime behavior that remains supported is covered by stage1 generated-native execution tests. Python bytecode, VM, interpreter, and host builtin internals are retired. |
+| `tests/test_bytecode.py` | Retired. The Python bytecode format, decoder, and VM are not supported compatibility targets after Python exit. |
+| `tests/test_intops.py` | Retired with Python integer helper internals; stage1 does not currently expose a division operator contract. |
+| `tests/test_loader.py` | Replaced by Rust stage1 import/package resolution tests and conformance import fixtures. Python loader internals are retired. |
+| `tests/test_semantic_plan.py` | Retired as Python implementation-internal coverage; supported semantic behavior moved to Rust checker tests and conformance fixtures. |
+| `tests/test_detect_secrets_script.py` | Kept outside language conformance; the current shell gate is `scripts/check-detect-secrets.sh`. |
+
+## Golden Program Migration
+
+| Retired golden program group | Stage1 destination or disposition |
+| --- | --- |
+| `arith`, `bool_values`, `if_else`, `string_concat`, `string_escape`, `array_basic`, `array_len` | Ported into `stage1/conformance/pass/legacy_core_programs`. |
+| `fn_basic`, `fn_recursive`, `array_fn`, `array_strings`, `array_while`, `vars` | Covered by existing stage1 examples, Rust project tests, and conformance fixtures for functions, arrays, and while execution. |
+| `assign`, `assign_outer`, `scopes`, `fn_scope`, `expr_stmt`, `let_infer`, `array_empty`, `array_neg_index`, `div`, `while_sum` | Either covered by the Rust checker/runtime suite or obsolete where stage1 intentionally differs, such as no standalone expression statement contract, no empty array literal support, no mutable assignment statement contract, and no current division operator contract. |
+| `array_push`, `array_set`, `string_builtins`, `math_builtins`, `fn_host_abs`, `fn_host_math_abs`, `fn_host_version` | Retired with Python host builtin APIs. Stage1 uses explicit stdlib modules and compiler-known intrinsics instead of the Python `host.*` namespace. |
+| `fn_closure_capture`, `fn_closure_recursive`, `fn_closure_shadow`, `fn_nested`, `fn_first_class_basic`, `fn_first_class_param`, `fn_first_class_reassign` | Retired as stage0-only function model coverage. Stage1 does not support closures, nested functions, or first-class function values. |
+| `for_basic`, `for_nested` | Retired until a Rust-owned `for` statement exists; current stage1 iteration coverage uses `while`, arrays, and borrowed-slice helpers. |
+
+## Current Stage1 Coverage
+
+Executable conformance fixtures currently cover migrated legacy core programs,
+functions across modules, nested package-local imports, struct field access,
+`Option`/`Result` control flow, and standard collection helpers over arrays and
+borrowed slices.
+
+Compile-fail fixtures currently cover use-after-move ownership, mutable borrow
+while a shared borrow is live, `Ok(...)` without a `Result<T, E>` context, and
+clock stdlib access without the required capability.

--- a/docs/python-exit-vm-disposition.md
+++ b/docs/python-exit-vm-disposition.md
@@ -61,7 +61,8 @@ binary.
 - Final Python deletion is not blocked on bytecode VM ownership.
 - Any behavior formerly protected by Python VM tests must move into Rust-owned
   coverage before deletion, tracked by
-  [#267](https://github.com/OMT-Global/axiom/issues/267).
+  [#267](https://github.com/OMT-Global/axiom/issues/267) and inventoried in
+  [Python Exit Conformance](python-exit-conformance.md).
 - CLI, package, and user-facing workflows must stay `axiomc`-owned, tracked by
   [#268](https://github.com/OMT-Global/axiom/issues/268).
 - Rust-only CI gates replace dual Python/Rust language gates, tracked by

--- a/stage1/conformance/README.md
+++ b/stage1/conformance/README.md
@@ -14,6 +14,9 @@ and compares stdout to the package-level expected output.
 
 Current executable fixtures cover:
 
+- `legacy_core_programs`: migrated golden-program coverage for integer
+  addition, bools, `if/else`, `while false`, string concat/escapes, array
+  indexing, and array length.
 - `functions_across_modules`: function calls and return values imported from a
   sibling module.
 - `struct_field_access`: struct construction, field access, and passing a

--- a/stage1/conformance/axiom.lock
+++ b/stage1/conformance/axiom.lock
@@ -31,6 +31,11 @@ version = "0.1.0"
 source = "path:pass/functions_across_modules"
 
 [[package]]
+name = "conformance-legacy-core-programs"
+version = "0.1.0"
+source = "path:pass/legacy_core_programs"
+
+[[package]]
 name = "conformance-outcome-control-flow"
 version = "0.1.0"
 source = "path:pass/outcome_control_flow"

--- a/stage1/conformance/axiom.toml
+++ b/stage1/conformance/axiom.toml
@@ -6,6 +6,7 @@ members = [
   "fail/stdlib_clock_without_capability",
   "pass/collection_operations",
   "pass/functions_across_modules",
+  "pass/legacy_core_programs",
   "pass/outcome_control_flow",
   "pass/package_local_modules",
   "pass/struct_field_access",

--- a/stage1/conformance/pass/legacy_core_programs/axiom.lock
+++ b/stage1/conformance/pass/legacy_core_programs/axiom.lock
@@ -1,0 +1,6 @@
+version = 1
+
+[[package]]
+name = "conformance-legacy-core-programs"
+version = "0.1.0"
+source = "path"

--- a/stage1/conformance/pass/legacy_core_programs/axiom.toml
+++ b/stage1/conformance/pass/legacy_core_programs/axiom.toml
@@ -1,0 +1,15 @@
+[package]
+name = "conformance-legacy-core-programs"
+version = "0.1.0"
+
+[build]
+entry = "src/main_test.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false

--- a/stage1/conformance/pass/legacy_core_programs/expected-output.txt
+++ b/stage1/conformance/pass/legacy_core_programs/expected-output.txt
@@ -1,0 +1,17 @@
+42
+85
+true
+1
+true
+true
+10
+40
+hello, axiom
+true
+true
+hello
+axiom
+10
+20
+30
+3

--- a/stage1/conformance/pass/legacy_core_programs/src/main_test.ax
+++ b/stage1/conformance/pass/legacy_core_programs/src/main_test.ax
@@ -1,0 +1,51 @@
+fn choose(flag: bool): bool {
+if flag {
+return false
+}
+return true
+}
+
+fn banner(): string {
+return "hello" + ", axiom"
+}
+
+let x: int = 40 + 2
+print x
+print x + 43
+
+let ready: bool = true
+print ready
+if ready {
+print 1
+}
+
+let changed: bool = 1 < 2
+print changed
+print choose(false)
+
+let branch: int = 2
+if branch == 2 {
+print 10
+} else {
+print 20
+}
+if branch != 2 {
+print 30
+} else {
+print 40
+}
+
+while false {
+print "never"
+}
+
+print banner()
+print "same" == "same"
+print "same" != "other"
+print "hello\naxiom"
+
+let values: [int] = [10, 20, 30]
+print values[0]
+print values[1]
+print values[2]
+print len(values)

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -3108,8 +3108,8 @@ mod tests {
     fn conformance_corpus_reports_stable_results() {
         let output =
             run_project_tests(&conformance_fixture()).expect("run stage1 conformance corpus");
-        assert_eq!(output.cases.len(), 9);
-        assert_eq!(output.passed, 9);
+        assert_eq!(output.cases.len(), 10);
+        assert_eq!(output.passed, 10);
         assert_eq!(output.failed, 0);
         assert!(
             output
@@ -3125,7 +3125,7 @@ mod tests {
                 .iter()
                 .filter(|case| case.expected_stdout.is_some())
                 .count(),
-            5
+            6
         );
     }
 


### PR DESCRIPTION
Closes #267

Implements the Ares-assigned fix for: Python exit: migrate conformance coverage into stage1 fixtures
