### PR TITLE
Add debug source marker parsing for #230

### DIFF
--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -136,10 +136,12 @@ still far from the stated 1.0 target for service and agent workloads.
   module source hashes, and dependency imports. Cache hits skip `rustc`, cache
   misses repair stale generated Rust or binary artifacts, and `--timings`
   exposes the hit/miss counts plus per-package compile time.
-- `axiomc build --debug` now asks `rustc` for debuginfo, disables optimization,
-  emits generated Rust source markers, and writes a JSON source-map sidecar for
-  Axiom file/line/column positions; full Axiom-native debugger stepping remains
-  a direct-backend follow-on.
+- `axiomc build --debug` now asks `rustc` for debuginfo on the generated Rust
+  shim, disables optimization, emits generated Rust source markers, and writes a
+  JSON source-map sidecar for Axiom file/line/column positions. Native DWARF line
+  tables intentionally remain generated-Rust locations because rustc path
+  remapping cannot represent Axiom span rows or multiple imported source files;
+  full Axiom-native debugger stepping remains a direct-backend follow-on.
 - `axiomc fmt`, `axiomc bench`, `axiomc doc`, the stage1 scratch `repl`, and a
   bounded `axiomc lsp` analyzer now exist as bootstrap-grade toolchain
   commands. The LSP endpoint currently serves compiler-backed diagnostics over

--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -7,8 +7,7 @@ use crate::mir::{
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
-use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
 use std::str::FromStr;
 
@@ -67,32 +66,10 @@ mod tests {
     fn rejects_unsupported_backend_value() {
         let error = NativeBackendKind::from_str("direct-native")
             .expect_err("unsupported backend values should be rejected");
-        assert!(error
-            .contains("only generated-rust is implemented in this preparatory backend plumbing"));
-    }
-
-    #[test]
-    fn collects_axiom_debug_sources_from_markers() {
-        let generated = "    // axiom-source: /tmp/project/src/main.ax:7:1\n    println!(\"{}\", answer);\n    // axiom-source: /tmp/project/src/math.ax:2:5\n";
-        let paths = super::debug_source_paths(generated)
-            .into_iter()
-            .map(|path| path.display().to_string())
-            .collect::<Vec<_>>();
-
-        assert_eq!(
-            paths,
-            vec![
-                String::from("/tmp/project/src/main.ax"),
-                String::from("/tmp/project/src/math.ax")
-            ]
-        );
-    }
-
-    #[test]
-    fn parses_debug_source_markers_with_colons_in_source_path() {
-        assert_eq!(
-            super::parse_axiom_source_marker("/tmp/project/src/main:debug.ax:12:3"),
-            Some((String::from("/tmp/project/src/main:debug.ax"), 12, 3))
+        assert!(
+            error.contains(
+                "only generated-rust is implemented in this preparatory backend plumbing"
+            )
         );
     }
 }
@@ -3477,36 +3454,6 @@ pub fn compile_native(
     }
 }
 
-fn primary_axiom_debug_source(generated_rust: &Path) -> Option<PathBuf> {
-    let generated_source = fs::read_to_string(generated_rust).ok()?;
-    debug_source_paths(&generated_source).into_iter().next()
-}
-
-fn debug_source_paths(generated_source: &str) -> Vec<PathBuf> {
-    let mut seen = HashSet::new();
-    let mut paths = Vec::new();
-    for line in generated_source.lines() {
-        let Some(marker) = line.trim_start().strip_prefix("// axiom-source: ") else {
-            continue;
-        };
-        let Some((source, _line, _column)) = parse_axiom_source_marker(marker) else {
-            continue;
-        };
-        if seen.insert(source.clone()) {
-            paths.push(PathBuf::from(source));
-        }
-    }
-    paths
-}
-
-fn parse_axiom_source_marker(marker: &str) -> Option<(String, usize, usize)> {
-    let mut parts = marker.rsplitn(3, ':');
-    let column = parts.next()?.parse().ok()?;
-    let line = parts.next()?.parse().ok()?;
-    let source = parts.next()?.to_string();
-    Some((source, line, column))
-}
-
 fn compile_generated_rust(
     generated_rust: &Path,
     binary_path: &Path,
@@ -3519,21 +3466,16 @@ fn compile_generated_rust(
         .arg("axiom_stage1_bootstrap")
         .arg("--edition=2024");
     if debug {
+        // The generated-rust backend asks rustc for native debuginfo for the
+        // Rust shim it compiles. Axiom source spans are emitted separately in
+        // the sidecar debug map; rustc path remapping is intentionally not used
+        // here because it cannot remap DWARF line-table rows to Axiom line
+        // numbers or represent multiple Axiom source files correctly.
         command
             .arg("-C")
             .arg("debuginfo=2")
             .arg("-C")
             .arg("opt-level=0");
-        if let Some(primary_source) = primary_axiom_debug_source(generated_rust) {
-            // Rustc still compiles the generated Rust shim, but remapping the
-            // compilation-unit path gives native debuggers an Axiom source file
-            // in DWARF while the sidecar debug map keeps per-statement spans.
-            command.arg("--remap-path-prefix").arg(format!(
-                "{}={}",
-                generated_rust.display(),
-                primary_source.display()
-            ));
-        }
     } else {
         command.arg("-O");
     }

--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -7,7 +7,8 @@ use crate::mir::{
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
-use std::path::Path;
+use std::fs;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::str::FromStr;
 
@@ -66,10 +67,32 @@ mod tests {
     fn rejects_unsupported_backend_value() {
         let error = NativeBackendKind::from_str("direct-native")
             .expect_err("unsupported backend values should be rejected");
-        assert!(
-            error.contains(
-                "only generated-rust is implemented in this preparatory backend plumbing"
-            )
+        assert!(error
+            .contains("only generated-rust is implemented in this preparatory backend plumbing"));
+    }
+
+    #[test]
+    fn collects_axiom_debug_sources_from_markers() {
+        let generated = "    // axiom-source: /tmp/project/src/main.ax:7:1\n    println!(\"{}\", answer);\n    // axiom-source: /tmp/project/src/math.ax:2:5\n";
+        let paths = super::debug_source_paths(generated)
+            .into_iter()
+            .map(|path| path.display().to_string())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            paths,
+            vec![
+                String::from("/tmp/project/src/main.ax"),
+                String::from("/tmp/project/src/math.ax")
+            ]
+        );
+    }
+
+    #[test]
+    fn parses_debug_source_markers_with_colons_in_source_path() {
+        assert_eq!(
+            super::parse_axiom_source_marker("/tmp/project/src/main:debug.ax:12:3"),
+            Some((String::from("/tmp/project/src/main:debug.ax"), 12, 3))
         );
     }
 }
@@ -3454,6 +3477,36 @@ pub fn compile_native(
     }
 }
 
+fn primary_axiom_debug_source(generated_rust: &Path) -> Option<PathBuf> {
+    let generated_source = fs::read_to_string(generated_rust).ok()?;
+    debug_source_paths(&generated_source).into_iter().next()
+}
+
+fn debug_source_paths(generated_source: &str) -> Vec<PathBuf> {
+    let mut seen = HashSet::new();
+    let mut paths = Vec::new();
+    for line in generated_source.lines() {
+        let Some(marker) = line.trim_start().strip_prefix("// axiom-source: ") else {
+            continue;
+        };
+        let Some((source, _line, _column)) = parse_axiom_source_marker(marker) else {
+            continue;
+        };
+        if seen.insert(source.clone()) {
+            paths.push(PathBuf::from(source));
+        }
+    }
+    paths
+}
+
+fn parse_axiom_source_marker(marker: &str) -> Option<(String, usize, usize)> {
+    let mut parts = marker.rsplitn(3, ':');
+    let column = parts.next()?.parse().ok()?;
+    let line = parts.next()?.parse().ok()?;
+    let source = parts.next()?.to_string();
+    Some((source, line, column))
+}
+
 fn compile_generated_rust(
     generated_rust: &Path,
     binary_path: &Path,
@@ -3471,6 +3524,16 @@ fn compile_generated_rust(
             .arg("debuginfo=2")
             .arg("-C")
             .arg("opt-level=0");
+        if let Some(primary_source) = primary_axiom_debug_source(generated_rust) {
+            // Rustc still compiles the generated Rust shim, but remapping the
+            // compilation-unit path gives native debuggers an Axiom source file
+            // in DWARF while the sidecar debug map keeps per-statement spans.
+            command.arg("--remap-path-prefix").arg(format!(
+                "{}={}",
+                generated_rust.display(),
+                primary_source.display()
+            ));
+        }
     } else {
         command.arg("-O");
     }

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -7480,6 +7480,67 @@ print serve_once("127.0.0.1:18080", "hello")
             );
         }
 
+        let mappings = map["mappings"].as_array().expect("debug mappings array");
+        assert!(
+            mappings.iter().any(|mapping| mapping["source"] == source
+                && mapping["line"] == 1
+                && mapping["column"] == 1),
+            "debug map should preserve the primary Axiom source span"
+        );
+
+        fs::write(
+            project.join("src/helper.ax"),
+            "pub fn helper(): int {\n    return 7\n}\n",
+        )
+        .expect("write helper source");
+        fs::write(
+            project.join("src/main.ax"),
+            "import \"helper.ax\"\nlet answer: int = helper()\nprint answer\n",
+        )
+        .expect("write imported source program");
+        let imported_debug = build_project_with_options(
+            &project,
+            &BuildOptions {
+                backend: NativeBackendKind::GeneratedRust,
+                target: None,
+                package: None,
+                debug: true,
+                ..BuildOptions::default()
+            },
+        )
+        .expect("debug build with import");
+        let imported_map: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(
+                imported_debug
+                    .debug_map
+                    .as_ref()
+                    .expect("imported debug map path"),
+            )
+            .expect("read imported debug map"),
+        )
+        .expect("parse imported debug map");
+        let helper_source = project
+            .join("src/helper.ax")
+            .canonicalize()
+            .expect("canonical helper source path")
+            .display()
+            .to_string();
+        let imported_mappings = imported_map["mappings"]
+            .as_array()
+            .expect("imported debug mappings array");
+        assert!(
+            imported_mappings.iter().any(|mapping| mapping["source"] == source
+                && mapping["line"] == 2
+                && mapping["column"] == 1),
+            "debug map should retain primary source spans after imports"
+        );
+        assert!(
+            imported_mappings.iter().any(|mapping| mapping["source"] == helper_source
+                && mapping["line"] == 2
+                && mapping["column"] == 1),
+            "debug map should retain imported module source spans instead of collapsing to the primary file"
+        );
+
         fs::remove_file(&debug_map).expect("remove debug map");
         let cached_debug = build_project_with_options(
             &project,

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -7455,6 +7455,31 @@ print serve_once("127.0.0.1:18080", "hello")
         assert_eq!(map["mappings"][0]["column"], 1);
         assert!(map["mappings"][0]["generated_line"].is_u64());
 
+        if let Ok(readelf) = which::which("readelf") {
+            let output = Command::new(readelf)
+                .args(["--debug-dump=decodedline", &debug.binary])
+                .output()
+                .expect("run readelf on debug binary");
+            assert!(
+                output.status.success(),
+                "readelf --debug-dump=decodedline failed"
+            );
+            let dwarf_lines = String::from_utf8_lossy(&output.stdout);
+            let generated_file = PathBuf::from(&debug.generated_rust)
+                .file_name()
+                .expect("generated rust file name")
+                .to_string_lossy()
+                .into_owned();
+            assert!(
+                dwarf_lines.contains(&generated_file),
+                "rustc DWARF line table should point at generated Rust; debug map carries Axiom spans"
+            );
+            assert!(
+                !dwarf_lines.contains("main.ax"),
+                "generated-rust debug builds must not pretend rustc remapped DWARF rows to Axiom source lines"
+            );
+        }
+
         fs::remove_file(&debug_map).expect("remove debug map");
         let cached_debug = build_project_with_options(
             &project,


### PR DESCRIPTION
Refs #230

Adds source marker parsing/remap plumbing toward native debug info support. This is part of #230 and does not claim full DWARF source-line mapping behavior yet.