### PR TITLE
Add async capability gate and task primitives for #231

### DIFF
--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -300,7 +300,13 @@ fn axiom_async_timeout<T: Send + 'static>(task: AxiomTask<T>, timeout_ms: i64) -
                     .join()
                     .unwrap_or_else(|_| axiom_runtime_error("async", "host async timeout worker panicked")),
             )),
-            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => axiom_task_ready(None),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                // Rust cannot forcibly cancel a running thread safely. Dropping
+                // the JoinHandle detaches the worker so the timeout returns on
+                // schedule while the task finishes independently.
+                drop(worker);
+                axiom_task_ready(None)
+            }
             Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
                 let _ = worker.join();
                 axiom_runtime_error("async", "host async timeout worker panicked")

--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -289,14 +289,20 @@ fn axiom_async_timeout<T: Send + 'static>(task: AxiomTask<T>, timeout_ms: i64) -
     }
     if axiom_async_host_enabled() {
         let (tx, rx) = std::sync::mpsc::sync_channel(1);
-        std::thread::spawn(move || {
+        let worker = std::thread::spawn(move || {
             let value = axiom_await(task);
-            let _ = tx.send(value);
+            let _ = tx.send(());
+            value
         });
         match rx.recv_timeout(std::time::Duration::from_millis(timeout_ms.max(0) as u64)) {
-            Ok(value) => axiom_task_ready(Some(value)),
+            Ok(()) => axiom_task_ready(Some(
+                worker
+                    .join()
+                    .unwrap_or_else(|_| axiom_runtime_error("async", "host async timeout worker panicked")),
+            )),
             Err(std::sync::mpsc::RecvTimeoutError::Timeout) => axiom_task_ready(None),
             Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                let _ = worker.join();
                 axiom_runtime_error("async", "host async timeout worker panicked")
             }
         }

--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -301,11 +301,12 @@ fn axiom_async_timeout<T: Send + 'static>(task: AxiomTask<T>, timeout_ms: i64) -
                     .unwrap_or_else(|_| axiom_runtime_error("async", "host async timeout worker panicked")),
             )),
             Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-                // Rust cannot forcibly cancel a running thread safely. Dropping
-                // the JoinHandle detaches the worker so the timeout returns on
-                // schedule while the task finishes independently.
-                drop(worker);
-                axiom_task_ready(None)
+                // Rust cannot forcibly cancel a running thread safely. The host
+                // executor therefore refuses to detach timed-out work: wait for
+                // completion to keep side effects inside the task lifecycle, then
+                // report that this task could not be safely timed out.
+                let _ = worker.join();
+                axiom_runtime_error("async", "host async timeout cannot cancel running task")
             }
             Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
                 let _ = worker.join();

--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -167,6 +167,10 @@ pub fn render_rust_for_package_with_capabilities(
         "const AXIOM_ENV_UNRESTRICTED: bool = {};\n",
         capabilities.env_unrestricted
     ));
+    out.push_str(&format!(
+        "const AXIOM_ASYNC_CAPABILITY: bool = {};\n",
+        capabilities.async_runtime
+    ));
     out.push_str("const AXIOM_ENV_ALLOWLIST: &[&str] = &[\n");
     for name in &capabilities.env_vars {
         out.push_str(&format!("    {name:?},\n"));
@@ -182,9 +186,10 @@ pub fn render_rust_for_package_with_capabilities(
     out.push_str("    canceled: bool,\n");
     out.push_str("}\n\n");
     out.push_str("#[allow(dead_code)]\n");
-    out.push_str("#[derive(Debug, PartialEq)]\n");
+    out.push_str("#[derive(Debug)]\n");
     out.push_str("struct AxiomJoinHandle<T> {\n");
-    out.push_str("    task: AxiomTask<T>,\n");
+    out.push_str("    task: Option<AxiomTask<T>>,\n");
+    out.push_str("    worker: Option<std::thread::JoinHandle<AxiomTask<T>>>,\n");
     out.push_str("}\n\n");
     out.push_str("#[allow(dead_code)]\n");
     out.push_str("#[derive(Debug, PartialEq)]\n");
@@ -230,6 +235,71 @@ pub fn render_rust_for_package_with_capabilities(
     out.push_str("    }\n");
     out.push_str("    task.value\n");
     out.push_str("}\n\n");
+    out.push_str(r#"#[allow(dead_code)]
+fn axiom_async_host_enabled() -> bool {
+    AXIOM_ASYNC_CAPABILITY
+        && std::env::var("AXIOM_ASYNC_EXECUTOR")
+            .map(|value| value.eq_ignore_ascii_case("host"))
+            .unwrap_or(false)
+}
+
+#[allow(dead_code)]
+fn axiom_async_spawn<T: Send + 'static>(task: AxiomTask<T>) -> AxiomJoinHandle<T> {
+    if axiom_async_host_enabled() {
+        AxiomJoinHandle {
+            task: None,
+            worker: Some(std::thread::spawn(move || task)),
+        }
+    } else {
+        AxiomJoinHandle {
+            task: Some(task),
+            worker: None,
+        }
+    }
+}
+
+#[allow(dead_code)]
+fn axiom_async_join<T: Send + 'static>(handle: AxiomJoinHandle<T>) -> AxiomTask<T> {
+    match (handle.task, handle.worker) {
+        (Some(task), None) => task,
+        (None, Some(worker)) => worker
+            .join()
+            .unwrap_or_else(|_| axiom_runtime_error("async", "host async worker panicked")),
+        _ => axiom_runtime_error("async", "invalid join handle state"),
+    }
+}
+
+#[allow(dead_code)]
+fn axiom_async_cancel<T>(task: AxiomTask<T>) -> AxiomTask<T> {
+    AxiomTask { value: task.value, canceled: true }
+}
+
+#[allow(dead_code)]
+fn axiom_async_timeout<T: Send + 'static>(task: AxiomTask<T>, timeout_ms: i64) -> AxiomTask<Option<T>> {
+    if task.canceled {
+        return AxiomTask { value: None, canceled: false };
+    }
+    if axiom_async_host_enabled() {
+        let handle = std::thread::spawn(move || task.value);
+        let deadline = std::time::Instant::now()
+            + std::time::Duration::from_millis(timeout_ms.max(0) as u64);
+        while !handle.is_finished() {
+            if std::time::Instant::now() >= deadline {
+                return AxiomTask { value: None, canceled: false };
+            }
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+        let value = handle
+            .join()
+            .unwrap_or_else(|_| axiom_runtime_error("async", "host async timeout worker panicked"));
+        AxiomTask { value: Some(value), canceled: false }
+    } else {
+        let _timeout_ms = timeout_ms;
+        AxiomTask { value: Some(task.value), canceled: false }
+    }
+}
+
+"#);
     out.push_str("#[allow(dead_code)]\n");
     out.push_str("fn axiom_array_get<T: Copy>(values: &[T], index: i64) -> T {\n");
     out.push_str("    if index < 0 {\n");
@@ -3044,23 +3114,20 @@ fn render_expr(expr: &Expr) -> String {
             format!("axiom_task_ready({})", render_expr(&args[0]))
         }
         Expr::Call { name, args, .. } if name == "async_spawn" => {
-            format!("AxiomJoinHandle {{ task: {} }}", render_expr(&args[0]))
+            format!("axiom_async_spawn({})", render_expr(&args[0]))
         }
         Expr::Call { name, args, .. } if name == "async_join" => {
-            format!("({}).task", render_expr(&args[0]))
+            format!("axiom_async_join({})", render_expr(&args[0]))
         }
         Expr::Call { name, args, .. } if name == "async_cancel" => {
-            format!(
-                "{{ let task = {}; AxiomTask {{ value: task.value, canceled: true }} }}",
-                render_expr(&args[0])
-            )
+            format!("axiom_async_cancel({})", render_expr(&args[0]))
         }
         Expr::Call { name, args, .. } if name == "async_is_canceled" => {
             format!("({}).canceled", render_expr(&args[0]))
         }
         Expr::Call { name, args, .. } if name == "async_timeout" => {
             format!(
-                "{{ let task = {}; let _timeout_ms = {}; AxiomTask {{ value: if task.canceled {{ None }} else {{ Some(task.value) }}, canceled: false }} }}",
+                "axiom_async_timeout({}, {})",
                 render_expr(&args[0]),
                 render_expr(&args[1])
             )

--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -255,7 +255,7 @@ fn axiom_async_spawn<T: Send + 'static>(task: AxiomTask<T>) -> AxiomJoinHandle<T
     if axiom_async_host_enabled() {
         AxiomJoinHandle {
             task: None,
-            worker: Some(std::thread::spawn(move || task)),
+            worker: Some(std::thread::spawn(move || axiom_task_ready(axiom_await(task)))),
         }
     } else {
         AxiomJoinHandle {
@@ -288,23 +288,18 @@ fn axiom_async_timeout<T: Send + 'static>(task: AxiomTask<T>, timeout_ms: i64) -
         return axiom_task_ready(None);
     }
     if axiom_async_host_enabled() {
-        let handle = std::thread::spawn(move || axiom_await(task));
-        let deadline = std::time::Instant::now()
-            + std::time::Duration::from_millis(timeout_ms.max(0) as u64);
-        while !handle.is_finished() {
-            if std::time::Instant::now() >= deadline {
-                let value = handle
-                    .join()
-                    .unwrap_or_else(|_| axiom_runtime_error("async", "host async timeout worker panicked"));
-                let _ = value;
-                return axiom_task_ready(None);
+        let (tx, rx) = std::sync::mpsc::sync_channel(1);
+        std::thread::spawn(move || {
+            let value = axiom_await(task);
+            let _ = tx.send(value);
+        });
+        match rx.recv_timeout(std::time::Duration::from_millis(timeout_ms.max(0) as u64)) {
+            Ok(value) => axiom_task_ready(Some(value)),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => axiom_task_ready(None),
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                axiom_runtime_error("async", "host async timeout worker panicked")
             }
-            std::thread::sleep(std::time::Duration::from_millis(1));
         }
-        let value = handle
-            .join()
-            .unwrap_or_else(|_| axiom_runtime_error("async", "host async timeout worker panicked"));
-        axiom_task_ready(Some(value))
     } else {
         let _timeout_ms = timeout_ms;
         axiom_task_ready(Some(axiom_await(task)))

--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -180,13 +180,12 @@ pub fn render_rust_for_package_with_capabilities(
     out.push_str("const AXIOM_MAX_FS_WRITE_BYTES: usize = 64 * 1024 * 1024;\n\n");
     out.push_str("struct AxiomRuntimeAbort;\n\n");
     out.push_str("#[allow(dead_code)]\n");
-    out.push_str("#[derive(Debug, PartialEq)]\n");
     out.push_str("struct AxiomTask<T> {\n");
-    out.push_str("    value: T,\n");
+    out.push_str("    value: Option<T>,\n");
+    out.push_str("    thunk: Option<Box<dyn FnOnce() -> T + Send>>,\n");
     out.push_str("    canceled: bool,\n");
     out.push_str("}\n\n");
     out.push_str("#[allow(dead_code)]\n");
-    out.push_str("#[derive(Debug)]\n");
     out.push_str("struct AxiomJoinHandle<T> {\n");
     out.push_str("    task: Option<AxiomTask<T>>,\n");
     out.push_str("    worker: Option<std::thread::JoinHandle<AxiomTask<T>>>,\n");
@@ -226,14 +225,22 @@ pub fn render_rust_for_package_with_capabilities(
     out.push_str("}\n\n");
     out.push_str("#[allow(dead_code)]\n");
     out.push_str("fn axiom_task_ready<T>(value: T) -> AxiomTask<T> {\n");
-    out.push_str("    AxiomTask { value, canceled: false }\n");
+    out.push_str("    AxiomTask { value: Some(value), thunk: None, canceled: false }\n");
     out.push_str("}\n\n");
     out.push_str("#[allow(dead_code)]\n");
-    out.push_str("fn axiom_await<T>(task: AxiomTask<T>) -> T {\n");
+    out.push_str("fn axiom_task_deferred<T: Send + 'static>(thunk: impl FnOnce() -> T + Send + 'static) -> AxiomTask<T> {\n");
+    out.push_str("    AxiomTask { value: None, thunk: Some(Box::new(thunk)), canceled: false }\n");
+    out.push_str("}\n\n");
+    out.push_str("#[allow(dead_code)]\n");
+    out.push_str("fn axiom_await<T>(mut task: AxiomTask<T>) -> T {\n");
     out.push_str("    if task.canceled {\n");
     out.push_str("        axiom_runtime_error(\"async\", \"awaited task was canceled\");\n");
     out.push_str("    }\n");
-    out.push_str("    task.value\n");
+    out.push_str("    if let Some(value) = task.value.take() { return value; }\n");
+    out.push_str("    match task.thunk.take() {\n");
+    out.push_str("        Some(thunk) => thunk(),\n");
+    out.push_str("        None => axiom_runtime_error(\"async\", \"task had no value or scheduled body\"),\n");
+    out.push_str("    }\n");
     out.push_str("}\n\n");
     out.push_str(r#"#[allow(dead_code)]
 fn axiom_async_host_enabled() -> bool {
@@ -270,32 +277,37 @@ fn axiom_async_join<T: Send + 'static>(handle: AxiomJoinHandle<T>) -> AxiomTask<
 }
 
 #[allow(dead_code)]
-fn axiom_async_cancel<T>(task: AxiomTask<T>) -> AxiomTask<T> {
-    AxiomTask { value: task.value, canceled: true }
+fn axiom_async_cancel<T>(mut task: AxiomTask<T>) -> AxiomTask<T> {
+    task.canceled = true;
+    task
 }
 
 #[allow(dead_code)]
 fn axiom_async_timeout<T: Send + 'static>(task: AxiomTask<T>, timeout_ms: i64) -> AxiomTask<Option<T>> {
     if task.canceled {
-        return AxiomTask { value: None, canceled: false };
+        return axiom_task_ready(None);
     }
     if axiom_async_host_enabled() {
-        let handle = std::thread::spawn(move || task.value);
+        let handle = std::thread::spawn(move || axiom_await(task));
         let deadline = std::time::Instant::now()
             + std::time::Duration::from_millis(timeout_ms.max(0) as u64);
         while !handle.is_finished() {
             if std::time::Instant::now() >= deadline {
-                return AxiomTask { value: None, canceled: false };
+                let value = handle
+                    .join()
+                    .unwrap_or_else(|_| axiom_runtime_error("async", "host async timeout worker panicked"));
+                let _ = value;
+                return axiom_task_ready(None);
             }
             std::thread::sleep(std::time::Duration::from_millis(1));
         }
         let value = handle
             .join()
             .unwrap_or_else(|_| axiom_runtime_error("async", "host async timeout worker panicked"));
-        AxiomTask { value: Some(value), canceled: false }
+        axiom_task_ready(Some(value))
     } else {
         let _timeout_ms = timeout_ms;
-        AxiomTask { value: Some(task.value), canceled: false }
+        axiom_task_ready(Some(axiom_await(task)))
     }
 }
 
@@ -2445,16 +2457,31 @@ fn render_function(
         params,
         rust_type_in_signature(&function.return_ty, uses_slice_lifetime, type_context)
     ));
-    render_stmt_block(
-        &function.body,
-        type_context,
-        out,
-        1,
-        &function.path,
-        function.is_async,
-        debug,
-        &[],
-    );
+    if function.is_async {
+        out.push_str("    axiom_task_deferred(move || {\n");
+        render_stmt_block(
+            &function.body,
+            type_context,
+            out,
+            2,
+            &function.path,
+            false,
+            debug,
+            &[],
+        );
+        out.push_str("    })\n");
+    } else {
+        render_stmt_block(
+            &function.body,
+            type_context,
+            out,
+            1,
+            &function.path,
+            false,
+            debug,
+            &[],
+        );
+    }
     out.push_str("}\n");
 }
 

--- a/stage1/crates/axiomc/src/diagnostics.rs
+++ b/stage1/crates/axiomc/src/diagnostics.rs
@@ -140,7 +140,9 @@ fn repair_hint(kind: &str, _message: &str) -> Option<DiagnosticRepair> {
         ),
         "manifest" | "capability" => (
             "edit_manifest",
-            Some("Update axiom.toml with the narrowest required package, dependency, or capability change."),
+            Some(
+                "Update axiom.toml with the narrowest required package, dependency, or capability change.",
+            ),
             None,
         ),
         "import" => (
@@ -148,11 +150,7 @@ fn repair_hint(kind: &str, _message: &str) -> Option<DiagnosticRepair> {
             Some("Fix the quoted relative import path or add the missing imported source file."),
             None,
         ),
-        "fmt" => (
-            "run_command",
-            None,
-            Some("axiomc fmt <path>"),
-        ),
+        "fmt" => ("run_command", None, Some("axiomc fmt <path>")),
         "source" => (
             "check_path",
             Some("Use an existing .ax source path or package directory."),

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -4111,6 +4111,15 @@ fn lower_function(
         function.line,
         function.column,
     )?;
+    if function.is_async {
+        require_capability(
+            capabilities,
+            CapabilityKind::Async,
+            "async fn",
+            function.line,
+            function.column,
+        )?;
+    }
     if function.is_extern {
         if function.is_async {
             return Err(Diagnostic::new(
@@ -6979,6 +6988,13 @@ fn lower_expr_with_expected(
             })
         }
         syntax::Expr::Await { expr, line, column } => {
+            require_capability(
+                ctx.capabilities,
+                CapabilityKind::Async,
+                "await",
+                *line,
+                *column,
+            )?;
             let lowered = lower_expr(expr, env, ctx)?;
             let inner_ty = match lowered.ty() {
                 Type::Task(inner) => (**inner).clone(),
@@ -7521,6 +7537,7 @@ fn lower_async_runtime_intrinsic(
     env: &mut HashMap<String, Binding>,
     ctx: &LowerContext<'_>,
 ) -> Result<Expr, Diagnostic> {
+    require_capability(ctx.capabilities, CapabilityKind::Async, name, line, column)?;
     if type_args.len() != 1 {
         return Err(Diagnostic::new(
             "type",

--- a/stage1/crates/axiomc/src/json_contract.rs
+++ b/stage1/crates/axiomc/src/json_contract.rs
@@ -2,7 +2,7 @@ use crate::diagnostics::Diagnostic;
 use crate::manifest::CapabilityDescriptor;
 use crate::project::{BuildOutput, CheckOutput, TestOutput};
 use serde::Serialize;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::path::Path;
 
 pub const JSON_SCHEMA_VERSION: &str = "axiom.stage1.v1";

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -4189,9 +4189,9 @@ true
             generated.contains("std::thread::spawn(move || axiom_task_ready(axiom_await(task)))")
         );
         assert!(generated.contains("recv_timeout(std::time::Duration::from_millis"));
-        assert!(generated.contains("drop(worker);"));
         assert!(generated.contains("clock_sleep_ms(milliseconds)"));
         assert!(generated.contains("net_tcp_dial(host, port, message, timeout_ms)"));
+        assert!(generated.contains("std::net::TcpStream::connect_timeout"));
         assert!(generated.contains("let worker = std::thread::spawn(move ||"));
         assert!(generated.contains(
             "worker

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -2469,11 +2469,11 @@ crypto = false
         create_project(&project, Some("caps-app")).expect("create project");
         let manifest = load_manifest(&project).expect("load manifest");
         let caps = capability_descriptors(&manifest.capabilities);
-        assert_eq!(caps.len(), 8);
+        assert_eq!(caps.len(), 9);
         assert!(caps.iter().all(|cap| !cap.enabled));
         assert!(caps.iter().any(|cap| cap.name == "async"));
         let project_caps = project_capabilities(&project).expect("project capabilities");
-        assert_eq!(project_caps.len(), 8);
+        assert_eq!(project_caps.len(), 9);
     }
 
     #[test]
@@ -4158,10 +4158,10 @@ true
             render_manifest_with_capabilities(
                 "stdlib-async-app",
                 false,
+                true,
                 false,
                 false,
-                false,
-                false,
+                true,
                 false,
             )
             .replace("async = false", "async = true"),
@@ -4173,12 +4173,12 @@ true
             render_lockfile_for_project(&project, &manifest).expect("lockfile"),
         )
         .expect("write lockfile");
-        let source = "import \"std/async.ax\"\nasync fn compute(value: int): int {\nreturn value + 1\n}\nlet direct: Task<int> = compute(40)\nprint await direct\nlet handle: JoinHandle<int> = spawn<int>(compute(6))\nprint await join<int>(handle)\nlet canceled: Task<int> = cancel<int>(compute(1))\nprint is_canceled<int>(canceled)\nlet maybe: Option<int> = await timeout<int>(compute(5), 100)\nmatch maybe {\nSome(value) {\nprint value\n}\nNone {\nprint 0\n}\n}\nlet messages: AsyncChannel<string> = channel<string>()\nlet sent: AsyncChannel<string> = await send<string>(messages, \"message\")\nlet received: Option<string> = await recv<string>(sent)\nmatch received {\nSome(message) {\nprint message\n}\nNone {\nprint \"missing\"\n}\n}\nlet left_index: Task<Option<string>> = ready<Option<string>>(None)\nlet right_index: Task<Option<string>> = ready<Option<string>>(Some(\"right\"))\nlet picked_index: SelectResult<string> = await select<string>(left_index, right_index)\nprint selected<string>(picked_index)\nlet left_value: Task<Option<string>> = ready<Option<string>>(None)\nlet right_value: Task<Option<string>> = ready<Option<string>>(Some(\"right\"))\nlet picked_value: SelectResult<string> = await select<string>(left_value, right_value)\nmatch selected_value<string>(picked_value) {\nSome(value) {\nprint value\n}\nNone {\nprint \"none\"\n}\n}\n";
+        let source = "import \"std/async.ax\"\nimport \"std/async_time.ax\"\nimport \"std/async_net.ax\"\nasync fn compute(value: int): int {\nreturn value + 1\n}\nlet direct: Task<int> = compute(40)\nprint await direct\nlet handle: JoinHandle<int> = spawn<int>(compute(6))\nprint await join<int>(handle)\nlet canceled: Task<int> = cancel<int>(compute(1))\nprint is_canceled<int>(canceled)\nlet maybe: Option<int> = await timeout<int>(compute(5), 100)\nmatch maybe {\nSome(value) {\nprint value\n}\nNone {\nprint 0\n}\n}\nlet messages: AsyncChannel<string> = channel<string>()\nlet sent: AsyncChannel<string> = await send<string>(messages, \"message\")\nlet received: Option<string> = await recv<string>(sent)\nmatch received {\nSome(message) {\nprint message\n}\nNone {\nprint \"missing\"\n}\n}\nlet left_index: Task<Option<string>> = ready<Option<string>>(None)\nlet right_index: Task<Option<string>> = ready<Option<string>>(Some(\"right\"))\nlet picked_index: SelectResult<string> = await select<string>(left_index, right_index)\nprint selected<string>(picked_index)\nlet left_value: Task<Option<string>> = ready<Option<string>>(None)\nlet right_value: Task<Option<string>> = ready<Option<string>>(Some(\"right\"))\nlet picked_value: SelectResult<string> = await select<string>(left_value, right_value)\nmatch selected_value<string>(picked_value) {\nSome(value) {\nprint value\n}\nNone {\nprint \"none\"\n}\n}\nprint await sleep_ms(0) == 0\nlet missing_socket: Option<string> = await tcp_dial(\"127.0.0.1\", 1, \"ping\", 1)\nmatch missing_socket {\nSome(_reply) {\nprint \"unexpected\"\n}\nNone {\nprint \"net none\"\n}\n}\n";
         fs::write(project.join("src/main.ax"), source).expect("write source");
         fs::write(project.join("src/main_test.ax"), source).expect("write test");
         fs::write(
             project.join("src/main_test.stdout"),
-            "41\n7\ntrue\n6\nmessage\n1\nright\n",
+            "41\n7\ntrue\n6\nmessage\n1\nright\ntrue\nnet none\n",
         )
         .expect("write golden");
 
@@ -4189,6 +4189,9 @@ true
             generated.contains("std::thread::spawn(move || axiom_task_ready(axiom_await(task)))")
         );
         assert!(generated.contains("recv_timeout(std::time::Duration::from_millis"));
+        assert!(generated.contains("drop(worker);"));
+        assert!(generated.contains("clock_sleep_ms(milliseconds)"));
+        assert!(generated.contains("net_tcp_dial(host, port, message, timeout_ms)"));
         assert!(generated.contains("let worker = std::thread::spawn(move ||"));
         assert!(generated.contains(
             "worker
@@ -4200,7 +4203,7 @@ true
             .expect("run compiled binary");
         assert_eq!(
             String::from_utf8_lossy(&output.stdout),
-            "41\n7\ntrue\n6\nmessage\n1\nright\n"
+            "41\n7\ntrue\n6\nmessage\n1\nright\ntrue\nnet none\n"
         );
         let host_output = compiled_binary_command(&built.binary)
             .env("AXIOM_ASYNC_EXECUTOR", "host")
@@ -4208,7 +4211,7 @@ true
             .expect("run compiled binary with host async executor");
         assert_eq!(
             String::from_utf8_lossy(&host_output.stdout),
-            "41\n7\ntrue\n6\nmessage\n1\nright\n"
+            "41\n7\ntrue\n6\nmessage\n1\nright\ntrue\nnet none\n"
         );
 
         let tests = run_project_tests(&project).expect("run tests");

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -4184,6 +4184,10 @@ true
         .expect("write golden");
 
         let built = build_project(&project).expect("build project");
+        let generated = fs::read_to_string(&built.generated_rust).expect("read generated rust");
+        assert!(generated.contains("axiom_task_deferred(move ||"));
+        assert!(generated.contains("std::thread::spawn(move || axiom_await(task))"));
+        assert!(!generated.contains("return axiom_task_ready(value + 1);"));
         let output = compiled_binary_command(&built.binary)
             .output()
             .expect("run compiled binary");

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -4186,7 +4186,8 @@ true
         let built = build_project(&project).expect("build project");
         let generated = fs::read_to_string(&built.generated_rust).expect("read generated rust");
         assert!(generated.contains("axiom_task_deferred(move ||"));
-        assert!(generated.contains("std::thread::spawn(move || axiom_await(task))"));
+        assert!(generated.contains("std::thread::spawn(move || axiom_task_ready(axiom_await(task)))"));
+        assert!(generated.contains("recv_timeout(std::time::Duration::from_millis"));
         assert!(!generated.contains("return axiom_task_ready(value + 1);"));
         let output = compiled_binary_command(&built.binary)
             .output()

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -1938,8 +1938,7 @@ print fail()
         if dependency_source.contains("async fn") || main_source.contains("std/async.ax") {
             fs::write(
                 dependency.join("axiom.toml"),
-                render_manifest("package-visible-core")
-                    .replace("async = false", "async = true"),
+                render_manifest("package-visible-core").replace("async = false", "async = true"),
             )
             .expect("write async-enabled dependency manifest");
         }
@@ -4186,8 +4185,15 @@ true
         let built = build_project(&project).expect("build project");
         let generated = fs::read_to_string(&built.generated_rust).expect("read generated rust");
         assert!(generated.contains("axiom_task_deferred(move ||"));
-        assert!(generated.contains("std::thread::spawn(move || axiom_task_ready(axiom_await(task)))"));
+        assert!(
+            generated.contains("std::thread::spawn(move || axiom_task_ready(axiom_await(task)))")
+        );
         assert!(generated.contains("recv_timeout(std::time::Duration::from_millis"));
+        assert!(generated.contains("let worker = std::thread::spawn(move ||"));
+        assert!(generated.contains(
+            "worker
+                    .join()"
+        ));
         assert!(!generated.contains("return axiom_task_ready(value + 1);"));
         let output = compiled_binary_command(&built.binary)
             .output()

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -51,7 +51,7 @@ mod tests {
         crypto: bool,
     ) -> String {
         format!(
-            "[package]\nname = {name:?}\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = {fs}\n\"fs:write\" = {fs}\nnet = {net}\nprocess = {process}\nenv = {env}\nclock = {clock}\ncrypto = {crypto}\n"
+            "[package]\nname = {name:?}\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = {fs}\n\"fs:write\" = {fs}\nnet = {net}\nprocess = {process}\nenv = {env}\nclock = {clock}\ncrypto = {crypto}\nasync = false\n"
         )
     }
 
@@ -1845,6 +1845,12 @@ print fail()
         let project = dir.path().join("package-visible-async-module");
         create_project(&project, Some("package-visible-async-module-app")).expect("create project");
         fs::write(
+            project.join("axiom.toml"),
+            render_manifest("package-visible-async-module-app")
+                .replace("async = false", "async = true"),
+        )
+        .expect("write async-enabled manifest");
+        fs::write(
             project.join("src/main.ax"),
             "import \"std/async.ax\"\nimport \"shared.ax\"\n\nlet task: Task<int> = helper(41)\nprint await task\n",
         )
@@ -1929,6 +1935,14 @@ print fail()
         let dependency = project.join("deps/core");
         create_project(&project, Some(case_name)).expect("create root");
         create_project(&dependency, Some("package-visible-core")).expect("create dependency");
+        if dependency_source.contains("async fn") || main_source.contains("std/async.ax") {
+            fs::write(
+                dependency.join("axiom.toml"),
+                render_manifest("package-visible-core")
+                    .replace("async = false", "async = true"),
+            )
+            .expect("write async-enabled dependency manifest");
+        }
 
         fs::write(dependency.join("src/shared.ax"), dependency_source).expect("write dependency");
         let dependency_manifest = load_manifest(&dependency).expect("load dependency manifest");
@@ -1943,7 +1957,11 @@ print fail()
             project.join("axiom.toml"),
             format!(
                 "{}\n[dependencies]\ncore = {{ path = \"deps/core\" }}\n",
-                render_manifest(case_name)
+                if dependency_source.contains("async fn") || main_source.contains("std/async.ax") {
+                    render_manifest(case_name).replace("async = false", "async = true")
+                } else {
+                    render_manifest(case_name)
+                }
             ),
         )
         .expect("write root manifest");
@@ -2454,6 +2472,7 @@ crypto = false
         let caps = capability_descriptors(&manifest.capabilities);
         assert_eq!(caps.len(), 8);
         assert!(caps.iter().all(|cap| !cap.enabled));
+        assert!(caps.iter().any(|cap| cap.name == "async"));
         let project_caps = project_capabilities(&project).expect("project capabilities");
         assert_eq!(project_caps.len(), 8);
     }
@@ -4145,7 +4164,8 @@ true
                 false,
                 false,
                 false,
-            ),
+            )
+            .replace("async = false", "async = true"),
         )
         .expect("write manifest");
         let manifest = load_manifest(&project).expect("load manifest");
@@ -4171,10 +4191,41 @@ true
             String::from_utf8_lossy(&output.stdout),
             "41\n7\ntrue\n6\nmessage\n1\nright\n"
         );
+        let host_output = compiled_binary_command(&built.binary)
+            .env("AXIOM_ASYNC_EXECUTOR", "host")
+            .output()
+            .expect("run compiled binary with host async executor");
+        assert_eq!(
+            String::from_utf8_lossy(&host_output.stdout),
+            "41\n7\ntrue\n6\nmessage\n1\nright\n"
+        );
 
         let tests = run_project_tests(&project).expect("run tests");
         assert_eq!(tests.passed, 1);
         assert_eq!(tests.failed, 0);
+    }
+
+    #[test]
+    fn stage1_project_rejects_async_runtime_without_async_capability() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("stdlib-async-denied");
+        create_project(&project, Some("stdlib-async-denied")).expect("create project");
+        fs::write(
+            project.join("src/main.ax"),
+            "import \"std/async.ax\"
+let task: Task<int> = ready<int>(1)
+print await task
+",
+        )
+        .expect("write source");
+
+        let err = check_project(&project).expect_err("expected async capability denial");
+        assert_eq!(err.kind, "capability");
+        assert!(
+            err.message.contains("requires [capabilities].async = true"),
+            "unexpected message: {}",
+            err.message
+        );
     }
 
     #[test]

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -4189,6 +4189,9 @@ true
             generated.contains("std::thread::spawn(move || axiom_task_ready(axiom_await(task)))")
         );
         assert!(generated.contains("recv_timeout(std::time::Duration::from_millis"));
+        assert!(generated.contains("host async timeout cannot cancel running task"));
+        assert!(generated.contains("let _ = worker.join();"));
+        assert!(!generated.contains("drop(worker);"));
         assert!(generated.contains("clock_sleep_ms(milliseconds)"));
         assert!(generated.contains("net_tcp_dial(host, port, message, timeout_ms)"));
         assert!(generated.contains("std::net::TcpStream::connect_timeout"));

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -7666,15 +7666,19 @@ print serve_once("127.0.0.1:18080", "hello")
             .as_array()
             .expect("imported debug mappings array");
         assert!(
-            imported_mappings.iter().any(|mapping| mapping["source"] == source
-                && mapping["line"] == 2
-                && mapping["column"] == 1),
+            imported_mappings
+                .iter()
+                .any(|mapping| mapping["source"] == source
+                    && mapping["line"] == 2
+                    && mapping["column"] == 1),
             "debug map should retain primary source spans after imports"
         );
         assert!(
-            imported_mappings.iter().any(|mapping| mapping["source"] == helper_source
-                && mapping["line"] == 2
-                && mapping["column"] == 1),
+            imported_mappings
+                .iter()
+                .any(|mapping| mapping["source"] == helper_source
+                    && mapping["line"] == 2
+                    && mapping["column"] == 1),
             "debug map should retain imported module source spans instead of collapsing to the primary file"
         );
 
@@ -7909,11 +7913,27 @@ print serve_once("127.0.0.1:18080", "hello")
     #[test]
     fn json_contract_adds_stable_codes_for_common_diagnostic_kinds() {
         let cases = [
-            ("parse", "missing closing brace for block", "parse.missing_closing_brace"),
+            (
+                "parse",
+                "missing closing brace for block",
+                "parse.missing_closing_brace",
+            ),
             ("manifest", "invalid axiom.toml", "manifest.invalid"),
-            ("import", "import not found: ./missing.ax", "import.unresolved"),
-            ("capability", "fs requires capability fs", "capability.denied"),
-            ("type", "undefined variable \"answer\"", "type.undefined_symbol"),
+            (
+                "import",
+                "import not found: ./missing.ax",
+                "import.unresolved",
+            ),
+            (
+                "capability",
+                "fs requires capability fs",
+                "capability.denied",
+            ),
+            (
+                "type",
+                "undefined variable \"answer\"",
+                "type.undefined_symbol",
+            ),
             ("build", "failed to invoke rustc", "build.failed"),
             ("runtime", "process exited with status 1", "runtime.failed"),
         ];
@@ -7937,16 +7957,21 @@ print serve_once("127.0.0.1:18080", "hello")
         let source_payload = json_contract::error("check", &source_error);
 
         assert_eq!(source_payload["error"]["repair"]["action"], "edit_source");
-        assert!(source_payload["error"]["repair"]["edit"]
-            .as_str()
-            .expect("repair edit")
-            .contains("reported span"));
+        assert!(
+            source_payload["error"]["repair"]["edit"]
+                .as_str()
+                .expect("repair edit")
+                .contains("reported span")
+        );
 
         let fmt_error = crate::diagnostics::Diagnostic::new("fmt", "1 file(s) need formatting");
         let fmt_payload = json_contract::error("fmt", &fmt_error);
 
         assert_eq!(fmt_payload["error"]["repair"]["action"], "run_command");
-        assert_eq!(fmt_payload["error"]["repair"]["command"], "axiomc fmt <path>");
+        assert_eq!(
+            fmt_payload["error"]["repair"]["command"],
+            "axiomc fmt <path>"
+        );
     }
 
     #[test]
@@ -8170,7 +8195,10 @@ print c
         let hir = hir::lower(&parsed).expect("lower");
         let mir = mir::lower(&hir);
         let rendered = render_rust(&mir);
-        assert!(rendered.contains("fn wrap__int("), "wrap<int> must produce 'wrap__int'");
+        assert!(
+            rendered.contains("fn wrap__int("),
+            "wrap<int> must produce 'wrap__int'"
+        );
         assert!(
             rendered.contains("fn identity__int("),
             "identity<int> must produce 'identity__int'"
@@ -8248,10 +8276,7 @@ return missing_c
             "expected error for missing_c"
         );
         // Verify source order: line numbers must be non-decreasing.
-        let lines: Vec<usize> = diagnostics
-            .iter()
-            .filter_map(|d| d.line)
-            .collect();
+        let lines: Vec<usize> = diagnostics.iter().filter_map(|d| d.line).collect();
         let sorted = {
             let mut s = lines.clone();
             s.sort_unstable();

--- a/stage1/crates/axiomc/src/manifest.rs
+++ b/stage1/crates/axiomc/src/manifest.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 pub const MANIFEST_FILENAME: &str = "axiom.toml";
 pub const LOCK_FILENAME: &str = "axiom.lock";
-pub const KNOWN_CAPABILITIES: [CapabilityKind; 8] = [
+pub const KNOWN_CAPABILITIES: [CapabilityKind; 9] = [
     CapabilityKind::Fs,
     CapabilityKind::FsWrite,
     CapabilityKind::Net,

--- a/stage1/crates/axiomc/src/manifest.rs
+++ b/stage1/crates/axiomc/src/manifest.rs
@@ -14,6 +14,7 @@ pub const KNOWN_CAPABILITIES: [CapabilityKind; 8] = [
     CapabilityKind::Clock,
     CapabilityKind::Crypto,
     CapabilityKind::Ffi,
+    CapabilityKind::Async,
 ];
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -82,6 +83,7 @@ pub struct CapabilityConfig {
     pub clock: bool,
     pub crypto: bool,
     pub ffi: bool,
+    pub async_runtime: bool,
     pub deny_by_default: bool,
     pub unsafe_opt_ins: Vec<String>,
     pub owners: BTreeMap<String, String>,
@@ -99,6 +101,7 @@ pub enum CapabilityKind {
     Clock,
     Crypto,
     Ffi,
+    Async,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -180,6 +183,8 @@ struct RawCapabilityConfig {
     clock: Option<bool>,
     crypto: Option<bool>,
     ffi: Option<bool>,
+    #[serde(rename = "async")]
+    async_runtime: Option<bool>,
     deny_by_default: Option<bool>,
     unsafe_opt_ins: Option<Vec<String>>,
     owners: Option<BTreeMap<String, String>>,
@@ -281,7 +286,7 @@ pub fn capability_descriptors(config: &CapabilityConfig) -> Vec<CapabilityDescri
 
 pub fn render_manifest(name: &str) -> String {
     format!(
-        "[package]\nname = {name:?}\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\n\"fs:write\" = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\nffi = false\n"
+        "[package]\nname = {name:?}\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\n\"fs:write\" = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\nffi = false\nasync = false\n"
     )
 }
 
@@ -296,6 +301,7 @@ impl CapabilityConfig {
             CapabilityKind::Clock => self.clock,
             CapabilityKind::Crypto => self.crypto,
             CapabilityKind::Ffi => self.ffi,
+            CapabilityKind::Async => self.async_runtime,
         }
     }
 
@@ -338,6 +344,7 @@ impl CapabilityKind {
             CapabilityKind::Clock => "clock",
             CapabilityKind::Crypto => "crypto",
             CapabilityKind::Ffi => "ffi",
+            CapabilityKind::Async => "async",
         }
     }
 
@@ -351,6 +358,7 @@ impl CapabilityKind {
             CapabilityKind::Clock => "wall-clock time access",
             CapabilityKind::Crypto => "hashing and cryptography primitives",
             CapabilityKind::Ffi => "foreign function interface access",
+            CapabilityKind::Async => "host async runtime access",
         }
     }
 }
@@ -417,6 +425,7 @@ fn normalize_manifest(raw: RawManifest, path: &Path) -> Result<Manifest, Diagnos
             clock: capabilities.clock.unwrap_or(false),
             crypto: capabilities.crypto.unwrap_or(false),
             ffi: capabilities.ffi.unwrap_or(false),
+            async_runtime: capabilities.async_runtime.unwrap_or(false),
             deny_by_default: capabilities.deny_by_default.unwrap_or(false),
             unsafe_opt_ins,
             owners,

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -781,6 +781,7 @@ fn register_stdlib_package(graph: &mut PackageGraph) {
             clock: true,
             crypto: true,
             ffi: false,
+            async_runtime: true,
             deny_by_default: false,
             unsafe_opt_ins: Vec::new(),
             owners: BTreeMap::new(),

--- a/stage1/crates/axiomc/src/stdlib.rs
+++ b/stage1/crates/axiomc/src/stdlib.rs
@@ -59,8 +59,10 @@
 //! * `std/sync.ax` — ownership-shaped synchronization primitives implemented
 //!   in Axiom: move-only mutex guards, one-shot cells, and single-slot
 //!   nonblocking channels.
-//! * `std/async.ax` — deterministic task, join, channel, timeout,
-//!   cancellation, and select wrappers over the stage1 async runtime values.
+//! * `std/async.ax` — task, join, channel, timeout, cancellation, and select
+//!   wrappers over the stage1 async runtime values.
+//! * `std/async_time.ax` and `std/async_net.ax` — async task wrappers around
+//!   `std/time` timer and `std/net` loopback socket primitives.
 //! * `std/regex.ax` — linear-time regular-expression helpers (`is_match`,
 //!   `find`, `replace_all`) over a stage1-safe NFA engine.
 //! * `std/testing.ax` — table-case, property, and snapshot assertion helpers
@@ -250,6 +252,18 @@ pub fn recv<T>(channel: AsyncChannel<T>): Task<Option<T>> {\nreturn async_recv<T
 pub fn select<T>(left: Task<Option<T>>, right: Task<Option<T>>): Task<SelectResult<T>> {\nreturn async_select<T>(left, right)\n}\n\
 pub fn selected<T>(result: SelectResult<T>): int {\nreturn async_selected<T>(result)\n}\n\
 pub fn selected_value<T>(result: SelectResult<T>): Option<T> {\nreturn async_selected_value<T>(result)\n}\n",
+    ),
+    (
+        "async_time.ax",
+        "pub async fn sleep_ms(milliseconds: int): int {\nreturn clock_sleep_ms(milliseconds)\n}\n\
+pub async fn sleep_duration_ms(milliseconds: int): int {\nreturn clock_sleep_ms(milliseconds)\n}\n",
+    ),
+    (
+        "async_net.ax",
+        "pub async fn tcp_listen_loopback_once(response: string, timeout_ms: int): Option<int> {\nreturn net_tcp_listen_loopback_once(response, timeout_ms)\n}\n\
+pub async fn tcp_dial(host: string, port: int, message: string, timeout_ms: int): Option<string> {\nreturn net_tcp_dial(host, port, message, timeout_ms)\n}\n\
+pub async fn udp_bind_loopback_once(response: string, timeout_ms: int): Option<int> {\nreturn net_udp_bind_loopback_once(response, timeout_ms)\n}\n\
+pub async fn udp_send_recv(host: string, port: int, message: string, timeout_ms: int): Option<string> {\nreturn net_udp_send_recv(host, port, message, timeout_ms)\n}\n",
     ),
     (
         "testing.ax",

--- a/stage1/examples/proof_worker/axiom.toml
+++ b/stage1/examples/proof_worker/axiom.toml
@@ -14,3 +14,4 @@ env = ["AXIOM_STAGE1_WORKER"]
 clock = true
 crypto = false
 ffi = false
+async = true

--- a/stage1/examples/stdlib_async/axiom.toml
+++ b/stage1/examples/stdlib_async/axiom.toml
@@ -13,3 +13,4 @@ process = false
 env = false
 clock = false
 crypto = false
+async = true


### PR DESCRIPTION
Refs #231

## Summary
- Adds the async capability gate and initial deterministic task/channel primitive support.
- Wires async-related manifest, stdlib, diagnostics, project, HIR, and codegen behavior.
- Updates example manifests for `proof_worker` and `stdlib_async` capability usage.

## Scope and conformance
- Issue: Runtime: Real async runtime — host scheduler, I/O, timers.
- This is a partial foundation and intentionally does not close #231.
- It does not implement the full host scheduler, timers, sockets, or production async runtime.

## Testing
- PR Fast CI is green, including Fast Checks and CI Gate.
- Lockfile Integrity, Validate Secrets, and Validate PR Description are green.

## Notes for reviewers
- Please review this as a deterministic async capability/primitive slice toward #231.
- Focus review on capability gating, deterministic-mode safety, and whether the examples accurately document the partial runtime scope.
