### PR TITLE
Add diagnostic code explain command

### DIFF
--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -42,6 +42,7 @@ cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/examples/ca
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/examples/proof_cli --json
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/examples/proof_worker --json
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- caps stage1/examples/hello --json
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- explain use_after_move --json
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- fmt stage1/examples/hello --check
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- doc stage1/examples/hello
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- bench stage1/examples/benchmarks --json
@@ -78,6 +79,9 @@ incremental generated-Rust cache.
 Parser diagnostics now preserve additional recovered top-level parse errors in
 the error payload's `related` array when possible, so editor tooling can show
 more than the first syntax error without waiting for full checker recovery.
+Stable diagnostic codes can be queried with `axiomc explain <code>` in text or
+JSON form; the current catalog covers the stable ownership codes emitted by the
+stage1 checker.
 
 ## Current gaps
 

--- a/stage1/crates/axiomc/src/diagnostic_catalog.rs
+++ b/stage1/crates/axiomc/src/diagnostic_catalog.rs
@@ -1,0 +1,97 @@
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+pub struct DiagnosticCodeInfo {
+    pub code: &'static str,
+    pub kind: &'static str,
+    pub title: &'static str,
+    pub explanation: &'static str,
+    pub example: &'static str,
+    pub suggested_fix: &'static str,
+}
+
+pub const STABLE_DIAGNOSTIC_CODES: &[DiagnosticCodeInfo] = &[
+    DiagnosticCodeInfo {
+        code: "use_after_move",
+        kind: "ownership",
+        title: "Use after move",
+        explanation: "A non-copy value was moved into another binding or call and then used again.",
+        example: "let alias: string = greeting\nprint greeting",
+        suggested_fix: "Keep using the moved-to binding, or redesign the code so the original value is no longer needed after the move.",
+    },
+    DiagnosticCodeInfo {
+        code: "move_while_borrowed",
+        kind: "ownership",
+        title: "Move while borrowed",
+        explanation: "An owned collection root was moved while a live borrowed slice still referred to it.",
+        example: "let slice: &[int] = values[0:1]\nlet moved: [int] = values",
+        suggested_fix: "End the borrowed-slice scope before moving the owner, or pass the borrowed view instead of moving the owner.",
+    },
+    DiagnosticCodeInfo {
+        code: "loop_move_outer_non_copy",
+        kind: "ownership",
+        title: "Loop move of outer non-copy value",
+        explanation: "A loop body moved a non-copy value declared outside the loop, so later iterations could observe a missing value.",
+        example: "let name: string = \"agent\"\nwhile true {\n  let moved: string = name\n}",
+        suggested_fix: "Move the value before the loop, create the value inside the loop, or use a copy-compatible value.",
+    },
+    DiagnosticCodeInfo {
+        code: "borrow_return_requires_param_origin",
+        kind: "ownership",
+        title: "Borrowed return without parameter origin",
+        explanation: "A function returned a borrowed value that was not derived from one of its borrowed parameters.",
+        example: "fn local(): &[int] {\n  let values: [int] = [1]\n  return values[0:1]\n}",
+        suggested_fix: "Return owned data, or derive the borrowed return from a borrowed parameter.",
+    },
+    DiagnosticCodeInfo {
+        code: "mutable_borrow_while_shared_live",
+        kind: "ownership",
+        title: "Mutable borrow while shared borrow is live",
+        explanation: "A mutable borrowed slice was created while a shared borrowed slice of the same owner was still live.",
+        example: "let shared: &[int] = values[0:1]\nlet mutable: &mut [int] = values[1:2]",
+        suggested_fix: "End the shared borrow before creating the mutable borrow.",
+    },
+    DiagnosticCodeInfo {
+        code: "shared_borrow_while_mutable_live",
+        kind: "ownership",
+        title: "Shared borrow while mutable borrow is live",
+        explanation: "A shared borrowed slice was created while a mutable borrowed slice of the same owner was still live.",
+        example: "let mutable: &mut [int] = values[0:1]\nlet shared: &[int] = values[1:2]",
+        suggested_fix: "End the mutable borrow before creating shared borrows.",
+    },
+];
+
+pub fn diagnostic_code_info(code: &str) -> Option<&'static DiagnosticCodeInfo> {
+    STABLE_DIAGNOSTIC_CODES
+        .iter()
+        .find(|info| info.code == code)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalog_contains_current_stable_ownership_codes() {
+        let codes = STABLE_DIAGNOSTIC_CODES
+            .iter()
+            .map(|info| info.code)
+            .collect::<Vec<_>>();
+
+        assert!(codes.contains(&"use_after_move"));
+        assert!(codes.contains(&"move_while_borrowed"));
+        assert!(codes.contains(&"loop_move_outer_non_copy"));
+        assert!(codes.contains(&"borrow_return_requires_param_origin"));
+        assert!(codes.contains(&"mutable_borrow_while_shared_live"));
+        assert!(codes.contains(&"shared_borrow_while_mutable_live"));
+    }
+
+    #[test]
+    fn lookup_returns_explanation_and_fix() {
+        let info = diagnostic_code_info("use_after_move").expect("code info");
+
+        assert_eq!(info.kind, "ownership");
+        assert!(info.explanation.contains("non-copy value"));
+        assert!(info.suggested_fix.contains("moved-to binding"));
+    }
+}

--- a/stage1/crates/axiomc/src/diagnostic_catalog.rs
+++ b/stage1/crates/axiomc/src/diagnostic_catalog.rs
@@ -59,6 +59,14 @@ pub const STABLE_DIAGNOSTIC_CODES: &[DiagnosticCodeInfo] = &[
         example: "let mutable: &mut [int] = values[0:1]\nlet shared: &[int] = values[1:2]",
         suggested_fix: "End the mutable borrow before creating shared borrows.",
     },
+    DiagnosticCodeInfo {
+        code: "mutable_borrow_while_mutable_live",
+        kind: "ownership",
+        title: "Mutable borrow while mutable borrow is live",
+        explanation: "A mutable borrowed slice was created while another mutable borrowed slice of the same owner was still live.",
+        example: "let first: &mut [int] = values[0:1]\nlet second: &mut [int] = values[1:2]",
+        suggested_fix: "End the first mutable borrow before creating another mutable borrow of the same owner.",
+    },
 ];
 
 pub fn diagnostic_code_info(code: &str) -> Option<&'static DiagnosticCodeInfo> {
@@ -84,6 +92,7 @@ mod tests {
         assert!(codes.contains(&"borrow_return_requires_param_origin"));
         assert!(codes.contains(&"mutable_borrow_while_shared_live"));
         assert!(codes.contains(&"shared_borrow_while_mutable_live"));
+        assert!(codes.contains(&"mutable_borrow_while_mutable_live"));
     }
 
     #[test]

--- a/stage1/crates/axiomc/src/diagnostic_catalog.rs
+++ b/stage1/crates/axiomc/src/diagnostic_catalog.rs
@@ -67,6 +67,54 @@ pub const STABLE_DIAGNOSTIC_CODES: &[DiagnosticCodeInfo] = &[
         example: "let first: &mut [int] = values[0:1]\nlet second: &mut [int] = values[1:2]",
         suggested_fix: "End the first mutable borrow before creating another mutable borrow of the same owner.",
     },
+    DiagnosticCodeInfo {
+        code: "closure_move_captured_non_copy",
+        kind: "ownership",
+        title: "Closure moves captured non-copy value",
+        explanation: "A closure body moved a captured non-copy value, so the captured binding would be unavailable after the closure runs.",
+        example: "let name: string = \"agent\"\nlet f = fn() {\n  let moved: string = name\n}",
+        suggested_fix: "Pass owned data into the closure deliberately, clone/copy only copy-compatible data, or restructure the closure so it borrows instead of moving the captured value.",
+    },
+    DiagnosticCodeInfo {
+        code: "closure_borrowed_slice_return",
+        kind: "ownership",
+        title: "Closure returns borrowed slice without safe origin",
+        explanation: "A closure returned a borrowed slice whose lifetime could not be tied to a safe borrowed parameter origin.",
+        example: "let f = fn(): &[int] {\n  let values: [int] = [1]\n  return values[0:1]\n}",
+        suggested_fix: "Return owned data from the closure, or derive the borrowed return from an explicit borrowed parameter.",
+    },
+    DiagnosticCodeInfo {
+        code: "rebind_not_supported",
+        kind: "binding",
+        title: "Rebinding is not supported",
+        explanation: "A binding name was declared more than once in the same unsupported rebinding context.",
+        example: "let count: int = 1\nlet count: int = 2",
+        suggested_fix: "Use a distinct binding name, or rewrite the code to avoid redeclaring the same local.",
+    },
+    DiagnosticCodeInfo {
+        code: "import_cycle",
+        kind: "imports",
+        title: "Import cycle detected",
+        explanation: "The package import graph contains a cycle, so the compiler cannot establish an acyclic module order.",
+        example: "// a.ax imports b.ax\n// b.ax imports a.ax",
+        suggested_fix: "Break the cycle by moving shared declarations into a third module or by depending in only one direction.",
+    },
+    DiagnosticCodeInfo {
+        code: "import_cycle_member",
+        kind: "imports",
+        title: "Import participates in a cycle",
+        explanation: "This import is one member of a larger import cycle reported by the project checker.",
+        example: "import \"./b.ax\"",
+        suggested_fix: "Inspect the full cycle diagnostic, then remove or invert one of the participating imports.",
+    },
+    DiagnosticCodeInfo {
+        code: "generated_rust_compilation_failed",
+        kind: "build",
+        title: "Generated Rust compilation failed",
+        explanation: "The generated Rust backend emitted code that rustc rejected while building the stage1 artifact.",
+        example: "axiomc build . --backend generated-rust",
+        suggested_fix: "Read the embedded rustc stderr, minimize the Axiom source that triggered it, and fix the backend lowering or source program as appropriate.",
+    },
 ];
 
 pub fn diagnostic_code_info(code: &str) -> Option<&'static DiagnosticCodeInfo> {
@@ -93,6 +141,12 @@ mod tests {
         assert!(codes.contains(&"mutable_borrow_while_shared_live"));
         assert!(codes.contains(&"shared_borrow_while_mutable_live"));
         assert!(codes.contains(&"mutable_borrow_while_mutable_live"));
+        assert!(codes.contains(&"closure_move_captured_non_copy"));
+        assert!(codes.contains(&"closure_borrowed_slice_return"));
+        assert!(codes.contains(&"rebind_not_supported"));
+        assert!(codes.contains(&"import_cycle"));
+        assert!(codes.contains(&"import_cycle_member"));
+        assert!(codes.contains(&"generated_rust_compilation_failed"));
     }
 
     #[test]

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod codegen;
+pub mod diagnostic_catalog;
 pub mod diagnostics;
 pub mod hir;
 pub mod json_contract;

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod codegen;
 pub mod dap;
+pub mod diagnostic_catalog;
 pub mod diagnostics;
 pub mod hir;
 pub mod json_contract;

--- a/stage1/crates/axiomc/src/main.rs
+++ b/stage1/crates/axiomc/src/main.rs
@@ -1,3 +1,4 @@
+use axiomc::diagnostic_catalog::{DiagnosticCodeInfo, diagnostic_code_info};
 use axiomc::diagnostics::Diagnostic;
 use axiomc::json_contract;
 use axiomc::new_project::create_project;
@@ -70,6 +71,12 @@ enum Command {
     /// Inspect manifest capability requirements.
     Caps {
         path: Option<PathBuf>,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Explain a stable diagnostic code.
+    Explain {
+        code: String,
         #[arg(long)]
         json: bool,
     },
@@ -231,6 +238,25 @@ fn main() {
                 Err(error) => print_error("caps", error, json),
             }
         }
+        Command::Explain { code, json } => match diagnostic_code_info(&code) {
+            Some(info) => {
+                if json {
+                    println!(
+                        "{}",
+                        json_contract::to_pretty_string(&explain_payload(info))
+                            .unwrap_or_else(|_| String::from("{}"))
+                    );
+                } else {
+                    println!("{}", explain_text(info));
+                }
+                0
+            }
+            None => print_error(
+                "explain",
+                Diagnostic::new("diagnostic", format!("unknown diagnostic code {code:?}")),
+                json,
+            ),
+        },
         Command::Fmt { path, check } => match format_axiom_sources(&path, check) {
             Ok(report) => {
                 for file in &report.files {
@@ -323,6 +349,27 @@ fn print_error(command: &str, error: Diagnostic, json: bool) -> i32 {
         }
     }
     1
+}
+
+fn explain_payload(info: &DiagnosticCodeInfo) -> serde_json::Value {
+    serde_json::json!({
+        "schema_version": json_contract::JSON_SCHEMA_VERSION,
+        "ok": true,
+        "command": "explain",
+        "diagnostic": info,
+    })
+}
+
+fn explain_text(info: &DiagnosticCodeInfo) -> String {
+    format!(
+        "{code} ({kind})\n{title}\n\n{explanation}\n\nExample:\n{example}\n\nSuggested fix:\n{suggested_fix}",
+        code = info.code,
+        kind = info.kind,
+        title = info.title,
+        explanation = info.explanation,
+        example = info.example,
+        suggested_fix = info.suggested_fix,
+    )
 }
 
 #[derive(Debug, Clone)]
@@ -730,6 +777,7 @@ mod tests {
         assert!(help.contains("Build and run a stage1 package native binary"));
         assert!(help.contains("Discover, build, and run package test entrypoints"));
         assert!(help.contains("Inspect manifest capability requirements"));
+        assert!(help.contains("Explain a stable diagnostic code"));
         assert!(help.contains("Format .ax source files"));
         assert!(help.contains("Generate Markdown and HTML API docs"));
         assert!(help.contains("Run discovered *_bench.ax entrypoints"));
@@ -773,6 +821,29 @@ mod tests {
             build_summary_lines(&build_output(None), false),
             vec![String::from("wrote dist/app")]
         );
+    }
+
+    #[test]
+    fn explain_text_includes_example_and_fix() {
+        let info = diagnostic_code_info("use_after_move").expect("diagnostic info");
+        let text = explain_text(info);
+
+        assert!(text.contains("use_after_move (ownership)"));
+        assert!(text.contains("Example:"));
+        assert!(text.contains("Suggested fix:"));
+    }
+
+    #[test]
+    fn explain_json_payload_is_versioned() {
+        let info = diagnostic_code_info("use_after_move").expect("diagnostic info");
+        let payload = explain_payload(info);
+
+        assert_eq!(
+            payload["schema_version"],
+            json_contract::JSON_SCHEMA_VERSION
+        );
+        assert_eq!(payload["command"], "explain");
+        assert_eq!(payload["diagnostic"]["code"], "use_after_move");
     }
 
     #[test]

--- a/stage1/crates/axiomc/src/main.rs
+++ b/stage1/crates/axiomc/src/main.rs
@@ -1,5 +1,6 @@
 use axiomc::codegen::NativeBackendKind;
 use axiomc::dap;
+use axiomc::diagnostic_catalog::{DiagnosticCodeInfo, diagnostic_code_info};
 use axiomc::diagnostics::Diagnostic;
 use axiomc::json_contract;
 use axiomc::lsp;
@@ -108,6 +109,12 @@ enum Command {
     Inspect {
         #[command(subcommand)]
         command: InspectCommand,
+    },
+    /// Explain a stable diagnostic code.
+    Explain {
+        code: String,
+        #[arg(long)]
+        json: bool,
     },
     /// Format .ax source files with the canonical stage1 style.
     Fmt {
@@ -383,6 +390,25 @@ fn main() {
                     Err(error) => print_error("caps", error, json),
                 }
             }
+        },
+        Command::Explain { code, json } => match diagnostic_code_info(&code) {
+            Some(info) => {
+                if json {
+                    println!(
+                        "{}",
+                        json_contract::to_pretty_string(&explain_payload(info))
+                            .unwrap_or_else(|_| String::from("{}"))
+                    );
+                } else {
+                    println!("{}", explain_text(info));
+                }
+                0
+            }
+            None => print_error(
+                "explain",
+                Diagnostic::new("diagnostic", format!("unknown diagnostic code {code:?}")),
+                json,
+            ),
         },
         Command::Inspect { command } => match command {
             InspectCommand::Symbols { path, json } => match inspect_symbols(&path) {
@@ -781,6 +807,36 @@ fn scope_diff(
         capability: name.to_string(),
         scopes,
     })
+}
+
+fn explain_payload(info: &DiagnosticCodeInfo) -> serde_json::Value {
+    serde_json::json!({
+        "schema_version": json_contract::JSON_SCHEMA_VERSION,
+        "ok": true,
+        "command": "explain",
+        "diagnostic": info,
+    })
+}
+
+fn explain_text(info: &DiagnosticCodeInfo) -> String {
+    format!(
+        "{code} ({kind})
+{title}
+
+{explanation}
+
+Example:
+{example}
+
+Suggested fix:
+{suggested_fix}",
+        code = info.code,
+        kind = info.kind,
+        title = info.title,
+        explanation = info.explanation,
+        example = info.example,
+        suggested_fix = info.suggested_fix,
+    )
 }
 
 fn print_error(command: &str, error: Diagnostic, json: bool) -> i32 {
@@ -1888,6 +1944,7 @@ mod tests {
         assert!(help.contains("Discover, build, and run package test entrypoints"));
         assert!(help.contains("Inspect manifest capability requirements"));
         assert!(help.contains("Inspect project metadata for agent tooling"));
+        assert!(help.contains("Explain a stable diagnostic code"));
         assert!(help.contains("Format .ax source files"));
         assert!(help.contains("Generate Markdown and HTML API docs"));
         assert!(help.contains("Run discovered *_bench.ax entrypoints"));
@@ -2237,6 +2294,29 @@ mod tests {
                 .iter()
                 .any(|symbol| symbol.name == "private_helper")
         );
+    }
+
+    #[test]
+    fn explain_text_includes_example_and_fix() {
+        let info = diagnostic_code_info("use_after_move").expect("diagnostic info");
+        let text = explain_text(info);
+
+        assert!(text.contains("use_after_move (ownership)"));
+        assert!(text.contains("Example:"));
+        assert!(text.contains("Suggested fix:"));
+    }
+
+    #[test]
+    fn explain_json_payload_is_versioned() {
+        let info = diagnostic_code_info("use_after_move").expect("diagnostic info");
+        let payload = explain_payload(info);
+
+        assert_eq!(
+            payload["schema_version"],
+            json_contract::JSON_SCHEMA_VERSION
+        );
+        assert_eq!(payload["command"], "explain");
+        assert_eq!(payload["diagnostic"]["code"], "use_after_move");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add a stable diagnostic catalog for the currently emitted ownership diagnostic codes.
- Add `axiomc explain <diagnostic-code>` with text and `--json` output.
- Document the new command in the stage1 command and JSON-contract docs.

## Governing Issue
Closes #375.

## Validation
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc explain --quiet`
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc catalog --quiet`
- [x] `git diff --check`
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc --quiet -- --skip build_project_wasm_alias_emits_wasm_artifact`

## Bootstrap Governance
- Issue-backed branch: `codex/issue-375-explain-diagnostics`.
- Scope is limited to stage1 diagnostic-code explanation metadata, CLI output, tests, and docs.
- No secrets, runtime auth, sessions, caches, or machine-local env files are included.

## Notes
- Full unskipped `cargo test --manifest-path stage1/Cargo.toml -p axiomc --quiet` is blocked in this local environment because `rustup` is not installed; the skipped test is `build_project_wasm_alias_emits_wasm_artifact`.
