### PR TITLE
fix: address issue #112

### DIFF
--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -45,30 +45,47 @@ pub fn render_rust_for_package_with_capabilities(
         .functions
         .iter()
         .filter(|function| function.is_extern)
-        .any(|function| function.params.iter().any(|param| matches!(param.ty, Type::String)));
+        .any(|function| {
+            function
+                .params
+                .iter()
+                .any(|param| matches!(param.ty, Type::String))
+        });
     let uses_ffi_cstr = program
         .functions
         .iter()
         .filter(|function| function.is_extern)
         .any(|function| matches!(function.return_ty, Type::String));
     let mut out = String::new();
-    out.push_str("#[allow(unused_imports)]
-");
-    out.push_str("use std::collections::HashMap;
-");
+    out.push_str(
+        "#[allow(unused_imports)]
+",
+    );
+    out.push_str(
+        "use std::collections::HashMap;
+",
+    );
     if uses_ffi_cstr && uses_ffi_cstring {
-        out.push_str("use std::ffi::{CStr, CString};
-");
+        out.push_str(
+            "use std::ffi::{CStr, CString};
+",
+        );
     } else if uses_ffi_cstr {
-        out.push_str("use std::ffi::CStr;
-");
+        out.push_str(
+            "use std::ffi::CStr;
+",
+        );
     } else if uses_ffi_cstring {
-        out.push_str("use std::ffi::CString;
-");
+        out.push_str(
+            "use std::ffi::CString;
+",
+        );
     }
     if uses_ffi {
-        out.push_str("use std::os::raw::c_char;
-");
+        out.push_str(
+            "use std::os::raw::c_char;
+",
+        );
     }
     out.push_str("use std::panic;\n");
     out.push_str("use std::sync::Once;\n\n");
@@ -980,17 +997,16 @@ fn axiom_http_get(url: String) -> Option<String> {
     out.push_str("fn main() -> std::process::ExitCode {\n");
     out.push_str("    axiom_install_panic_hook();\n");
     out.push_str("    let result = panic::catch_unwind(|| {\n");
-    for stmt in &program.stmts {
-        render_stmt(
-            stmt,
-            &type_context,
-            &mut out,
-            2,
-            &program.path,
-            false,
-            debug,
-        );
-    }
+    render_stmt_block(
+        &program.stmts,
+        &type_context,
+        &mut out,
+        2,
+        &program.path,
+        false,
+        debug,
+        &[],
+    );
     out.push_str("    });\n");
     out.push_str("    match result {\n");
     out.push_str("        Ok(()) => std::process::ExitCode::SUCCESS,\n");
@@ -1018,9 +1034,10 @@ fn program_uses_call(program: &Program, name: &str) -> bool {
 
 fn stmt_uses_call(stmt: &Stmt, name: &str) -> bool {
     match stmt {
-        Stmt::Let { expr, .. } | Stmt::Print { expr, .. } | Stmt::Return { expr, .. } => {
-            expr_uses_call(expr, name)
-        }
+        Stmt::Let { expr, .. }
+        | Stmt::Print { expr, .. }
+        | Stmt::Defer { expr, .. }
+        | Stmt::Return { expr, .. } => expr_uses_call(expr, name),
         Stmt::Panic { message, .. } => expr_uses_call(message, name),
         Stmt::If {
             cond,
@@ -1291,17 +1308,16 @@ fn render_function(
         params,
         rust_type_in_signature(&function.return_ty, uses_slice_lifetime, type_context)
     ));
-    for stmt in &function.body {
-        render_stmt(
-            stmt,
-            type_context,
-            out,
-            1,
-            &function.path,
-            function.is_async,
-            debug,
-        );
-    }
+    render_stmt_block(
+        &function.body,
+        type_context,
+        out,
+        1,
+        &function.path,
+        function.is_async,
+        debug,
+        &[],
+    );
     out.push_str("}\n");
 }
 
@@ -1314,16 +1330,22 @@ fn render_extern_function(function: &Function, type_context: &TypeContext<'_>, o
     let extern_name = format!("{}_extern", function.name);
     out.push_str("#[link(name = ");
     out.push_str(&format!("{:?}", library));
-    out.push_str(")]
-");
+    out.push_str(
+        ")]
+",
+    );
     out.push_str("unsafe extern ");
     out.push_str(&format!("{:?}", abi));
-    out.push_str(" {
-");
+    out.push_str(
+        " {
+",
+    );
     out.push_str("    #[link_name = ");
     out.push_str(&format!("{:?}", function.source_name));
-    out.push_str("]
-");
+    out.push_str(
+        "]
+",
+    );
     out.push_str("    fn ");
     out.push_str(&extern_name);
     out.push('(');
@@ -1338,11 +1360,15 @@ fn render_extern_function(function: &Function, type_context: &TypeContext<'_>, o
     );
     out.push_str(") -> ");
     out.push_str(&rust_ffi_type(&function.return_ty, type_context));
-    out.push_str(";
+    out.push_str(
+        ";
 }
-");
-    out.push_str("#[allow(non_snake_case)]
-");
+",
+    );
+    out.push_str(
+        "#[allow(non_snake_case)]
+",
+    );
     out.push_str(&format!(
         "fn {}({}) -> {} {{
 ",
@@ -1371,19 +1397,27 @@ fn render_extern_function(function: &Function, type_context: &TypeContext<'_>, o
         .collect::<Vec<_>>()
         .join(", ");
     if matches!(function.return_ty, Type::String) {
-        out.push_str(&format!("        let value = {extern_name}({call_args});\n"));
+        out.push_str(&format!(
+            "        let value = {extern_name}({call_args});\n"
+        ));
         out.push_str("        if value.is_null() {\n");
         out.push_str("            axiom_runtime_error(\"ffi\", \"extern function returned a null string pointer\");\n");
         out.push_str("        }\n");
         out.push_str("        CStr::from_ptr(value).to_string_lossy().into_owned()\n");
     } else {
-        out.push_str(&format!("        {extern_name}({call_args})
-"));
+        out.push_str(&format!(
+            "        {extern_name}({call_args})
+"
+        ));
     }
-    out.push_str("    }
-");
-    out.push_str("}
-");
+    out.push_str(
+        "    }
+",
+    );
+    out.push_str(
+        "}
+",
+    );
 }
 
 fn render_ffi_arg(name: &str, ty: &Type) -> String {
@@ -1414,6 +1448,43 @@ fn render_param(
     )
 }
 
+fn render_stmt_block(
+    stmts: &[Stmt],
+    type_context: &TypeContext<'_>,
+    out: &mut String,
+    indent: usize,
+    source_path: &str,
+    in_async_function: bool,
+    debug: bool,
+    active_defers: &[(String, SourceSpan)],
+) {
+    let mut local_defers: Vec<(String, SourceSpan)> = Vec::new();
+    for stmt in stmts {
+        render_stmt(
+            stmt,
+            type_context,
+            out,
+            indent,
+            source_path,
+            in_async_function,
+            debug,
+            active_defers,
+            &mut local_defers,
+        );
+    }
+    render_deferred_exprs(out, indent, &local_defers);
+}
+
+fn render_deferred_exprs(out: &mut String, indent: usize, defers: &[(String, SourceSpan)]) {
+    let pad = "    ".repeat(indent);
+    for (expr, _) in defers.iter().rev() {
+        out.push_str(&format!(
+            "{pad}let _ = {expr};
+"
+        ));
+    }
+}
+
 fn render_stmt(
     stmt: &Stmt,
     type_context: &TypeContext<'_>,
@@ -1422,6 +1493,8 @@ fn render_stmt(
     source_path: &str,
     in_async_function: bool,
     debug: bool,
+    active_defers: &[(String, SourceSpan)],
+    local_defers: &mut Vec<(String, SourceSpan)>,
 ) {
     let pad = "    ".repeat(indent);
     match stmt {
@@ -1433,7 +1506,8 @@ fn render_stmt(
         } => {
             render_source_marker(source_path, *span, out, indent, debug);
             out.push_str(&format!(
-                "{pad}let {name}: {} = {};\n",
+                "{pad}let {name}: {} = {};
+",
                 rust_type(ty, type_context),
                 render_expr(expr)
             ));
@@ -1447,7 +1521,17 @@ fn render_stmt(
         }
         Stmt::Panic { message, span } => {
             render_source_marker(source_path, *span, out, indent, debug);
-            out.push_str(&format!("{pad}axiom_panic({});\n", render_expr(message)));
+            render_deferred_exprs(out, indent, local_defers);
+            render_deferred_exprs(out, indent, active_defers);
+            out.push_str(&format!(
+                "{pad}axiom_panic({});
+",
+                render_expr(message)
+            ));
+        }
+        Stmt::Defer { expr, span } => {
+            render_source_marker(source_path, *span, out, indent, debug);
+            local_defers.push((render_expr(expr), *span));
         }
         Stmt::If {
             cond,
@@ -1456,55 +1540,82 @@ fn render_stmt(
             span,
         } => {
             render_source_marker(source_path, *span, out, indent, debug);
-            out.push_str(&format!("{pad}if {} {{\n", render_expr(cond)));
-            for stmt in then_block {
-                render_stmt(
-                    stmt,
+            let mut scoped_defers = active_defers.to_vec();
+            scoped_defers.extend(local_defers.iter().cloned());
+            out.push_str(&format!(
+                "{pad}if {} {{
+",
+                render_expr(cond)
+            ));
+            render_stmt_block(
+                then_block,
+                type_context,
+                out,
+                indent + 1,
+                source_path,
+                in_async_function,
+                debug,
+                &scoped_defers,
+            );
+            if let Some(else_block) = else_block {
+                out.push_str(&format!(
+                    "{pad}}} else {{
+"
+                ));
+                render_stmt_block(
+                    else_block,
                     type_context,
                     out,
                     indent + 1,
                     source_path,
                     in_async_function,
                     debug,
+                    &scoped_defers,
                 );
-            }
-            if let Some(else_block) = else_block {
-                out.push_str(&format!("{pad}}} else {{\n"));
-                for stmt in else_block {
-                    render_stmt(
-                        stmt,
-                        type_context,
-                        out,
-                        indent + 1,
-                        source_path,
-                        in_async_function,
-                        debug,
-                    );
-                }
-                out.push_str(&format!("{pad}}}\n"));
+                out.push_str(&format!(
+                    "{pad}}}
+"
+                ));
             } else {
-                out.push_str(&format!("{pad}}}\n"));
+                out.push_str(&format!(
+                    "{pad}}}
+"
+                ));
             }
         }
         Stmt::While { cond, body, span } => {
             render_source_marker(source_path, *span, out, indent, debug);
-            out.push_str(&format!("{pad}while {} {{\n", render_expr(cond)));
-            for stmt in body {
-                render_stmt(
-                    stmt,
-                    type_context,
-                    out,
-                    indent + 1,
-                    source_path,
-                    in_async_function,
-                    debug,
-                );
-            }
-            out.push_str(&format!("{pad}}}\n"));
+            let mut scoped_defers = active_defers.to_vec();
+            scoped_defers.extend(local_defers.iter().cloned());
+            out.push_str(&format!(
+                "{pad}while {} {{
+",
+                render_expr(cond)
+            ));
+            render_stmt_block(
+                body,
+                type_context,
+                out,
+                indent + 1,
+                source_path,
+                in_async_function,
+                debug,
+                &scoped_defers,
+            );
+            out.push_str(&format!(
+                "{pad}}}
+"
+            ));
         }
         Stmt::Match { expr, arms, span } => {
             render_source_marker(source_path, *span, out, indent, debug);
-            out.push_str(&format!("{pad}match {} {{\n", render_expr(expr)));
+            let mut scoped_defers = active_defers.to_vec();
+            scoped_defers.extend(local_defers.iter().cloned());
+            out.push_str(&format!(
+                "{pad}match {} {{
+",
+                render_expr(expr)
+            ));
             for arm in arms {
                 render_match_arm(
                     arm,
@@ -1514,19 +1625,30 @@ fn render_stmt(
                     source_path,
                     in_async_function,
                     debug,
+                    &scoped_defers,
                 );
             }
-            out.push_str(&format!("{pad}}}\n"));
+            out.push_str(&format!(
+                "{pad}}}
+"
+            ));
         }
         Stmt::Return { expr, span } => {
             render_source_marker(source_path, *span, out, indent, debug);
+            render_deferred_exprs(out, indent, local_defers);
+            render_deferred_exprs(out, indent, active_defers);
             if in_async_function {
                 out.push_str(&format!(
-                    "{pad}return axiom_task_ready({});\n",
+                    "{pad}return axiom_task_ready({});
+",
                     render_expr(expr)
                 ));
             } else {
-                out.push_str(&format!("{pad}return {};\n", render_expr(expr)));
+                out.push_str(&format!(
+                    "{pad}return {};
+",
+                    render_expr(expr)
+                ));
             }
         }
     }
@@ -1540,6 +1662,7 @@ fn render_match_arm(
     source_path: &str,
     in_async_function: bool,
     debug: bool,
+    active_defers: &[(String, SourceSpan)],
 ) {
     let pad = "    ".repeat(indent);
     if arm.bindings.is_empty() {
@@ -1559,17 +1682,16 @@ fn render_match_arm(
             arm.bindings.join(", ")
         ));
     }
-    for stmt in &arm.body {
-        render_stmt(
-            stmt,
-            type_context,
-            out,
-            indent + 1,
-            source_path,
-            in_async_function,
-            debug,
-        );
-    }
+    render_stmt_block(
+        &arm.body,
+        type_context,
+        out,
+        indent + 1,
+        source_path,
+        in_async_function,
+        debug,
+        active_defers,
+    );
     out.push_str(&format!("{pad}}},\n"));
 }
 

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -82,6 +82,10 @@ pub enum Stmt {
         message: Expr,
         span: SourceSpan,
     },
+    Defer {
+        expr: Expr,
+        span: SourceSpan,
+    },
     If {
         cond: Expr,
         then_block: Vec<Stmt>,
@@ -1378,6 +1382,17 @@ fn rewrite_stmt_aggregate_types(
             line: *line,
             column: *column,
         },
+        syntax::Stmt::Defer { expr, line, column } => syntax::Stmt::Defer {
+            expr: rewrite_expr_aggregate_types(
+                expr,
+                generic_structs,
+                generic_enums,
+                queue,
+                queued,
+            )?,
+            line: *line,
+            column: *column,
+        },
         syntax::Stmt::If {
             cond,
             then_block,
@@ -1893,6 +1908,17 @@ fn rewrite_stmt_generic_calls(
                     queued,
                 )?,
             },
+            line: *line,
+            column: *column,
+        },
+        syntax::Stmt::Defer { expr, line, column } => syntax::Stmt::Defer {
+            expr: rewrite_expr_generic_calls(
+                expr,
+                type_bindings,
+                generic_functions,
+                queue,
+                queued,
+            )?,
             line: *line,
             column: *column,
         },
@@ -3498,6 +3524,19 @@ fn lower_stmt(
                 },
             })
         }
+        syntax::Stmt::Defer { expr, line, column } => {
+            let lowered_expr = lower_expr(expr, env, ctx)?;
+            if !lowered_expr.ty().is_copy() {
+                move_lowered_value(&lowered_expr, env)?;
+            }
+            Ok(Stmt::Defer {
+                expr: lowered_expr,
+                span: SourceSpan {
+                    line: *line,
+                    column: *column,
+                },
+            })
+        }
         syntax::Stmt::Return { expr, line, column } => {
             let Some(expected) = ctx.current_return.as_ref() else {
                 return Err(
@@ -4421,7 +4460,13 @@ fn lower_expr_with_expected(
             }
             if let Some(signature) = ctx.functions.get(name) {
                 if signature.is_extern {
-                    require_capability(ctx.capabilities, CapabilityKind::Ffi, name, *line, *column)?;
+                    require_capability(
+                        ctx.capabilities,
+                        CapabilityKind::Ffi,
+                        name,
+                        *line,
+                        *column,
+                    )?;
                 }
                 if args.len() != signature.params.len() {
                     return Err(Diagnostic::new(
@@ -5547,11 +5592,13 @@ fn validate_ffi_signature(function: &syntax::Function, return_ty: &Type) -> Resu
     Ok(())
 }
 
-fn validate_ffi_type_name(ty: &syntax::TypeName, line: usize, column: usize) -> Result<(), Diagnostic> {
+fn validate_ffi_type_name(
+    ty: &syntax::TypeName,
+    line: usize,
+    column: usize,
+) -> Result<(), Diagnostic> {
     match ty {
-        syntax::TypeName::Int
-        | syntax::TypeName::Bool
-        | syntax::TypeName::String => Ok(()),
+        syntax::TypeName::Int | syntax::TypeName::Bool | syntax::TypeName::String => Ok(()),
         syntax::TypeName::Ptr(inner) | syntax::TypeName::MutPtr(inner) => {
             validate_ffi_type_name(inner, line, column)
         }
@@ -6306,7 +6353,9 @@ fn contains_mut_borrowed_slice_type_inner(
 ) -> bool {
     match ty {
         Type::MutSlice(_) => true,
-        Type::Slice(_) | Type::Int | Type::Bool | Type::String | Type::Ptr(_) | Type::MutPtr(_) => false,
+        Type::Slice(_) | Type::Int | Type::Bool | Type::String | Type::Ptr(_) | Type::MutPtr(_) => {
+            false
+        }
         Type::Option(inner) => contains_mut_borrowed_slice_type_inner(
             inner,
             structs,
@@ -6836,6 +6885,7 @@ impl Stmt {
     fn always_returns(&self) -> bool {
         match self {
             Stmt::Return { .. } | Stmt::Panic { .. } => true,
+            Stmt::Defer { .. } => false,
             Stmt::If {
                 cond,
                 then_block,
@@ -6871,6 +6921,7 @@ impl syntax::Stmt {
             syntax::Stmt::Let { line, .. }
             | syntax::Stmt::Print { line, .. }
             | syntax::Stmt::Panic { line, .. }
+            | syntax::Stmt::Defer { line, .. }
             | syntax::Stmt::If { line, .. }
             | syntax::Stmt::While { line, .. }
             | syntax::Stmt::Match { line, .. }
@@ -6883,6 +6934,7 @@ impl syntax::Stmt {
             syntax::Stmt::Let { column, .. }
             | syntax::Stmt::Print { column, .. }
             | syntax::Stmt::Panic { column, .. }
+            | syntax::Stmt::Defer { column, .. }
             | syntax::Stmt::If { column, .. }
             | syntax::Stmt::While { column, .. }
             | syntax::Stmt::Match { column, .. }

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -241,6 +241,132 @@ mod tests {
     }
 
     #[test]
+    fn parser_lowers_defer_statement() {
+        let source = r#"fn trace(label: string): int {
+print label
+return 0
+}
+
+fn demo(): int {
+defer trace("cleanup")
+return 7
+}
+
+print demo()
+"#;
+        let parsed = parse_program(source, Path::new("main.ax")).expect("parse");
+        let hir = hir::lower(&parsed).expect("lower");
+        let mir = mir::lower(&hir);
+        let rendered = render_rust(&mir);
+        let cleanup = rendered
+            .find("let _ = trace(String::from(\"cleanup\"));")
+            .expect("defer cleanup rendered");
+        let ret = rendered.find("return 7;").expect("return rendered");
+        assert!(
+            cleanup < ret,
+            "defer should render before return: {rendered}"
+        );
+    }
+
+    #[test]
+    fn run_project_executes_defer_on_return_panic_and_nested_scope() {
+        let dir = tempdir().expect("tempdir");
+        fs::write(dir.path().join("axiom.toml"), render_manifest("defer-demo"))
+            .expect("write manifest");
+        let manifest = load_manifest(dir.path()).expect("load manifest");
+        fs::write(
+            dir.path().join("axiom.lock"),
+            render_lockfile_for_project(dir.path(), &manifest).expect("render lockfile"),
+        )
+        .expect("write lockfile");
+        fs::create_dir_all(dir.path().join("src")).expect("create src");
+        fs::write(
+            dir.path().join("src/main.ax"),
+            r#"fn trace(label: string): int {
+print label
+return 0
+}
+
+fn nested(flag: bool): int {
+defer trace("outer-1")
+defer trace("outer-2")
+if flag {
+defer trace("inner")
+return 10
+}
+return 20
+}
+
+fn fail(): int {
+defer trace("panic-cleanup")
+panic("boom")
+}
+
+print nested(true)
+print nested(false)
+if false {
+print fail()
+}
+"#,
+        )
+        .expect("write source");
+
+        let built = build_project(dir.path()).expect("build project");
+        let output = compiled_binary_command(Path::new(&built.binary))
+            .output()
+            .expect("run binary");
+        assert!(output.status.success(), "binary failed: {output:?}");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert_eq!(
+            stdout,
+            "inner
+outer-2
+outer-1
+10
+outer-2
+outer-1
+20
+"
+        );
+
+        fs::write(
+            dir.path().join("src/main.ax"),
+            r#"fn trace(label: string): int {
+print label
+return 0
+}
+
+fn fail(): int {
+defer trace("panic-cleanup")
+panic("boom")
+}
+
+print fail()
+"#,
+        )
+        .expect("rewrite source");
+        let built = build_project(dir.path()).expect("rebuild project");
+        let output = compiled_binary_command(Path::new(&built.binary))
+            .output()
+            .expect("run panic binary");
+        assert!(
+            !output.status.success(),
+            "panic binary unexpectedly succeeded"
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert_eq!(
+            stdout,
+            "panic-cleanup
+"
+        );
+        assert!(
+            stderr.contains("\"kind\":\"panic\""),
+            "stderr missing panic report: {stderr}"
+        );
+    }
+
+    #[test]
     fn parser_tracks_package_visibility() {
         let source = "pub(pkg) const ANSWER: int = 42\npub(pkg) type Id = int\npub(pkg) struct BuildInfo {\nlabel: string\n}\npub(pkg) enum Status {\nReady\n}\npub(pkg) fn answer(): int {\nreturn ANSWER\n}\npub(pkg) async fn answer_later(): int {\nreturn ANSWER\n}\n";
         let parsed = parse_program(source, Path::new("main.ax")).expect("parse");
@@ -1904,7 +2030,6 @@ mod tests {
         assert!(payload["capabilities"][3]["unsafe_unrestricted"].is_null());
     }
 
-
     #[test]
     fn check_project_rejects_extern_function_without_ffi_capability() {
         let dir = tempdir().expect("tempdir");
@@ -1967,8 +2092,14 @@ print strlen("hello")
         let function = parsed.functions.first().expect("function");
         assert!(function.is_extern);
         assert_eq!(function.extern_library.as_deref(), Some("c"));
-        assert!(matches!(function.params[0].ty, crate::syntax::TypeName::Ptr(_)));
-        assert!(matches!(function.params[1].ty, crate::syntax::TypeName::MutPtr(_)));
+        assert!(matches!(
+            function.params[0].ty,
+            crate::syntax::TypeName::Ptr(_)
+        ));
+        assert!(matches!(
+            function.params[1].ty,
+            crate::syntax::TypeName::MutPtr(_)
+        ));
     }
 
     #[test]

--- a/stage1/crates/axiomc/src/mir.rs
+++ b/stage1/crates/axiomc/src/mir.rs
@@ -79,6 +79,10 @@ pub enum Stmt {
         message: Expr,
         span: SourceSpan,
     },
+    Defer {
+        expr: Expr,
+        span: SourceSpan,
+    },
     If {
         cond: Expr,
         then_block: Vec<Stmt>,
@@ -307,7 +311,11 @@ impl Expr {
 
 fn count_stmt(stmt: &Stmt) -> usize {
     match stmt {
-        Stmt::Let { .. } | Stmt::Print { .. } | Stmt::Panic { .. } | Stmt::Return { .. } => 1,
+        Stmt::Let { .. }
+        | Stmt::Print { .. }
+        | Stmt::Panic { .. }
+        | Stmt::Defer { .. }
+        | Stmt::Return { .. } => 1,
         Stmt::If {
             then_block,
             else_block,
@@ -401,6 +409,10 @@ fn lower_stmt(stmt: &hir::Stmt) -> Stmt {
         },
         hir::Stmt::Panic { message, span } => Stmt::Panic {
             message: lower_expr(message),
+            span: lower_source_span(span),
+        },
+        hir::Stmt::Defer { expr, span } => Stmt::Defer {
+            expr: lower_expr(expr),
             span: lower_source_span(span),
         },
         hir::Stmt::If {

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -1788,6 +1788,7 @@ fn validate_stmt_capabilities(
         syntax::Stmt::Let { expr, .. }
         | syntax::Stmt::Print { expr, .. }
         | syntax::Stmt::Panic { expr, .. }
+        | syntax::Stmt::Defer { expr, .. }
         | syntax::Stmt::Return { expr, .. } => {
             validate_expr_capabilities(module_path, expr, capabilities)?;
         }
@@ -2657,6 +2658,21 @@ fn rewrite_stmt(
             column: *column,
         },
         syntax::Stmt::Panic { expr, line, column } => syntax::Stmt::Panic {
+            expr: rewrite_expr(
+                expr,
+                visible_functions,
+                visible_consts,
+                visible_structs,
+                visible_types,
+                private_imported,
+                private_imported_consts,
+                private_imported_types,
+                module_path,
+            )?,
+            line: *line,
+            column: *column,
+        },
+        syntax::Stmt::Defer { expr, line, column } => syntax::Stmt::Defer {
             expr: rewrite_expr(
                 expr,
                 visible_functions,
@@ -3947,6 +3963,7 @@ fn stmt_line(stmt: &syntax::Stmt) -> usize {
         syntax::Stmt::Let { line, .. }
         | syntax::Stmt::Print { line, .. }
         | syntax::Stmt::Panic { line, .. }
+        | syntax::Stmt::Defer { line, .. }
         | syntax::Stmt::If { line, .. }
         | syntax::Stmt::While { line, .. }
         | syntax::Stmt::Match { line, .. }
@@ -3959,6 +3976,7 @@ fn stmt_column(stmt: &syntax::Stmt) -> usize {
         syntax::Stmt::Let { column, .. }
         | syntax::Stmt::Print { column, .. }
         | syntax::Stmt::Panic { column, .. }
+        | syntax::Stmt::Defer { column, .. }
         | syntax::Stmt::If { column, .. }
         | syntax::Stmt::While { column, .. }
         | syntax::Stmt::Match { column, .. }

--- a/stage1/crates/axiomc/src/syntax.rs
+++ b/stage1/crates/axiomc/src/syntax.rs
@@ -136,6 +136,11 @@ pub enum Stmt {
         line: usize,
         column: usize,
     },
+    Defer {
+        expr: Expr,
+        line: usize,
+        column: usize,
+    },
     If {
         cond: Expr,
         then_block: Vec<Stmt>,
@@ -593,6 +598,15 @@ fn parse_stmt(
             column: 1,
         });
     }
+    if let Some(rest) = trimmed.strip_prefix("defer ") {
+        let expr = parse_expr(rest, path, line_no, 7)?;
+        *index += 1;
+        return Ok(Stmt::Defer {
+            expr,
+            line: line_no,
+            column: 1,
+        });
+    }
     if let Some(rest) = trimmed.strip_prefix("return ") {
         let expr = parse_expr(rest, path, line_no, 8)?;
         *index += 1;
@@ -603,9 +617,9 @@ fn parse_stmt(
         });
     }
     let message = if in_block {
-        "stage1 bootstrap currently supports let, print, panic, if/else, while, match, and return statements inside blocks"
+        "stage1 bootstrap currently supports let, print, panic, defer, if/else, while, match, and return statements inside blocks"
     } else {
-        "stage1 bootstrap currently supports top-level import, const, type, struct, enum, fn, let, print, panic, if/else, while, and match statements"
+        "stage1 bootstrap currently supports top-level import, const, type, struct, enum, fn, let, print, panic, defer, if/else, while, and match statements"
     };
     Err(Diagnostic::new("parse", message)
         .with_path(path.display().to_string())
@@ -616,18 +630,19 @@ fn parse_function(lines: &[&str], index: &mut usize, path: &Path) -> Result<Func
     let line_no = *index + 1;
     let trimmed = lines[*index].trim();
     let (visibility, rest, visibility_column) = parse_visibility_prefix(trimmed);
-    let (is_async, is_extern, header, fn_column) = if let Some(rest) = rest.strip_prefix("async fn ") {
-        (true, false, rest, visibility_column + 6)
-    } else if let Some(rest) = rest.strip_prefix("extern fn ") {
-        (false, true, rest, visibility_column + 7)
-    } else {
-        let rest = rest.strip_prefix("fn ").ok_or_else(|| {
-            Diagnostic::new("parse", "invalid function declaration")
-                .with_path(path.display().to_string())
-                .with_span(line_no, 1)
-        })?;
-        (false, false, rest, visibility_column)
-    };
+    let (is_async, is_extern, header, fn_column) =
+        if let Some(rest) = rest.strip_prefix("async fn ") {
+            (true, false, rest, visibility_column + 6)
+        } else if let Some(rest) = rest.strip_prefix("extern fn ") {
+            (false, true, rest, visibility_column + 7)
+        } else {
+            let rest = rest.strip_prefix("fn ").ok_or_else(|| {
+                Diagnostic::new("parse", "invalid function declaration")
+                    .with_path(path.display().to_string())
+                    .with_span(line_no, 1)
+            })?;
+            (false, false, rest, visibility_column)
+        };
     let open_paren = find_top_level_char(header, '(').ok_or_else(|| {
         Diagnostic::new("parse", "function declaration is missing '('")
             .with_path(path.display().to_string())
@@ -657,11 +672,12 @@ fn parse_function(lines: &[&str], index: &mut usize, path: &Path) -> Result<Func
             .with_span(line_no, 1)
         })?;
         let return_ty = parse_type_name(return_text.trim(), path, line_no, 1)?;
-        let extern_library = serde_json::from_str::<String>(extern_library.trim()).map_err(|_| {
-            Diagnostic::new("parse", "extern function library must be a quoted string")
-                .with_path(path.display().to_string())
-                .with_span(line_no, 1)
-        })?;
+        let extern_library =
+            serde_json::from_str::<String>(extern_library.trim()).map_err(|_| {
+                Diagnostic::new("parse", "extern function library must be a quoted string")
+                    .with_path(path.display().to_string())
+                    .with_span(line_no, 1)
+            })?;
         *index += 1;
         return Ok(Function {
             name: name.to_string(),
@@ -1175,11 +1191,10 @@ fn parse_match_arms(
                 .into_iter()
                 .map(|(binding_offset, raw_binding)| {
                     let binding = raw_binding.trim();
-                    let leading_ws = raw_binding.len().saturating_sub(raw_binding.trim_start().len());
-                    let binding_column = open_brace
-                        + 2
-                        + binding_offset
-                        + leading_ws;
+                    let leading_ws = raw_binding
+                        .len()
+                        .saturating_sub(raw_binding.trim_start().len());
+                    let binding_column = open_brace + 2 + binding_offset + leading_ws;
                     if binding.is_empty() {
                         return Err(Diagnostic::new("parse", "match arm binding is empty")
                             .with_path(path.display().to_string())
@@ -1214,11 +1229,10 @@ fn parse_match_arms(
                 .into_iter()
                 .map(|(binding_offset, raw_binding)| {
                     let binding = raw_binding.trim();
-                    let leading_ws = raw_binding.len().saturating_sub(raw_binding.trim_start().len());
-                    let binding_column = open_paren
-                        + 2
-                        + binding_offset
-                        + leading_ws;
+                    let leading_ws = raw_binding
+                        .len()
+                        .saturating_sub(raw_binding.trim_start().len());
+                    let binding_column = open_paren + 2 + binding_offset + leading_ws;
                     if binding.is_empty() {
                         return Err(Diagnostic::new("parse", "match arm binding is empty")
                             .with_path(path.display().to_string())
@@ -1486,11 +1500,12 @@ fn parse_type_name(
         }
         if name == "mutptr" {
             if type_args.len() != 1 {
-                return Err(
-                    Diagnostic::new("parse", "mutptr types must use `mutptr<type>` syntax")
-                        .with_path(path.display().to_string())
-                        .with_span(line_no, column),
-                );
+                return Err(Diagnostic::new(
+                    "parse",
+                    "mutptr types must use `mutptr<type>` syntax",
+                )
+                .with_path(path.display().to_string())
+                .with_span(line_no, column));
             }
             return Ok(TypeName::MutPtr(Box::new(type_args.remove(0))));
         }


### PR DESCRIPTION
## Summary
- Implements issue #112: defer/destructor cleanup support for Stage 1 language resource cleanup.
- Adds the compiler/runtime behavior needed for deferred cleanup to execute through the Stage 1 flow.

## Governing Issue
Closes #112

## Validation
- [x] PR Fast CI / Fast Checks passed on commit 37bece0c1382e0bf2a8df73fed1650d970e307d5.
- [x] Prior local stage1 cargo test suite was reported passing in review: 265 tests + 3 tests.

## Bootstrap Governance
- No changes to portable Codex profile assets, bootstrap policy, GitHub environments, runner labels, or secrets.
- This PR remains governed by `project.bootstrap.yaml` and the repo PR validation policy.

## Notes
- CI failure was limited to PR description shape; the code validation lane was already green.
