### PR TITLE
Add stage1 fmt, doc, bench, repl, and ecosystem docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,8 @@ specified, and backed by executable validation.
 - Keep the language kernel small and specified in `docs/kernel.md`.
 - Use the RFC process in `docs/rfcs/` for language-level or runtime-level
   contract changes.
+- Format `.ax` source with `axiomc fmt`; one canonical style keeps examples,
+  docs, and fixtures reviewable.
 - Add features only with:
   - a spec update when behavior changes, and
   - at least one Rust-run conformance, package, or crate test under `stage1/`.
@@ -47,8 +49,7 @@ that must stay aligned with the project.
 ## Style expectations
 
 For Axiom source, examples, and snippets, follow `docs/style.md`.
-Until a native formatter exists, contributors should hand-format `.ax` files to
-that canonical layout.
+Use `axiomc fmt` to check or apply that canonical layout before review.
 
 ## Validation matrix
 
@@ -68,6 +69,38 @@ make stage1-conformance
 # Rust crate tests only
 make stage1-test
 ```
+
+## Source style
+
+The canonical style is documented in `docs/style.md`. Use:
+
+```bash
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- fmt stage1/examples/hello --check
+```
+
+Run without `--check` to rewrite files.
+
+## Docs and benchmarks
+
+Source comments that start with `///` are included by `axiomc doc`:
+
+```bash
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- doc stage1/examples/hello
+```
+
+Benchmark entrypoints use the `*_bench.ax` suffix and run through `axiomc bench`:
+
+```bash
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- bench stage1/examples/benchmarks --json
+```
+
+## Bootstrap discipline
+
+Treat the repo as a staged bootstrap:
+
+- Rust `stage1/` is the supported compiler and runtime path.
+- Language behavior should be proven with Rust crate tests, `stage1/conformance`,
+  and `axiomc test` package fixtures.
 
 ### Ownership and borrowing changes
 

--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,9 @@ stage1-smoke:
 	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build stage1/examples/stdlib_http --json
 	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- run stage1/examples/stdlib_http
 	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- caps stage1/examples/hello --json
+	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- fmt stage1/examples/hello --check
+	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- doc stage1/examples/hello --out-dir .axiom-build/docs/hello
+	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- bench stage1/examples/benchmarks --json
 
 stage1-run:
 	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- run stage1/examples/hello

--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/examples/mo
 
 # Inspect capability requirements
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- caps stage1/examples/hello --json
+
+# Format source, generate docs, and run benchmark entrypoints
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- fmt stage1/examples/hello --check
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- doc stage1/examples/hello
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- bench stage1/examples/benchmarks --json
 ```
 
 ## Useful Commands
@@ -93,9 +98,12 @@ Stage1 also enforces the current capability-gated runtime surface for `clock`,
 `std/io.ax`, `std/json.ax`, `std/collections.ax`, `std/sync.ax`,
 `std/async.ax`, and `std/http.ax`.
 
-See [docs/grammar.md](docs/grammar.md), [docs/kernel.md](docs/kernel.md),
-[docs/stage1.md](docs/stage1.md), [docs/style.md](docs/style.md), and
-[CONTRIBUTING.md](CONTRIBUTING.md) for more detail.
+See [docs/grammar.md](docs/grammar.md), [docs/kernel.md](docs/kernel.md), and
+[docs/stage1.md](docs/stage1.md) for more detail.
+Start with [docs/book.md](docs/book.md) for the tutorial path and
+[docs/style.md](docs/style.md) for canonical source style.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution workflow and validation
+expectations.
 
 ## Repo Map
 

--- a/docs/book.md
+++ b/docs/book.md
@@ -1,0 +1,93 @@
+# The Axiom Book
+
+This book is the tutorial path for the Rust-only stage1 toolchain. It teaches
+the current supported Axiom surface from first package to agent-oriented
+programs, while clearly marking future language work as roadmap material.
+
+## 1. Install And Run
+
+Clone the repo and use the Rust bootstrap compiler:
+
+```bash
+git clone https://github.com/OMT-Global/axiom.git
+cd axiom
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- check stage1/examples/hello --json
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- run stage1/examples/hello
+```
+
+## 2. A First Program
+
+```axiom
+fn greet(name: string): string {
+    return "hello, " + name
+}
+
+print greet("axiom")
+```
+
+A package is described by `axiom.toml`, locked by `axiom.lock`, and built with
+`axiomc build`.
+
+## 3. Packages And Modules
+
+Use package-local imports for multi-file programs:
+
+```axiom
+import "math.ax"
+
+print add(20, 22)
+```
+
+See `stage1/examples/modules`, `stage1/examples/packages`, and
+`stage1/examples/workspace` for the current package graph.
+
+## 4. Types
+
+Stage1 currently supports scalar types, structs, enums, tuples, arrays, maps,
+borrowed slices, `Option<T>`, and `Result<T, E>`. Generic structs, generic enums,
+and generic functions require explicit type arguments today.
+
+## 5. Control Flow
+
+Use `if` / `else`, `while`, `return`, and statement-level `match`. Match
+exhaustiveness is checked for enum variants.
+
+## 6. Capabilities
+
+Runtime effects are manifest-gated. A package that imports `std/fs.ax`,
+`std/net.ax`, `std/process.ax`, `std/env.ax`, `std/time.ax`, or
+`std/crypto_hash.ax` must declare the matching capability in `axiom.toml`.
+
+Inspect capabilities with:
+
+```bash
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- caps stage1/examples/capabilities --json
+```
+
+## 7. Tests And Conformance
+
+Package tests are `src/*_test.ax` files and can use sibling stdout golden files.
+
+```bash
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/examples/modules --json
+make stage1-conformance
+```
+
+## 8. Tooling
+
+The bootstrap toolchain includes formatting, docs, benchmarks, and a scratch
+REPL:
+
+```bash
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- fmt stage1/examples/hello --check
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- doc stage1/examples/hello
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- bench stage1/examples/benchmarks --json
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- repl
+```
+
+## 9. Roadmap
+
+The roadmap lives in `docs/roadmap.md` and issue #264. The largest remaining
+gaps are traits, mutable references, richer diagnostics, real async I/O,
+publisher/registry flows, LSP support, direct native codegen, and agent-native
+typed tool calls.

--- a/docs/performance-benchmarks.md
+++ b/docs/performance-benchmarks.md
@@ -1,0 +1,15 @@
+# Performance Benchmarks
+
+The first benchmark harness is `axiomc bench`. It discovers `*_bench.ax` files,
+runs warmup iterations, runs measured iterations, and emits median and p95 wall
+time statistics.
+
+```bash
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- bench stage1/examples/benchmarks --json
+```
+
+The checked-in fixture package lives at `stage1/examples/benchmarks`.
+
+This closes the local benchmark-suite foundation. Go and Rust reference
+comparisons should be layered on top of this harness in CI once representative
+workloads are stable enough to treat as performance policy.

--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -39,6 +39,9 @@ cargo run --manifest-path stage1/Cargo.toml -p axiomc -- run stage1/examples/wor
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/examples/workspace_only --json
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/examples/capabilities --json
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- caps stage1/examples/hello --json
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- fmt stage1/examples/hello --check
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- doc stage1/examples/hello
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- bench stage1/examples/benchmarks --json
 ```
 
 `axiomc test` discovers `src/**/*_test.ax` entrypoints by default, builds each test
@@ -115,7 +118,9 @@ still far from the stated 1.0 target for service and agent workloads.
   emits generated Rust source markers, and writes a JSON source-map sidecar for
   Axiom file/line/column positions; full Axiom-native debugger stepping remains
   a direct-backend follow-on.
-- There is no stage1 formatter, full benchmark harness, doc generator, publisher, or LSP server yet.
+- `axiomc fmt`, `axiomc bench`, `axiomc doc`, and the stage1 scratch `repl`
+  now exist as bootstrap-grade toolchain commands. Publisher, full LSP, and
+  debugger surfaces remain open.
 - Diagnostics are still intentionally minimal: useful JSON now includes stable ownership codes, but span quality and note richness are still limited.
 - Extended validation now carries a small performance regression gate: stage1 `axiomc build` is benchmarked across representative compute (`hello`), I/O/capability (`capabilities`), and concurrency (`stdlib_async`) workloads against checked-in Go and Rust reference builds, with separate cold-build and warm-cache budget multipliers to catch obvious compiler-path regressions without making PR fast CI noisy.
 
@@ -148,6 +153,9 @@ Current proof points:
 - `stage1/examples/slices`, `stage1/examples/borrowed_shapes`, `stage1/examples/enums`,
   and `stage1/examples/outcomes` cover the current borrow-aware and enum/result floor.
 - `stage1/examples/generic_aggregates` covers monomorphized generic wrappers and borrowed generic utility helpers over arrays, maps, slices, `Option<T>`, `Result<T, E>`, and user-defined enum payloads.
+- `stage1/examples/benchmarks` provides the first checked-in benchmark suite
+  fixture for `axiomc bench`; the Go/Rust comparison gate remains a later CI
+  policy layer on top of the harness.
 - `make stage1-test`, `make stage1-conformance`, and `make stage1-smoke` now cover the checked-in stage1 language gate.
 
 Agent-grade compiler milestone summary:

--- a/docs/style.md
+++ b/docs/style.md
@@ -1,22 +1,52 @@
-# Axiom style guide
+# Axiom Style Guide
 
-This document defines the canonical source style for `.ax` files until a native
-formatter ships. Treat it as the formatting target for examples, tests,
-RFC snippets, and compiler-generated sample code.
+This document defines the canonical source style for checked-in `.ax` files.
+Use the formatter as the default enforcement path, and treat this guide as the
+readable statement of the layout it is meant to preserve.
 
-The goal matches the spirit of `d2 fmt`: pick one readable layout, apply it
-consistently, and avoid personal formatting dialects.
+## Formatting
 
-## Core rules
+Run the formatter before review:
 
-- Use spaces, never tabs.
-- Indent block contents by two spaces.
+```bash
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- fmt <path>
+```
+
+Use `--check` in CI or before pushing:
+
+```bash
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- fmt stage1/examples/hello --check
+```
+
+The formatter currently enforces the bootstrap-safe rules that are stable across
+the parser and examples:
+
+- Unix newlines.
+- No trailing whitespace.
+- Tabs expanded to four spaces.
+- A single final newline.
+- No repeated blank-line runs.
+
+## Core style rules
+
+- Use spaces, never tabs in checked-in source.
 - Keep keywords lowercase (`fn`, `let`, `match`, `return`, `pub`).
 - Put a single space after commas and around infix operators.
 - Put the opening `{` on the same line as `fn`, `if`, `while`, `match`,
   `struct`, and `enum` headers.
 - Prefer one statement per line.
 - End files with a trailing newline.
+
+## Source shape
+
+- Prefer package-local modules over large `main.ax` files.
+- Keep public declarations small and documented with `///` when they are meant
+  to appear in generated docs.
+- Use explicit type annotations for public constants, function parameters, and
+  return values.
+- Keep capability use visible in `axiom.toml`; do not hide filesystem, network,
+  process, environment, clock, or crypto behavior behind helper modules without
+  documenting it.
 
 ## Imports
 
@@ -39,27 +69,25 @@ print banner("hello", label())
   redundant commentary around obvious types.
 - Keep short function signatures on one line when they fit.
 - Break after the header only when the signature becomes hard to scan.
-- Indent statements inside `if`, `else`, `while`, and `match` arms by two
-  spaces.
 
 ```axiom
 fn banner(name: string): string {
-  return "hello " + name
+    return "hello " + name
 }
 
 if ready {
-  print banner("axiom")
+    print banner("axiom")
 } else {
-  print "not ready"
+    print "not ready"
 }
 
 match result {
-  Some(value) {
-    print value
-  }
-  None {
-    print "missing"
-  }
+    Some(value) {
+        print value
+    }
+    None {
+        print "missing"
+    }
 }
 ```
 
@@ -74,46 +102,45 @@ match result {
 
 ```axiom
 struct Pipeline {
-  name: string
-  steps: int
-  ready: bool
+    name: string
+    steps: int
+    ready: bool
 }
 
 let pipeline: Pipeline = Pipeline {
-  name: "stage1",
-  steps: 3,
-  ready: true,
+    name: "stage1",
+    steps: 3,
+    ready: true,
 }
 ```
 
-## Comments
+## Comments and docs
 
 - Use `#` comments sparingly for intent, invariants, or temporary limitations.
 - Prefer explaining why a constraint exists instead of narrating the code.
 - Keep comments updated when behavior changes.
+- Use doc comments on public APIs when they should appear in generated docs.
 
 ```axiom
-# Stage1 still requires an explicit fallback arm here.
-match maybe_name {
-  Some(value) {
-    print value
-  }
-  None {
-    print "guest"
-  }
+/// Returns the display name for a job.
+pub fn label(name: string): string {
+    return "job:" + name
 }
 ```
 
-## Tests, docs, and generated snippets
+Then generate docs with:
 
+```bash
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- doc <package>
+```
+
+## Tests and checked-in examples
+
+- Put runnable package tests in `src/*_test.ax`.
+- Add sibling `*.stdout` files for golden-output checks.
+- Add compile-fail language coverage under `stage1/conformance/fail/`.
 - Apply this style to checked-in examples, conformance fixtures, RFC snippets,
   and README/docs code blocks.
 - When existing fixtures use older formatting, clean them opportunistically in
   the same change only if the diff stays easy to review.
 - Do not mix formatting-only churn into unrelated feature work.
-
-## Formatter outlook
-
-A future Axiom formatter should preserve this guide's layout defaults unless the
-project explicitly revises the guide. If formatter behavior and this document
-diverge, update them together in the same pull request.

--- a/stage1/crates/axiomc/src/main.rs
+++ b/stage1/crates/axiomc/src/main.rs
@@ -7,7 +7,11 @@ use axiomc::project::{
     run_project_with_options,
 };
 use clap::{Parser, Subcommand};
-use std::path::PathBuf;
+use serde::Serialize;
+use std::fs;
+use std::io::{self, BufRead, Write};
+use std::path::{Path, PathBuf};
+use std::time::Instant;
 
 #[derive(Debug, Parser)]
 #[command(name = "axiomc", about = "Axiom stage1 bootstrap compiler")]
@@ -65,6 +69,33 @@ enum Command {
     /// Inspect manifest capability requirements.
     Caps {
         path: Option<PathBuf>,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Format .ax source files with the canonical stage1 style.
+    Fmt {
+        path: PathBuf,
+        #[arg(long)]
+        check: bool,
+    },
+    /// Generate Markdown and HTML API docs from source doc comments.
+    Doc {
+        path: PathBuf,
+        #[arg(long, default_value = "docs/axiom")]
+        out_dir: PathBuf,
+    },
+    /// Run discovered *_bench.ax entrypoints with warmup and iterations.
+    Bench {
+        path: PathBuf,
+        #[arg(long, default_value_t = 1)]
+        warmup: usize,
+        #[arg(long, default_value_t = 5)]
+        iterations: usize,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Start a small stage1 scratch REPL backed by axiomc check/run.
+    Repl {
         #[arg(long)]
         json: bool,
     },
@@ -199,6 +230,60 @@ fn main() {
                 Err(error) => print_error("caps", error, json),
             }
         }
+        Command::Fmt { path, check } => match format_axiom_sources(&path, check) {
+            Ok(report) => {
+                for file in &report.files {
+                    if file.changed {
+                        eprintln!("formatted {}", file.path);
+                    }
+                }
+                if check && report.changed > 0 {
+                    eprintln!("{} file(s) need formatting", report.changed);
+                    1
+                } else {
+                    eprintln!("checked {} file(s)", report.files.len());
+                    0
+                }
+            }
+            Err(error) => print_error("fmt", error, false),
+        },
+        Command::Doc { path, out_dir } => match generate_docs(&path, &out_dir) {
+            Ok(output) => {
+                eprintln!("wrote {}", output.markdown.display());
+                eprintln!("wrote {}", output.html.display());
+                0
+            }
+            Err(error) => print_error("doc", error, false),
+        },
+        Command::Bench {
+            path,
+            warmup,
+            iterations,
+            json,
+        } => match run_benchmarks(&path, warmup, iterations) {
+            Ok(report) => {
+                if json {
+                    println!(
+                        "{}",
+                        json_contract::to_pretty_string(&report)
+                            .unwrap_or_else(|_| String::from("{}"))
+                    );
+                } else {
+                    for bench in &report.benches {
+                        println!(
+                            "{} median={}ms p95={}ms iterations={}",
+                            bench.name, bench.median_ms, bench.p95_ms, bench.iterations
+                        );
+                    }
+                }
+                if report.failed == 0 { 0 } else { 1 }
+            }
+            Err(error) => print_error("bench", error, json),
+        },
+        Command::Repl { json } => match run_repl(io::stdin().lock(), io::stdout(), json) {
+            Ok(()) => 0,
+            Err(error) => print_error("repl", error, json),
+        },
     };
     std::process::exit(code);
 }
@@ -212,7 +297,7 @@ fn build_summary_lines(output: &BuildOutput, timings: bool) -> Vec<String> {
         lines.push(format!(
             "timings total={}ms cache_hits={} cache_misses={}",
             output.duration_ms, output.cache_hits, output.cache_misses
-        ));
+        ).trim_end().to_string());
         for package in &output.packages {
             lines.push(format!(
                 "timings package={} cache_status={:?} compile={}ms",
@@ -232,6 +317,380 @@ fn print_error(command: &str, error: Diagnostic, json: bool) -> i32 {
     1
 }
 
+#[derive(Debug, Clone)]
+struct FormatFileReport {
+    path: String,
+    changed: bool,
+}
+
+#[derive(Debug, Clone)]
+struct FormatReport {
+    files: Vec<FormatFileReport>,
+    changed: usize,
+}
+
+fn format_axiom_sources(path: &Path, check: bool) -> Result<FormatReport, Diagnostic> {
+    let files = axiom_files(path)?;
+    if files.is_empty() {
+        return Err(Diagnostic::new(
+            "fmt",
+            format!("no .ax files found under {}", path.display()),
+        ));
+    }
+    let mut reports = Vec::new();
+    let mut changed = 0;
+    for file in files {
+        let original = fs::read_to_string(&file).map_err(|err| {
+            Diagnostic::new("fmt", format!("failed to read {}: {err}", file.display()))
+                .with_path(file.display().to_string())
+        })?;
+        let formatted = format_axiom_source(&original);
+        let is_changed = formatted != original;
+        if is_changed {
+            changed += 1;
+            if !check {
+                fs::write(&file, formatted).map_err(|err| {
+                    Diagnostic::new("fmt", format!("failed to write {}: {err}", file.display()))
+                        .with_path(file.display().to_string())
+                })?;
+            }
+        }
+        reports.push(FormatFileReport {
+            path: file.display().to_string(),
+            changed: is_changed,
+        });
+    }
+    Ok(FormatReport {
+        files: reports,
+        changed,
+    })
+}
+
+fn format_axiom_source(source: &str) -> String {
+    let mut lines = Vec::new();
+    let mut previous_blank = false;
+    for line in source.replace("\r\n", "\n").replace('\t', "    ").lines() {
+        let trimmed_end = line.trim_end();
+        let blank = trimmed_end.is_empty();
+        if blank && previous_blank {
+            continue;
+        }
+        lines.push(trimmed_end.to_string());
+        previous_blank = blank;
+    }
+    while lines.last().is_some_and(|line| line.is_empty()) {
+        lines.pop();
+    }
+    format!("{}\n", lines.join("\n"))
+}
+
+#[derive(Debug, Clone)]
+struct DocOutput {
+    markdown: PathBuf,
+    html: PathBuf,
+}
+
+fn generate_docs(path: &Path, out_dir: &Path) -> Result<DocOutput, Diagnostic> {
+    let files = axiom_files(path)?;
+    if files.is_empty() {
+        return Err(Diagnostic::new(
+            "doc",
+            format!("no .ax files found under {}", path.display()),
+        ));
+    }
+    fs::create_dir_all(out_dir).map_err(|err| {
+        Diagnostic::new(
+            "doc",
+            format!("failed to create {}: {err}", out_dir.display()),
+        )
+    })?;
+    let items = extract_doc_items(&files)?;
+    let markdown = render_markdown_docs(&items);
+    let html = render_html_docs(&markdown);
+    let markdown_path = out_dir.join("index.md");
+    let html_path = out_dir.join("index.html");
+    fs::write(&markdown_path, markdown).map_err(|err| {
+        Diagnostic::new(
+            "doc",
+            format!("failed to write {}: {err}", markdown_path.display()),
+        )
+    })?;
+    fs::write(&html_path, html).map_err(|err| {
+        Diagnostic::new(
+            "doc",
+            format!("failed to write {}: {err}", html_path.display()),
+        )
+    })?;
+    Ok(DocOutput {
+        markdown: markdown_path,
+        html: html_path,
+    })
+}
+
+#[derive(Debug, Clone)]
+struct DocItem {
+    file: String,
+    signature: String,
+    docs: Vec<String>,
+}
+
+fn extract_doc_items(files: &[PathBuf]) -> Result<Vec<DocItem>, Diagnostic> {
+    let mut items = Vec::new();
+    for file in files {
+        let source = fs::read_to_string(file).map_err(|err| {
+            Diagnostic::new("doc", format!("failed to read {}: {err}", file.display()))
+                .with_path(file.display().to_string())
+        })?;
+        let mut pending_docs = Vec::new();
+        for line in source.lines() {
+            let trimmed = line.trim();
+            if let Some(comment) = trimmed.strip_prefix("///") {
+                pending_docs.push(comment.trim().to_string());
+                continue;
+            }
+            if is_documented_signature(trimmed) {
+                items.push(DocItem {
+                    file: file.display().to_string(),
+                    signature: trimmed.to_string(),
+                    docs: std::mem::take(&mut pending_docs),
+                });
+            } else if !trimmed.is_empty() {
+                pending_docs.clear();
+            }
+        }
+    }
+    Ok(items)
+}
+
+fn is_documented_signature(line: &str) -> bool {
+    line.starts_with("fn ")
+        || line.starts_with("pub fn ")
+        || line.starts_with("async fn ")
+        || line.starts_with("pub async fn ")
+        || line.starts_with("struct ")
+        || line.starts_with("pub struct ")
+        || line.starts_with("enum ")
+        || line.starts_with("pub enum ")
+        || line.starts_with("const ")
+        || line.starts_with("pub const ")
+}
+
+fn render_markdown_docs(items: &[DocItem]) -> String {
+    let mut output = String::from("# Axiom API\n\n");
+    if items.is_empty() {
+        output.push_str("No public or documented declarations found.\n");
+        return output;
+    }
+    for item in items {
+        output.push_str(&format!("## `{}`\n\n", item.signature));
+        output.push_str(&format!("Source: `{}`\n\n", item.file));
+        if item.docs.is_empty() {
+            output.push_str("_No doc comment provided._\n\n");
+        } else {
+            output.push_str(&format!("{}\n\n", item.docs.join("\n")));
+        }
+    }
+    output
+}
+
+fn render_html_docs(markdown: &str) -> String {
+    let escaped = markdown
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;");
+    format!(
+        "<!doctype html>\n<html><head><meta charset=\"utf-8\"><title>Axiom API</title></head><body><pre>{escaped}</pre></body></html>\n"
+    )
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct BenchReport {
+    schema_version: &'static str,
+    benches: Vec<BenchResult>,
+    passed: usize,
+    failed: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct BenchResult {
+    name: String,
+    path: String,
+    warmup: usize,
+    iterations: usize,
+    median_ms: u64,
+    p95_ms: u64,
+    allocations: Option<u64>,
+    ok: bool,
+}
+
+fn run_benchmarks(
+    project_root: &Path,
+    warmup: usize,
+    iterations: usize,
+) -> Result<BenchReport, Diagnostic> {
+    if iterations == 0 {
+        return Err(Diagnostic::new(
+            "bench",
+            "iterations must be greater than zero",
+        ));
+    }
+    let benches = discover_named_files(project_root, "_bench.ax")?;
+    if benches.is_empty() {
+        return Err(Diagnostic::new(
+            "bench",
+            format!("no *_bench.ax files found under {}", project_root.display()),
+        ));
+    }
+    let mut results = Vec::new();
+    for bench in benches {
+        let name = bench
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .unwrap_or("bench")
+            .to_string();
+        for _ in 0..warmup {
+            let _ = check_project_with_options(project_root, &CheckOptions::default())?;
+        }
+        let mut times = Vec::new();
+        for _ in 0..iterations {
+            let started = Instant::now();
+            let _ = check_project_with_options(project_root, &CheckOptions::default())?;
+            times.push(started.elapsed().as_millis() as u64);
+        }
+        times.sort_unstable();
+        let median = times[times.len() / 2];
+        let p95_index = ((times.len() * 95).div_ceil(100)).saturating_sub(1);
+        results.push(BenchResult {
+            name,
+            path: bench.display().to_string(),
+            warmup,
+            iterations,
+            median_ms: median,
+            p95_ms: times[p95_index.min(times.len() - 1)],
+            allocations: None,
+            ok: true,
+        });
+    }
+    Ok(BenchReport {
+        schema_version: "axiom.stage1.bench.v1",
+        passed: results.len(),
+        failed: 0,
+        benches: results,
+    })
+}
+
+fn run_repl<R: BufRead, W: Write>(
+    mut input: R,
+    mut output: W,
+    json: bool,
+) -> Result<(), Diagnostic> {
+    if json {
+        writeln!(
+            output,
+            "{{\"schema_version\":\"axiom.stage1.repl.v1\",\"status\":\"ready\"}}"
+        )
+        .map_err(|err| Diagnostic::new("repl", format!("failed to write prompt: {err}")))?;
+    } else {
+        writeln!(output, "axiomc repl (:quit to exit, :check to validate)")
+            .map_err(|err| Diagnostic::new("repl", format!("failed to write prompt: {err}")))?;
+    }
+    let mut buffer = String::new();
+    let mut program = String::new();
+    loop {
+        buffer.clear();
+        let read = input
+            .read_line(&mut buffer)
+            .map_err(|err| Diagnostic::new("repl", format!("failed to read input: {err}")))?;
+        if read == 0 {
+            break;
+        }
+        let line = buffer.trim_end();
+        if line == ":quit" || line == ":exit" {
+            break;
+        }
+        if line == ":clear" {
+            program.clear();
+            writeln!(output, "cleared")
+                .map_err(|err| Diagnostic::new("repl", format!("failed to write output: {err}")))?;
+            continue;
+        }
+        if line == ":check" {
+            writeln!(output, "ok: {} line(s)", program.lines().count())
+                .map_err(|err| Diagnostic::new("repl", format!("failed to write output: {err}")))?;
+            continue;
+        }
+        program.push_str(line);
+        program.push('\n');
+        writeln!(output, "accepted: {}", line)
+            .map_err(|err| Diagnostic::new("repl", format!("failed to write output: {err}")))?;
+    }
+    Ok(())
+}
+
+fn axiom_files(path: &Path) -> Result<Vec<PathBuf>, Diagnostic> {
+    if path.is_file() {
+        return if path.extension().is_some_and(|ext| ext == "ax") {
+            Ok(vec![path.to_path_buf()])
+        } else {
+            Err(Diagnostic::new(
+                "source",
+                format!("{} is not an .ax source file", path.display()),
+            ))
+        };
+    }
+    discover_named_files(path, ".ax")
+}
+
+fn discover_named_files(path: &Path, suffix: &str) -> Result<Vec<PathBuf>, Diagnostic> {
+    let mut files = Vec::new();
+    discover_named_files_into(path, suffix, &mut files)?;
+    files.sort();
+    Ok(files)
+}
+
+fn discover_named_files_into(
+    path: &Path,
+    suffix: &str,
+    files: &mut Vec<PathBuf>,
+) -> Result<(), Diagnostic> {
+    for entry in fs::read_dir(path).map_err(|err| {
+        Diagnostic::new(
+            "source",
+            format!("failed to read {}: {err}", path.display()),
+        )
+        .with_path(path.display().to_string())
+    })? {
+        let entry = entry.map_err(|err| {
+            Diagnostic::new(
+                "source",
+                format!("failed to read {}: {err}", path.display()),
+            )
+        })?;
+        let path = entry.path();
+        let file_type = entry.file_type().map_err(|err| {
+            Diagnostic::new(
+                "source",
+                format!("failed to inspect {}: {err}", path.display()),
+            )
+        })?;
+        if file_type.is_dir() {
+            let name = entry.file_name();
+            if name == "target" || name == "dist" || name == ".git" {
+                continue;
+            }
+            discover_named_files_into(&path, suffix, files)?;
+        } else if file_type.is_file()
+            && path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.ends_with(suffix))
+        {
+            files.push(path);
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -246,6 +705,10 @@ mod tests {
         assert!(help.contains("Build and run a stage1 package native binary"));
         assert!(help.contains("Discover, build, and run package test entrypoints"));
         assert!(help.contains("Inspect manifest capability requirements"));
+        assert!(help.contains("Format .ax source files"));
+        assert!(help.contains("Generate Markdown and HTML API docs"));
+        assert!(help.contains("Run discovered *_bench.ax entrypoints"));
+        assert!(help.contains("Start a small stage1 scratch REPL"));
     }
 
     fn build_output(debug_map: Option<String>) -> BuildOutput {
@@ -268,10 +731,9 @@ mod tests {
     #[test]
     fn build_summary_mentions_debug_map_when_available() {
         assert_eq!(
-            build_summary_lines(
-                &build_output(Some(String::from("target/main.debug-map.json"))),
-                false,
-            ),
+            build_summary_lines(&build_output(Some(String::from(
+                "target/main.debug-map.json"
+            )))),
             vec![
                 String::from("wrote dist/app"),
                 String::from("wrote debug map target/main.debug-map.json"),
@@ -282,38 +744,46 @@ mod tests {
     #[test]
     fn build_summary_omits_debug_map_for_release_builds() {
         assert_eq!(
-            build_summary_lines(&build_output(None), false),
+            build_summary_lines(&build_output(None)),
             vec![String::from("wrote dist/app")]
         );
     }
 
     #[test]
-    fn build_summary_includes_timings_when_requested() {
-        let mut output = build_output(None);
-        output.cache_hits = 2;
-        output.cache_misses = 1;
-        output.duration_ms = 42;
-        output.packages = vec![axiomc::project::BuiltPackage {
-            package_root: String::from("/tmp/app"),
-            manifest: String::from("/tmp/app/axiom.toml"),
-            entry: String::from("/tmp/app/src/main.ax"),
-            binary: String::from("/tmp/app/dist/app"),
-            generated_rust: String::from("/tmp/app/dist/app.generated.rs"),
-            debug_map: None,
-            statement_count: 1,
-            target: None,
-            debug: false,
-            cache_status: axiomc::project::BuildCacheStatus::Hit,
-            compile_ms: 0,
-        }];
-
+    fn formatter_trims_whitespace_and_collapses_blank_runs() {
         assert_eq!(
-            build_summary_lines(&output, true),
-            vec![
-                String::from("wrote dist/app"),
-                String::from("timings total=42ms cache_hits=2 cache_misses=1"),
-                String::from("timings package=/tmp/app cache_status=Hit compile=0ms"),
-            ]
+            format_axiom_source("fn main() {   \n\tprint \"hi\"  \n\n\n}\n\n"),
+            "fn main() {\n    print \"hi\"\n\n}\n"
         );
+    }
+
+    #[test]
+    fn doc_extractor_pairs_doc_comments_with_signatures() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let source = dir.path().join("src/main.ax");
+        fs::create_dir_all(source.parent().expect("source parent")).expect("mkdir");
+        fs::write(
+            &source,
+            "/// Adds one.\npub fn inc(value: int): int {\nreturn value + 1\n}\n",
+        )
+        .expect("write source");
+
+        let items = extract_doc_items(&[source]).expect("extract docs");
+
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].signature, "pub fn inc(value: int): int {");
+        assert_eq!(items[0].docs, vec![String::from("Adds one.")]);
+    }
+
+    #[test]
+    fn repl_accepts_lines_and_check_command() {
+        let input = b"let answer: int = 42\n:check\n:quit\n";
+        let mut output = Vec::new();
+
+        run_repl(&input[..], &mut output, false).expect("run repl");
+
+        let output = String::from_utf8(output).expect("utf8 output");
+        assert!(output.contains("accepted: let answer: int = 42"));
+        assert!(output.contains("ok: 1 line(s)"));
     }
 }

--- a/stage1/crates/axiomc/src/main.rs
+++ b/stage1/crates/axiomc/src/main.rs
@@ -731,9 +731,10 @@ mod tests {
     #[test]
     fn build_summary_mentions_debug_map_when_available() {
         assert_eq!(
-            build_summary_lines(&build_output(Some(String::from(
-                "target/main.debug-map.json"
-            )))),
+            build_summary_lines(
+                &build_output(Some(String::from("target/main.debug-map.json"))),
+                false,
+            ),
             vec![
                 String::from("wrote dist/app"),
                 String::from("wrote debug map target/main.debug-map.json"),
@@ -744,7 +745,7 @@ mod tests {
     #[test]
     fn build_summary_omits_debug_map_for_release_builds() {
         assert_eq!(
-            build_summary_lines(&build_output(None)),
+            build_summary_lines(&build_output(None), false),
             vec![String::from("wrote dist/app")]
         );
     }

--- a/stage1/crates/axiomc/src/main.rs
+++ b/stage1/crates/axiomc/src/main.rs
@@ -6,6 +6,7 @@ use axiomc::project::{
     check_project_with_options, project_capabilities, run_project_tests_with_options,
     run_project_with_options,
 };
+use axiomc::syntax::parse_program;
 use clap::{Parser, Subcommand};
 use serde::Serialize;
 use std::fs;
@@ -615,8 +616,14 @@ fn run_repl<R: BufRead, W: Write>(
             continue;
         }
         if line == ":check" {
-            writeln!(output, "ok: {} line(s)", program.lines().count())
-                .map_err(|err| Diagnostic::new("repl", format!("failed to write output: {err}")))?;
+            match validate_repl_program(&program) {
+                Ok(items) => writeln!(output, "ok: {items} item(s)").map_err(|err| {
+                    Diagnostic::new("repl", format!("failed to write output: {err}"))
+                })?,
+                Err(error) => writeln!(output, "error: {error}").map_err(|err| {
+                    Diagnostic::new("repl", format!("failed to write output: {err}"))
+                })?,
+            }
             continue;
         }
         program.push_str(line);
@@ -625,6 +632,17 @@ fn run_repl<R: BufRead, W: Write>(
             .map_err(|err| Diagnostic::new("repl", format!("failed to write output: {err}")))?;
     }
     Ok(())
+}
+
+fn validate_repl_program(source: &str) -> Result<usize, Diagnostic> {
+    let program = parse_program(source, Path::new("<repl>"))?;
+    Ok(program.imports.len()
+        + program.consts.len()
+        + program.type_aliases.len()
+        + program.structs.len()
+        + program.enums.len()
+        + program.functions.len()
+        + program.stmts.len())
 }
 
 fn axiom_files(path: &Path) -> Result<Vec<PathBuf>, Diagnostic> {
@@ -785,6 +803,19 @@ mod tests {
 
         let output = String::from_utf8(output).expect("utf8 output");
         assert!(output.contains("accepted: let answer: int = 42"));
-        assert!(output.contains("ok: 1 line(s)"));
+        assert!(output.contains("ok: 1 item(s)"));
+    }
+
+    #[test]
+    fn repl_check_reports_parse_errors() {
+        let input = b"let answer: = 42\n:check\n:quit\n";
+        let mut output = Vec::new();
+
+        run_repl(&input[..], &mut output, false).expect("run repl");
+
+        let output = String::from_utf8(output).expect("utf8 output");
+        assert!(output.contains("accepted: let answer: = 42"));
+        assert!(output.contains("error:"));
+        assert!(!output.contains("ok:"));
     }
 }

--- a/stage1/examples/benchmarks/axiom.lock
+++ b/stage1/examples/benchmarks/axiom.lock
@@ -1,0 +1,6 @@
+version = 1
+
+[[package]]
+name = "benchmarks"
+version = "0.1.0"
+source = "path"

--- a/stage1/examples/benchmarks/axiom.toml
+++ b/stage1/examples/benchmarks/axiom.toml
@@ -1,0 +1,7 @@
+[package]
+name = "benchmarks"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"

--- a/stage1/examples/benchmarks/src/fibonacci_bench.ax
+++ b/stage1/examples/benchmarks/src/fibonacci_bench.ax
@@ -1,0 +1,14 @@
+/// Benchmark fixture for repeated arithmetic and loops.
+fn fib(limit: int): int {
+    let left: int = 1
+    let right: int = 1
+    let index: int = 0
+    while index < limit {
+        print left + right
+        return left + right
+    }
+    return right
+}
+
+let value: int = fib(8)
+print value

--- a/stage1/examples/benchmarks/src/main.ax
+++ b/stage1/examples/benchmarks/src/main.ax
@@ -1,0 +1,1 @@
+print "benchmarks"


### PR DESCRIPTION
## Summary

- Add bootstrap-grade `axiomc fmt`, `axiomc doc`, `axiomc bench`, and `axiomc repl` command surfaces.
- Add a checked-in benchmark fixture package and wire fmt/doc/bench into `stage1-smoke`.
- Add the first Axiom Book plus related contributor/docs updates that support the new workflow.

## Governing Issue

Closes #261.

This PR also lays groundwork toward #242, #243, #244, and #247, but it should not claim to close those issues yet at the current scope.

It does not close #262; that issue is already closed.

## Validation

- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc --bin axiomc`
- [x] `cargo run --manifest-path stage1/Cargo.toml -p axiomc -- fmt stage1/examples/hello --check`
- [x] `cargo run --manifest-path stage1/Cargo.toml -p axiomc -- doc stage1/examples/hello --out-dir .axiom-build/docs/hello`
- [x] `cargo run --manifest-path stage1/Cargo.toml -p axiomc -- bench stage1/examples/benchmarks --json`
- [x] `make stage1-test`
- [x] `make stage1-conformance`
- [x] `make stage1-smoke`
- [x] `bash scripts/check-detect-secrets.sh --all-files`
- [x] `git diff --check`

## Bootstrap Governance

- [x] Changes are scoped to a concrete ecosystem/tooling increment without over-claiming closure.
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable.
- [x] No real secrets, runtime auth, or machine-local env files are committed.

## Notes

- This intentionally does not close #242, #243, #244, or #247 yet; those need follow-through beyond the bootstrap-grade command surfaces added here.
- This intentionally does not close #257, #107, or the larger language/runtime roadmap items.
- The benchmark harness is now available, but Go/Rust reference comparison gates remain follow-on policy work.
