### PR TITLE
feat: add std testing helpers

### DIFF
--- a/docs/book.md
+++ b/docs/book.md
@@ -67,7 +67,7 @@ cargo run --manifest-path stage1/Cargo.toml -p axiomc -- caps stage1/examples/ca
 
 ## 7. Tests And Conformance
 
-Package tests are `src/*_test.ax` files and can use sibling stdout golden files.
+Package tests are `src/*_test.ax` files and can use sibling stdout golden files. `std/testing.ax` adds table-case, property, and snapshot assertion helpers for richer package tests.
 
 ```bash
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/examples/modules --json

--- a/docs/stage1-stdlib-status.md
+++ b/docs/stage1-stdlib-status.md
@@ -20,7 +20,7 @@ complete.
 | #234 net sockets | Only DNS resolution and HTTP client GET exist. | Raw sockets need host:port capability policy and async integration. |
 | #236 crypto | Only `std/crypto_hash.ax sha256` exists. | HMAC, AEAD, Ed25519, RNG, and constant-time helpers need real audited implementations. |
 | #238 regex | No regex stdlib module exists. | A linear-time engine should be selected and integrated deliberately. |
-| #240 richer testing | `axiomc test` discovers `*_test.ax`, golden stdout, and assertion helpers. | Table tests, property tests, snapshot helpers, and benchmark framework integration need a separate test-harness design. |
+| #240 richer testing | `axiomc test` discovers `*_test.ax`, golden stdout, assertion helpers, and `std/testing.ax` table/property/snapshot helpers; `axiomc bench` is the benchmark harness. | Richer randomized generation and benchmark CI policy remain future harness design work. |
 | #97 HTTP server | `std/http.ax get` is client-only. | Server lifecycle, routing, response APIs, capability policy, and concurrent handling remain AG4.3 work. |
 
 ## Verification handles

--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -54,8 +54,13 @@ as a native artifact, executes it, and compares stdout against a sibling
 helpers `assert_eq`, `assert_ne`, `assert_true`, and `assert_contains`; they
 return `0` on success so they fit in the current statement-only bootstrap
 surface via ordinary `let` bindings, and they abort the test with a source
-location plus expected/actual detail on failure. Projects that need explicit
-naming or inline expectations can still declare `[[tests]]` entries in
+location plus expected/actual detail on failure. For richer stdlib-oriented
+coverage, `import "std/testing.ax"` exposes table-case helpers
+(`table_int` / `table_bool` / `table_string`), a named `property(name, holds)`
+helper for QuickCheck-style sampled checks expressed as deterministic loops or
+fixtures, and `snapshot(name, actual, expected)` for inline golden assertions.
+Projects that need explicit naming or inline expectations can still declare
+`[[tests]]` entries in
 `axiom.toml`. The command now also accepts `--filter <pattern>` to run a subset
 of discovered tests by test name or entry path, and the default CLI summary now
 prints `passed` / `failed` / `skipped` counts. Workspace-only roots are now

--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -2070,6 +2070,25 @@ fn render_expr(expr: &Expr) -> String {
                 render_expr(&args[2])
             )
         }
+        Expr::Call { name, args, .. } if name == "assert_property" => {
+            format!(
+                "{{ let name = {}; let holds = {}; if holds {{ 0i64 }} else {{ axiom_assert_fail(format!(\"property {{:?}} failed\", name), {}, {}) }} }}",
+                render_expr(&args[0]),
+                render_expr(&args[1]),
+                render_expr(&args[2]),
+                render_expr(&args[3])
+            )
+        }
+        Expr::Call { name, args, .. } if name == "assert_snapshot" => {
+            format!(
+                "{{ let name = {}; let actual = {}; let expected = {}; if actual == expected {{ 0i64 }} else {{ axiom_assert_fail(format!(\"snapshot {{:?}} mismatch: expected {{:?}}, got {{:?}}\", name, expected, actual), {}, {}) }} }}",
+                render_expr(&args[0]),
+                render_expr(&args[1]),
+                render_expr(&args[2]),
+                render_expr(&args[3]),
+                render_expr(&args[4])
+            )
+        }
         Expr::Call { name, args, .. } if name == "assert_contains" => {
             format!(
                 "{{ let haystack = {}; let needle = {}; if haystack.contains(&needle) {{ 0i64 }} else {{ axiom_assert_fail(format!(\"expected {{:?}} to contain {{:?}}\", haystack, needle), {}, {}) }} }}",
@@ -2086,6 +2105,16 @@ fn render_expr(expr: &Expr) -> String {
                 render_expr(&args[1]),
                 render_expr(&args[2]),
                 render_expr(&args[3])
+            )
+        }
+        Expr::Call { name, args, .. } if name == "assert_case_eq" => {
+            format!(
+                "{{ let name = {}; let left = {}; let right = {}; if left == right {{ 0i64 }} else {{ axiom_assert_fail(format!(\"table case {{:?}} failed: expected {{:?}}, got {{:?}}\", name, right, left), {}, {}) }} }}",
+                render_expr(&args[0]),
+                render_expr(&args[1]),
+                render_expr(&args[2]),
+                render_expr(&args[3]),
+                render_expr(&args[4])
             )
         }
         Expr::Call { name, args, .. } if name == "assert_ne" => {

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -4166,6 +4166,74 @@ fn lower_expr_with_expected(
                     ty: Type::Int,
                 });
             }
+            if name == "assert_property" {
+                if args.len() != 2 {
+                    return Err(Diagnostic::new(
+                        "type",
+                        format!("assert_property expects 2 arguments, got {}", args.len()),
+                    )
+                    .with_span(*line, *column));
+                }
+                let label = lower_expr_with_expected(&args[0], Some(&Type::String), env, ctx)?;
+                if label.ty() != &Type::String {
+                    return Err(Diagnostic::new(
+                        "type",
+                        format!("assert_property expects a string name, got {}", label.ty()),
+                    )
+                    .with_span(args[0].line(), args[0].column()));
+                }
+                let holds = lower_expr_with_expected(&args[1], Some(&Type::Bool), env, ctx)?;
+                if holds.ty() != &Type::Bool {
+                    return Err(Diagnostic::new(
+                        "type",
+                        format!(
+                            "assert_property expects a bool condition, got {}",
+                            holds.ty()
+                        ),
+                    )
+                    .with_span(args[1].line(), args[1].column()));
+                }
+                move_lowered_value(&label, env)?;
+                move_lowered_value(&holds, env)?;
+                return Ok(Expr::Call {
+                    name: name.clone(),
+                    args: with_assert_location(vec![label, holds], *line, *column),
+                    ty: Type::Int,
+                });
+            }
+            if name == "assert_snapshot" {
+                if args.len() != 3 {
+                    return Err(Diagnostic::new(
+                        "type",
+                        format!("assert_snapshot expects 3 arguments, got {}", args.len()),
+                    )
+                    .with_span(*line, *column));
+                }
+                let label = lower_expr_with_expected(&args[0], Some(&Type::String), env, ctx)?;
+                let actual = lower_expr_with_expected(&args[1], Some(&Type::String), env, ctx)?;
+                let expected = lower_expr_with_expected(&args[2], Some(&Type::String), env, ctx)?;
+                for (expr, role) in [
+                    (&label, "name"),
+                    (&actual, "actual"),
+                    (&expected, "expected"),
+                ] {
+                    if expr.ty() != &Type::String {
+                        return Err(Diagnostic::new(
+                            "type",
+                            format!("assert_snapshot expects string {role}, got {}", expr.ty()),
+                        )
+                        .with_span(*line, *column));
+                    }
+                }
+                move_lowered_value(&label, env)?;
+                move_lowered_value(&actual, env)?;
+                move_lowered_value(&expected, env)?;
+                return Ok(Expr::Call {
+                    name: name.clone(),
+                    args: with_assert_location(vec![label, actual, expected], *line, *column),
+                    ty: Type::Int,
+                });
+            }
             if name == "assert_contains" {
                 if args.len() != 2 {
                     return Err(Diagnostic::new(
@@ -4204,15 +4272,36 @@ fn lower_expr_with_expected(
                     ty: Type::Int,
                 });
             }
-            if name == "assert_eq" || name == "assert_ne" {
-                if args.len() != 2 {
+            if name == "assert_eq" || name == "assert_ne" || name == "assert_case_eq" {
+                let has_label = name == "assert_case_eq";
+                let expected_args = if has_label { 3 } else { 2 };
+                if args.len() != expected_args {
                     return Err(Diagnostic::new(
                         "type",
-                        format!("{name} expects 2 arguments, got {}", args.len()),
+                        format!(
+                            "{name} expects {expected_args} arguments, got {}",
+                            args.len()
+                        ),
                     )
                     .with_span(*line, *column));
                 }
-                let lhs = lower_expr(&args[0], env, ctx)?;
+                let mut lowered_args = Vec::new();
+                let value_start = if has_label {
+                    let label = lower_expr_with_expected(&args[0], Some(&Type::String), env, ctx)?;
+                    if label.ty() != &Type::String {
+                        return Err(Diagnostic::new(
+                            "type",
+                            format!("{name} expects a string case name, got {}", label.ty()),
+                        )
+                        .with_span(args[0].line(), args[0].column()));
+                    }
+                    move_lowered_value(&label, env)?;
+                    lowered_args.push(label);
+                    1
+                } else {
+                    0
+                };
+                let lhs = lower_expr(&args[value_start], env, ctx)?;
                 if !matches!(lhs.ty(), Type::Int | Type::Bool | Type::String) {
                     return Err(Diagnostic::new(
                         "type",
@@ -4223,19 +4312,22 @@ fn lower_expr_with_expected(
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }
-                let rhs = lower_expr_with_expected(&args[1], Some(lhs.ty()), env, ctx)?;
+                let rhs =
+                    lower_expr_with_expected(&args[value_start + 1], Some(lhs.ty()), env, ctx)?;
                 if rhs.ty() != lhs.ty() {
                     return Err(Diagnostic::new(
                         "type",
                         format!("{name} requires both arguments to share one type"),
                     )
-                    .with_span(args[1].line(), args[1].column()));
+                    .with_span(args[value_start + 1].line(), args[value_start + 1].column()));
                 }
                 move_lowered_value(&lhs, env)?;
                 move_lowered_value(&rhs, env)?;
+                lowered_args.push(lhs);
+                lowered_args.push(rhs);
                 return Ok(Expr::Call {
                     name: name.clone(),
-                    args: with_assert_location(vec![lhs, rhs], *line, *column),
+                    args: with_assert_location(lowered_args, *line, *column),
                     ty: Type::Int,
                 });
             }

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -3927,6 +3927,26 @@ print strlen("hello")
     }
 
     #[test]
+    fn run_project_tests_supports_std_testing_helpers() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("runner-std-testing");
+        create_project(&project, Some("runner-std-testing-app")).expect("create project");
+        fs::write(
+            project.join("src/main_test.ax"),
+            "import \"std/testing.ax\"\nlet int_case: int = table_int(\"double two\", 2 + 2, 4)\nlet bool_case: int = table_bool(\"bool equality\", true, true)\nlet string_case: int = table_string(\"greeting\", \"hello\" + \" world\", \"hello world\")\nlet property_case: int = property(\"addition identity\", 40 + 2 == 42)\nlet snapshot_case: int = snapshot(\"json line\", \"{\\\"ok\\\":true}\", \"{\\\"ok\\\":true}\")\nprint int_case + bool_case + string_case + property_case + snapshot_case\n",
+        )
+        .expect("write std testing test");
+        fs::write(project.join("src/main_test.stdout"), "0\n").expect("write golden");
+
+        let output = run_project_tests(&project).expect("run tests");
+        assert_eq!(output.passed, 1);
+        assert_eq!(output.failed, 0);
+        let case = output.cases.first().expect("test case");
+        assert_eq!(case.stdout, "0\n");
+        assert!(case.ok);
+    }
+
+    #[test]
     fn run_project_tests_reports_assertion_failure_details() {
         let dir = tempdir().expect("tempdir");
         let project = dir.path().join("runner-assertion-fail");

--- a/stage1/crates/axiomc/src/stdlib.rs
+++ b/stage1/crates/axiomc/src/stdlib.rs
@@ -57,6 +57,8 @@
 //!   nonblocking channels.
 //! * `std/async.ax` — deterministic task, join, channel, timeout,
 //!   cancellation, and select wrappers over the stage1 async runtime values.
+//! * `std/testing.ax` — table-case, property, and snapshot assertion helpers
+//!   layered over the bootstrap test intrinsics.
 
 use std::path::{Path, PathBuf};
 
@@ -198,6 +200,14 @@ pub fn recv<T>(channel: AsyncChannel<T>): Task<Option<T>> {\nreturn async_recv<T
 pub fn select<T>(left: Task<Option<T>>, right: Task<Option<T>>): Task<SelectResult<T>> {\nreturn async_select<T>(left, right)\n}\n\
 pub fn selected<T>(result: SelectResult<T>): int {\nreturn async_selected<T>(result)\n}\n\
 pub fn selected_value<T>(result: SelectResult<T>): Option<T> {\nreturn async_selected_value<T>(result)\n}\n",
+    ),
+    (
+        "testing.ax",
+        "pub fn table_int(name: string, actual: int, expected: int): int {\nreturn assert_case_eq(name, actual, expected)\n}\n\
+pub fn table_bool(name: string, actual: bool, expected: bool): int {\nreturn assert_case_eq(name, actual, expected)\n}\n\
+pub fn table_string(name: string, actual: string, expected: string): int {\nreturn assert_case_eq(name, actual, expected)\n}\n\
+pub fn property(name: string, holds: bool): int {\nreturn assert_property(name, holds)\n}\n\
+pub fn snapshot(name: string, actual: string, expected: string): int {\nreturn assert_snapshot(name, actual, expected)\n}\n",
     ),
     (
         "http.ax",


### PR DESCRIPTION
Closes #240

Adds stage1 stdlib testing helpers for richer test fixtures.

Summary:
- add `std/testing.ax` helper surface
- thread helper support through HIR/codegen
- document the new testing helper module/status

Validation:
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc testing -- --nocapture`
