### PR TITLE
fix: address issue #107

### DIFF
--- a/.github/workflows/extended-validation.yml
+++ b/.github/workflows/extended-validation.yml
@@ -95,6 +95,22 @@ jobs:
       - name: Scan repository for secret patterns
         run: bash scripts/check-detect-secrets.sh --all-files
 
+  performance-benchmarks:
+    name: Performance Benchmarks
+    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
+    timeout-minutes: 20
+    needs: changes
+    if: needs.changes.outputs.app == 'true' || needs.changes.outputs.ci == 'true'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4 pinned 2026-04-19
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable pinned 2026-04-19
+      - name: Set up Go
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6 pinned 2026-04-19
+        with:
+          go-version: '1.24.2'
+      - name: Run stage1 benchmark gate
+        run: make stage1-bench-gate
+
   extended-validation-gate:
     name: Extended Validation Gate
     runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
@@ -103,6 +119,7 @@ jobs:
       - changes
       - fast-checks
       - validate-secrets
+      - performance-benchmarks
     steps:
       - name: Check extended validation jobs
         env:
@@ -110,6 +127,7 @@ jobs:
             changes=${{ needs.changes.result }}
             fast-checks=${{ needs.fast-checks.result }}
             validate-secrets=${{ needs.validate-secrets.result }}
+            performance-benchmarks=${{ needs.performance-benchmarks.result }}
         run: |
           failed=0
           for entry in $RESULTS; do

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test smoke docs-python-exit docs-python-exit-test stage1-test stage1-conformance stage1-smoke stage1-run
+.PHONY: test smoke docs-python-exit docs-python-exit-test stage1-test stage1-conformance stage1-smoke stage1-bench-gate stage1-run
 
 test: docs-python-exit stage1-test
 
@@ -16,6 +16,9 @@ stage1-test:
 
 stage1-conformance:
 	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/conformance --json
+
+stage1-bench-gate:
+	python3 scripts/ci/check-stage1-benchmarks.py
 
 stage1-smoke:
 	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- check stage1/examples/hello --json

--- a/docs/stage1-agent-grade-compiler.md
+++ b/docs/stage1-agent-grade-compiler.md
@@ -364,4 +364,4 @@ After AG5 closes, the next compiler track is:
 
 - replace generated-Rust codegen with a direct native backend
 - add `fmt`, `bench`, `doc`, `publish`, and LSP
-- add benchmark gates against simple Go and Rust references
+- keep benchmark gates against simple Go and Rust references green

--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -115,9 +115,9 @@ still far from the stated 1.0 target for service and agent workloads.
   emits generated Rust source markers, and writes a JSON source-map sidecar for
   Axiom file/line/column positions; full Axiom-native debugger stepping remains
   a direct-backend follow-on.
-- There is no stage1 formatter, benchmark harness, doc generator, publisher, or LSP server yet.
+- There is no stage1 formatter, full benchmark harness, doc generator, publisher, or LSP server yet.
 - Diagnostics are still intentionally minimal: useful JSON now includes stable ownership codes, but span quality and note richness are still limited.
-- There are no performance targets or regression gates yet.
+- Extended validation now carries a small performance regression gate: stage1 `axiomc build` for `stage1/examples/hello` is benchmarked against checked-in Go and Rust reference builds, with separate cold-build and warm-cache budget multipliers to catch obvious compiler-path regressions without making PR fast CI noisy.
 
 ## Execution plan
 

--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -117,7 +117,7 @@ still far from the stated 1.0 target for service and agent workloads.
   a direct-backend follow-on.
 - There is no stage1 formatter, full benchmark harness, doc generator, publisher, or LSP server yet.
 - Diagnostics are still intentionally minimal: useful JSON now includes stable ownership codes, but span quality and note richness are still limited.
-- Extended validation now carries a small performance regression gate: stage1 `axiomc build` for `stage1/examples/hello` is benchmarked against checked-in Go and Rust reference builds, with separate cold-build and warm-cache budget multipliers to catch obvious compiler-path regressions without making PR fast CI noisy.
+- Extended validation now carries a small performance regression gate: stage1 `axiomc build` is benchmarked across representative compute (`hello`), I/O/capability (`capabilities`), and concurrency (`stdlib_async`) workloads against checked-in Go and Rust reference builds, with separate cold-build and warm-cache budget multipliers to catch obvious compiler-path regressions without making PR fast CI noisy.
 
 ## Execution plan
 

--- a/scripts/ci/check-stage1-benchmarks.py
+++ b/scripts/ci/check-stage1-benchmarks.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import tempfile
 import time
+from dataclasses import dataclass
 from pathlib import Path
 
 ROUNDS = 5
@@ -17,10 +18,24 @@ COLD_BUILD_LIMIT_MULTIPLIER = 4.0
 WARM_BUILD_LIMIT_MULTIPLIER = 2.0
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-HELLO_PROJECT = REPO_ROOT / "stage1/examples/hello"
 AXIOMC_MANIFEST = REPO_ROOT / "stage1/Cargo.toml"
 AXIOMC_BIN = REPO_ROOT / "stage1/target/debug/axiomc"
-REF_DIR = REPO_ROOT / "stage1/benchmarks/reference/hello"
+REF_ROOT = REPO_ROOT / "stage1/benchmarks/reference"
+
+
+@dataclass(frozen=True)
+class Workload:
+    name: str
+    kind: str
+    project: Path
+    reference: Path
+
+
+WORKLOADS = [
+    Workload("hello", "compute", REPO_ROOT / "stage1/examples/hello", REF_ROOT / "hello"),
+    Workload("capabilities", "io", REPO_ROOT / "stage1/examples/capabilities", REF_ROOT / "capabilities"),
+    Workload("stdlib_async", "concurrency", REPO_ROOT / "stage1/examples/stdlib_async", REF_ROOT / "stdlib_async"),
+]
 
 
 def run(cmd: list[str], *, cwd: Path | None = None) -> float:
@@ -66,25 +81,22 @@ def build_axiomc() -> None:
     )
 
 
-def axiom_cold_build() -> float:
-    shutil.rmtree(HELLO_PROJECT / "dist", ignore_errors=True)
-    return run([str(AXIOMC_BIN), "build", str(HELLO_PROJECT), "--json"], cwd=REPO_ROOT)
+def axiom_build(workload: Workload, *, cold: bool) -> float:
+    if cold:
+        shutil.rmtree(workload.project / "dist", ignore_errors=True)
+    return run([str(AXIOMC_BIN), "build", str(workload.project), "--json"], cwd=REPO_ROOT)
 
 
-def axiom_warm_build() -> float:
-    return run([str(AXIOMC_BIN), "build", str(HELLO_PROJECT), "--json"], cwd=REPO_ROOT)
-
-
-def go_build(temp_dir: Path) -> float:
-    output = temp_dir / "hello-go"
+def go_build(workload: Workload, temp_dir: Path) -> float:
+    output = temp_dir / f"{workload.name}-go"
     output.unlink(missing_ok=True)
-    return run(["go", "build", "-o", str(output), str(REF_DIR / "main.go")], cwd=temp_dir)
+    return run(["go", "build", "-o", str(output), str(workload.reference / "main.go")], cwd=temp_dir)
 
 
-def rust_build(temp_dir: Path) -> float:
-    output = temp_dir / "hello-rust"
+def rust_build(workload: Workload, temp_dir: Path) -> float:
+    output = temp_dir / f"{workload.name}-rust"
     output.unlink(missing_ok=True)
-    return run(["rustc", str(REF_DIR / "main.rs"), "-O", "-o", str(output)], cwd=temp_dir)
+    return run(["rustc", str(workload.reference / "main.rs"), "-O", "-o", str(output)], cwd=temp_dir)
 
 
 def check_limit(label: str, actual_ms: float, limit_ms: float) -> None:
@@ -94,35 +106,25 @@ def check_limit(label: str, actual_ms: float, limit_ms: float) -> None:
         raise SystemExit(1)
 
 
-def main() -> int:
-    os.chdir(REPO_ROOT)
-    ensure_tools()
-    build_axiomc()
+def benchmark_workload(workload: Workload, temp_dir: Path) -> dict:
+    print(f"warming benchmark commands for {workload.name} ({workload.kind})...")
+    axiom_build(workload, cold=True)
+    axiom_build(workload, cold=False)
+    go_build(workload, temp_dir)
+    rust_build(workload, temp_dir)
 
-    with tempfile.TemporaryDirectory(prefix="axiom-stage1-bench-") as temp_name:
-        temp_dir = Path(temp_name)
-
-        print("warming benchmark commands...")
-        axiom_cold_build()
-        axiom_warm_build()
-        go_build(temp_dir)
-        rust_build(temp_dir)
-
-        print("collecting benchmark medians...")
-        axiom_cold_samples, axiom_cold_median = collect_samples(axiom_cold_build)
-        axiom_warm_samples, axiom_warm_median = collect_samples(axiom_warm_build)
-        go_samples, go_median = collect_samples(lambda: go_build(temp_dir))
-        rust_samples, rust_median = collect_samples(lambda: rust_build(temp_dir))
+    print(f"collecting benchmark medians for {workload.name}...")
+    axiom_cold_samples, axiom_cold_median = collect_samples(lambda: axiom_build(workload, cold=True))
+    axiom_warm_samples, axiom_warm_median = collect_samples(lambda: axiom_build(workload, cold=False))
+    go_samples, go_median = collect_samples(lambda: go_build(workload, temp_dir))
+    rust_samples, rust_median = collect_samples(lambda: rust_build(workload, temp_dir))
 
     reference_floor = max(min(go_median, rust_median), BASELINE_FLOOR_MS)
     cold_limit = reference_floor * COLD_BUILD_LIMIT_MULTIPLIER
     warm_limit = reference_floor * WARM_BUILD_LIMIT_MULTIPLIER
 
-    report = {
-        "rounds": ROUNDS,
-        "baseline_floor_ms": BASELINE_FLOOR_MS,
-        "cold_build_limit_multiplier": COLD_BUILD_LIMIT_MULTIPLIER,
-        "warm_build_limit_multiplier": WARM_BUILD_LIMIT_MULTIPLIER,
+    result = {
+        "kind": workload.kind,
         "samples_ms": {
             "axiom_cold_build": axiom_cold_samples,
             "axiom_warm_build": axiom_warm_samples,
@@ -142,9 +144,29 @@ def main() -> int:
         },
     }
 
+    check_limit(f"{workload.name} axiom cold build", axiom_cold_median, cold_limit)
+    check_limit(f"{workload.name} axiom warm build", axiom_warm_median, warm_limit)
+    return result
+
+
+def main() -> int:
+    os.chdir(REPO_ROOT)
+    ensure_tools()
+    build_axiomc()
+
+    with tempfile.TemporaryDirectory(prefix="axiom-stage1-bench-") as temp_name:
+        temp_dir = Path(temp_name)
+        workloads = {workload.name: benchmark_workload(workload, temp_dir) for workload in WORKLOADS}
+
+    report = {
+        "rounds": ROUNDS,
+        "baseline_floor_ms": BASELINE_FLOOR_MS,
+        "cold_build_limit_multiplier": COLD_BUILD_LIMIT_MULTIPLIER,
+        "warm_build_limit_multiplier": WARM_BUILD_LIMIT_MULTIPLIER,
+        "workloads": workloads,
+    }
+
     print(json.dumps(report, indent=2))
-    check_limit("axiom cold build", axiom_cold_median, cold_limit)
-    check_limit("axiom warm build", axiom_warm_median, warm_limit)
     return 0
 
 

--- a/scripts/ci/check-stage1-benchmarks.py
+++ b/scripts/ci/check-stage1-benchmarks.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+ROUNDS = 5
+BASELINE_FLOOR_MS = 50.0
+COLD_BUILD_LIMIT_MULTIPLIER = 4.0
+WARM_BUILD_LIMIT_MULTIPLIER = 2.0
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HELLO_PROJECT = REPO_ROOT / "stage1/examples/hello"
+AXIOMC_MANIFEST = REPO_ROOT / "stage1/Cargo.toml"
+AXIOMC_BIN = REPO_ROOT / "stage1/target/debug/axiomc"
+REF_DIR = REPO_ROOT / "stage1/benchmarks/reference/hello"
+
+
+def run(cmd: list[str], *, cwd: Path | None = None) -> float:
+    started = time.perf_counter()
+    completed = subprocess.run(
+        cmd,
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    elapsed_ms = (time.perf_counter() - started) * 1000.0
+    if completed.returncode != 0:
+        if completed.stdout:
+            sys.stdout.write(completed.stdout)
+        if completed.stderr:
+            sys.stderr.write(completed.stderr)
+        raise SystemExit(completed.returncode)
+    return elapsed_ms
+
+
+def median_ms(samples: list[float]) -> float:
+    return float(statistics.median(samples))
+
+
+def collect_samples(fn, rounds: int = ROUNDS) -> tuple[list[float], float]:
+    samples = [fn() for _ in range(rounds)]
+    return samples, median_ms(samples)
+
+
+def ensure_tools() -> None:
+    required = ["cargo", "rustc", "go"]
+    missing = [tool for tool in required if shutil.which(tool) is None]
+    if missing:
+        raise SystemExit(f"missing required benchmark tools: {', '.join(missing)}")
+
+
+def build_axiomc() -> None:
+    subprocess.run(
+        ["cargo", "build", "--manifest-path", str(AXIOMC_MANIFEST), "-p", "axiomc"],
+        cwd=REPO_ROOT,
+        check=True,
+    )
+
+
+def axiom_cold_build() -> float:
+    shutil.rmtree(HELLO_PROJECT / "dist", ignore_errors=True)
+    return run([str(AXIOMC_BIN), "build", str(HELLO_PROJECT), "--json"], cwd=REPO_ROOT)
+
+
+def axiom_warm_build() -> float:
+    return run([str(AXIOMC_BIN), "build", str(HELLO_PROJECT), "--json"], cwd=REPO_ROOT)
+
+
+def go_build(temp_dir: Path) -> float:
+    output = temp_dir / "hello-go"
+    output.unlink(missing_ok=True)
+    return run(["go", "build", "-o", str(output), str(REF_DIR / "main.go")], cwd=temp_dir)
+
+
+def rust_build(temp_dir: Path) -> float:
+    output = temp_dir / "hello-rust"
+    output.unlink(missing_ok=True)
+    return run(["rustc", str(REF_DIR / "main.rs"), "-O", "-o", str(output)], cwd=temp_dir)
+
+
+def check_limit(label: str, actual_ms: float, limit_ms: float) -> None:
+    status = "PASS" if actual_ms <= limit_ms else "FAIL"
+    print(f"{status} {label}: {actual_ms:.1f} ms <= {limit_ms:.1f} ms")
+    if actual_ms > limit_ms:
+        raise SystemExit(1)
+
+
+def main() -> int:
+    os.chdir(REPO_ROOT)
+    ensure_tools()
+    build_axiomc()
+
+    with tempfile.TemporaryDirectory(prefix="axiom-stage1-bench-") as temp_name:
+        temp_dir = Path(temp_name)
+
+        print("warming benchmark commands...")
+        axiom_cold_build()
+        axiom_warm_build()
+        go_build(temp_dir)
+        rust_build(temp_dir)
+
+        print("collecting benchmark medians...")
+        axiom_cold_samples, axiom_cold_median = collect_samples(axiom_cold_build)
+        axiom_warm_samples, axiom_warm_median = collect_samples(axiom_warm_build)
+        go_samples, go_median = collect_samples(lambda: go_build(temp_dir))
+        rust_samples, rust_median = collect_samples(lambda: rust_build(temp_dir))
+
+    reference_floor = max(min(go_median, rust_median), BASELINE_FLOOR_MS)
+    cold_limit = reference_floor * COLD_BUILD_LIMIT_MULTIPLIER
+    warm_limit = reference_floor * WARM_BUILD_LIMIT_MULTIPLIER
+
+    report = {
+        "rounds": ROUNDS,
+        "baseline_floor_ms": BASELINE_FLOOR_MS,
+        "cold_build_limit_multiplier": COLD_BUILD_LIMIT_MULTIPLIER,
+        "warm_build_limit_multiplier": WARM_BUILD_LIMIT_MULTIPLIER,
+        "samples_ms": {
+            "axiom_cold_build": axiom_cold_samples,
+            "axiom_warm_build": axiom_warm_samples,
+            "go_build": go_samples,
+            "rust_build": rust_samples,
+        },
+        "medians_ms": {
+            "axiom_cold_build": axiom_cold_median,
+            "axiom_warm_build": axiom_warm_median,
+            "go_build": go_median,
+            "rust_build": rust_median,
+        },
+        "reference_floor_ms": reference_floor,
+        "limits_ms": {
+            "axiom_cold_build": cold_limit,
+            "axiom_warm_build": warm_limit,
+        },
+    }
+
+    print(json.dumps(report, indent=2))
+    check_limit("axiom cold build", axiom_cold_median, cold_limit)
+    check_limit("axiom warm build", axiom_warm_median, warm_limit)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/stage1/benchmarks/reference/capabilities/README.md
+++ b/stage1/benchmarks/reference/capabilities/README.md
@@ -1,0 +1,6 @@
+# Stage1 benchmark reference: capabilities
+
+This I/O-oriented reference workload mirrors `stage1/examples/capabilities` closely
+enough for the stage1 build regression gate. It exercises filesystem reads,
+environment lookup, time, hashing-shaped work, and localhost resolution in the
+native Go and Rust baselines.

--- a/stage1/benchmarks/reference/capabilities/main.go
+++ b/stage1/benchmarks/reference/capabilities/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"net"
+	"os"
+	"time"
+)
+
+func main() {
+	if value, err := os.ReadFile("stage1/examples/capabilities/src/fixture.txt"); err == nil {
+		fmt.Println(string(value))
+	} else {
+		fmt.Println("missing")
+	}
+
+	if _, err := net.LookupHost("localhost"); err == nil {
+		fmt.Println(true)
+	} else {
+		fmt.Println(false)
+	}
+
+	fmt.Printf("%x\n", sha256.Sum256([]byte("abc")))
+	fmt.Println(time.Now().UnixMilli() > 0)
+
+	if value, ok := os.LookupEnv("__AXIOM_STAGE1_MISSING__"); ok {
+		fmt.Println(value)
+	} else {
+		fmt.Println("none")
+	}
+}

--- a/stage1/benchmarks/reference/capabilities/main.rs
+++ b/stage1/benchmarks/reference/capabilities/main.rs
@@ -1,0 +1,29 @@
+use std::collections::hash_map::DefaultHasher;
+use std::env;
+use std::fs;
+use std::hash::{Hash, Hasher};
+use std::net::ToSocketAddrs;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn pseudo_sha_shape(input: &str) -> String {
+    let mut hasher = DefaultHasher::new();
+    input.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+fn main() {
+    match fs::read_to_string("stage1/examples/capabilities/src/fixture.txt") {
+        Ok(value) => println!("{}", value),
+        Err(_) => println!("missing"),
+    }
+
+    println!("{}", "localhost:0".to_socket_addrs().is_ok());
+    println!("{}", pseudo_sha_shape("abc"));
+    let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis();
+    println!("{}", now > 0);
+
+    match env::var("__AXIOM_STAGE1_MISSING__") {
+        Ok(value) => println!("{}", value),
+        Err(_) => println!("none"),
+    }
+}

--- a/stage1/benchmarks/reference/hello/README.md
+++ b/stage1/benchmarks/reference/hello/README.md
@@ -1,0 +1,6 @@
+# Stage1 benchmark reference: hello
+
+This directory holds the simple Go and Rust reference builds used by the
+stage1 performance regression gate. They intentionally mirror the semantics of
+`stage1/examples/hello` so the benchmark compares the current Axiom stage1
+build path against small native-language baselines.

--- a/stage1/benchmarks/reference/hello/main.go
+++ b/stage1/benchmarks/reference/hello/main.go
@@ -1,0 +1,19 @@
+package main
+
+import "fmt"
+
+func banner(name string) string { return "hello " + name }
+func lucky(base int) int        { return base + 2 }
+func isReady(value int) bool    { return value == 42 }
+
+func main() {
+	answer := lucky(40)
+	ready := isReady(answer)
+	if ready {
+		fmt.Println(banner("from stage1"))
+	} else {
+		fmt.Println("stage1 failed")
+	}
+	fmt.Println(answer)
+	fmt.Println(ready)
+}

--- a/stage1/benchmarks/reference/hello/main.rs
+++ b/stage1/benchmarks/reference/hello/main.rs
@@ -1,0 +1,23 @@
+fn banner(name: &str) -> String {
+    format!("hello {}", name)
+}
+
+fn lucky(base: i32) -> i32 {
+    base + 2
+}
+
+fn is_ready(value: i32) -> bool {
+    value == 42
+}
+
+fn main() {
+    let answer = lucky(40);
+    let ready = is_ready(answer);
+    if ready {
+        println!("{}", banner("from stage1"));
+    } else {
+        println!("stage1 failed");
+    }
+    println!("{}", answer);
+    println!("{}", ready);
+}

--- a/stage1/benchmarks/reference/stdlib_async/README.md
+++ b/stage1/benchmarks/reference/stdlib_async/README.md
@@ -1,0 +1,6 @@
+# Stage1 benchmark reference: stdlib_async
+
+This concurrency-oriented reference workload mirrors `stage1/examples/stdlib_async`
+for the stage1 build regression gate. The Go and Rust versions exercise a small
+spawn/join/channel-shaped program so benchmark coverage is not limited to the
+basic hello path.

--- a/stage1/benchmarks/reference/stdlib_async/main.go
+++ b/stage1/benchmarks/reference/stdlib_async/main.go
@@ -1,0 +1,13 @@
+package main
+
+import "fmt"
+
+func compute(value int, ch chan<- int) {
+	ch <- value * 7
+}
+
+func main() {
+	ch := make(chan int, 1)
+	go compute(6, ch)
+	fmt.Println(<-ch)
+}

--- a/stage1/benchmarks/reference/stdlib_async/main.rs
+++ b/stage1/benchmarks/reference/stdlib_async/main.rs
@@ -1,0 +1,14 @@
+use std::sync::mpsc;
+use std::thread;
+
+fn compute(value: i32) -> i32 {
+    value * 7
+}
+
+fn main() {
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        tx.send(compute(6)).unwrap();
+    });
+    println!("{}", rx.recv().unwrap());
+}


### PR DESCRIPTION
## Summary

- add representative stage1 benchmark coverage for compute, I/O/capability, and concurrency workloads
- compare each Axiom workload against checked-in Go and Rust reference builds
- keep separate cold-build and warm-cache budget checks in the extended validation gate

## Governing Issue

Closes #107

## Validation

- [x] Relevant local checks passed (`make stage1-bench-gate`)
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Notes

- No additional local checks were skipped.
- Benchmark coverage now includes `hello` as compute, `capabilities` as I/O/capability, and `stdlib_async` as concurrency.
