### PR TITLE
docs: add roadmap issue disposition ledger

### DIFF
--- a/docs/roadmap-status.md
+++ b/docs/roadmap-status.md
@@ -17,8 +17,9 @@ letting large roadmap issues become implicit work queues.
 - `docs/stage1-agent-grade-compiler.md` is the execution contract for the
   AG0-AG5 compiler track.
 - GitHub issues remain the source of record for agent execution work. Broad
-  roadmap issues should either point to a current execution issue, be closed as
-  already shipped, or be deferred until their prerequisite milestone is active.
+  roadmap issues should either point to a current execution issue, be closed
+  only when already shipped, or remain open until their prerequisite milestone
+  is active.
 
 ## Current Execution Bar
 
@@ -32,7 +33,7 @@ scope when it advances one of these active contracts:
   `docs/bootstrap/onboarding.md`.
 
 The following are explicitly outside the current agent-grade bar unless a new
-issue reopens them with scoped acceptance criteria and owner approval:
+issue scopes them with testable acceptance criteria and owner approval:
 
 - Hosted package registry service design or operation.
 - `axiomc publish` and package upload workflows.
@@ -45,9 +46,9 @@ issue reopens them with scoped acceptance criteria and owner approval:
 | Issue | Status | Disposition | Evidence and rationale |
 | --- | --- | --- | --- |
 | [#264](https://github.com/OMT-Global/axiom/issues/264) Roadmap parity and agentic-native lead | Complete with this ledger | Close as completed when this PR lands | The broad roadmap is now represented by `docs/roadmap.md`, this ledger, and the AG0-AG5 execution contract. Future work should use scoped child issues rather than keeping the umbrella issue open as an implicit backlog. |
-| [#263](https://github.com/OMT-Global/axiom/issues/263) Hosted package registry | Deferred outside current bar | Close as not planned for this execution pass | A hosted registry depends on publish, signed packages, trust roots, and service ownership. The current repo has no registry service and the agent-grade bar explicitly excludes registry publishing. |
-| [#245](https://github.com/OMT-Global/axiom/issues/245) `axiomc publish` and package registry | Deferred outside current bar | Close as not planned for this execution pass | `docs/stage1-agent-grade-compiler.md` explicitly says publish and registry publishing are not required for the agent-grade bar. Stage1 currently supports local path dependencies and lockfiles, not package upload. |
-| [#248](https://github.com/OMT-Global/axiom/issues/248) Lockfile integrity and signed packages | Deferred outside current bar | Close as not planned for this execution pass | Stage1 lockfiles are deterministic for local path graphs, but signed packages, SBOMs, and offline verification require a registry and trust model that do not exist in the current execution scope. |
+| [#263](https://github.com/OMT-Global/axiom/issues/263) Hosted package registry | Deferred outside current bar | Keep open until implemented or formally descoped | A hosted registry depends on publish, signed packages, trust roots, and service ownership. The current repo has no registry service and the agent-grade bar explicitly excludes registry publishing. |
+| [#245](https://github.com/OMT-Global/axiom/issues/245) `axiomc publish` and package registry | Deferred outside current bar | Keep open until implemented or formally descoped | `docs/stage1-agent-grade-compiler.md` explicitly says publish and registry publishing are not required for the agent-grade bar. Stage1 currently supports local path dependencies and lockfiles, not package upload. |
+| [#248](https://github.com/OMT-Global/axiom/issues/248) Lockfile integrity and signed packages | Deferred outside current bar | Keep open until implemented or formally descoped | Stage1 lockfiles are deterministic for local path graphs, but signed packages, SBOMs, and offline verification require a registry and trust model that do not exist in the current execution scope. |
 | [#101](https://github.com/OMT-Global/axiom/issues/101) AG5.3 proof workload fixtures | Open, blocked | Keep open | The issue requires CLI, worker, and HTTP service proof workloads. AG4.3 HTTP server support remains open, so the HTTP service fixture cannot honestly close yet. |
 | [#102](https://github.com/OMT-Global/axiom/issues/102) AG5.4 CI closure | Open, blocked | Keep open | CI can only make proof workloads blocking after #101 exists. This remains blocked on AG5.3 and AG4.3. |
 | [#243](https://github.com/OMT-Global/axiom/issues/243) `axiomc bench` | Already shipped | Close as completed | `axiomc bench` is implemented in `stage1/crates/axiomc/src/main.rs`, documented in README and `docs/stage1.md`, and has a checked-in fixture at `stage1/examples/benchmarks`. |
@@ -56,9 +57,9 @@ issue reopens them with scoped acceptance criteria and owner approval:
 
 ## Reopening Rule
 
-Deferred registry, publish, and supply-chain work may be reopened as new scoped
-issues after the agent-grade bar is met or after an explicit owner decision
-creates an ecosystem milestone. A reopen issue must name:
+Deferred registry, publish, and supply-chain work should remain open until the
+agent-grade bar is met or until an explicit owner decision creates an ecosystem
+milestone. A scoped implementation issue must name:
 
 - the prerequisite milestone it depends on;
 - the concrete `axiomc` user workflow it enables;

--- a/docs/roadmap-status.md
+++ b/docs/roadmap-status.md
@@ -1,0 +1,67 @@
+# Roadmap Status Ledger
+
+This ledger is the issue-facing status layer for broad roadmap, ecosystem, and
+governance work. It keeps the executable plan grounded in the current
+`project.bootstrap.yaml` control plane and the stage1 execution docs instead of
+letting large roadmap issues become implicit work queues.
+
+## Control Plane
+
+- `project.bootstrap.yaml` is the source of truth for repo governance,
+  reviewers, CODEOWNERS, required checks, environments, runner policy, and home
+  profile sync.
+- `docs/bootstrap/onboarding.md` records the PR body, validation, environment,
+  and runner expectations that new roadmap PRs must follow.
+- `docs/stage1.md` is the short status page for the supported Rust-only
+  `axiomc` workflow.
+- `docs/stage1-agent-grade-compiler.md` is the execution contract for the
+  AG0-AG5 compiler track.
+- GitHub issues remain the source of record for agent execution work. Broad
+  roadmap issues should either point to a current execution issue, be closed as
+  already shipped, or be deferred until their prerequisite milestone is active.
+
+## Current Execution Bar
+
+The current execution bar is the stage1 agent-grade compiler track. Work is in
+scope when it advances one of these active contracts:
+
+- Rust-only `axiomc` behavior under `stage1/`.
+- `make stage1-test`, `make stage1-conformance`, and `make stage1-smoke`.
+- The AG4/AG5 proof path in `docs/stage1-agent-grade-compiler.md`.
+- Bootstrap governance defined in `project.bootstrap.yaml` and
+  `docs/bootstrap/onboarding.md`.
+
+The following are explicitly outside the current agent-grade bar unless a new
+issue reopens them with scoped acceptance criteria and owner approval:
+
+- Hosted package registry service design or operation.
+- `axiomc publish` and package upload workflows.
+- Signed third-party packages, SBOM emission, and registry trust roots.
+- Direct-native backend replacement.
+- Post-agent-grade ecosystem services.
+
+## Issue Disposition
+
+| Issue | Status | Disposition | Evidence and rationale |
+| --- | --- | --- | --- |
+| [#264](https://github.com/OMT-Global/axiom/issues/264) Roadmap parity and agentic-native lead | Complete with this ledger | Close as completed when this PR lands | The broad roadmap is now represented by `docs/roadmap.md`, this ledger, and the AG0-AG5 execution contract. Future work should use scoped child issues rather than keeping the umbrella issue open as an implicit backlog. |
+| [#263](https://github.com/OMT-Global/axiom/issues/263) Hosted package registry | Deferred outside current bar | Close as not planned for this execution pass | A hosted registry depends on publish, signed packages, trust roots, and service ownership. The current repo has no registry service and the agent-grade bar explicitly excludes registry publishing. |
+| [#245](https://github.com/OMT-Global/axiom/issues/245) `axiomc publish` and package registry | Deferred outside current bar | Close as not planned for this execution pass | `docs/stage1-agent-grade-compiler.md` explicitly says publish and registry publishing are not required for the agent-grade bar. Stage1 currently supports local path dependencies and lockfiles, not package upload. |
+| [#248](https://github.com/OMT-Global/axiom/issues/248) Lockfile integrity and signed packages | Deferred outside current bar | Close as not planned for this execution pass | Stage1 lockfiles are deterministic for local path graphs, but signed packages, SBOMs, and offline verification require a registry and trust model that do not exist in the current execution scope. |
+| [#101](https://github.com/OMT-Global/axiom/issues/101) AG5.3 proof workload fixtures | Open, blocked | Keep open | The issue requires CLI, worker, and HTTP service proof workloads. AG4.3 HTTP server support remains open, so the HTTP service fixture cannot honestly close yet. |
+| [#102](https://github.com/OMT-Global/axiom/issues/102) AG5.4 CI closure | Open, blocked | Keep open | CI can only make proof workloads blocking after #101 exists. This remains blocked on AG5.3 and AG4.3. |
+| [#243](https://github.com/OMT-Global/axiom/issues/243) `axiomc bench` | Already shipped | Close as completed | `axiomc bench` is implemented in `stage1/crates/axiomc/src/main.rs`, documented in README and `docs/stage1.md`, and has a checked-in fixture at `stage1/examples/benchmarks`. |
+| [#244](https://github.com/OMT-Global/axiom/issues/244) `axiomc doc` | Already shipped | Close as completed | `axiomc doc` generates Markdown and HTML docs from source doc comments in `stage1/crates/axiomc/src/main.rs` and is documented in README and `docs/stage1.md`. |
+| [#247](https://github.com/OMT-Global/axiom/issues/247) stage1 REPL | Already shipped | Close as completed | `axiomc repl` is implemented in `stage1/crates/axiomc/src/main.rs`, includes JSON ready output, and is documented as a bootstrap-grade toolchain command in `docs/stage1.md`. |
+
+## Reopening Rule
+
+Deferred registry, publish, and supply-chain work may be reopened as new scoped
+issues after the agent-grade bar is met or after an explicit owner decision
+creates an ecosystem milestone. A reopen issue must name:
+
+- the prerequisite milestone it depends on;
+- the concrete `axiomc` user workflow it enables;
+- the verification gate it will add or update;
+- whether `project.bootstrap.yaml` needs governance, environment, or runner
+  changes.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -3,6 +3,9 @@
 This file tracks the Rust compiler line under `stage1/`. New work should target
 the Rust-only `axiomc` workflow.
 
+For issue-level roadmap disposition, current execution scope, and deferred
+ecosystem work, see the [Roadmap Status Ledger](roadmap-status.md).
+
 The Python `stage0` interpreter and bytecode VM are retired as supported
 implementation surfaces; see
 [Python Exit VM Disposition](python-exit-vm-disposition.md) and the


### PR DESCRIPTION
## Summary

- Adds `docs/roadmap-status.md` as the roadmap/governance status ledger.
- Links `docs/roadmap.md` to the new ledger so broad roadmap issues have an in-repo source of truth.
- Records which issues are current scope, blocked, deferred, already shipped, or ready for closure evidence.

## Governing Issue

Closes #264.

Refs #263, #245, #248, #101, #102, #243, #244, and #247.

## Validation

- [x] `git diff --check`
- [x] `bash scripts/ci/run-fast-checks.sh`

## Bootstrap Governance

- Keeps `project.bootstrap.yaml` as the control plane for repo governance, reviewers, required checks, environments, runner policy, and home profile sync.
- Aligns PR and validation expectations with `docs/bootstrap/onboarding.md`.
- Does not copy auth state, sessions, caches, runtime env, or machine-local secrets.

## Notes

- #243, #244, and #247 have already shipped on main via `axiomc bench`, `axiomc doc`, and `axiomc repl` evidence.
- #245, #248, and #263 remain open because deferred roadmap status is not enough closure evidence under the current closure bar.
- #101 and #102 remain open because AG5 proof workloads are blocked on AG4.3 HTTP server support.
