### PR TITLE
Expose build cache timings

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ cargo run --manifest-path stage1/Cargo.toml -p axiomc -- check stage1/examples/h
 # Build a native binary
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build stage1/examples/hello --json
 
+# Inspect build cache and compile timing
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build stage1/examples/hello --timings
+
 # Run a package
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- run stage1/examples/hello
 

--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -26,6 +26,7 @@ carry the 1.0 package model.
 ```bash
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- check stage1/examples/hello --json
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build stage1/examples/hello --json
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build stage1/examples/hello --timings
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build stage1/examples/hello --debug
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build stage1/examples/hello --target "$(rustc -vV | sed -n 's/^host: //p')"
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- run stage1/examples/hello
@@ -65,7 +66,9 @@ requested Rust target triple when `--target <triple>` is used and report
 `debug: true` when `axiomc build --debug` requests an unoptimized debuginfo build
 with generated source-position markers. Debug builds also report `debug_map`,
 a JSON sidecar that maps generated Rust statement lines back to Axiom
-file/line/column positions.
+file/line/column positions. `axiomc build --timings` prints total build time,
+cache hit/miss counts, and per-package compile timing/cache status for the
+incremental generated-Rust cache.
 
 ## Current gaps
 
@@ -103,6 +106,11 @@ still far from the stated 1.0 target for service and agent workloads.
 ### Backend and tooling gaps
 
 - Native builds still work by generating Rust and invoking `rustc`; there is no Cranelift backend yet.
+- Generated-Rust builds now use a persistent per-artifact cache keyed by
+  compiler version, target, debug mode, manifest/lockfile hash, rendered Rust,
+  module source hashes, and dependency imports. Cache hits skip `rustc`, cache
+  misses repair stale generated Rust or binary artifacts, and `--timings`
+  exposes the hit/miss counts plus per-package compile time.
 - `axiomc build --debug` now asks `rustc` for debuginfo, disables optimization,
   emits generated Rust source markers, and writes a JSON source-map sidecar for
   Axiom file/line/column positions; full Axiom-native debugger stepping remains

--- a/stage1/crates/axiomc/src/main.rs
+++ b/stage1/crates/axiomc/src/main.rs
@@ -40,6 +40,8 @@ enum Command {
         #[arg(long)]
         debug: bool,
         #[arg(long)]
+        timings: bool,
+        #[arg(long)]
         target: Option<String>,
         #[arg(short = 'p', long = "package")]
         package: Option<String>,
@@ -105,6 +107,7 @@ fn main() {
             path,
             json,
             debug,
+            timings,
             target,
             package,
         } => {
@@ -120,7 +123,7 @@ fn main() {
                     if json {
                         println!("{}", json_contract::build_success(&path, &output));
                     } else {
-                        for line in build_summary_lines(&output) {
+                        for line in build_summary_lines(&output, timings) {
                             eprintln!("{line}");
                         }
                     }
@@ -200,10 +203,22 @@ fn main() {
     std::process::exit(code);
 }
 
-fn build_summary_lines(output: &BuildOutput) -> Vec<String> {
+fn build_summary_lines(output: &BuildOutput, timings: bool) -> Vec<String> {
     let mut lines = vec![format!("wrote {}", output.binary)];
     if let Some(debug_map) = &output.debug_map {
         lines.push(format!("wrote debug map {debug_map}"));
+    }
+    if timings {
+        lines.push(format!(
+            "timings total={}ms cache_hits={} cache_misses={}",
+            output.duration_ms, output.cache_hits, output.cache_misses
+        ));
+        for package in &output.packages {
+            lines.push(format!(
+                "timings package={} cache_status={:?} compile={}ms",
+                package.package_root, package.cache_status, package.compile_ms
+            ));
+        }
     }
     lines
 }
@@ -253,9 +268,10 @@ mod tests {
     #[test]
     fn build_summary_mentions_debug_map_when_available() {
         assert_eq!(
-            build_summary_lines(&build_output(Some(String::from(
-                "target/main.debug-map.json"
-            )))),
+            build_summary_lines(
+                &build_output(Some(String::from("target/main.debug-map.json"))),
+                false,
+            ),
             vec![
                 String::from("wrote dist/app"),
                 String::from("wrote debug map target/main.debug-map.json"),
@@ -266,8 +282,38 @@ mod tests {
     #[test]
     fn build_summary_omits_debug_map_for_release_builds() {
         assert_eq!(
-            build_summary_lines(&build_output(None)),
+            build_summary_lines(&build_output(None), false),
             vec![String::from("wrote dist/app")]
+        );
+    }
+
+    #[test]
+    fn build_summary_includes_timings_when_requested() {
+        let mut output = build_output(None);
+        output.cache_hits = 2;
+        output.cache_misses = 1;
+        output.duration_ms = 42;
+        output.packages = vec![axiomc::project::BuiltPackage {
+            package_root: String::from("/tmp/app"),
+            manifest: String::from("/tmp/app/axiom.toml"),
+            entry: String::from("/tmp/app/src/main.ax"),
+            binary: String::from("/tmp/app/dist/app"),
+            generated_rust: String::from("/tmp/app/dist/app.generated.rs"),
+            debug_map: None,
+            statement_count: 1,
+            target: None,
+            debug: false,
+            cache_status: axiomc::project::BuildCacheStatus::Hit,
+            compile_ms: 0,
+        }];
+
+        assert_eq!(
+            build_summary_lines(&output, true),
+            vec![
+                String::from("wrote dist/app"),
+                String::from("timings total=42ms cache_hits=2 cache_misses=1"),
+                String::from("timings package=/tmp/app cache_status=Hit compile=0ms"),
+            ]
         );
     }
 }


### PR DESCRIPTION
## Summary

- Add `axiomc build --timings` to print total build duration, cache hit/miss counts, and per-package cache status/compile time.
- Keep existing JSON output unchanged while documenting that JSON already carries cache metrics.
- Document the generated-Rust cache key inputs and the new timing command in README/stage1 docs.

## Governing Issue

Closes #229.

## Validation

- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc --bin axiomc`
- [x] `rm -rf stage1/examples/hello/dist && cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build stage1/examples/hello --timings && cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build stage1/examples/hello --timings`
- [x] `make stage1-test`
- [x] `bash scripts/check-detect-secrets.sh --all-files`
- [x] `git diff --check`

## Bootstrap Governance

- [x] Changes are scoped to issue #229.
- [x] Contributor or PR guidance changes are reflected in docs when applicable.
- [x] No real secrets, runtime auth, or machine-local env files are committed.

## Notes

- The branch verifies a miss then hit locally: first build reports `cache_hits=0 cache_misses=1`; second build reports `cache_hits=1 cache_misses=0`.
