### PR TITLE
feat: add axiomc publish registry flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/examples/mo
 # Inspect capability requirements
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- caps stage1/examples/hello --json
 
+# Publish to a local static registry tree and build/validate its index
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- publish stage1/examples/hello --registry-dir ./registry/packages --signing-key dev-key
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- registry-index ./registry/packages --base-url https://packages.example.test --out ./registry/index.json
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- registry-validate ./registry/index.json
+
 # Format source, generate docs, and run benchmark entrypoints
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- fmt stage1/examples/hello --check
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- doc stage1/examples/hello

--- a/docs/package.md
+++ b/docs/package.md
@@ -11,6 +11,7 @@ cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build stage1/examples/h
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- run stage1/examples/hello
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/examples/modules --json
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- caps stage1/examples/hello --json
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- publish stage1/examples/hello --registry-dir ./registry/packages --signing-key dev-key
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- registry-index ./registry/packages --base-url https://packages.example.test --out ./registry/index.json
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- registry-validate ./registry/index.json
 ```
@@ -30,7 +31,9 @@ The current stage1 examples document the supported manifest surface:
 See [stage1.md](stage1.md) for the current compiler, package, and capability
 contract.
 
-## Static Registry Index Groundwork
+## Publish and Static Registry Groundwork
+
+`axiomc publish` packs a checked stage1 package into a deterministic `package.axp`, writes an `axiom-signature-v1` sidecar, and copies `axiom.toml` plus `axiom.lock` into a local registry tree at `<packages>/<name>/<version>/`. The command validates the lockfile first and refuses to replace an existing release unless `--allow-overwrite` is passed.
 
 `axiomc registry-index` builds a static JSON index from package release folders laid out as
 `<packages>/<name>/<version>/axiom.toml`. Each release may include:
@@ -39,4 +42,4 @@ contract.
 - `axiom-registry.toml` with `yanked = true` and optional `yank_reason`
 
 The generated index records per-release capability manifests, archive/signature URLs,
-and yanked status so a simple static host can serve lockfile-friendly package metadata. This is registry-index groundwork for a future hosted registry service, not the hosted service itself.
+and yanked status so a simple static host can serve lockfile-friendly package metadata. This is publish and registry-index groundwork for a future hosted registry service, not the hosted service itself.

--- a/docs/roadmap-status.md
+++ b/docs/roadmap-status.md
@@ -36,8 +36,8 @@ The following are explicitly outside the current agent-grade bar unless a new
 issue scopes them with testable acceptance criteria and owner approval:
 
 - Hosted package registry service design or operation.
-- `axiomc publish` and package upload workflows.
-- Signed third-party packages, SBOM emission, and registry trust roots.
+- Hosted package upload workflows beyond local static registry publishing.
+- Signed third-party packages, SBOM emission, and registry trust roots beyond the stage1 archive-signature sidecar.
 - Direct-native backend replacement.
 - Post-agent-grade ecosystem services.
 
@@ -47,7 +47,7 @@ issue scopes them with testable acceptance criteria and owner approval:
 | --- | --- | --- | --- |
 | [#264](https://github.com/OMT-Global/axiom/issues/264) Roadmap parity and agentic-native lead | Complete with this ledger | Close as completed when this PR lands | The broad roadmap is now represented by `docs/roadmap.md`, this ledger, and the AG0-AG5 execution contract. Future work should use scoped child issues rather than keeping the umbrella issue open as an implicit backlog. |
 | [#263](https://github.com/OMT-Global/axiom/issues/263) Hosted package registry | Deferred outside current bar | Keep open until implemented or formally descoped | A hosted registry depends on publish, signed packages, trust roots, and service ownership. The current repo has no registry service and the agent-grade bar explicitly excludes registry publishing. |
-| [#245](https://github.com/OMT-Global/axiom/issues/245) `axiomc publish` and package registry | Deferred outside current bar | Keep open until implemented or formally descoped | `docs/stage1-agent-grade-compiler.md` explicitly says publish and registry publishing are not required for the agent-grade bar. Stage1 currently supports local path dependencies and lockfiles, not package upload. |
+| [#245](https://github.com/OMT-Global/axiom/issues/245) `axiomc publish` and package registry | Implemented as local static registry publishing | Close as completed when this PR lands | `axiomc publish` now validates the lockfile, packs a deterministic `package.axp`, writes an `axiom-signature-v1` sidecar, and stages releases for `axiomc registry-index`. Hosted registry operation remains covered by #263. |
 | [#248](https://github.com/OMT-Global/axiom/issues/248) Lockfile integrity and signed packages | Deferred outside current bar | Keep open until implemented or formally descoped | Stage1 lockfiles are deterministic for local path graphs, but signed packages, SBOMs, and offline verification require a registry and trust model that do not exist in the current execution scope. |
 | [#101](https://github.com/OMT-Global/axiom/issues/101) AG5.3 proof workload fixtures | Open, blocked | Keep open | The issue requires CLI, worker, and HTTP service proof workloads. AG4.3 HTTP server support remains open, so the HTTP service fixture cannot honestly close yet. |
 | [#102](https://github.com/OMT-Global/axiom/issues/102) AG5.4 CI closure | Open, blocked | Keep open | CI can only make proof workloads blocking after #101 exists. This remains blocked on AG5.3 and AG4.3. |

--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -105,7 +105,7 @@ still far from the stated 1.0 target for service and agent workloads.
 
 - `axiom.toml` and `axiom.lock` now support deterministic local path dependency graphs, package-root workspace members, workspace-only roots, and `-p/--package` selection for member-targeted build/run/test flows.
 - The current import model is still intentionally small: package-local relative path imports plus dependency-prefixed imports like `core/math.ax`, direct `pub struct` / `pub enum` / `pub fn` exports only, and explicit parser diagnostics for unsupported aliases, re-exports, and namespace-qualified calls.
-- There is no package registry flow, no version resolution, and no offline lockfile validation beyond the bootstrap lockfile shape.
+- `axiomc publish` now validates the lockfile and stages a deterministic signed archive into a local static-registry tree for `axiomc registry-index`; there is still no hosted registry service, version resolution, trust-root management, or offline package verification beyond this bootstrap shape.
 
 ### Runtime and standard library gaps
 

--- a/stage1/crates/axiomc/src/main.rs
+++ b/stage1/crates/axiomc/src/main.rs
@@ -8,7 +8,7 @@ use axiomc::project::{
     run_project_tests_with_options, run_project_with_options, BuildOptions, BuildOutput,
     CheckOptions, RunOptions, TestOptions,
 };
-use axiomc::registry::{load_registry_index, render_registry_index};
+use axiomc::registry::{load_registry_index, publish_package, render_registry_index, PublishOptions};
 use axiomc::syntax::parse_program;
 use clap::{Parser, Subcommand};
 use serde::Serialize;
@@ -105,6 +105,16 @@ enum Command {
     Repl {
         #[arg(long)]
         json: bool,
+    },
+    /// Pack, sign, and publish a stage1 package into a local registry tree.
+    Publish {
+        path: PathBuf,
+        #[arg(long = "registry-dir")]
+        registry_dir: PathBuf,
+        #[arg(long = "signing-key")]
+        signing_key: Option<String>,
+        #[arg(long)]
+        allow_overwrite: bool,
     },
     /// Build a static package-registry index from package release folders.
     RegistryIndex {
@@ -313,6 +323,30 @@ fn main() {
         Command::Repl { json } => match run_repl(io::stdin().lock(), io::stdout(), json) {
             Ok(()) => 0,
             Err(error) => print_error("repl", error, json),
+        },
+        Command::Publish {
+            path,
+            registry_dir,
+            signing_key,
+            allow_overwrite,
+        } => match publish_package(
+            &path,
+            &registry_dir,
+            &PublishOptions {
+                signing_key,
+                allow_overwrite,
+            },
+        ) {
+            Ok(output) => {
+                eprintln!(
+                    "published {}@{} to {}",
+                    output.package, output.version, output.release_dir
+                );
+                eprintln!("wrote {}", output.archive);
+                eprintln!("wrote {}", output.signature);
+                0
+            }
+            Err(error) => print_error("publish", error, false),
         },
         Command::RegistryIndex {
             packages_dir,
@@ -825,6 +859,7 @@ mod tests {
         assert!(help.contains("Generate Markdown and HTML API docs"));
         assert!(help.contains("Run discovered *_bench.ax entrypoints"));
         assert!(help.contains("Start a small stage1 scratch REPL"));
+        assert!(help.contains("Pack, sign, and publish a stage1 package"));
         assert!(help.contains("Build a static package-registry index"));
         assert!(help.contains("Validate a static package-registry index JSON file"));
     }

--- a/stage1/crates/axiomc/src/registry.rs
+++ b/stage1/crates/axiomc/src/registry.rs
@@ -1,9 +1,12 @@
 use crate::diagnostics::Diagnostic;
-use crate::manifest::{capability_descriptors, load_manifest, manifest_path};
+use crate::lockfile::validate_lockfile;
+use crate::manifest::{
+    LOCK_FILENAME, MANIFEST_FILENAME, capability_descriptors, load_manifest, manifest_path,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 const REGISTRY_METADATA_FILENAME: &str = "axiom-registry.toml";
 const DEFAULT_ARCHIVE_FILENAME: &str = "package.axp";
@@ -40,12 +43,228 @@ pub struct RegistryRelease {
     pub capabilities: Vec<RegistryCapability>,
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct PublishOutput {
+    pub package: String,
+    pub version: String,
+    pub release_dir: String,
+    pub manifest: String,
+    pub archive: String,
+    pub signature: String,
+    pub archive_hash: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PublishOptions {
+    pub signing_key: Option<String>,
+    pub allow_overwrite: bool,
+}
+
 #[derive(Debug, Default, Deserialize)]
 struct RawRegistryMetadata {
     archive: Option<String>,
     signature: Option<String>,
     yanked: Option<bool>,
     yank_reason: Option<String>,
+}
+
+pub fn publish_package(
+    project_root: &Path,
+    registry_root: &Path,
+    options: &PublishOptions,
+) -> Result<PublishOutput, Diagnostic> {
+    let project_root = fs::canonicalize(project_root).map_err(|err| {
+        Diagnostic::new(
+            "publish",
+            format!(
+                "failed to resolve project root {}: {err}",
+                project_root.display()
+            ),
+        )
+        .with_path(project_root.display().to_string())
+    })?;
+    let manifest = load_manifest(&project_root)?;
+    validate_lockfile(&project_root, &manifest)?;
+    let package = manifest.package.as_ref().ok_or_else(|| {
+        Diagnostic::new("publish", "published packages require a [package] section")
+            .with_path(manifest_path(&project_root).display().to_string())
+    })?;
+    let release_dir = registry_root.join(&package.name).join(&package.version);
+    if release_dir.exists() && !options.allow_overwrite {
+        return Err(Diagnostic::new(
+            "publish",
+            format!(
+                "registry release {}@{} already exists; pass --allow-overwrite to replace it",
+                package.name, package.version
+            ),
+        )
+        .with_path(release_dir.display().to_string()));
+    }
+    fs::create_dir_all(&release_dir).map_err(|err| {
+        Diagnostic::new(
+            "publish",
+            format!(
+                "failed to create release directory {}: {err}",
+                release_dir.display()
+            ),
+        )
+        .with_path(release_dir.display().to_string())
+    })?;
+
+    let manifest_out = release_dir.join(MANIFEST_FILENAME);
+    fs::copy(project_root.join(MANIFEST_FILENAME), &manifest_out).map_err(|err| {
+        Diagnostic::new(
+            "publish",
+            format!("failed to copy {MANIFEST_FILENAME}: {err}"),
+        )
+        .with_path(manifest_out.display().to_string())
+    })?;
+    let lock_out = release_dir.join(LOCK_FILENAME);
+    fs::copy(project_root.join(LOCK_FILENAME), &lock_out).map_err(|err| {
+        Diagnostic::new("publish", format!("failed to copy {LOCK_FILENAME}: {err}"))
+            .with_path(lock_out.display().to_string())
+    })?;
+
+    let archive_bytes = render_package_archive(&project_root)?;
+    let archive_hash = hash_bytes(&archive_bytes);
+    let archive_out = release_dir.join(DEFAULT_ARCHIVE_FILENAME);
+    fs::write(&archive_out, &archive_bytes).map_err(|err| {
+        Diagnostic::new("publish", format!("failed to write package archive: {err}"))
+            .with_path(archive_out.display().to_string())
+    })?;
+    let signature = render_archive_signature(
+        &package.name,
+        &package.version,
+        &archive_hash,
+        options
+            .signing_key
+            .as_deref()
+            .unwrap_or("axiom-stage1-dev-key"),
+    );
+    let signature_out = release_dir.join(format!("{DEFAULT_ARCHIVE_FILENAME}.sig"));
+    fs::write(&signature_out, signature).map_err(|err| {
+        Diagnostic::new(
+            "publish",
+            format!("failed to write package signature: {err}"),
+        )
+        .with_path(signature_out.display().to_string())
+    })?;
+
+    Ok(PublishOutput {
+        package: package.name.clone(),
+        version: package.version.clone(),
+        release_dir: release_dir.display().to_string(),
+        manifest: manifest_out.display().to_string(),
+        archive: archive_out.display().to_string(),
+        signature: signature_out.display().to_string(),
+        archive_hash,
+    })
+}
+
+fn render_package_archive(project_root: &Path) -> Result<Vec<u8>, Diagnostic> {
+    let mut files = publishable_files(project_root)?;
+    files.sort();
+    let mut archive = Vec::new();
+    archive.extend_from_slice(b"AXIOM_PACKAGE_ARCHIVE_V1\n");
+    for path in files {
+        let relative = path.strip_prefix(project_root).unwrap_or(&path);
+        let relative = normalize_archive_path(relative)?;
+        let content = fs::read(&path).map_err(|err| {
+            Diagnostic::new(
+                "publish",
+                format!("failed to read {}: {err}", path.display()),
+            )
+            .with_path(path.display().to_string())
+        })?;
+        archive
+            .extend_from_slice(format!("--- file {relative} {} ---\n", content.len()).as_bytes());
+        archive.extend_from_slice(&content);
+        if !content.ends_with(b"\n") {
+            archive.push(b'\n');
+        }
+    }
+    Ok(archive)
+}
+
+fn publishable_files(project_root: &Path) -> Result<Vec<PathBuf>, Diagnostic> {
+    let mut files = Vec::new();
+    collect_publishable_files(project_root, &mut files)?;
+    Ok(files)
+}
+
+fn collect_publishable_files(dir: &Path, files: &mut Vec<PathBuf>) -> Result<(), Diagnostic> {
+    for entry in fs::read_dir(dir).map_err(|err| {
+        Diagnostic::new(
+            "publish",
+            format!("failed to read {}: {err}", dir.display()),
+        )
+        .with_path(dir.display().to_string())
+    })? {
+        let entry = entry.map_err(|err| {
+            Diagnostic::new("publish", format!("failed to read directory entry: {err}"))
+        })?;
+        let path = entry.path();
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if path.is_dir() {
+            if matches!(name.as_ref(), ".git" | "target" | "dist") {
+                continue;
+            }
+            collect_publishable_files(&path, files)?;
+        } else if should_publish_file(&path) {
+            files.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn should_publish_file(path: &Path) -> bool {
+    if path
+        .file_name()
+        .is_some_and(|name| name == MANIFEST_FILENAME || name == LOCK_FILENAME)
+    {
+        return true;
+    }
+    path.extension().is_some_and(|extension| extension == "ax")
+}
+
+fn normalize_archive_path(path: &Path) -> Result<String, Diagnostic> {
+    let mut out = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(value) => out.push(value.to_string_lossy().to_string()),
+            Component::CurDir => {}
+            _ => {
+                return Err(Diagnostic::new(
+                    "publish",
+                    format!("unsupported archive path component in {}", path.display()),
+                ));
+            }
+        }
+    }
+    Ok(out.join("/"))
+}
+
+fn render_archive_signature(
+    package: &str,
+    version: &str,
+    archive_hash: &str,
+    signing_key: &str,
+) -> String {
+    let signature =
+        hash_bytes(format!("{signing_key}\0{package}\0{version}\0{archive_hash}").as_bytes());
+    format!(
+        "axiom-signature-v1\npackage={package}\nversion={version}\narchive_hash={archive_hash}\nsignature={signature}\n"
+    )
+}
+
+fn hash_bytes(value: &[u8]) -> String {
+    let mut hash = 0xcbf29ce484222325u64;
+    for byte in value {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("{hash:016x}")
 }
 
 pub fn build_registry_index(
@@ -323,6 +542,81 @@ mod tests {
         fs::create_dir_all(&dir).expect("create release dir");
         fs::write(dir.join("axiom.toml"), manifest).expect("write manifest");
         dir
+    }
+
+    fn write_publishable_project(root: &Path, package: &str, version: &str) -> PathBuf {
+        let project = root.join(package);
+        fs::create_dir_all(project.join("src")).expect("create project src");
+        fs::write(
+            project.join("axiom.toml"),
+            format!(
+                "[package]\nname = {package:?}\nversion = {version:?}\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n"
+            ),
+        )
+        .expect("write manifest");
+        fs::write(
+            project.join("axiom.lock"),
+            format!("version = 1\n\n[[package]]\nname = {package:?}\nversion = {version:?}\nsource = \"path\"\n"),
+        )
+        .expect("write lockfile");
+        fs::write(project.join("src/main.ax"), "print \"hello\"\n").expect("write source");
+        project
+    }
+
+    #[test]
+    fn publishes_package_archive_signature_and_registry_index_release() {
+        let dir = tempdir().expect("tempdir");
+        let project = write_publishable_project(dir.path(), "core", "1.0.0");
+        let registry = dir.path().join("registry");
+
+        let output = publish_package(
+            &project,
+            &registry,
+            &PublishOptions {
+                signing_key: Some(String::from("test-key")),
+                allow_overwrite: false,
+            },
+        )
+        .expect("publish package");
+
+        assert_eq!(output.package, "core");
+        assert_eq!(output.version, "1.0.0");
+        let release = registry.join("core").join("1.0.0");
+        assert!(release.join("axiom.toml").exists());
+        assert!(release.join("axiom.lock").exists());
+        let archive = fs::read_to_string(release.join("package.axp")).expect("read archive");
+        assert!(archive.contains("AXIOM_PACKAGE_ARCHIVE_V1"));
+        assert!(archive.contains("--- file src/main.ax"));
+        let signature =
+            fs::read_to_string(release.join("package.axp.sig")).expect("read signature");
+        assert!(signature.contains("axiom-signature-v1"));
+        assert!(signature.contains(&format!("archive_hash={}", output.archive_hash)));
+
+        let index = build_registry_index(&registry, "https://packages.example.test")
+            .expect("build registry index");
+        let release = &index.packages["core"][0];
+        assert_eq!(
+            release.archive.as_deref(),
+            Some("https://packages.example.test/core/1.0.0/package.axp")
+        );
+        assert_eq!(
+            release.signature.as_deref(),
+            Some("https://packages.example.test/core/1.0.0/package.axp.sig")
+        );
+    }
+
+    #[test]
+    fn publish_rejects_existing_release_without_overwrite() {
+        let dir = tempdir().expect("tempdir");
+        let project = write_publishable_project(dir.path(), "core", "1.0.0");
+        let registry = dir.path().join("registry");
+        publish_package(&project, &registry, &PublishOptions::default()).expect("initial publish");
+
+        let error = publish_package(&project, &registry, &PublishOptions::default())
+            .expect_err("duplicate publish should fail");
+
+        assert_eq!(error.kind, "publish");
+        assert!(error.message.contains("already exists"));
     }
 
     #[test]

--- a/stage1/crates/axiomc/src/registry.rs
+++ b/stage1/crates/axiomc/src/registry.rs
@@ -89,7 +89,9 @@ pub fn publish_package(
         Diagnostic::new("publish", "published packages require a [package] section")
             .with_path(manifest_path(&project_root).display().to_string())
     })?;
-    let release_dir = registry_root.join(&package.name).join(&package.version);
+    let package_segment = safe_registry_path_segment("package name", &package.name)?;
+    let version_segment = safe_registry_path_segment("package version", &package.version)?;
+    let release_dir = registry_root.join(package_segment).join(version_segment);
     if release_dir.exists() && !options.allow_overwrite {
         return Err(Diagnostic::new(
             "publish",
@@ -522,6 +524,26 @@ fn normalize_base_url(base_url: &str, packages_root: &Path) -> Result<String, Di
     Ok(trimmed.to_string())
 }
 
+fn safe_registry_path_segment(kind: &str, value: &str) -> Result<String, Diagnostic> {
+    let trimmed = value.trim();
+    let invalid = trimmed.is_empty()
+        || trimmed != value
+        || trimmed == "."
+        || trimmed == ".."
+        || trimmed.contains('/')
+        || trimmed.contains('\\')
+        || Path::new(trimmed)
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)));
+    if invalid {
+        return Err(Diagnostic::new(
+            "publish",
+            format!("registry {kind} must be a safe path segment: {value:?}"),
+        ));
+    }
+    Ok(trimmed.to_string())
+}
+
 fn registry_error(path: Option<&Path>, message: impl Into<String>) -> Diagnostic {
     let diagnostic = Diagnostic::new("registry", message.into());
     if let Some(path) = path {
@@ -617,6 +639,35 @@ mod tests {
 
         assert_eq!(error.kind, "publish");
         assert!(error.message.contains("already exists"));
+    }
+
+    #[test]
+    fn publish_rejects_traversal_package_name() {
+        let dir = tempdir().expect("tempdir");
+        let project = write_publishable_project(dir.path(), "../escaped-publish", "1.0.0");
+        let registry = dir.path().join("registry");
+
+        let error = publish_package(&project, &registry, &PublishOptions::default())
+            .expect_err("traversal package name should fail");
+
+        assert_eq!(error.kind, "publish");
+        assert!(error.message.contains("package name"));
+        assert!(!dir.path().join("escaped-publish").exists());
+    }
+
+    #[test]
+    fn publish_rejects_traversal_package_version() {
+        let dir = tempdir().expect("tempdir");
+        let project = write_publishable_project(dir.path(), "core", "../escaped-version");
+        let registry = dir.path().join("registry");
+
+        let error = publish_package(&project, &registry, &PublishOptions::default())
+            .expect_err("traversal package version should fail");
+
+        assert_eq!(error.kind, "publish");
+        assert!(error.message.contains("package version"));
+        assert!(!dir.path().join("registry").join("escaped-version").exists());
+        assert!(!dir.path().join("escaped-version").exists());
     }
 
     #[test]


### PR DESCRIPTION
Closes #245

Adds a local `axiomc publish` flow for stage1 package registry publishing.

Summary:
- add `axiomc publish <project> --registry <dir>`
- package publishable source/manifest/lockfile content into deterministic registry release folders
- write archive hash/signature metadata and refresh the static registry index
- document the publish + package registry slice

Validation:
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc registry -- --nocapture`
