### PR TITLE
Add initial AG5 proof workload fixtures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,14 @@ stage1-smoke:
 	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- check stage1/examples/stdlib_http --json
 	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build stage1/examples/stdlib_http --json
 	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- run stage1/examples/stdlib_http
+	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- check stage1/examples/proof_cli --json
+	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build stage1/examples/proof_cli --json
+	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- run stage1/examples/proof_cli
+	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/examples/proof_cli --json
+	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- check stage1/examples/proof_worker --json
+	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build stage1/examples/proof_worker --json
+	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- run stage1/examples/proof_worker
+	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/examples/proof_worker --json
 	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- caps stage1/examples/hello --json
 	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- fmt stage1/examples/hello --check
 	cargo run --manifest-path stage1/Cargo.toml -p axiomc -- doc stage1/examples/hello --out-dir .axiom-build/docs/hello

--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -38,6 +38,8 @@ cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build stage1/examples/w
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- run stage1/examples/workspace_only --package workspace-app
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/examples/workspace_only --json
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/examples/capabilities --json
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/examples/proof_cli --json
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/examples/proof_worker --json
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- caps stage1/examples/hello --json
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- fmt stage1/examples/hello --check
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- doc stage1/examples/hello
@@ -156,6 +158,11 @@ Current proof points:
 - `stage1/examples/benchmarks` provides the first checked-in benchmark suite
   fixture for `axiomc bench`; the Go/Rust comparison gate remains a later CI
   policy layer on top of the harness.
+- `stage1/examples/proof_cli` and `stage1/examples/proof_worker` provide the
+  first two AG5 proof-workload fixtures. The CLI fixture proves a multi-package
+  Axiom program, while the worker fixture proves deterministic queue-style async
+  processing. The small HTTP service fixture remains blocked on server-side HTTP
+  support.
 - `make stage1-test`, `make stage1-conformance`, and `make stage1-smoke` now cover the checked-in stage1 language gate.
 
 Agent-grade compiler milestone summary:

--- a/stage1/examples/proof_cli/axiom.lock
+++ b/stage1/examples/proof_cli/axiom.lock
@@ -1,0 +1,11 @@
+version = 1
+
+[[package]]
+name = "proof-cli"
+version = "0.1.0"
+source = "path"
+
+[[package]]
+name = "proof-cli-core"
+version = "0.1.0"
+source = "path:deps/core"

--- a/stage1/examples/proof_cli/axiom.toml
+++ b/stage1/examples/proof_cli/axiom.toml
@@ -1,0 +1,22 @@
+[package]
+name = "proof-cli"
+version = "0.1.0"
+
+[workspace]
+members = ["deps/core"]
+
+[dependencies]
+core = { path = "deps/core" }
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false
+ffi = false

--- a/stage1/examples/proof_cli/deps/core/axiom.lock
+++ b/stage1/examples/proof_cli/deps/core/axiom.lock
@@ -1,0 +1,6 @@
+version = 1
+
+[[package]]
+name = "proof-cli-core"
+version = "0.1.0"
+source = "path"

--- a/stage1/examples/proof_cli/deps/core/axiom.toml
+++ b/stage1/examples/proof_cli/deps/core/axiom.toml
@@ -1,0 +1,16 @@
+[package]
+name = "proof-cli-core"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false
+ffi = false

--- a/stage1/examples/proof_cli/deps/core/src/main.ax
+++ b/stage1/examples/proof_cli/deps/core/src/main.ax
@@ -1,0 +1,3 @@
+import "render.ax"
+
+print render_command("core", "1")

--- a/stage1/examples/proof_cli/deps/core/src/main_test.ax
+++ b/stage1/examples/proof_cli/deps/core/src/main_test.ax
@@ -1,0 +1,3 @@
+import "render.ax"
+
+print render_command("core", "1")

--- a/stage1/examples/proof_cli/deps/core/src/main_test.stdout
+++ b/stage1/examples/proof_cli/deps/core/src/main_test.stdout
@@ -1,0 +1,1 @@
+proof-cli core 1

--- a/stage1/examples/proof_cli/deps/core/src/render.ax
+++ b/stage1/examples/proof_cli/deps/core/src/render.ax
@@ -1,0 +1,3 @@
+pub fn render_command(name: string, code: string): string {
+return "proof-cli " + name + " " + code
+}

--- a/stage1/examples/proof_cli/src/main.ax
+++ b/stage1/examples/proof_cli/src/main.ax
@@ -1,0 +1,4 @@
+import "core/render.ax"
+
+print render_command("status", "3")
+print render_command("run", "7")

--- a/stage1/examples/proof_cli/src/main_test.ax
+++ b/stage1/examples/proof_cli/src/main_test.ax
@@ -1,0 +1,4 @@
+import "core/render.ax"
+
+print render_command("status", "3")
+print render_command("run", "7")

--- a/stage1/examples/proof_cli/src/main_test.stdout
+++ b/stage1/examples/proof_cli/src/main_test.stdout
@@ -1,0 +1,2 @@
+proof-cli status 3
+proof-cli run 7

--- a/stage1/examples/proof_worker/axiom.lock
+++ b/stage1/examples/proof_worker/axiom.lock
@@ -1,0 +1,6 @@
+version = 1
+
+[[package]]
+name = "proof-worker"
+version = "0.1.0"
+source = "path"

--- a/stage1/examples/proof_worker/axiom.toml
+++ b/stage1/examples/proof_worker/axiom.toml
@@ -1,0 +1,16 @@
+[package]
+name = "proof-worker"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false
+ffi = false

--- a/stage1/examples/proof_worker/src/main.ax
+++ b/stage1/examples/proof_worker/src/main.ax
@@ -1,0 +1,18 @@
+import "std/async.ax"
+
+async fn process(job: string): string {
+return "processed " + job
+}
+
+let queue: AsyncChannel<string> = channel<string>()
+let queued: AsyncChannel<string> = await send<string>(queue, "invoice")
+let job: Option<string> = await recv<string>(queued)
+match job {
+Some(name) {
+let handle: JoinHandle<string> = spawn<string>(process(name))
+print await join<string>(handle)
+}
+None {
+print "idle"
+}
+}

--- a/stage1/examples/proof_worker/src/main_test.ax
+++ b/stage1/examples/proof_worker/src/main_test.ax
@@ -1,0 +1,18 @@
+import "std/async.ax"
+
+async fn process(job: string): string {
+return "processed " + job
+}
+
+let queue: AsyncChannel<string> = channel<string>()
+let queued: AsyncChannel<string> = await send<string>(queue, "invoice")
+let job: Option<string> = await recv<string>(queued)
+match job {
+Some(name) {
+let handle: JoinHandle<string> = spawn<string>(process(name))
+print await join<string>(handle)
+}
+None {
+print "idle"
+}
+}

--- a/stage1/examples/proof_worker/src/main_test.stdout
+++ b/stage1/examples/proof_worker/src/main_test.stdout
@@ -1,0 +1,1 @@
+processed invoice


### PR DESCRIPTION
## Summary

- Add `stage1/examples/proof_cli`, a multi-package Axiom CLI proof fixture with root and dependency package tests.
- Add `stage1/examples/proof_worker`, a deterministic async queue-style worker proof fixture.
- Wire both proof fixtures into `make stage1-smoke` and document their AG5 status in `docs/stage1.md`.

## Governing Issue

Refs #101.
Refs #102.

## Validation

- [x] `cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/examples/proof_cli --json`
- [x] `cargo run --manifest-path stage1/Cargo.toml -p axiomc -- run stage1/examples/proof_cli`
- [x] `cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/examples/proof_worker --json`
- [x] `cargo run --manifest-path stage1/Cargo.toml -p axiomc -- run stage1/examples/proof_worker`
- [x] `make stage1-smoke`
- [x] `make stage1-test`
- [x] `git diff --check`

## Bootstrap Governance

- Kept scope to stage1 examples, smoke coverage, and status docs.
- Did not duplicate the Subagent E closures for #243, #244, #245, #247, #248, or #263.
- No secrets, auth state, sessions, caches, or machine-local files are included.

## Notes

- This advances #101/#102 but does not close them: the HTTP service proof fixture is still blocked by server-side HTTP support (#97).
