### PR TITLE
fix: address issue #117

### DIFF
--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -36,6 +36,9 @@ return_stmt    := "return" expr ;
 if_stmt        := "if" expr block ("else" block)? ;
 while_stmt     := "while" expr block ;
 match_stmt     := "match" expr "{" match_arm+ "}" ;
+match_arm      := IDENT match_payload? block ;
+match_payload  := "(" IDENT ("," IDENT)* ")"
+               | "{" IDENT ("," IDENT)* "}" ;
 block          := "{" stmt* "}" ;
 
 type           := IDENT type_args?
@@ -63,3 +66,5 @@ expr           := literal
 
 Comments start with `#` and run to end-of-line. See
 [stage1.md](stage1.md) for the current implementation scope and known gaps.
+Pattern guards and nested destructuring patterns are not supported in the
+current stage1 parser.

--- a/stage1/conformance/README.md
+++ b/stage1/conformance/README.md
@@ -66,5 +66,7 @@ Current compile-fail fixtures cover:
   self-recursive enum payloads without an indirection boundary.
 - `match_guard_not_supported`: parse diagnostics for unsupported `if` guard
   clauses on match arms.
+- `named_nested_match_pattern_not_supported`: parse diagnostics for
+  unsupported nested destructuring inside named match patterns.
 - `nested_match_pattern_not_supported`: parse diagnostics for unsupported
   nested destructuring inside match patterns.

--- a/stage1/conformance/README.md
+++ b/stage1/conformance/README.md
@@ -64,3 +64,7 @@ Current compile-fail fixtures cover:
   struct-enum cycles without an indirection boundary.
 - `recursive_enum_without_indirection`: type diagnostics for direct
   self-recursive enum payloads without an indirection boundary.
+- `match_guard_not_supported`: parse diagnostics for unsupported `if` guard
+  clauses on match arms.
+- `nested_match_pattern_not_supported`: parse diagnostics for unsupported
+  nested destructuring inside match patterns.

--- a/stage1/conformance/axiom.lock
+++ b/stage1/conformance/axiom.lock
@@ -6,9 +6,19 @@ version = "0.1.0"
 source = "path:fail/for_loop_requires_iteration_protocol"
 
 [[package]]
+name = "conformance-match-guard-not-supported"
+version = "0.1.0"
+source = "path:fail/match_guard_not_supported"
+
+[[package]]
 name = "conformance-mutable-borrow-while-shared-live"
 version = "0.1.0"
 source = "path:fail/mutable_borrow_while_shared_live"
+
+[[package]]
+name = "conformance-nested-match-pattern-not-supported"
+version = "0.1.0"
+source = "path:fail/nested_match_pattern_not_supported"
 
 [[package]]
 name = "conformance-ownership-use-after-move"

--- a/stage1/conformance/axiom.lock
+++ b/stage1/conformance/axiom.lock
@@ -16,6 +16,11 @@ version = "0.1.0"
 source = "path:fail/mutable_borrow_while_shared_live"
 
 [[package]]
+name = "conformance-named-nested-match-pattern-not-supported"
+version = "0.1.0"
+source = "path:fail/named_nested_match_pattern_not_supported"
+
+[[package]]
 name = "conformance-nested-match-pattern-not-supported"
 version = "0.1.0"
 source = "path:fail/nested_match_pattern_not_supported"

--- a/stage1/conformance/axiom.toml
+++ b/stage1/conformance/axiom.toml
@@ -3,6 +3,7 @@ members = [
   "fail/for_loop_requires_iteration_protocol",
   "fail/match_guard_not_supported",
   "fail/mutable_borrow_while_shared_live",
+  "fail/named_nested_match_pattern_not_supported",
   "fail/nested_match_pattern_not_supported",
   "fail/ownership_use_after_move",
   "fail/panic_rejects_unreachable_statement",

--- a/stage1/conformance/axiom.toml
+++ b/stage1/conformance/axiom.toml
@@ -1,7 +1,9 @@
 [workspace]
 members = [
   "fail/for_loop_requires_iteration_protocol",
+  "fail/match_guard_not_supported",
   "fail/mutable_borrow_while_shared_live",
+  "fail/nested_match_pattern_not_supported",
   "fail/ownership_use_after_move",
   "fail/panic_rejects_unreachable_statement",
   "fail/panic_rejects_multiple_arguments",

--- a/stage1/conformance/fail/match_guard_not_supported/axiom.lock
+++ b/stage1/conformance/fail/match_guard_not_supported/axiom.lock
@@ -1,0 +1,6 @@
+version = 1
+
+[[package]]
+name = "conformance-match-guard-not-supported"
+version = "0.1.0"
+source = "path"

--- a/stage1/conformance/fail/match_guard_not_supported/axiom.toml
+++ b/stage1/conformance/fail/match_guard_not_supported/axiom.toml
@@ -1,0 +1,15 @@
+[package]
+name = "conformance-match-guard-not-supported"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false

--- a/stage1/conformance/fail/match_guard_not_supported/expected-error.json
+++ b/stage1/conformance/fail/match_guard_not_supported/expected-error.json
@@ -1,0 +1,8 @@
+{
+  "kind": "parse",
+  "code": null,
+  "message": "match arm guards are not supported yet",
+  "path": "src/main.ax",
+  "line": 8,
+  "column": 9
+}

--- a/stage1/conformance/fail/match_guard_not_supported/src/main.ax
+++ b/stage1/conformance/fail/match_guard_not_supported/src/main.ax
@@ -1,0 +1,20 @@
+enum OptionInt {
+Some(int)
+None
+}
+
+fn describe(value: OptionInt): int {
+match value {
+Some(n) if n > 0 {
+return n
+}
+Some(n) {
+return 0
+}
+None {
+return 0
+}
+}
+}
+
+print describe(Some(1))

--- a/stage1/conformance/fail/named_nested_match_pattern_not_supported/axiom.lock
+++ b/stage1/conformance/fail/named_nested_match_pattern_not_supported/axiom.lock
@@ -1,0 +1,6 @@
+version = 1
+
+[[package]]
+name = "conformance-named-nested-match-pattern-not-supported"
+version = "0.1.0"
+source = "path"

--- a/stage1/conformance/fail/named_nested_match_pattern_not_supported/axiom.toml
+++ b/stage1/conformance/fail/named_nested_match_pattern_not_supported/axiom.toml
@@ -1,0 +1,15 @@
+[package]
+name = "conformance-named-nested-match-pattern-not-supported"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false

--- a/stage1/conformance/fail/named_nested_match_pattern_not_supported/expected-error.json
+++ b/stage1/conformance/fail/named_nested_match_pattern_not_supported/expected-error.json
@@ -4,5 +4,5 @@
   "message": "nested match patterns are not supported yet",
   "path": "src/main.ax",
   "line": 6,
-  "column": 7
+  "column": 15
 }

--- a/stage1/conformance/fail/named_nested_match_pattern_not_supported/expected-error.json
+++ b/stage1/conformance/fail/named_nested_match_pattern_not_supported/expected-error.json
@@ -1,0 +1,8 @@
+{
+  "kind": "parse",
+  "code": null,
+  "message": "nested match patterns are not supported yet",
+  "path": "src/main.ax",
+  "line": 6,
+  "column": 7
+}

--- a/stage1/conformance/fail/named_nested_match_pattern_not_supported/src/main.ax
+++ b/stage1/conformance/fail/named_nested_match_pattern_not_supported/src/main.ax
@@ -1,0 +1,9 @@
+enum Event {
+Tick { payload: (int, bool) }
+}
+
+match Tick { payload: (1, true) } {
+Tick { payload: (count, true) } {
+print count
+}
+}

--- a/stage1/conformance/fail/nested_match_pattern_not_supported/axiom.lock
+++ b/stage1/conformance/fail/nested_match_pattern_not_supported/axiom.lock
@@ -1,0 +1,6 @@
+version = 1
+
+[[package]]
+name = "conformance-nested-match-pattern-not-supported"
+version = "0.1.0"
+source = "path"

--- a/stage1/conformance/fail/nested_match_pattern_not_supported/axiom.toml
+++ b/stage1/conformance/fail/nested_match_pattern_not_supported/axiom.toml
@@ -1,0 +1,15 @@
+[package]
+name = "conformance-nested-match-pattern-not-supported"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false

--- a/stage1/conformance/fail/nested_match_pattern_not_supported/expected-error.json
+++ b/stage1/conformance/fail/nested_match_pattern_not_supported/expected-error.json
@@ -1,0 +1,8 @@
+{
+  "kind": "parse",
+  "code": null,
+  "message": "nested match patterns are not supported yet",
+  "path": "src/main.ax",
+  "line": 6,
+  "column": 6
+}

--- a/stage1/conformance/fail/nested_match_pattern_not_supported/src/main.ax
+++ b/stage1/conformance/fail/nested_match_pattern_not_supported/src/main.ax
@@ -1,0 +1,9 @@
+enum Pair {
+Wrap((int, bool))
+}
+
+match Wrap((1, true)) {
+Wrap((count, true)) {
+print count
+}
+}

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -3455,8 +3455,8 @@ mod tests {
     fn conformance_corpus_reports_stable_results() {
         let output =
             run_project_tests(&conformance_fixture()).expect("run stage1 conformance corpus");
-        assert_eq!(output.cases.len(), 22);
-        assert_eq!(output.passed, 22);
+        assert_eq!(output.cases.len(), 24);
+        assert_eq!(output.passed, 24);
         assert_eq!(output.failed, 0);
         assert!(
             output
@@ -3464,7 +3464,7 @@ mod tests {
                 .iter()
                 .filter(|case| case.expected_error.is_some())
                 .count()
-                == 15
+                == 17
         );
         assert_eq!(
             output

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -338,7 +338,7 @@ mod tests {
         assert_eq!(error.kind, "parse");
         assert_eq!(error.message, "nested match patterns are not supported yet");
         assert_eq!(error.line, Some(6));
-        assert_eq!(error.column, Some(12));
+        assert_eq!(error.column, Some(13));
     }
 
     #[test]
@@ -349,7 +349,7 @@ mod tests {
         assert_eq!(error.kind, "parse");
         assert_eq!(error.message, "nested match patterns are not supported yet");
         assert_eq!(error.line, Some(6));
-        assert_eq!(error.column, Some(7));
+        assert_eq!(error.column, Some(15));
     }
 
     #[test]
@@ -360,7 +360,7 @@ mod tests {
         assert_eq!(error.kind, "parse");
         assert_eq!(error.message, "nested match patterns are not supported yet");
         assert_eq!(error.line, Some(6));
-        assert_eq!(error.column, Some(11));
+        assert_eq!(error.column, Some(20));
     }
 
     #[test]

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -288,6 +288,21 @@ mod tests {
     }
 
     #[test]
+    fn parser_accepts_match_arm_identifiers_containing_if() {
+        let source = "enum Prize {\nGift(int)\nNone\n}\n\nmatch Gift(3) {\nGift(gift_value) {\nprint gift_value\n}\nNone {\nprint 0\n}\n}\n";
+        let parsed = parse_program(source, Path::new("main.ax")).expect("parse");
+
+        match &parsed.stmts[0] {
+            crate::syntax::Stmt::Match { arms, .. } => {
+                assert_eq!(arms.len(), 2);
+                assert_eq!(arms[0].variant, "Gift");
+                assert_eq!(arms[0].bindings, vec!["gift_value".to_string()]);
+            }
+            other => panic!("expected match statement, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn parser_rejects_nested_match_patterns() {
         let source = "enum Pair {\nWrap((int, bool))\n}\n\nmatch Wrap((1, true)) {\nWrap((count, true)) {\nprint count\n}\n}\n";
         let error = parse_program(source, Path::new("main.ax"))

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -300,6 +300,17 @@ mod tests {
     }
 
     #[test]
+    fn parser_rejects_nested_named_match_patterns() {
+        let source = "enum Event {\nTick { payload: (int, bool) }\n}\n\nmatch Tick { payload: (1, true) } {\nTick { payload: (count, true) } {\nprint count\n}\n}\n";
+        let error = parse_program(source, Path::new("main.ax"))
+            .expect_err("nested named match patterns should fail during parsing");
+        assert_eq!(error.kind, "parse");
+        assert_eq!(error.message, "nested match patterns are not supported yet");
+        assert_eq!(error.line, Some(6));
+        assert_eq!(error.column, Some(7));
+    }
+
+    #[test]
     fn parser_lowers_generic_functions_to_monomorphized_copies() {
         let source = "fn identity<T>(value: T): T {\nreturn value\n}\n\nfn singleton<T>(value: T): [T] {\nreturn [value]\n}\n\nlet answer: int = identity<int>(42)\nlet label: string = identity<string>(\"stage1\")\nlet values: [int] = singleton<int>(answer)\nprint answer\nprint label\nprint len(values)\n";
         let parsed = parse_program(source, Path::new("main.ax")).expect("parse");

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -267,7 +267,6 @@ mod tests {
     }
 
     #[test]
-<<<<<<< HEAD
     fn parser_rejects_for_loops_explicitly() {
         let source = "fn main(): int {\nfor value in [1, 2, 3] {\nprint value\n}\nreturn 0\n}\n";
         let error = parse_program(source, Path::new("main.ax"))
@@ -276,7 +275,9 @@ mod tests {
         assert_eq!(error.line, Some(2));
         assert_eq!(error.column, Some(1));
         assert!(error.message.contains("does not support `for` loops yet"));
-=======
+    }
+
+    #[test]
     fn parser_rejects_match_arm_guards() {
         let source = "enum OptionInt {\nSome(int)\nNone\n}\n\nfn describe(value: OptionInt): int {\nmatch value {\nSome(n) if n > 0 {\nreturn n\n}\nNone {\nreturn 0\n}\n}\n}\n";
         let error = parse_program(source, Path::new("main.ax"))
@@ -327,7 +328,6 @@ mod tests {
         assert_eq!(error.message, "nested match patterns are not supported yet");
         assert_eq!(error.line, Some(6));
         assert_eq!(error.column, Some(6));
->>>>>>> e12139c (test: add parser regressions for match diagnostics)
     }
 
     #[test]
@@ -3541,8 +3541,8 @@ mod tests {
     fn conformance_corpus_reports_stable_results() {
         let output =
             run_project_tests(&conformance_fixture()).expect("run stage1 conformance corpus");
-        assert_eq!(output.cases.len(), 24);
-        assert_eq!(output.passed, 24);
+        assert_eq!(output.cases.len(), 25);
+        assert_eq!(output.passed, 25);
         assert_eq!(output.failed, 0);
         assert!(
             output
@@ -3550,7 +3550,7 @@ mod tests {
                 .iter()
                 .filter(|case| case.expected_error.is_some())
                 .count()
-                == 17
+                == 18
         );
         assert_eq!(
             output

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -331,6 +331,17 @@ mod tests {
     }
 
     #[test]
+    fn parser_reports_nested_match_pattern_at_offending_positional_binding() {
+        let source = "enum Pair {\nWrap(int, (int, bool))\n}\n\nmatch Wrap(1, (2, true)) {\nWrap(value, (count, true)) {\nprint value\n}\n}\n";
+        let error = parse_program(source, Path::new("main.ax"))
+            .expect_err("nested positional bindings should report the offending binding");
+        assert_eq!(error.kind, "parse");
+        assert_eq!(error.message, "nested match patterns are not supported yet");
+        assert_eq!(error.line, Some(6));
+        assert_eq!(error.column, Some(12));
+    }
+
+    #[test]
     fn parser_rejects_nested_named_match_patterns() {
         let source = "enum Event {\nTick { payload: (int, bool) }\n}\n\nmatch Tick { payload: (1, true) } {\nTick { payload: (count, true) } {\nprint count\n}\n}\n";
         let error = parse_program(source, Path::new("main.ax"))
@@ -339,6 +350,17 @@ mod tests {
         assert_eq!(error.message, "nested match patterns are not supported yet");
         assert_eq!(error.line, Some(6));
         assert_eq!(error.column, Some(7));
+    }
+
+    #[test]
+    fn parser_reports_nested_match_pattern_at_offending_named_binding() {
+        let source = "enum Event {\nTick { tag: int, payload: (int, bool) }\n}\n\nmatch Tick { tag: 1, payload: (2, true) } {\nTick { tag, payload: (count, true) } {\nprint tag\n}\n}\n";
+        let error = parse_program(source, Path::new("main.ax"))
+            .expect_err("nested named bindings should report the offending binding");
+        assert_eq!(error.kind, "parse");
+        assert_eq!(error.message, "nested match patterns are not supported yet");
+        assert_eq!(error.line, Some(6));
+        assert_eq!(error.column, Some(11));
     }
 
     #[test]

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -267,6 +267,7 @@ mod tests {
     }
 
     #[test]
+<<<<<<< HEAD
     fn parser_rejects_for_loops_explicitly() {
         let source = "fn main(): int {\nfor value in [1, 2, 3] {\nprint value\n}\nreturn 0\n}\n";
         let error = parse_program(source, Path::new("main.ax"))
@@ -275,6 +276,27 @@ mod tests {
         assert_eq!(error.line, Some(2));
         assert_eq!(error.column, Some(1));
         assert!(error.message.contains("does not support `for` loops yet"));
+=======
+    fn parser_rejects_match_arm_guards() {
+        let source = "enum OptionInt {\nSome(int)\nNone\n}\n\nfn describe(value: OptionInt): int {\nmatch value {\nSome(n) if n > 0 {\nreturn n\n}\nNone {\nreturn 0\n}\n}\n}\n";
+        let error = parse_program(source, Path::new("main.ax"))
+            .expect_err("match arm guards should fail during parsing");
+        assert_eq!(error.kind, "parse");
+        assert_eq!(error.message, "match arm guards are not supported yet");
+        assert_eq!(error.line, Some(8));
+        assert_eq!(error.column, Some(9));
+    }
+
+    #[test]
+    fn parser_rejects_nested_match_patterns() {
+        let source = "enum Pair {\nWrap((int, bool))\n}\n\nmatch Wrap((1, true)) {\nWrap((count, true)) {\nprint count\n}\n}\n";
+        let error = parse_program(source, Path::new("main.ax"))
+            .expect_err("nested match patterns should fail during parsing");
+        assert_eq!(error.kind, "parse");
+        assert_eq!(error.message, "nested match patterns are not supported yet");
+        assert_eq!(error.line, Some(6));
+        assert_eq!(error.column, Some(6));
+>>>>>>> e12139c (test: add parser regressions for match diagnostics)
     }
 
     #[test]

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -303,6 +303,22 @@ mod tests {
     }
 
     #[test]
+    fn parser_accepts_named_match_arm_identifiers_containing_if() {
+        let source = "enum Prize {\nGift { gift_value: int }\nNone\n}\n\nmatch Gift { gift_value: 3 } {\nGift { gift_value } {\nprint gift_value\n}\nNone {\nprint 0\n}\n}\n";
+        let parsed = parse_program(source, Path::new("main.ax")).expect("parse");
+
+        match &parsed.stmts[0] {
+            crate::syntax::Stmt::Match { arms, .. } => {
+                assert_eq!(arms.len(), 2);
+                assert_eq!(arms[0].variant, "Gift");
+                assert!(arms[0].is_named);
+                assert_eq!(arms[0].bindings, vec!["gift_value".to_string()]);
+            }
+            other => panic!("expected match statement, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn parser_rejects_nested_match_patterns() {
         let source = "enum Pair {\nWrap((int, bool))\n}\n\nmatch Wrap((1, true)) {\nWrap((count, true)) {\nprint count\n}\n}\n";
         let error = parse_program(source, Path::new("main.ax"))

--- a/stage1/crates/axiomc/src/syntax.rs
+++ b/stage1/crates/axiomc/src/syntax.rs
@@ -1123,14 +1123,18 @@ fn parse_match_arms(
                     .with_path(path.display().to_string())
                     .with_span(line_no, open_brace + 2));
             }
-            let bindings = split_top_level(bindings_raw, ',')
+            let bindings = split_top_level_with_offsets(bindings_raw, ',')
                 .into_iter()
-                .map(|binding| {
+                .map(|(binding_offset, binding)| {
                     let binding = binding.trim();
+                    let binding_column = open_brace
+                        + 2
+                        + binding_offset
+                        + binding.len().saturating_sub(binding.trim_start().len());
                     if binding.is_empty() {
                         return Err(Diagnostic::new("parse", "match arm binding is empty")
                             .with_path(path.display().to_string())
-                            .with_span(line_no, open_brace + 2));
+                            .with_span(line_no, binding_column));
                     }
                     if looks_like_nested_match_pattern(binding) {
                         return Err(Diagnostic::new(
@@ -1138,9 +1142,9 @@ fn parse_match_arms(
                             "nested match patterns are not supported yet",
                         )
                         .with_path(path.display().to_string())
-                        .with_span(line_no, open_brace + 2));
+                        .with_span(line_no, binding_column));
                     }
-                    validate_ident(binding, path, line_no, open_brace + 2)?;
+                    validate_ident(binding, path, line_no, binding_column)?;
                     Ok(binding.to_string())
                 })
                 .collect::<Result<Vec<_>, Diagnostic>>()?;
@@ -1157,14 +1161,18 @@ fn parse_match_arms(
                     .with_path(path.display().to_string())
                     .with_span(line_no, open_paren + 2));
             }
-            let bindings = split_top_level(bindings_raw, ',')
+            let bindings = split_top_level_with_offsets(bindings_raw, ',')
                 .into_iter()
-                .map(|binding| {
+                .map(|(binding_offset, binding)| {
                     let binding = binding.trim();
+                    let binding_column = open_paren
+                        + 2
+                        + binding_offset
+                        + binding.len().saturating_sub(binding.trim_start().len());
                     if binding.is_empty() {
                         return Err(Diagnostic::new("parse", "match arm binding is empty")
                             .with_path(path.display().to_string())
-                            .with_span(line_no, open_paren + 2));
+                            .with_span(line_no, binding_column));
                     }
                     if looks_like_nested_match_pattern(binding) {
                         return Err(Diagnostic::new(
@@ -1172,9 +1180,9 @@ fn parse_match_arms(
                             "nested match patterns are not supported yet",
                         )
                         .with_path(path.display().to_string())
-                        .with_span(line_no, open_paren + 2));
+                        .with_span(line_no, binding_column));
                     }
-                    validate_ident(binding, path, line_no, open_paren + 2)?;
+                    validate_ident(binding, path, line_no, binding_column)?;
                     Ok(binding.to_string())
                 })
                 .collect::<Result<Vec<_>, Diagnostic>>()?;
@@ -2025,6 +2033,13 @@ fn looks_like_nested_match_pattern(raw: &str) -> bool {
 }
 
 fn split_top_level(raw: &str, delimiter: char) -> Vec<&str> {
+    split_top_level_with_offsets(raw, delimiter)
+        .into_iter()
+        .map(|(_, part)| part)
+        .collect()
+}
+
+fn split_top_level_with_offsets(raw: &str, delimiter: char) -> Vec<(usize, &str)> {
     let mut parts = Vec::new();
     let mut in_string = false;
     let mut escaped = false;
@@ -2056,13 +2071,13 @@ fn split_top_level(raw: &str, delimiter: char) -> Vec<&str> {
             '[' => bracket_depth += 1,
             ']' => bracket_depth = bracket_depth.saturating_sub(1),
             _ if ch == delimiter && paren_depth == 0 && brace_depth == 0 && bracket_depth == 0 => {
-                parts.push(&raw[start..index]);
+                parts.push((start, &raw[start..index]));
                 start = index + ch.len_utf8();
             }
             _ => {}
         }
     }
-    parts.push(&raw[start..]);
+    parts.push((start, &raw[start..]));
     parts
 }
 

--- a/stage1/crates/axiomc/src/syntax.rs
+++ b/stage1/crates/axiomc/src/syntax.rs
@@ -1097,6 +1097,20 @@ fn parse_match_arms(
                 .with_path(path.display().to_string())
                 .with_span(line_no, 1)
         })?;
+        if let Some(column) = find_top_level_keyword(variant, "if") {
+            return Err(
+                Diagnostic::new("parse", "match arm guards are not supported yet")
+                    .with_path(path.display().to_string())
+                    .with_span(line_no, column + 1),
+            );
+        }
+        if variant.starts_with('(') {
+            return Err(
+                Diagnostic::new("parse", "nested match patterns are not supported yet")
+                    .with_path(path.display().to_string())
+                    .with_span(line_no, 1),
+            );
+        }
         let (variant, bindings, is_named) = if variant.ends_with('}')
             && let Some(open_brace) = find_top_level_char(variant, '{')
             && matches!(find_matching_brace(variant, open_brace), Some(close) if close == variant.len() - 1)
@@ -1117,6 +1131,14 @@ fn parse_match_arms(
                         return Err(Diagnostic::new("parse", "match arm binding is empty")
                             .with_path(path.display().to_string())
                             .with_span(line_no, open_brace + 2));
+                    }
+                    if looks_like_nested_match_pattern(binding) {
+                        return Err(Diagnostic::new(
+                            "parse",
+                            "nested match patterns are not supported yet",
+                        )
+                        .with_path(path.display().to_string())
+                        .with_span(line_no, open_brace + 2));
                     }
                     validate_ident(binding, path, line_no, open_brace + 2)?;
                     Ok(binding.to_string())
@@ -1143,6 +1165,14 @@ fn parse_match_arms(
                         return Err(Diagnostic::new("parse", "match arm binding is empty")
                             .with_path(path.display().to_string())
                             .with_span(line_no, open_paren + 2));
+                    }
+                    if looks_like_nested_match_pattern(binding) {
+                        return Err(Diagnostic::new(
+                            "parse",
+                            "nested match patterns are not supported yet",
+                        )
+                        .with_path(path.display().to_string())
+                        .with_span(line_no, open_paren + 2));
                     }
                     validate_ident(binding, path, line_no, open_paren + 2)?;
                     Ok(binding.to_string())
@@ -1987,6 +2017,13 @@ fn validate_ident(
     Ok(())
 }
 
+fn looks_like_nested_match_pattern(raw: &str) -> bool {
+    find_top_level_char(raw, '(').is_some()
+        || find_top_level_char(raw, '{').is_some()
+        || find_top_level_char(raw, '[').is_some()
+        || find_top_level_char(raw, ':').is_some()
+}
+
 fn split_top_level(raw: &str, delimiter: char) -> Vec<&str> {
     let mut parts = Vec::new();
     let mut in_string = false;
@@ -2027,6 +2064,68 @@ fn split_top_level(raw: &str, delimiter: char) -> Vec<&str> {
     }
     parts.push(&raw[start..]);
     parts
+}
+
+fn find_top_level_keyword(raw: &str, keyword: &str) -> Option<usize> {
+    let mut in_string = false;
+    let mut escaped = false;
+    let mut paren_depth = 0usize;
+    let mut brace_depth = 0usize;
+    let mut bracket_depth = 0usize;
+    let mut angle_depth = 0usize;
+    let chars: Vec<(usize, char)> = raw.char_indices().collect();
+    for cursor in 0..chars.len() {
+        let (index, ch) = chars[cursor];
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        if ch == '\\' && in_string {
+            escaped = true;
+            continue;
+        }
+        if ch == '"' {
+            in_string = !in_string;
+            continue;
+        }
+        if in_string {
+            continue;
+        }
+        match ch {
+            '(' => paren_depth += 1,
+            ')' => paren_depth = paren_depth.saturating_sub(1),
+            '{' => brace_depth += 1,
+            '}' => brace_depth = brace_depth.saturating_sub(1),
+            '[' => bracket_depth += 1,
+            ']' => bracket_depth = bracket_depth.saturating_sub(1),
+            '<' if paren_depth == 0 && brace_depth == 0 && bracket_depth == 0 => {
+                angle_depth += 1;
+            }
+            '>' if paren_depth == 0 && brace_depth == 0 && bracket_depth == 0 => {
+                angle_depth = angle_depth.saturating_sub(1);
+            }
+            _ => {}
+        }
+        if paren_depth != 0 || brace_depth != 0 || bracket_depth != 0 || angle_depth != 0 {
+            continue;
+        }
+        if !raw[index..].starts_with(keyword) {
+            continue;
+        }
+        let before = if cursor == 0 {
+            None
+        } else {
+            Some(chars[cursor - 1].1)
+        };
+        let after_index = index + keyword.len();
+        let after = raw[after_index..].chars().next();
+        if before.is_none_or(|ch| ch.is_ascii_whitespace())
+            && after.is_none_or(|ch| ch.is_ascii_whitespace())
+        {
+            return Some(index);
+        }
+    }
+    None
 }
 
 fn split_top_level_type(raw: &str, delimiter: char) -> Vec<&str> {

--- a/stage1/crates/axiomc/src/syntax.rs
+++ b/stage1/crates/axiomc/src/syntax.rs
@@ -1117,32 +1117,33 @@ fn parse_match_arms(
         {
             let name = variant[..open_brace].trim();
             validate_ident(name, path, line_no, 1)?;
-            let bindings_raw = variant[open_brace + 1..variant.len() - 1].trim();
-            if bindings_raw.is_empty() {
+            let bindings_raw = &variant[open_brace + 1..variant.len() - 1];
+            if bindings_raw.trim().is_empty() {
                 return Err(Diagnostic::new("parse", "match arm binding is empty")
                     .with_path(path.display().to_string())
                     .with_span(line_no, open_brace + 2));
             }
             let bindings = split_top_level_with_offsets(bindings_raw, ',')
                 .into_iter()
-                .map(|(binding_offset, binding)| {
-                    let binding = binding.trim();
+                .map(|(binding_offset, raw_binding)| {
+                    let binding = raw_binding.trim();
+                    let leading_ws = raw_binding.len().saturating_sub(raw_binding.trim_start().len());
                     let binding_column = open_brace
                         + 2
                         + binding_offset
-                        + binding.len().saturating_sub(binding.trim_start().len());
+                        + leading_ws;
                     if binding.is_empty() {
                         return Err(Diagnostic::new("parse", "match arm binding is empty")
                             .with_path(path.display().to_string())
                             .with_span(line_no, binding_column));
                     }
-                    if looks_like_nested_match_pattern(binding) {
+                    if let Some(nested_offset) = find_nested_match_pattern_offset(binding) {
                         return Err(Diagnostic::new(
                             "parse",
                             "nested match patterns are not supported yet",
                         )
                         .with_path(path.display().to_string())
-                        .with_span(line_no, binding_column));
+                        .with_span(line_no, binding_column + nested_offset));
                     }
                     validate_ident(binding, path, line_no, binding_column)?;
                     Ok(binding.to_string())
@@ -1155,32 +1156,33 @@ fn parse_match_arms(
         {
             let name = variant[..open_paren].trim();
             validate_ident(name, path, line_no, 1)?;
-            let bindings_raw = variant[open_paren + 1..variant.len() - 1].trim();
-            if bindings_raw.is_empty() {
+            let bindings_raw = &variant[open_paren + 1..variant.len() - 1];
+            if bindings_raw.trim().is_empty() {
                 return Err(Diagnostic::new("parse", "match arm binding is empty")
                     .with_path(path.display().to_string())
                     .with_span(line_no, open_paren + 2));
             }
             let bindings = split_top_level_with_offsets(bindings_raw, ',')
                 .into_iter()
-                .map(|(binding_offset, binding)| {
-                    let binding = binding.trim();
+                .map(|(binding_offset, raw_binding)| {
+                    let binding = raw_binding.trim();
+                    let leading_ws = raw_binding.len().saturating_sub(raw_binding.trim_start().len());
                     let binding_column = open_paren
                         + 2
                         + binding_offset
-                        + binding.len().saturating_sub(binding.trim_start().len());
+                        + leading_ws;
                     if binding.is_empty() {
                         return Err(Diagnostic::new("parse", "match arm binding is empty")
                             .with_path(path.display().to_string())
                             .with_span(line_no, binding_column));
                     }
-                    if looks_like_nested_match_pattern(binding) {
+                    if let Some(nested_offset) = find_nested_match_pattern_offset(binding) {
                         return Err(Diagnostic::new(
                             "parse",
                             "nested match patterns are not supported yet",
                         )
                         .with_path(path.display().to_string())
-                        .with_span(line_no, binding_column));
+                        .with_span(line_no, binding_column + nested_offset));
                     }
                     validate_ident(binding, path, line_no, binding_column)?;
                     Ok(binding.to_string())
@@ -2025,11 +2027,11 @@ fn validate_ident(
     Ok(())
 }
 
-fn looks_like_nested_match_pattern(raw: &str) -> bool {
-    find_top_level_char(raw, '(').is_some()
-        || find_top_level_char(raw, '{').is_some()
-        || find_top_level_char(raw, '[').is_some()
-        || find_top_level_char(raw, ':').is_some()
+fn find_nested_match_pattern_offset(raw: &str) -> Option<usize> {
+    ['(', '{', '[', ':']
+        .into_iter()
+        .filter_map(|ch| find_top_level_char(raw, ch))
+        .min()
 }
 
 fn split_top_level(raw: &str, delimiter: char) -> Vec<&str> {


### PR DESCRIPTION
Closes #117

Implements the Ares-assigned fix for: Language: Pattern matching guards and nested patterns
