### PR TITLE
fix: address issue #120

### DIFF
--- a/stage1/conformance/README.md
+++ b/stage1/conformance/README.md
@@ -56,3 +56,7 @@ Current compile-fail fixtures cover:
   intrinsics without the manifest opt-in.
 - `package_visibility_dependency_boundary`: import diagnostics for `pub(pkg)`
   items that are referenced across a dependency package boundary.
+- `recursive_struct_without_indirection`: type diagnostics for direct
+  self-recursive struct fields without an indirection boundary.
+- `recursive_struct_enum_without_indirection`: type diagnostics for recursive
+  struct-enum cycles without an indirection boundary.

--- a/stage1/conformance/README.md
+++ b/stage1/conformance/README.md
@@ -58,5 +58,7 @@ Current compile-fail fixtures cover:
   items that are referenced across a dependency package boundary.
 - `recursive_struct_without_indirection`: type diagnostics for direct
   self-recursive struct fields without an indirection boundary.
+- `recursive_mutual_struct_without_indirection`: type diagnostics for
+  mutually recursive struct fields without an indirection boundary.
 - `recursive_struct_enum_without_indirection`: type diagnostics for recursive
   struct-enum cycles without an indirection boundary.

--- a/stage1/conformance/README.md
+++ b/stage1/conformance/README.md
@@ -62,3 +62,5 @@ Current compile-fail fixtures cover:
   mutually recursive struct fields without an indirection boundary.
 - `recursive_struct_enum_without_indirection`: type diagnostics for recursive
   struct-enum cycles without an indirection boundary.
+- `recursive_enum_without_indirection`: type diagnostics for direct
+  self-recursive enum payloads without an indirection boundary.

--- a/stage1/conformance/axiom.lock
+++ b/stage1/conformance/axiom.lock
@@ -46,6 +46,11 @@ version = "0.1.0"
 source = "path:fail/panic_requires_string_argument"
 
 [[package]]
+name = "conformance-recursive-mutual-struct-without-indirection"
+version = "0.1.0"
+source = "path:fail/recursive_mutual_struct_without_indirection"
+
+[[package]]
 name = "conformance-result-ok-without-context"
 version = "0.1.0"
 source = "path:fail/result_ok_without_context"

--- a/stage1/conformance/axiom.lock
+++ b/stage1/conformance/axiom.lock
@@ -46,6 +46,11 @@ version = "0.1.0"
 source = "path:fail/panic_requires_string_argument"
 
 [[package]]
+name = "conformance-recursive-enum-without-indirection"
+version = "0.1.0"
+source = "path:fail/recursive_enum_without_indirection"
+
+[[package]]
 name = "conformance-recursive-mutual-struct-without-indirection"
 version = "0.1.0"
 source = "path:fail/recursive_mutual_struct_without_indirection"

--- a/stage1/conformance/axiom.lock
+++ b/stage1/conformance/axiom.lock
@@ -51,6 +51,16 @@ version = "0.1.0"
 source = "path:fail/recursive_mutual_struct_without_indirection"
 
 [[package]]
+name = "conformance-recursive-struct-enum-without-indirection"
+version = "0.1.0"
+source = "path:fail/recursive_struct_enum_without_indirection"
+
+[[package]]
+name = "conformance-recursive-struct-without-indirection"
+version = "0.1.0"
+source = "path:fail/recursive_struct_without_indirection"
+
+[[package]]
 name = "conformance-result-ok-without-context"
 version = "0.1.0"
 source = "path:fail/result_ok_without_context"

--- a/stage1/conformance/axiom.toml
+++ b/stage1/conformance/axiom.toml
@@ -9,6 +9,8 @@ members = [
   "fail/panic_requires_string_argument",
   "fail/package_visibility_dependency_boundary",
   "fail/recursive_mutual_struct_without_indirection",
+  "fail/recursive_struct_enum_without_indirection",
+  "fail/recursive_struct_without_indirection",
   "fail/result_ok_without_context",
   "fail/stdlib_clock_without_capability",
   "pass/collection_operations",

--- a/stage1/conformance/axiom.toml
+++ b/stage1/conformance/axiom.toml
@@ -8,6 +8,7 @@ members = [
   "fail/panic_requires_single_argument",
   "fail/panic_requires_string_argument",
   "fail/package_visibility_dependency_boundary",
+  "fail/recursive_enum_without_indirection",
   "fail/recursive_mutual_struct_without_indirection",
   "fail/recursive_struct_enum_without_indirection",
   "fail/recursive_struct_without_indirection",

--- a/stage1/conformance/axiom.toml
+++ b/stage1/conformance/axiom.toml
@@ -8,6 +8,7 @@ members = [
   "fail/panic_requires_single_argument",
   "fail/panic_requires_string_argument",
   "fail/package_visibility_dependency_boundary",
+  "fail/recursive_mutual_struct_without_indirection",
   "fail/result_ok_without_context",
   "fail/stdlib_clock_without_capability",
   "pass/collection_operations",

--- a/stage1/conformance/fail/recursive_enum_without_indirection/axiom.lock
+++ b/stage1/conformance/fail/recursive_enum_without_indirection/axiom.lock
@@ -1,0 +1,6 @@
+version = 1
+
+[[package]]
+name = "conformance-recursive-enum-without-indirection"
+version = "0.1.0"
+source = "path"

--- a/stage1/conformance/fail/recursive_enum_without_indirection/axiom.toml
+++ b/stage1/conformance/fail/recursive_enum_without_indirection/axiom.toml
@@ -1,0 +1,15 @@
+[package]
+name = "conformance-recursive-enum-without-indirection"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false

--- a/stage1/conformance/fail/recursive_enum_without_indirection/expected-error.json
+++ b/stage1/conformance/fail/recursive_enum_without_indirection/expected-error.json
@@ -1,0 +1,8 @@
+{
+  "kind": "type",
+  "code": null,
+  "message": "recursive payload variant \"Cons\" in enum \"conformance_recursive_enum_without_indirection_main_List\" requires indirection; unboxed recursive types are not supported",
+  "path": "src/main.ax",
+  "line": 2,
+  "column": 1
+}

--- a/stage1/conformance/fail/recursive_enum_without_indirection/src/main.ax
+++ b/stage1/conformance/fail/recursive_enum_without_indirection/src/main.ax
@@ -1,0 +1,6 @@
+enum List {
+Cons(List)
+Nil
+}
+
+print 0

--- a/stage1/conformance/fail/recursive_mutual_struct_without_indirection/axiom.lock
+++ b/stage1/conformance/fail/recursive_mutual_struct_without_indirection/axiom.lock
@@ -1,0 +1,6 @@
+version = 1
+
+[[package]]
+name = "conformance-recursive-mutual-struct-without-indirection"
+version = "0.1.0"
+source = "path"

--- a/stage1/conformance/fail/recursive_mutual_struct_without_indirection/axiom.toml
+++ b/stage1/conformance/fail/recursive_mutual_struct_without_indirection/axiom.toml
@@ -1,0 +1,15 @@
+[package]
+name = "conformance-recursive-mutual-struct-without-indirection"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false

--- a/stage1/conformance/fail/recursive_mutual_struct_without_indirection/expected-error.json
+++ b/stage1/conformance/fail/recursive_mutual_struct_without_indirection/expected-error.json
@@ -1,0 +1,8 @@
+{
+  "kind": "type",
+  "code": null,
+  "message": "recursive field \"next\" in struct \"conformance_recursive_mutual_struct_without_indirection_main_Node\" requires indirection; unboxed recursive types are not supported",
+  "path": "src/main.ax",
+  "line": 2,
+  "column": 1
+}

--- a/stage1/conformance/fail/recursive_mutual_struct_without_indirection/src/main.ax
+++ b/stage1/conformance/fail/recursive_mutual_struct_without_indirection/src/main.ax
@@ -1,0 +1,9 @@
+struct Node {
+next: Link
+}
+
+struct Link {
+node: Node
+}
+
+print 0

--- a/stage1/conformance/fail/recursive_struct_enum_without_indirection/axiom.lock
+++ b/stage1/conformance/fail/recursive_struct_enum_without_indirection/axiom.lock
@@ -1,0 +1,6 @@
+version = 1
+
+[[package]]
+name = "conformance-recursive-struct-enum-without-indirection"
+version = "0.1.0"
+source = "path"

--- a/stage1/conformance/fail/recursive_struct_enum_without_indirection/axiom.toml
+++ b/stage1/conformance/fail/recursive_struct_enum_without_indirection/axiom.toml
@@ -1,0 +1,15 @@
+[package]
+name = "conformance-recursive-struct-enum-without-indirection"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false

--- a/stage1/conformance/fail/recursive_struct_enum_without_indirection/expected-error.json
+++ b/stage1/conformance/fail/recursive_struct_enum_without_indirection/expected-error.json
@@ -1,0 +1,8 @@
+{
+  "kind": "type",
+  "code": null,
+  "message": "recursive field \"expr\" in struct \"ExprNode\" requires indirection; unboxed recursive types are not supported",
+  "path": "src/main.ax",
+  "line": 2,
+  "column": 1
+}

--- a/stage1/conformance/fail/recursive_struct_enum_without_indirection/expected-error.json
+++ b/stage1/conformance/fail/recursive_struct_enum_without_indirection/expected-error.json
@@ -1,7 +1,7 @@
 {
   "kind": "type",
   "code": null,
-  "message": "recursive field \"expr\" in struct \"ExprNode\" requires indirection; unboxed recursive types are not supported",
+  "message": "recursive field \"expr\" in struct \"conformance_recursive_struct_enum_without_indirection_main_ExprNode\" requires indirection; unboxed recursive types are not supported",
   "path": "src/main.ax",
   "line": 2,
   "column": 1

--- a/stage1/conformance/fail/recursive_struct_enum_without_indirection/src/main.ax
+++ b/stage1/conformance/fail/recursive_struct_enum_without_indirection/src/main.ax
@@ -1,0 +1,10 @@
+struct ExprNode {
+expr: Expr
+}
+
+enum Expr {
+Wrap(ExprNode)
+Lit(int)
+}
+
+print 0

--- a/stage1/conformance/fail/recursive_struct_without_indirection/axiom.lock
+++ b/stage1/conformance/fail/recursive_struct_without_indirection/axiom.lock
@@ -1,0 +1,6 @@
+version = 1
+
+[[package]]
+name = "conformance-recursive-struct-without-indirection"
+version = "0.1.0"
+source = "path"

--- a/stage1/conformance/fail/recursive_struct_without_indirection/axiom.toml
+++ b/stage1/conformance/fail/recursive_struct_without_indirection/axiom.toml
@@ -1,0 +1,15 @@
+[package]
+name = "conformance-recursive-struct-without-indirection"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false

--- a/stage1/conformance/fail/recursive_struct_without_indirection/expected-error.json
+++ b/stage1/conformance/fail/recursive_struct_without_indirection/expected-error.json
@@ -1,7 +1,7 @@
 {
   "kind": "type",
   "code": null,
-  "message": "recursive field \"next\" in struct \"Node\" requires indirection; unboxed recursive types are not supported",
+  "message": "recursive field \"next\" in struct \"conformance_recursive_struct_without_indirection_main_Node\" requires indirection; unboxed recursive types are not supported",
   "path": "src/main.ax",
   "line": 2,
   "column": 1

--- a/stage1/conformance/fail/recursive_struct_without_indirection/expected-error.json
+++ b/stage1/conformance/fail/recursive_struct_without_indirection/expected-error.json
@@ -1,0 +1,8 @@
+{
+  "kind": "type",
+  "code": null,
+  "message": "recursive field \"next\" in struct \"Node\" requires indirection; unboxed recursive types are not supported",
+  "path": "src/main.ax",
+  "line": 2,
+  "column": 1
+}

--- a/stage1/conformance/fail/recursive_struct_without_indirection/src/main.ax
+++ b/stage1/conformance/fail/recursive_struct_without_indirection/src/main.ax
@@ -1,0 +1,5 @@
+struct Node {
+next: Node
+}
+
+print 0

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -320,6 +320,14 @@ pub fn lower_with_capabilities(
     let (enums, variants) =
         collect_enum_definitions(&program.enums, &struct_names, &enum_names, &aliases)?;
     let structs = collect_struct_definitions(&program.structs, &enum_names, &aliases)?;
+    validate_recursive_type_cycles(
+        &program,
+        &structs,
+        &enums,
+        &struct_names,
+        &enum_names,
+        &aliases,
+    )?;
     let functions = collect_function_signatures(&program.functions, &structs, &enums, &aliases)?;
     let mut lowered_structs = structs.values().cloned().collect::<Vec<_>>();
     lowered_structs.sort_by(|lhs, rhs| lhs.name.cmp(&rhs.name));
@@ -356,6 +364,143 @@ pub fn lower_with_capabilities(
         functions: lowered_functions,
         stmts,
     })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum AggregateRef {
+    Struct(String),
+    Enum(String),
+}
+
+fn validate_recursive_type_cycles(
+    program: &syntax::Program,
+    structs: &HashMap<String, StructDef>,
+    enums: &HashMap<String, EnumDef>,
+    syntax_structs: &HashMap<String, syntax::StructDecl>,
+    syntax_enums: &HashMap<String, ()>,
+    aliases: &HashMap<String, syntax::TypeAliasDecl>,
+) -> Result<(), Diagnostic> {
+    for struct_decl in &program.structs {
+        let owner = AggregateRef::Struct(struct_decl.name.clone());
+        for field in &struct_decl.fields {
+            let ty = lower_type(
+                &field.ty,
+                syntax_structs,
+                syntax_enums,
+                aliases,
+                field.line,
+                field.column,
+            )?;
+            if type_has_unboxed_recursive_path(&ty, &owner, structs, enums, &mut HashSet::new()) {
+                return Err(Diagnostic::new(
+                    "type",
+                    format!(
+                        "recursive field {:?} in struct {:?} requires indirection; unboxed recursive types are not supported",
+                        field.name, struct_decl.name
+                    ),
+                )
+                .with_span(field.line, field.column));
+            }
+        }
+    }
+
+    for enum_decl in &program.enums {
+        let owner = AggregateRef::Enum(enum_decl.name.clone());
+        for variant in &enum_decl.variants {
+            for payload_ty in &variant.payload_tys {
+                let ty = lower_type(
+                    payload_ty,
+                    syntax_structs,
+                    syntax_enums,
+                    aliases,
+                    variant.line,
+                    variant.column,
+                )?;
+                if type_has_unboxed_recursive_path(&ty, &owner, structs, enums, &mut HashSet::new())
+                {
+                    return Err(Diagnostic::new(
+                        "type",
+                        format!(
+                            "recursive payload variant {:?} in enum {:?} requires indirection; unboxed recursive types are not supported",
+                            variant.name, enum_decl.name
+                        ),
+                    )
+                    .with_span(variant.line, variant.column));
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn type_has_unboxed_recursive_path(
+    ty: &Type,
+    owner: &AggregateRef,
+    structs: &HashMap<String, StructDef>,
+    enums: &HashMap<String, EnumDef>,
+    visiting: &mut HashSet<AggregateRef>,
+) -> bool {
+    match ty {
+        Type::Int | Type::Bool | Type::String => false,
+        Type::Struct(name) => {
+            let current = AggregateRef::Struct(name.clone());
+            if &current == owner {
+                return true;
+            }
+            if !visiting.insert(current.clone()) {
+                return false;
+            }
+            let result = structs
+                .get(name)
+                .map(|struct_def| {
+                    struct_def.fields.iter().any(|field| {
+                        type_has_unboxed_recursive_path(&field.ty, owner, structs, enums, visiting)
+                    })
+                })
+                .unwrap_or(false);
+            visiting.remove(&current);
+            result
+        }
+        Type::Enum(name) => {
+            let current = AggregateRef::Enum(name.clone());
+            if &current == owner {
+                return true;
+            }
+            if !visiting.insert(current.clone()) {
+                return false;
+            }
+            let result = enums
+                .get(name)
+                .map(|enum_def| {
+                    enum_def.variants.iter().any(|variant| {
+                        variant.payload_tys.iter().any(|payload_ty| {
+                            type_has_unboxed_recursive_path(
+                                payload_ty, owner, structs, enums, visiting,
+                            )
+                        })
+                    })
+                })
+                .unwrap_or(false);
+            visiting.remove(&current);
+            result
+        }
+        Type::Slice(_) | Type::MutSlice(_) | Type::Map(_, _) | Type::Array(_) => false,
+        Type::Option(inner)
+        | Type::Task(inner)
+        | Type::JoinHandle(inner)
+        | Type::AsyncChannel(inner)
+        | Type::SelectResult(inner) => {
+            type_has_unboxed_recursive_path(inner, owner, structs, enums, visiting)
+        }
+        Type::Result(ok, err) => {
+            type_has_unboxed_recursive_path(ok, owner, structs, enums, visiting)
+                || type_has_unboxed_recursive_path(err, owner, structs, enums, visiting)
+        }
+        Type::Tuple(elements) => elements.iter().any(|element| {
+            type_has_unboxed_recursive_path(element, owner, structs, enums, visiting)
+        }),
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -2398,16 +2543,6 @@ fn collect_struct_definitions(
                 .with_span(field.line, field.column));
             }
             let ty = lower_type(&field.ty, &names, enums, aliases, field.line, field.column)?;
-            if matches!(&ty, Type::Struct(name) if name == &struct_decl.name) {
-                return Err(Diagnostic::new(
-                    "type",
-                    format!(
-                        "recursive field {:?} in struct {:?} is not supported yet",
-                        field.name, struct_decl.name
-                    ),
-                )
-                .with_span(field.line, field.column));
-            }
             fields.push(StructField {
                 name: field.name.clone(),
                 ty,
@@ -2582,19 +2717,6 @@ fn collect_enum_definitions(
                     )
                     .with_span(variant.line, variant.column));
                 }
-            }
-            if payload_tys
-                .iter()
-                .any(|ty| matches!(ty, Type::Enum(name) if name == &enum_decl.name))
-            {
-                return Err(Diagnostic::new(
-                    "type",
-                    format!(
-                        "recursive payload variant {:?} in enum {:?} is not supported yet",
-                        variant.name, enum_decl.name
-                    ),
-                )
-                .with_span(variant.line, variant.column));
             }
             lowered_variants.push(EnumVariantDef {
                 name: variant.name.clone(),

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -3445,8 +3445,8 @@ mod tests {
     fn conformance_corpus_reports_stable_results() {
         let output =
             run_project_tests(&conformance_fixture()).expect("run stage1 conformance corpus");
-        assert_eq!(output.cases.len(), 17);
-        assert_eq!(output.passed, 17);
+        assert_eq!(output.cases.len(), 18);
+        assert_eq!(output.passed, 18);
         assert_eq!(output.failed, 0);
         assert!(
             output
@@ -3454,7 +3454,7 @@ mod tests {
                 .iter()
                 .filter(|case| case.expected_error.is_some())
                 .count()
-                == 10
+                == 11
         );
         assert_eq!(
             output

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -3445,8 +3445,8 @@ mod tests {
     fn conformance_corpus_reports_stable_results() {
         let output =
             run_project_tests(&conformance_fixture()).expect("run stage1 conformance corpus");
-        assert_eq!(output.cases.len(), 20);
-        assert_eq!(output.passed, 20);
+        assert_eq!(output.cases.len(), 21);
+        assert_eq!(output.passed, 21);
         assert_eq!(output.failed, 0);
         assert!(
             output
@@ -3454,7 +3454,7 @@ mod tests {
                 .iter()
                 .filter(|case| case.expected_error.is_some())
                 .count()
-                == 13
+                == 14
         );
         assert_eq!(
             output

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -3445,8 +3445,8 @@ mod tests {
     fn conformance_corpus_reports_stable_results() {
         let output =
             run_project_tests(&conformance_fixture()).expect("run stage1 conformance corpus");
-        assert_eq!(output.cases.len(), 18);
-        assert_eq!(output.passed, 18);
+        assert_eq!(output.cases.len(), 20);
+        assert_eq!(output.passed, 20);
         assert_eq!(output.failed, 0);
         assert!(
             output
@@ -3454,7 +3454,7 @@ mod tests {
                 .iter()
                 .filter(|case| case.expected_error.is_some())
                 .count()
-                == 11
+                == 13
         );
         assert_eq!(
             output

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -4145,6 +4145,22 @@ mod tests {
     }
 
     #[test]
+    fn check_project_rejects_recursive_enum_without_indirection() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("recursive-enum");
+        create_project(&project, Some("recursive-enum-app")).expect("create project");
+        fs::write(
+            project.join("src/main.ax"),
+            "enum List {\nCons(List)\nNil\n}\n\nprint 0\n",
+        )
+        .expect("write source");
+
+        let error = check_project(&project).expect_err("recursive enum should fail");
+        assert!(error.message.contains("requires indirection"));
+        assert_eq!(error.kind, "type");
+    }
+
+    #[test]
     fn build_project_allows_recursive_struct_through_array_indirection() {
         let dir = tempdir().expect("tempdir");
         let project = dir.path().join("recursive-struct-array");

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -4111,6 +4111,54 @@ mod tests {
     }
 
     #[test]
+    fn check_project_rejects_mutually_recursive_structs_without_indirection() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("mutually-recursive-structs");
+        create_project(&project, Some("mutually-recursive-structs-app")).expect("create project");
+        fs::write(
+            project.join("src/main.ax"),
+            "struct Node {\nnext: Link\n}\n\nstruct Link {\nnode: Node\n}\n\nprint 0\n",
+        )
+        .expect("write source");
+
+        let error = check_project(&project).expect_err("mutually recursive structs should fail");
+        assert!(error.message.contains("requires indirection"));
+        assert_eq!(error.kind, "type");
+    }
+
+    #[test]
+    fn check_project_rejects_mutually_recursive_struct_enum_without_indirection() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("mutually-recursive-struct-enum");
+        create_project(&project, Some("mutually-recursive-struct-enum-app"))
+            .expect("create project");
+        fs::write(
+            project.join("src/main.ax"),
+            "struct ExprNode {\nexpr: Expr\n}\n\nenum Expr {\nWrap(ExprNode)\nLit(int)\n}\n\nprint 0\n",
+        )
+        .expect("write source");
+
+        let error =
+            check_project(&project).expect_err("mutually recursive struct and enum should fail");
+        assert!(error.message.contains("requires indirection"));
+        assert_eq!(error.kind, "type");
+    }
+
+    #[test]
+    fn build_project_allows_recursive_struct_through_array_indirection() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("recursive-struct-array");
+        create_project(&project, Some("recursive-struct-array-app")).expect("create project");
+        fs::write(
+            project.join("src/main.ax"),
+            "struct Node {\nchildren: [Node]\n}\n\nprint 0\n",
+        )
+        .expect("write source");
+
+        build_project(&project).expect("recursive struct through array indirection should build");
+    }
+
+    #[test]
     fn check_project_rejects_recursive_const() {
         let dir = tempdir().expect("tempdir");
         let project = dir.path().join("recursive-const");


### PR DESCRIPTION
Closes #120

Implements the Ares-assigned fix for: Type system: Recursive types (with boxing/indirection)
