### PR TITLE
fix: address issue #222

### DIFF
--- a/stage1/crates/axiomc/src/diagnostics.rs
+++ b/stage1/crates/axiomc/src/diagnostics.rs
@@ -140,7 +140,9 @@ fn repair_hint(kind: &str, _message: &str) -> Option<DiagnosticRepair> {
         ),
         "manifest" | "capability" => (
             "edit_manifest",
-            Some("Update axiom.toml with the narrowest required package, dependency, or capability change."),
+            Some(
+                "Update axiom.toml with the narrowest required package, dependency, or capability change.",
+            ),
             None,
         ),
         "import" => (
@@ -148,11 +150,7 @@ fn repair_hint(kind: &str, _message: &str) -> Option<DiagnosticRepair> {
             Some("Fix the quoted relative import path or add the missing imported source file."),
             None,
         ),
-        "fmt" => (
-            "run_command",
-            None,
-            Some("axiomc fmt <path>"),
-        ),
+        "fmt" => ("run_command", None, Some("axiomc fmt <path>")),
         "source" => (
             "check_path",
             Some("Use an existing .ax source path or package directory."),

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -1959,7 +1959,7 @@ fn collect_type_params(ty: &syntax::TypeName, type_params: &[String], found: &mu
         | syntax::TypeName::Slice(inner)
         | syntax::TypeName::MutSlice(inner)
         | syntax::TypeName::Option(inner)
-        | syntax::TypeName::Array(inner) => collect_type_params(inner, type_params, found),
+        | syntax::TypeName::Array(inner, _) => collect_type_params(inner, type_params, found),
         syntax::TypeName::Result(ok, err) | syntax::TypeName::Map(ok, err) => {
             collect_type_params(ok, type_params, found);
             collect_type_params(err, type_params, found);
@@ -2344,8 +2344,8 @@ fn rewrite_aggregate_type_name(
                 column,
             )?),
         ),
-        syntax::TypeName::Array(inner) => {
-            syntax::TypeName::Array(Box::new(rewrite_aggregate_type_name(
+        syntax::TypeName::Array(inner, len) => syntax::TypeName::Array(
+            Box::new(rewrite_aggregate_type_name(
                 inner,
                 generic_structs,
                 generic_enums,
@@ -2353,8 +2353,9 @@ fn rewrite_aggregate_type_name(
                 queued,
                 line,
                 column,
-            )?))
-        }
+            )?),
+            len.clone(),
+        ),
         syntax::TypeName::Int => syntax::TypeName::Int,
         syntax::TypeName::Bool => syntax::TypeName::Bool,
         syntax::TypeName::String => syntax::TypeName::String,
@@ -3557,9 +3558,10 @@ fn substitute_type_name(
             Box::new(substitute_type_name(key, type_bindings)),
             Box::new(substitute_type_name(value, type_bindings)),
         ),
-        syntax::TypeName::Array(inner) => {
-            syntax::TypeName::Array(Box::new(substitute_type_name(inner, type_bindings)))
-        }
+        syntax::TypeName::Array(inner, len) => syntax::TypeName::Array(
+            Box::new(substitute_type_name(inner, type_bindings)),
+            len.clone(),
+        ),
         syntax::TypeName::Int => syntax::TypeName::Int,
         syntax::TypeName::Bool => syntax::TypeName::Bool,
         syntax::TypeName::String => syntax::TypeName::String,
@@ -3644,8 +3646,21 @@ fn type_name_monomorph_suffix(ty: &syntax::TypeName) -> String {
             type_name_monomorph_suffix(key),
             type_name_monomorph_suffix(value)
         ),
-        syntax::TypeName::Array(inner) => format!("array_{}", type_name_monomorph_suffix(inner)),
+        syntax::TypeName::Array(inner, len) => match len {
+            Some(len) => format!(
+                "array_{}_{}",
+                type_name_monomorph_suffix(inner),
+                sanitize_symbol_suffix(len)
+            ),
+            None => format!("array_{}", type_name_monomorph_suffix(inner)),
+        },
     }
+}
+
+fn sanitize_symbol_suffix(raw: &str) -> String {
+    raw.chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' })
+        .collect()
 }
 
 fn ownership_error(code: &'static str, message: impl Into<String>) -> Diagnostic {
@@ -9015,7 +9030,7 @@ fn lower_type_inner<T, U>(
                 )?),
             ))
         }
-        syntax::TypeName::Array(inner) => Ok(Type::Array(Box::new(lower_type_inner(
+        syntax::TypeName::Array(inner, _) => Ok(Type::Array(Box::new(lower_type_inner(
             inner, structs, enums, aliases, resolving, line, column,
         )?))),
     }

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -204,7 +204,7 @@ pub enum Expr {
     },
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Eq)]
 pub enum Type {
     Error,
     Int,
@@ -220,11 +220,43 @@ pub enum Type {
     Result(Box<Type>, Box<Type>),
     Tuple(Vec<Type>),
     Map(Box<Type>, Box<Type>),
-    Array(Box<Type>),
+    Array(Box<Type>, Option<usize>),
     Task(Box<Type>),
     JoinHandle(Box<Type>),
     AsyncChannel(Box<Type>),
     SelectResult(Box<Type>),
+}
+
+
+impl PartialEq for Type {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Type::Error, Type::Error)
+            | (Type::Int, Type::Int)
+            | (Type::Bool, Type::Bool)
+            | (Type::String, Type::String) => true,
+            (Type::Struct(lhs), Type::Struct(rhs)) | (Type::Enum(lhs), Type::Enum(rhs)) => lhs == rhs,
+            (Type::Ptr(lhs), Type::Ptr(rhs))
+            | (Type::MutPtr(lhs), Type::MutPtr(rhs))
+            | (Type::Slice(lhs), Type::Slice(rhs))
+            | (Type::MutSlice(lhs), Type::MutSlice(rhs))
+            | (Type::Option(lhs), Type::Option(rhs))
+            | (Type::Task(lhs), Type::Task(rhs))
+            | (Type::JoinHandle(lhs), Type::JoinHandle(rhs))
+            | (Type::AsyncChannel(lhs), Type::AsyncChannel(rhs))
+            | (Type::SelectResult(lhs), Type::SelectResult(rhs)) => lhs == rhs,
+            (Type::Result(lhs_ok, lhs_err), Type::Result(rhs_ok, rhs_err))
+            | (Type::Map(lhs_ok, lhs_err), Type::Map(rhs_ok, rhs_err)) => {
+                lhs_ok == rhs_ok && lhs_err == rhs_err
+            }
+            (Type::Tuple(lhs), Type::Tuple(rhs)) => lhs == rhs,
+            (Type::Array(lhs_inner, lhs_len), Type::Array(rhs_inner, rhs_len)) => {
+                lhs_inner == rhs_inner
+                    && (lhs_len == rhs_len || lhs_len.is_none() || rhs_len.is_none())
+            }
+            _ => false,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -375,9 +407,9 @@ fn lower_with_capabilities_impl(
         collect_type_names(&program.structs, &program.enums, &program.type_aliases)
             .map_err(single_diagnostic)?;
     let (enums, variants) =
-        collect_enum_definitions(&program.enums, &struct_names, &enum_names, &aliases)
+        collect_enum_definitions(&program.enums, &struct_names, &enum_names, &aliases, &consts)
             .map_err(single_diagnostic)?;
-    let structs = collect_struct_definitions(&program.structs, &enum_names, &aliases)
+    let structs = collect_struct_definitions(&program.structs, &enum_names, &aliases, &consts)
         .map_err(single_diagnostic)?;
     validate_recursive_type_cycles(
         &program,
@@ -386,12 +418,15 @@ fn lower_with_capabilities_impl(
         &struct_names,
         &enum_names,
         &aliases,
+        &consts,
     )
     .map_err(single_diagnostic)?;
-    let functions = collect_function_signatures(&program.functions, &structs, &enums, &aliases)
-        .map_err(single_diagnostic)?;
-    let methods = collect_method_signatures(&program.functions, &structs, &enums, &aliases)
-        .map_err(single_diagnostic)?;
+    let functions =
+        collect_function_signatures(&program.functions, &structs, &enums, &aliases, &consts)
+            .map_err(single_diagnostic)?;
+    let methods =
+        collect_method_signatures(&program.functions, &structs, &enums, &aliases, &consts)
+            .map_err(single_diagnostic)?;
     let mut diagnostics = Vec::new();
     let mut lowered_structs = structs.values().cloned().collect::<Vec<_>>();
     lowered_structs.sort_by(|lhs, rhs| lhs.name.cmp(&rhs.name));
@@ -408,6 +443,7 @@ fn lower_with_capabilities_impl(
             &structs,
             &enums,
             &aliases,
+            &consts,
             &variants,
             &functions,
             &methods,
@@ -618,6 +654,7 @@ fn validate_recursive_type_cycles(
     syntax_structs: &HashMap<String, syntax::StructDecl>,
     syntax_enums: &HashMap<String, ()>,
     aliases: &HashMap<String, syntax::TypeAliasDecl>,
+    consts: &HashMap<String, syntax::ConstDecl>,
 ) -> Result<(), Diagnostic> {
     for struct_decl in &program.structs {
         let owner = AggregateRef::Struct(struct_decl.name.clone());
@@ -627,6 +664,7 @@ fn validate_recursive_type_cycles(
                 syntax_structs,
                 syntax_enums,
                 aliases,
+                consts,
                 field.line,
                 field.column,
             )?;
@@ -652,6 +690,7 @@ fn validate_recursive_type_cycles(
                     syntax_structs,
                     syntax_enums,
                     aliases,
+                    consts,
                     variant.line,
                     variant.column,
                 )?;
@@ -726,7 +765,7 @@ fn type_has_unboxed_recursive_path(
             visiting.remove(&current);
             result
         }
-        Type::Slice(_) | Type::MutSlice(_) | Type::Map(_, _) | Type::Array(_) => false,
+        Type::Slice(_) | Type::MutSlice(_) | Type::Map(_, _) | Type::Array(_, _) => false,
         Type::Option(inner)
         | Type::Task(inner)
         | Type::JoinHandle(inner)
@@ -940,7 +979,7 @@ fn infer_generic_calls_in_stmt(
             expr: infer_generic_calls_in_expr(expr, return_ty, env, generic_functions)?,
             line: *line,
             column: *column,
-        },
+        }
     })
 }
 
@@ -2581,7 +2620,7 @@ fn rewrite_stmt_aggregate_types(
             )?,
             line: *line,
             column: *column,
-        },
+        }
     })
 }
 
@@ -2931,7 +2970,7 @@ fn rewrite_expr_aggregate_types(
             )?),
             line: *line,
             column: *column,
-        },
+        }
     })
 }
 
@@ -3149,7 +3188,7 @@ fn rewrite_stmt_generic_calls(
             )?,
             line: *line,
             column: *column,
-        },
+        }
     })
 }
 
@@ -3518,7 +3557,7 @@ fn rewrite_expr_generic_calls(
             )?),
             line: *line,
             column: *column,
-        },
+        }
     })
 }
 
@@ -3661,7 +3700,7 @@ fn type_name_monomorph_suffix(ty: &syntax::TypeName) -> String {
                 sanitize_symbol_suffix(len)
             ),
             None => format!("array_{}", type_name_monomorph_suffix(inner)),
-        },
+        }
     }
 }
 
@@ -3696,7 +3735,7 @@ impl Type {
             | Type::Struct(_)
             | Type::Enum(_)
             | Type::Map(_, _)
-            | Type::Array(_)
+            | Type::Array(_, _)
             | Type::Task(_)
             | Type::JoinHandle(_)
             | Type::AsyncChannel(_)
@@ -3718,7 +3757,7 @@ impl Type {
             | Type::Option(_)
             | Type::Result(_, _)
             | Type::Map(_, _)
-            | Type::Array(_)
+            | Type::Array(_, _)
             | Type::Task(_)
             | Type::JoinHandle(_)
             | Type::AsyncChannel(_)
@@ -3731,6 +3770,7 @@ fn collect_struct_definitions(
     structs: &[syntax::StructDecl],
     enums: &HashMap<String, ()>,
     aliases: &HashMap<String, syntax::TypeAliasDecl>,
+    consts: &HashMap<String, syntax::ConstDecl>,
 ) -> Result<HashMap<String, StructDef>, Diagnostic> {
     let mut names = HashMap::new();
     for struct_decl in structs {
@@ -3768,7 +3808,15 @@ fn collect_struct_definitions(
                 )
                 .with_span(field.line, field.column));
             }
-            let ty = lower_type(&field.ty, &names, enums, aliases, field.line, field.column)?;
+            let ty = lower_type(
+                &field.ty,
+                &names,
+                enums,
+                aliases,
+                consts,
+                field.line,
+                field.column,
+            )?;
             fields.push(StructField {
                 name: field.name.clone(),
                 ty,
@@ -3855,6 +3903,7 @@ fn collect_enum_definitions(
     structs: &HashMap<String, syntax::StructDecl>,
     enum_names: &HashMap<String, ()>,
     aliases: &HashMap<String, syntax::TypeAliasDecl>,
+    consts: &HashMap<String, syntax::ConstDecl>,
 ) -> Result<(HashMap<String, EnumDef>, HashMap<String, Vec<VariantInfo>>), Diagnostic> {
     let mut lowered = HashMap::new();
     let mut variants = HashMap::new();
@@ -3896,6 +3945,7 @@ fn collect_enum_definitions(
                                 structs,
                                 enum_names,
                                 aliases,
+                                consts,
                                 variant.line,
                                 variant.column,
                             )
@@ -3912,6 +3962,7 @@ fn collect_enum_definitions(
                         structs,
                         enum_names,
                         aliases,
+                        consts,
                         variant.line,
                         variant.column,
                     )
@@ -3966,6 +4017,7 @@ fn collect_function_signatures(
     structs: &HashMap<String, StructDef>,
     enums: &HashMap<String, EnumDef>,
     aliases: &HashMap<String, syntax::TypeAliasDecl>,
+    consts: &HashMap<String, syntax::ConstDecl>,
 ) -> Result<HashMap<String, FunctionSig>, Diagnostic> {
     let mut signatures = HashMap::new();
     for function in functions {
@@ -3974,6 +4026,7 @@ fn collect_function_signatures(
             structs,
             enums,
             aliases,
+            consts,
             function.line,
             function.column,
         )?;
@@ -3984,6 +4037,7 @@ fn collect_function_signatures(
                 structs,
                 enums,
                 aliases,
+                consts,
                 function.line,
                 function.column,
             )?;
@@ -3997,6 +4051,7 @@ fn collect_function_signatures(
                 structs,
                 enums,
                 aliases,
+                consts,
                 param.line,
                 param.column,
             )?);
@@ -4040,6 +4095,7 @@ fn collect_method_signatures(
     structs: &HashMap<String, StructDef>,
     enums: &HashMap<String, EnumDef>,
     aliases: &HashMap<String, syntax::TypeAliasDecl>,
+    consts: &HashMap<String, syntax::ConstDecl>,
 ) -> Result<HashMap<String, HashMap<String, MethodSig>>, Diagnostic> {
     let mut methods: HashMap<String, HashMap<String, MethodSig>> = HashMap::new();
     for function in functions {
@@ -4058,6 +4114,7 @@ fn collect_method_signatures(
             structs,
             enums,
             aliases,
+            consts,
             function.line,
             function.column,
         )?;
@@ -4073,6 +4130,7 @@ fn collect_method_signatures(
             structs,
             enums,
             aliases,
+            consts,
             function.line,
             function.column,
         )?;
@@ -4086,6 +4144,7 @@ fn collect_method_signatures(
                 structs,
                 enums,
                 aliases,
+                consts,
                 param.line,
                 param.column,
             )?);
@@ -4121,6 +4180,7 @@ fn lower_function(
     structs: &HashMap<String, StructDef>,
     enums: &HashMap<String, EnumDef>,
     aliases: &HashMap<String, syntax::TypeAliasDecl>,
+    consts: &HashMap<String, syntax::ConstDecl>,
     variants: &HashMap<String, Vec<VariantInfo>>,
     functions: &HashMap<String, FunctionSig>,
     methods: &HashMap<String, HashMap<String, MethodSig>>,
@@ -4131,6 +4191,7 @@ fn lower_function(
         structs,
         enums,
         aliases,
+        consts,
         function.line,
         function.column,
     )?;
@@ -4165,6 +4226,7 @@ fn lower_function(
             structs,
             enums,
             aliases,
+            consts,
             function.line,
             function.column,
         )?;
@@ -4203,7 +4265,15 @@ fn lower_function(
                     .with_span(param.line, param.column),
             );
         }
-        let ty = lower_type(&param.ty, structs, enums, aliases, param.line, param.column)?;
+        let ty = lower_type(
+            &param.ty,
+            structs,
+            enums,
+            aliases,
+            consts,
+            param.line,
+            param.column,
+        )?;
         env.insert(
             param.name.clone(),
             Binding {
@@ -4222,9 +4292,8 @@ fn lower_function(
             ty,
         });
     }
-    let consts = HashMap::new();
     let ctx = LowerContext {
-        consts: &consts,
+        consts,
         structs,
         enums,
         aliases,
@@ -4528,7 +4597,15 @@ fn lower_stmt(
                 )
                 .with_span(*line, *column));
             }
-            let expected = lower_type(ty, ctx.structs, ctx.enums, ctx.aliases, *line, *column)?;
+            let expected = lower_type(
+                ty,
+                ctx.structs,
+                ctx.enums,
+                ctx.aliases,
+                ctx.consts,
+                *line,
+                *column,
+            )?;
             let expected_array_len = declared_array_len(ty, ctx, *line, *column)?;
             let lowered_expr = lower_expr_with_expected(expr, Some(&expected), env, ctx)?;
             let actual = lowered_expr.ty().clone();
@@ -5626,7 +5703,7 @@ fn lower_expr_with_expected(
                 let lowered = lower_expr(&args[0], env, ctx)?;
                 if !matches!(
                     lowered.ty(),
-                    Type::Array(_) | Type::Slice(_) | Type::MutSlice(_)
+                    Type::Array(_, _) | Type::Slice(_) | Type::MutSlice(_)
                 ) {
                     return Err(Diagnostic::new(
                         "type",
@@ -6649,7 +6726,7 @@ fn lower_expr_with_expected(
                 }
                 let lowered = lower_expr(&args[0], env, ctx)?;
                 let element_ty = match lowered.ty() {
-                    Type::Array(element_ty)
+                    Type::Array(element_ty, _)
                     | Type::Slice(element_ty)
                     | Type::MutSlice(element_ty) => (*element_ty.clone()).clone(),
                     _ => {
@@ -6674,7 +6751,7 @@ fn lower_expr_with_expected(
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }
-                if matches!(lowered.ty(), Type::Array(_)) && !element_ty.is_copy() {
+                if matches!(lowered.ty(), Type::Array(_, _)) && !element_ty.is_copy() {
                     move_lowered_owner_value(&lowered, env)?;
                 }
                 return Ok(Expr::Call {
@@ -7540,7 +7617,7 @@ fn lower_expr_with_expected(
             let element_ty = element_ty.expect("non-empty array literal must have an element type");
             Ok(Expr::ArrayLiteral {
                 elements: lowered_elements,
-                ty: Type::Array(Box::new(element_ty)),
+                ty: Type::Array(Box::new(element_ty), Some(elements.len())),
             })
         }
         syntax::Expr::Slice {
@@ -7552,7 +7629,9 @@ fn lower_expr_with_expected(
         } => {
             let lowered_base = lower_projection_base_expr(base, env, ctx)?;
             let element_ty = match lowered_base.ty() {
-                Type::Array(element_ty) | Type::Slice(element_ty) | Type::MutSlice(element_ty) => {
+                Type::Array(element_ty, _)
+                | Type::Slice(element_ty)
+                | Type::MutSlice(element_ty) => {
                     (*element_ty.clone()).clone()
                 }
                 _ => {
@@ -7600,7 +7679,7 @@ fn lower_expr_with_expected(
                 None
             };
             let ty = match (expected, lowered_base.ty()) {
-                (Some(Type::MutSlice(_)), Type::Array(_) | Type::MutSlice(_)) => {
+                (Some(Type::MutSlice(_)), Type::Array(_, _) | Type::MutSlice(_)) => {
                     Type::MutSlice(Box::new(element_ty))
                 }
                 (_, Type::MutSlice(_)) => Type::MutSlice(Box::new(element_ty)),
@@ -7622,7 +7701,7 @@ fn lower_expr_with_expected(
             let lowered_base = lower_projection_base_expr(base, env, ctx)?;
             let lowered_index = lower_expr(index, env, ctx)?;
             let result_ty = match lowered_base.ty() {
-                Type::Array(element_ty) => {
+                Type::Array(element_ty, _) => {
                     if lowered_index.ty() != &Type::Int {
                         return Err(Diagnostic::new(
                             "type",
@@ -7718,6 +7797,7 @@ fn lower_async_runtime_intrinsic(
         ctx.structs,
         ctx.enums,
         ctx.aliases,
+        ctx.consts,
         line,
         column,
     )?;
@@ -8410,7 +8490,7 @@ fn expr_borrow_origin(
             .and_then(|binding| binding.borrow_origin.clone()),
         Expr::Slice { base, .. } => match base.ty() {
             Type::Slice(_) | Type::MutSlice(_) => expr_borrow_origin(base, env, ctx),
-            Type::Array(_) => Some(BorrowOrigin::Local),
+            Type::Array(_, _) => Some(BorrowOrigin::Local),
             _ => Some(BorrowOrigin::Local),
         },
         Expr::Call { name, args, .. } => ctx
@@ -8558,7 +8638,7 @@ fn expr_borrowed_owners(
             .unwrap_or_default(),
         Expr::Slice { base, .. } => match base.ty() {
             Type::Slice(_) | Type::MutSlice(_) => expr_borrowed_owners(base, env, ctx),
-            Type::Array(_) => owned_borrow_root(base).into_iter().collect(),
+            Type::Array(_, _) => owned_borrow_root(base).into_iter().collect(),
             _ => HashSet::new(),
         },
         Expr::Call { name, args, .. } => ctx
@@ -8695,7 +8775,7 @@ fn contains_borrowed_slice_type_inner(
                 visiting_enums,
             )
         }
-        Type::Array(inner)
+        Type::Array(inner, _)
         | Type::Task(inner)
         | Type::JoinHandle(inner)
         | Type::AsyncChannel(inner)
@@ -8812,7 +8892,7 @@ fn contains_mut_borrowed_slice_type_inner(
                 visiting_enums,
             )
         }
-        Type::Array(inner)
+        Type::Array(inner, _)
         | Type::Task(inner)
         | Type::JoinHandle(inner)
         | Type::AsyncChannel(inner)
@@ -9066,7 +9146,7 @@ fn lower_literal(literal: &syntax::Literal) -> Expr {
         syntax::Literal::String(value) => Expr::Literal {
             ty: Type::String,
             value: LiteralValue::String(value.clone()),
-        },
+        }
     }
 }
 
@@ -9075,11 +9155,12 @@ fn lower_type<T, U>(
     structs: &HashMap<String, T>,
     enums: &HashMap<String, U>,
     aliases: &HashMap<String, syntax::TypeAliasDecl>,
+    consts: &HashMap<String, syntax::ConstDecl>,
     line: usize,
     column: usize,
 ) -> Result<Type, Diagnostic> {
     let mut resolving = HashSet::new();
-    lower_type_inner(ty, structs, enums, aliases, &mut resolving, line, column)
+    lower_type_inner(ty, structs, enums, aliases, consts, &mut resolving, line, column)
 }
 
 fn lower_type_inner<T, U>(
@@ -9087,6 +9168,7 @@ fn lower_type_inner<T, U>(
     structs: &HashMap<String, T>,
     enums: &HashMap<String, U>,
     aliases: &HashMap<String, syntax::TypeAliasDecl>,
+    consts: &HashMap<String, syntax::ConstDecl>,
     resolving: &mut HashSet<String>,
     line: usize,
     column: usize,
@@ -9105,7 +9187,7 @@ fn lower_type_inner<T, U>(
                     .with_span(line, column));
                 }
                 let inner = Box::new(lower_type_inner(
-                    &args[0], structs, enums, aliases, resolving, line, column,
+                    &args[0], structs, enums, aliases, consts, resolving, line, column,
                 )?);
                 return Ok(match name.as_str() {
                     "Task" => Type::Task(inner),
@@ -9141,6 +9223,7 @@ fn lower_type_inner<T, U>(
                     structs,
                     enums,
                     aliases,
+                    consts,
                     resolving,
                     type_alias.line,
                     type_alias.column,
@@ -9151,38 +9234,40 @@ fn lower_type_inner<T, U>(
             Err(Diagnostic::new("type", format!("unknown type {name:?}")).with_span(line, column))
         }
         syntax::TypeName::Ptr(inner) => Ok(Type::Ptr(Box::new(lower_type_inner(
-            inner, structs, enums, aliases, resolving, line, column,
+            inner, structs, enums, aliases, consts, resolving, line, column,
         )?))),
         syntax::TypeName::MutPtr(inner) => Ok(Type::MutPtr(Box::new(lower_type_inner(
-            inner, structs, enums, aliases, resolving, line, column,
+            inner, structs, enums, aliases, consts, resolving, line, column,
         )?))),
         syntax::TypeName::Slice(inner) => Ok(Type::Slice(Box::new(lower_type_inner(
-            inner, structs, enums, aliases, resolving, line, column,
+            inner, structs, enums, aliases, consts, resolving, line, column,
         )?))),
         syntax::TypeName::MutSlice(inner) => Ok(Type::MutSlice(Box::new(lower_type_inner(
-            inner, structs, enums, aliases, resolving, line, column,
+            inner, structs, enums, aliases, consts, resolving, line, column,
         )?))),
         syntax::TypeName::Option(inner) => Ok(Type::Option(Box::new(lower_type_inner(
-            inner, structs, enums, aliases, resolving, line, column,
+            inner, structs, enums, aliases, consts, resolving, line, column,
         )?))),
         syntax::TypeName::Result(ok, err) => Ok(Type::Result(
             Box::new(lower_type_inner(
-                ok, structs, enums, aliases, resolving, line, column,
+                ok, structs, enums, aliases, consts, resolving, line, column,
             )?),
             Box::new(lower_type_inner(
-                err, structs, enums, aliases, resolving, line, column,
+                err, structs, enums, aliases, consts, resolving, line, column,
             )?),
         )),
         syntax::TypeName::Tuple(elements) => Ok(Type::Tuple(
             elements
                 .iter()
                 .map(|element| {
-                    lower_type_inner(element, structs, enums, aliases, resolving, line, column)
+                    lower_type_inner(
+                        element, structs, enums, aliases, consts, resolving, line, column,
+                    )
                 })
                 .collect::<Result<Vec<_>, _>>()?,
         )),
         syntax::TypeName::Map(key, value) => {
-            let key = lower_type_inner(key, structs, enums, aliases, resolving, line, column)?;
+            let key = lower_type_inner(key, structs, enums, aliases, consts, resolving, line, column)?;
             if !key.supports_map_key() {
                 return Err(Diagnostic::new(
                     "type",
@@ -9193,13 +9278,23 @@ fn lower_type_inner<T, U>(
             Ok(Type::Map(
                 Box::new(key),
                 Box::new(lower_type_inner(
-                    value, structs, enums, aliases, resolving, line, column,
+                    value, structs, enums, aliases, consts, resolving, line, column,
                 )?),
             ))
         }
-        syntax::TypeName::Array(inner, _) => Ok(Type::Array(Box::new(lower_type_inner(
-            inner, structs, enums, aliases, resolving, line, column,
-        )?))),
+        syntax::TypeName::Array(inner, len) => {
+            let len = len
+                .as_ref()
+                .map(|raw| resolve_const_array_len(raw.trim(), consts, line, column))
+                .transpose()?
+                .map(|value| value as usize);
+            Ok(Type::Array(
+                Box::new(lower_type_inner(
+                    inner, structs, enums, aliases, consts, resolving, line, column,
+                )?),
+                len,
+            ))
+        }
     }
 }
 
@@ -9436,7 +9531,8 @@ impl std::fmt::Display for Type {
                     .join(", ")
             ),
             Type::Map(key, value) => write!(f, "{{{key}: {value}}}"),
-            Type::Array(inner) => write!(f, "[{inner}]"),
+            Type::Array(inner, Some(len)) => write!(f, "[{inner}; {len}]"),
+            Type::Array(inner, None) => write!(f, "[{inner}]"),
             Type::Task(inner) => write!(f, "Task<{inner}>"),
             Type::JoinHandle(inner) => write!(f, "JoinHandle<{inner}>"),
             Type::AsyncChannel(inner) => write!(f, "AsyncChannel<{inner}>"),

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -299,6 +299,7 @@ enum BorrowKind {
 }
 
 struct LowerContext<'a> {
+    consts: &'a HashMap<String, syntax::ConstDecl>,
     structs: &'a HashMap<String, StructDef>,
     enums: &'a HashMap<String, EnumDef>,
     aliases: &'a HashMap<String, syntax::TypeAliasDecl>,
@@ -364,6 +365,12 @@ fn lower_with_capabilities_impl(
     recover: bool,
 ) -> Result<Program, Vec<Diagnostic>> {
     let program = monomorphize_program(program).map_err(single_diagnostic)?;
+    let consts = program
+        .consts
+        .iter()
+        .map(|constant| (constant.name.clone(), constant.clone()))
+        .collect::<HashMap<_, _>>();
+    validate_const_array_lengths_in_program(&program, &consts).map_err(single_diagnostic)?;
     let (struct_names, enum_names, aliases) =
         collect_type_names(&program.structs, &program.enums, &program.type_aliases)
             .map_err(single_diagnostic)?;
@@ -412,6 +419,7 @@ fn lower_with_capabilities_impl(
         }
     }
     let ctx = LowerContext {
+        consts: &consts,
         structs: &structs,
         enums: &enums,
         aliases: &aliases,
@@ -1366,10 +1374,10 @@ fn infer_expr_type_name(
         syntax::Expr::ArrayLiteral { elements, .. } => elements
             .first()
             .and_then(|element| infer_expr_type_name(element, None, env, generic_functions))
-            .map(|inner| syntax::TypeName::Array(Box::new(inner))),
+            .map(|inner| syntax::TypeName::Array(Box::new(inner), None)),
         syntax::Expr::Slice { base, .. } => {
             match infer_expr_type_name(base, None, env, generic_functions)? {
-                syntax::TypeName::Array(inner)
+                syntax::TypeName::Array(inner, _)
                 | syntax::TypeName::Slice(inner)
                 | syntax::TypeName::MutSlice(inner) => Some(syntax::TypeName::Slice(inner)),
                 other => Some(other),
@@ -1377,7 +1385,7 @@ fn infer_expr_type_name(
         }
         syntax::Expr::Index { base, .. } => {
             match infer_expr_type_name(base, None, env, generic_functions)? {
-                syntax::TypeName::Array(inner)
+                syntax::TypeName::Array(inner, _)
                 | syntax::TypeName::Slice(inner)
                 | syntax::TypeName::MutSlice(inner) => Some(*inner),
                 syntax::TypeName::Map(_, value) => Some(*value),
@@ -1422,7 +1430,7 @@ fn contains_generic_type_param(ty: &syntax::TypeName, type_params: &HashSet<Stri
         | syntax::TypeName::Slice(inner)
         | syntax::TypeName::MutSlice(inner)
         | syntax::TypeName::Option(inner)
-        | syntax::TypeName::Array(inner) => contains_generic_type_param(inner, type_params),
+        | syntax::TypeName::Array(inner, _) => contains_generic_type_param(inner, type_params),
         syntax::TypeName::Result(ok, err) | syntax::TypeName::Map(ok, err) => {
             contains_generic_type_param(ok, type_params)
                 || contains_generic_type_param(err, type_params)
@@ -1550,8 +1558,8 @@ fn unify_generic_type_name(
                 Ok(())
             }
         }
-        syntax::TypeName::Array(lhs) => {
-            if let syntax::TypeName::Array(rhs) = actual {
+        syntax::TypeName::Array(lhs, _) => {
+            if let syntax::TypeName::Array(rhs, _) = actual {
                 unify_generic_type_name(lhs, rhs, type_params, bindings, line, column)
             } else if contains_generic_type_param(pattern, type_params) {
                 Err(generic_constraint_mismatch(pattern, actual, line, column))
@@ -4214,7 +4222,9 @@ fn lower_function(
             ty,
         });
     }
+    let consts = HashMap::new();
     let ctx = LowerContext {
+        consts: &consts,
         structs,
         enums,
         aliases,
@@ -4349,6 +4359,148 @@ fn insert_type_error_binding_for_failed_stmt(
     }
 }
 
+fn declared_array_len(
+    ty: &syntax::TypeName,
+    ctx: &LowerContext<'_>,
+    line: usize,
+    column: usize,
+) -> Result<Option<usize>, Diagnostic> {
+    match ty {
+        syntax::TypeName::Array(_, Some(raw)) => {
+            let value = resolve_const_array_len(raw.trim(), ctx.consts, line, column)?;
+            if value < 0 {
+                return Err(Diagnostic::new("type", "array length must be non-negative")
+                    .with_span(line, column));
+            }
+            Ok(Some(value as usize))
+        }
+        _ => Ok(None),
+    }
+}
+
+fn resolve_const_array_len(
+    raw: &str,
+    consts: &HashMap<String, syntax::ConstDecl>,
+    line: usize,
+    column: usize,
+) -> Result<i64, Diagnostic> {
+    if let Ok(value) = raw.parse::<i64>() {
+        return Ok(value);
+    }
+    let Some(const_decl) = consts.get(raw) else {
+        return Err(Diagnostic::new(
+            "type",
+            format!("array length {raw:?} must be a known int const/static expression"),
+        )
+        .with_span(line, column));
+    };
+    eval_const_int_expr(&const_decl.expr).ok_or_else(|| {
+        Diagnostic::new(
+            "type",
+            format!(
+                "array length const {:?} must evaluate to int",
+                const_decl.name
+            ),
+        )
+        .with_span(const_decl.line, const_decl.column)
+    })
+}
+
+fn eval_const_int_expr(expr: &syntax::Expr) -> Option<i64> {
+    match expr {
+        syntax::Expr::Literal(syntax::Literal::Int(value)) => Some(*value),
+        syntax::Expr::BinaryAdd { lhs, rhs, .. } => {
+            Some(eval_const_int_expr(lhs)? + eval_const_int_expr(rhs)?)
+        }
+        _ => None,
+    }
+}
+
+fn validate_const_array_lengths_in_program(
+    program: &syntax::Program,
+    consts: &HashMap<String, syntax::ConstDecl>,
+) -> Result<(), Diagnostic> {
+    for struct_decl in &program.structs {
+        for field in &struct_decl.fields {
+            validate_const_array_lengths_in_type(&field.ty, consts, field.line, field.column)?;
+        }
+    }
+    for enum_decl in &program.enums {
+        for variant in &enum_decl.variants {
+            for payload_ty in &variant.payload_tys {
+                validate_const_array_lengths_in_type(
+                    payload_ty,
+                    consts,
+                    variant.line,
+                    variant.column,
+                )?;
+            }
+        }
+    }
+    for alias in &program.type_aliases {
+        validate_const_array_lengths_in_type(&alias.ty, consts, alias.line, alias.column)?;
+    }
+    for function in &program.functions {
+        validate_const_array_lengths_in_type(
+            &function.return_ty,
+            consts,
+            function.line,
+            function.column,
+        )?;
+        for param in &function.params {
+            validate_const_array_lengths_in_type(&param.ty, consts, param.line, param.column)?;
+        }
+    }
+    for stmt in &program.stmts {
+        if let syntax::Stmt::Let { ty, line, column, .. } = stmt {
+            validate_const_array_lengths_in_type(ty, consts, *line, *column)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_const_array_lengths_in_type(
+    ty: &syntax::TypeName,
+    consts: &HashMap<String, syntax::ConstDecl>,
+    line: usize,
+    column: usize,
+) -> Result<(), Diagnostic> {
+    match ty {
+        syntax::TypeName::Array(inner, len) => {
+            if let Some(raw) = len {
+                let value = resolve_const_array_len(raw.trim(), consts, line, column)?;
+                if value < 0 {
+                    return Err(Diagnostic::new("type", "array length must be non-negative")
+                        .with_span(line, column));
+                }
+            }
+            validate_const_array_lengths_in_type(inner, consts, line, column)
+        }
+        syntax::TypeName::Slice(inner)
+        | syntax::TypeName::MutSlice(inner)
+        | syntax::TypeName::Option(inner) => {
+            validate_const_array_lengths_in_type(inner, consts, line, column)
+        }
+        syntax::TypeName::Result(ok, err) | syntax::TypeName::Map(ok, err) => {
+            validate_const_array_lengths_in_type(ok, consts, line, column)?;
+            validate_const_array_lengths_in_type(err, consts, line, column)
+        }
+        syntax::TypeName::Tuple(elements) => {
+            for element in elements {
+                validate_const_array_lengths_in_type(element, consts, line, column)?;
+            }
+            Ok(())
+        }
+        syntax::TypeName::Named(_, args) => {
+            for arg in args {
+                validate_const_array_lengths_in_type(arg, consts, line, column)?;
+            }
+            Ok(())
+        }
+        _ => Ok(()),
+    }
+}
+
 fn lower_stmt(
     stmt: &syntax::Stmt,
     env: &mut HashMap<String, Binding>,
@@ -4377,8 +4529,23 @@ fn lower_stmt(
                 .with_span(*line, *column));
             }
             let expected = lower_type(ty, ctx.structs, ctx.enums, ctx.aliases, *line, *column)?;
+            let expected_array_len = declared_array_len(ty, ctx, *line, *column)?;
             let lowered_expr = lower_expr_with_expected(expr, Some(&expected), env, ctx)?;
             let actual = lowered_expr.ty().clone();
+            if let Some(expected_len) = expected_array_len {
+                if let syntax::Expr::ArrayLiteral { elements, .. } = expr {
+                    if elements.len() != expected_len {
+                        return Err(Diagnostic::new(
+                            "type",
+                            format!(
+                                "array literal length mismatch: declared {expected_len}, got {}",
+                                elements.len()
+                            ),
+                        )
+                        .with_span(*line, *column));
+                    }
+                }
+            }
             if actual != expected && !actual.is_error() && !expected.is_error() {
                 return Err(Diagnostic::new(
                     "type",

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -227,7 +227,6 @@ pub enum Type {
     SelectResult(Box<Type>),
 }
 
-
 impl PartialEq for Type {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
@@ -235,7 +234,9 @@ impl PartialEq for Type {
             | (Type::Int, Type::Int)
             | (Type::Bool, Type::Bool)
             | (Type::String, Type::String) => true,
-            (Type::Struct(lhs), Type::Struct(rhs)) | (Type::Enum(lhs), Type::Enum(rhs)) => lhs == rhs,
+            (Type::Struct(lhs), Type::Struct(rhs)) | (Type::Enum(lhs), Type::Enum(rhs)) => {
+                lhs == rhs
+            }
             (Type::Ptr(lhs), Type::Ptr(rhs))
             | (Type::MutPtr(lhs), Type::MutPtr(rhs))
             | (Type::Slice(lhs), Type::Slice(rhs))
@@ -251,11 +252,47 @@ impl PartialEq for Type {
             }
             (Type::Tuple(lhs), Type::Tuple(rhs)) => lhs == rhs,
             (Type::Array(lhs_inner, lhs_len), Type::Array(rhs_inner, rhs_len)) => {
-                lhs_inner == rhs_inner
-                    && (lhs_len == rhs_len || lhs_len.is_none() || rhs_len.is_none())
+                lhs_inner == rhs_inner && lhs_len == rhs_len
             }
             _ => false,
         }
+    }
+}
+
+fn type_assignable_to(actual: &Type, expected: &Type) -> bool {
+    match (actual, expected) {
+        (_, Type::Error) | (Type::Error, _) => true,
+        (Type::Array(actual_inner, actual_len), Type::Array(expected_inner, expected_len)) => {
+            type_assignable_to(actual_inner, expected_inner)
+                && match expected_len {
+                    Some(len) => actual_len == &Some(*len),
+                    None => true,
+                }
+        }
+        (Type::Ptr(actual_inner), Type::Ptr(expected_inner))
+        | (Type::MutPtr(actual_inner), Type::MutPtr(expected_inner))
+        | (Type::Slice(actual_inner), Type::Slice(expected_inner))
+        | (Type::MutSlice(actual_inner), Type::MutSlice(expected_inner))
+        | (Type::Option(actual_inner), Type::Option(expected_inner))
+        | (Type::Task(actual_inner), Type::Task(expected_inner))
+        | (Type::JoinHandle(actual_inner), Type::JoinHandle(expected_inner))
+        | (Type::AsyncChannel(actual_inner), Type::AsyncChannel(expected_inner))
+        | (Type::SelectResult(actual_inner), Type::SelectResult(expected_inner)) => {
+            type_assignable_to(actual_inner, expected_inner)
+        }
+        (Type::Result(actual_ok, actual_err), Type::Result(expected_ok, expected_err))
+        | (Type::Map(actual_ok, actual_err), Type::Map(expected_ok, expected_err)) => {
+            type_assignable_to(actual_ok, expected_ok)
+                && type_assignable_to(actual_err, expected_err)
+        }
+        (Type::Tuple(actual), Type::Tuple(expected)) => {
+            actual.len() == expected.len()
+                && actual
+                    .iter()
+                    .zip(expected.iter())
+                    .all(|(actual, expected)| type_assignable_to(actual, expected))
+        }
+        _ => actual == expected,
     }
 }
 
@@ -406,9 +443,14 @@ fn lower_with_capabilities_impl(
     let (struct_names, enum_names, aliases) =
         collect_type_names(&program.structs, &program.enums, &program.type_aliases)
             .map_err(single_diagnostic)?;
-    let (enums, variants) =
-        collect_enum_definitions(&program.enums, &struct_names, &enum_names, &aliases, &consts)
-            .map_err(single_diagnostic)?;
+    let (enums, variants) = collect_enum_definitions(
+        &program.enums,
+        &struct_names,
+        &enum_names,
+        &aliases,
+        &consts,
+    )
+    .map_err(single_diagnostic)?;
     let structs = collect_struct_definitions(&program.structs, &enum_names, &aliases, &consts)
         .map_err(single_diagnostic)?;
     validate_recursive_type_cycles(
@@ -979,7 +1021,7 @@ fn infer_generic_calls_in_stmt(
             expr: infer_generic_calls_in_expr(expr, return_ty, env, generic_functions)?,
             line: *line,
             column: *column,
-        }
+        },
     })
 }
 
@@ -2620,7 +2662,7 @@ fn rewrite_stmt_aggregate_types(
             )?,
             line: *line,
             column: *column,
-        }
+        },
     })
 }
 
@@ -2970,7 +3012,7 @@ fn rewrite_expr_aggregate_types(
             )?),
             line: *line,
             column: *column,
-        }
+        },
     })
 }
 
@@ -3188,7 +3230,7 @@ fn rewrite_stmt_generic_calls(
             )?,
             line: *line,
             column: *column,
-        }
+        },
     })
 }
 
@@ -3557,7 +3599,7 @@ fn rewrite_expr_generic_calls(
             )?),
             line: *line,
             column: *column,
-        }
+        },
     })
 }
 
@@ -3700,7 +3742,7 @@ fn type_name_monomorph_suffix(ty: &syntax::TypeName) -> String {
                 sanitize_symbol_suffix(len)
             ),
             None => format!("array_{}", type_name_monomorph_suffix(inner)),
-        }
+        },
     }
 }
 
@@ -4521,7 +4563,10 @@ fn validate_const_array_lengths_in_program(
         }
     }
     for stmt in &program.stmts {
-        if let syntax::Stmt::Let { ty, line, column, .. } = stmt {
+        if let syntax::Stmt::Let {
+            ty, line, column, ..
+        } = stmt
+        {
             validate_const_array_lengths_in_type(ty, consts, *line, *column)?;
         }
     }
@@ -4623,7 +4668,8 @@ fn lower_stmt(
                     }
                 }
             }
-            if actual != expected && !actual.is_error() && !expected.is_error() {
+            if !type_assignable_to(&actual, &expected) && !actual.is_error() && !expected.is_error()
+            {
                 return Err(Diagnostic::new(
                     "type",
                     format!("let binding {name:?} expects {expected}, got {actual}"),
@@ -5129,7 +5175,7 @@ fn lower_stmt(
                 );
             };
             let lowered_expr = lower_expr_with_expected(expr, Some(expected), env, ctx)?;
-            if lowered_expr.ty() != expected {
+            if !type_assignable_to(lowered_expr.ty(), expected) {
                 return Err(Diagnostic::new(
                     "type",
                     format!("return expects {expected}, got {}", lowered_expr.ty()),
@@ -6785,7 +6831,7 @@ fn lower_expr_with_expected(
                 let mut temporary_borrows = Vec::new();
                 for (arg, expected) in args.iter().zip(signature.params.iter()) {
                     let lowered = lower_expr_with_expected(arg, Some(expected), env, ctx)?;
-                    if lowered.ty() != expected {
+                    if !type_assignable_to(lowered.ty(), expected) {
                         return Err(Diagnostic::new(
                             "type",
                             format!(
@@ -7318,7 +7364,7 @@ fn lower_expr_with_expected(
                     .with_span(field.line, field.column));
                 }
                 let lowered = lower_expr_with_expected(&field.expr, Some(expected), env, ctx)?;
-                if lowered.ty() != expected {
+                if !type_assignable_to(lowered.ty(), expected) {
                     return Err(Diagnostic::new(
                         "type",
                         format!(
@@ -7631,9 +7677,7 @@ fn lower_expr_with_expected(
             let element_ty = match lowered_base.ty() {
                 Type::Array(element_ty, _)
                 | Type::Slice(element_ty)
-                | Type::MutSlice(element_ty) => {
-                    (*element_ty.clone()).clone()
-                }
+                | Type::MutSlice(element_ty) => (*element_ty.clone()).clone(),
                 _ => {
                     return Err(Diagnostic::new(
                         "type",
@@ -9146,7 +9190,7 @@ fn lower_literal(literal: &syntax::Literal) -> Expr {
         syntax::Literal::String(value) => Expr::Literal {
             ty: Type::String,
             value: LiteralValue::String(value.clone()),
-        }
+        },
     }
 }
 
@@ -9160,7 +9204,16 @@ fn lower_type<T, U>(
     column: usize,
 ) -> Result<Type, Diagnostic> {
     let mut resolving = HashSet::new();
-    lower_type_inner(ty, structs, enums, aliases, consts, &mut resolving, line, column)
+    lower_type_inner(
+        ty,
+        structs,
+        enums,
+        aliases,
+        consts,
+        &mut resolving,
+        line,
+        column,
+    )
 }
 
 fn lower_type_inner<T, U>(
@@ -9267,7 +9320,9 @@ fn lower_type_inner<T, U>(
                 .collect::<Result<Vec<_>, _>>()?,
         )),
         syntax::TypeName::Map(key, value) => {
-            let key = lower_type_inner(key, structs, enums, aliases, consts, resolving, line, column)?;
+            let key = lower_type_inner(
+                key, structs, enums, aliases, consts, resolving, line, column,
+            )?;
             if !key.supports_map_key() {
                 return Err(Diagnostic::new(
                     "type",

--- a/stage1/crates/axiomc/src/json_contract.rs
+++ b/stage1/crates/axiomc/src/json_contract.rs
@@ -2,7 +2,7 @@ use crate::diagnostics::Diagnostic;
 use crate::manifest::CapabilityDescriptor;
 use crate::project::{BuildOutput, CheckOutput, TestOutput};
 use serde::Serialize;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::path::Path;
 
 pub const JSON_SCHEMA_VERSION: &str = "axiom.stage1.v1";

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -5954,6 +5954,45 @@ print serve_once("127.0.0.1:18080", "hello")
         );
     }
 
+
+    #[test]
+    fn build_project_rejects_mismatched_const_sized_array_bindings() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("mismatched-const-sized-array-bindings");
+        create_project(&project, Some("mismatched-const-sized-array-bindings-app"))
+            .expect("create project");
+        fs::write(
+            project.join("src/main.ax"),
+            "let three: [int; 3] = [1, 2, 3]\nlet two: [int; 2] = three\nprint len(two)\n",
+        )
+        .expect("write source");
+        let error = build_project(&project).expect_err("mismatched array binding should fail");
+        assert!(
+            error.message.contains("expects [int; 2], got [int; 3]"),
+            "unexpected diagnostic: {error:?}"
+        );
+    }
+
+    #[test]
+    fn build_project_resolves_const_sized_arrays_inside_function_bodies() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("function-local-const-sized-arrays");
+        create_project(&project, Some("function-local-const-sized-arrays-app"))
+            .expect("create project");
+        fs::write(
+            project.join("src/main.ax"),
+            "const WIDTH: int = 3\nfn f(): int {\nlet xs: [int; WIDTH] = [1, 2, 3]\nreturn len(xs)\n}\nprint f()\n",
+        )
+        .expect("write source");
+        let built = build_project(&project)
+            .expect("build project with const-sized array inside function body");
+        let output = compiled_binary_command(&built.binary)
+            .output()
+            .expect("run compiled binary");
+        assert_eq!(String::from_utf8_lossy(&output.stdout), "3
+");
+    }
+
     #[test]
     fn build_project_rejects_unknown_const_sized_array_lengths_in_signatures() {
         let dir = tempdir().expect("tempdir");

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -5903,6 +5903,77 @@ print serve_once("127.0.0.1:18080", "hello")
     }
 
     #[test]
+    fn build_project_rejects_unknown_const_sized_array_lengths() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("unknown-const-sized-arrays");
+        create_project(&project, Some("unknown-const-sized-arrays-app")).expect("create project");
+        fs::write(
+            project.join("src/main.ax"),
+            "let values: [int; MISSING] = [1, 2, 3]\nprint len(values)\n",
+        )
+        .expect("write source");
+        let error = build_project(&project).expect_err("unknown array length const should fail");
+        assert!(
+            error.message.contains("known int const/static expression"),
+            "unexpected diagnostic: {error:?}"
+        );
+    }
+
+    #[test]
+    fn build_project_rejects_non_int_const_sized_array_lengths() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("non-int-const-sized-arrays");
+        create_project(&project, Some("non-int-const-sized-arrays-app")).expect("create project");
+        fs::write(
+            project.join("src/main.ax"),
+            "const WIDTH: bool = true\nlet values: [int; WIDTH] = [1, 2, 3]\nprint len(values)\n",
+        )
+        .expect("write source");
+        let error = build_project(&project).expect_err("non-int array length const should fail");
+        assert!(
+            error.message.contains("must evaluate to int"),
+            "unexpected diagnostic: {error:?}"
+        );
+    }
+
+    #[test]
+    fn build_project_rejects_mismatched_const_sized_array_literals() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("mismatched-const-sized-arrays");
+        create_project(&project, Some("mismatched-const-sized-arrays-app"))
+            .expect("create project");
+        fs::write(
+            project.join("src/main.ax"),
+            "let values: [int; 2] = [1, 2, 3]\nprint len(values)\n",
+        )
+        .expect("write source");
+        let error = build_project(&project).expect_err("mismatched array literal should fail");
+        assert!(
+            error.message.contains("array literal length mismatch"),
+            "unexpected diagnostic: {error:?}"
+        );
+    }
+
+    #[test]
+    fn build_project_rejects_unknown_const_sized_array_lengths_in_signatures() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("signature-unknown-const-sized-arrays");
+        create_project(&project, Some("signature-unknown-const-sized-arrays-app"))
+            .expect("create project");
+        fs::write(
+            project.join("src/main.ax"),
+            "fn first(values: [int; MISSING]): int {\nreturn values[0]\n}\nprint 1\n",
+        )
+        .expect("write source");
+        let error = build_project(&project)
+            .expect_err("unknown array length const in function signature should fail");
+        assert!(
+            error.message.contains("known int const/static expression"),
+            "unexpected diagnostic: {error:?}"
+        );
+    }
+
+    #[test]
     fn build_project_emits_native_binary_with_static_declarations() {
         let dir = tempdir().expect("tempdir");
         let project = dir.path().join("static-declarations");

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -5954,7 +5954,6 @@ print serve_once("127.0.0.1:18080", "hello")
         );
     }
 
-
     #[test]
     fn build_project_rejects_mismatched_const_sized_array_bindings() {
         let dir = tempdir().expect("tempdir");
@@ -5969,6 +5968,54 @@ print serve_once("127.0.0.1:18080", "hello")
         let error = build_project(&project).expect_err("mismatched array binding should fail");
         assert!(
             error.message.contains("expects [int; 2], got [int; 3]"),
+            "unexpected diagnostic: {error:?}"
+        );
+    }
+
+    #[test]
+    fn build_project_rejects_unsized_array_binding_to_sized_array() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("unsized-to-sized-array-binding");
+        create_project(&project, Some("unsized-to-sized-array-binding-app"))
+            .expect("create project");
+        fs::write(
+            project.join("src/main.ax"),
+            "let three: [int] = [1, 2, 3]
+let two: [int; 2] = three
+print len(two)
+",
+        )
+        .expect("write source");
+        let error =
+            build_project(&project).expect_err("unsized array should not satisfy sized binding");
+        assert!(
+            error.message.contains("expects [int; 2], got [int]"),
+            "unexpected diagnostic: {error:?}"
+        );
+    }
+
+    #[test]
+    fn build_project_rejects_unsized_array_argument_to_sized_parameter() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("unsized-to-sized-array-argument");
+        create_project(&project, Some("unsized-to-sized-array-argument-app"))
+            .expect("create project");
+        fs::write(
+            project.join("src/main.ax"),
+            "fn takes_two(xs: [int; 2]): int {
+return len(xs)
+}
+let three: [int] = [1, 2, 3]
+print takes_two(three)
+",
+        )
+        .expect("write source");
+        let error =
+            build_project(&project).expect_err("unsized array should not satisfy sized parameter");
+        assert!(
+            error
+                .message
+                .contains("expects argument type [int; 2], got [int]"),
             "unexpected diagnostic: {error:?}"
         );
     }
@@ -5989,8 +6036,11 @@ print serve_once("127.0.0.1:18080", "hello")
         let output = compiled_binary_command(&built.binary)
             .output()
             .expect("run compiled binary");
-        assert_eq!(String::from_utf8_lossy(&output.stdout), "3
-");
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout),
+            "3
+"
+        );
     }
 
     #[test]
@@ -7756,15 +7806,19 @@ print serve_once("127.0.0.1:18080", "hello")
             .as_array()
             .expect("imported debug mappings array");
         assert!(
-            imported_mappings.iter().any(|mapping| mapping["source"] == source
-                && mapping["line"] == 2
-                && mapping["column"] == 1),
+            imported_mappings
+                .iter()
+                .any(|mapping| mapping["source"] == source
+                    && mapping["line"] == 2
+                    && mapping["column"] == 1),
             "debug map should retain primary source spans after imports"
         );
         assert!(
-            imported_mappings.iter().any(|mapping| mapping["source"] == helper_source
-                && mapping["line"] == 2
-                && mapping["column"] == 1),
+            imported_mappings
+                .iter()
+                .any(|mapping| mapping["source"] == helper_source
+                    && mapping["line"] == 2
+                    && mapping["column"] == 1),
             "debug map should retain imported module source spans instead of collapsing to the primary file"
         );
 
@@ -7999,11 +8053,27 @@ print serve_once("127.0.0.1:18080", "hello")
     #[test]
     fn json_contract_adds_stable_codes_for_common_diagnostic_kinds() {
         let cases = [
-            ("parse", "missing closing brace for block", "parse.missing_closing_brace"),
+            (
+                "parse",
+                "missing closing brace for block",
+                "parse.missing_closing_brace",
+            ),
             ("manifest", "invalid axiom.toml", "manifest.invalid"),
-            ("import", "import not found: ./missing.ax", "import.unresolved"),
-            ("capability", "fs requires capability fs", "capability.denied"),
-            ("type", "undefined variable \"answer\"", "type.undefined_symbol"),
+            (
+                "import",
+                "import not found: ./missing.ax",
+                "import.unresolved",
+            ),
+            (
+                "capability",
+                "fs requires capability fs",
+                "capability.denied",
+            ),
+            (
+                "type",
+                "undefined variable \"answer\"",
+                "type.undefined_symbol",
+            ),
             ("build", "failed to invoke rustc", "build.failed"),
             ("runtime", "process exited with status 1", "runtime.failed"),
         ];
@@ -8027,16 +8097,21 @@ print serve_once("127.0.0.1:18080", "hello")
         let source_payload = json_contract::error("check", &source_error);
 
         assert_eq!(source_payload["error"]["repair"]["action"], "edit_source");
-        assert!(source_payload["error"]["repair"]["edit"]
-            .as_str()
-            .expect("repair edit")
-            .contains("reported span"));
+        assert!(
+            source_payload["error"]["repair"]["edit"]
+                .as_str()
+                .expect("repair edit")
+                .contains("reported span")
+        );
 
         let fmt_error = crate::diagnostics::Diagnostic::new("fmt", "1 file(s) need formatting");
         let fmt_payload = json_contract::error("fmt", &fmt_error);
 
         assert_eq!(fmt_payload["error"]["repair"]["action"], "run_command");
-        assert_eq!(fmt_payload["error"]["repair"]["command"], "axiomc fmt <path>");
+        assert_eq!(
+            fmt_payload["error"]["repair"]["command"],
+            "axiomc fmt <path>"
+        );
     }
 
     #[test]
@@ -8260,7 +8335,10 @@ print c
         let hir = hir::lower(&parsed).expect("lower");
         let mir = mir::lower(&hir);
         let rendered = render_rust(&mir);
-        assert!(rendered.contains("fn wrap__int("), "wrap<int> must produce 'wrap__int'");
+        assert!(
+            rendered.contains("fn wrap__int("),
+            "wrap<int> must produce 'wrap__int'"
+        );
         assert!(
             rendered.contains("fn identity__int("),
             "identity<int> must produce 'identity__int'"
@@ -8338,10 +8416,7 @@ return missing_c
             "expected error for missing_c"
         );
         // Verify source order: line numbers must be non-decreasing.
-        let lines: Vec<usize> = diagnostics
-            .iter()
-            .filter_map(|d| d.line)
-            .collect();
+        let lines: Vec<usize> = diagnostics.iter().filter_map(|d| d.line).collect();
         let sorted = {
             let mut s = lines.clone();
             s.sort_unstable();

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -31,7 +31,7 @@ mod tests {
         command_for_build_output, command_for_executable, project_capabilities, run_project_tests,
         run_project_tests_with_options, run_project_with_options,
     };
-    use crate::syntax::{Visibility, parse_program, parse_program_with_recovery};
+    use crate::syntax::{Stmt, TypeName, Visibility, parse_program, parse_program_with_recovery};
     use serde::Serialize;
     use std::fs;
     use std::path::{Path, PathBuf};
@@ -620,7 +620,7 @@ print fail()
 
     #[test]
     fn parser_tracks_package_visibility() {
-        let source = "pub(pkg) const ANSWER: int = 42\npub(pkg) type Id = int\npub(pkg) struct BuildInfo {\nlabel: string\n}\npub(pkg) enum Status {\nReady\n}\npub(pkg) fn answer(): int {\nreturn ANSWER\n}\npub(pkg) async fn answer_later(): int {\nreturn ANSWER\n}\n";
+        let source = "pub(pkg) static ANSWER: int = 42\npub(pkg) type Id = int\npub(pkg) struct BuildInfo {\nlabel: string\n}\npub(pkg) enum Status {\nReady\n}\npub(pkg) fn answer(): int {\nreturn ANSWER\n}\npub(pkg) async fn answer_later(): int {\nreturn ANSWER\n}\n";
         let parsed = parse_program(source, Path::new("main.ax")).expect("parse");
         assert_eq!(parsed.consts[0].visibility, Visibility::Package);
         assert_eq!(parsed.type_aliases[0].visibility, Visibility::Package);
@@ -1829,7 +1829,7 @@ print fail()
         .expect("write main");
         fs::write(
             project.join("src/shared.ax"),
-            "pub(pkg) const ANSWER: int = 42\npub(pkg) type Id = int\npub(pkg) struct BuildInfo {\nlabel: string\n}\npub(pkg) enum Status {\nReady\n}\npub(pkg) fn helper(): Id {\nreturn ANSWER\n}\npub(pkg) fn build(): BuildInfo {\nreturn BuildInfo { label: \"package\" }\n}\npub(pkg) fn ready(): Status {\nreturn Ready\n}\n",
+            "pub(pkg) static ANSWER: int = 42\npub(pkg) type Id = int\npub(pkg) struct BuildInfo {\nlabel: string\n}\npub(pkg) enum Status {\nReady\n}\npub(pkg) fn helper(): Id {\nreturn ANSWER\n}\npub(pkg) fn build(): BuildInfo {\nreturn BuildInfo { label: \"package\" }\n}\npub(pkg) fn ready(): Status {\nreturn Ready\n}\n",
         )
         .expect("write shared");
         let built = build_project(&project).expect("build package-visible module");
@@ -5869,6 +5869,54 @@ print serve_once("127.0.0.1:18080", "hello")
             String::from_utf8_lossy(&output.stdout),
             "42\ntrue\nstage1\n"
         );
+    }
+
+    #[test]
+    fn parser_accepts_const_sized_array_types() {
+        let source =
+            "const WIDTH: int = 3\nlet values: [int; WIDTH] = [1, 2, 3]\nprint len(values)\n";
+        let parsed = parse_program(source, Path::new("main.ax")).expect("parse const-sized array");
+        let Stmt::Let { ty, .. } = &parsed.stmts[0] else {
+            panic!("expected let statement");
+        };
+        assert_eq!(
+            ty,
+            &TypeName::Array(Box::new(TypeName::Int), Some(String::from("WIDTH")))
+        );
+    }
+
+    #[test]
+    fn build_project_emits_native_binary_with_const_sized_arrays() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("const-sized-arrays");
+        create_project(&project, Some("const-sized-arrays-app")).expect("create project");
+        fs::write(
+            project.join("src/main.ax"),
+            "const WIDTH: int = 3\nlet values: [int; WIDTH] = [1, 2, 3]\nprint len(values)\n",
+        )
+        .expect("write source");
+        let built = build_project(&project).expect("build project with const-sized arrays");
+        let output = compiled_binary_command(&built.binary)
+            .output()
+            .expect("run compiled binary");
+        assert_eq!(String::from_utf8_lossy(&output.stdout), "3\n");
+    }
+
+    #[test]
+    fn build_project_emits_native_binary_with_static_declarations() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("static-declarations");
+        create_project(&project, Some("static-declarations-app")).expect("create project");
+        fs::write(
+            project.join("src/main.ax"),
+            "static ANSWER: int = 40 + 2\nstatic READY: bool = ANSWER == 42\nprint ANSWER\nprint READY\n",
+        )
+        .expect("write source");
+        let built = build_project(&project).expect("build project with static declarations");
+        let output = compiled_binary_command(&built.binary)
+            .output()
+            .expect("run compiled binary");
+        assert_eq!(String::from_utf8_lossy(&output.stdout), "42\ntrue\n");
     }
 
     #[test]

--- a/stage1/crates/axiomc/src/mir.rs
+++ b/stage1/crates/axiomc/src/mir.rs
@@ -587,7 +587,7 @@ fn lower_type(ty: &hir::Type) -> Type {
         hir::Type::Map(key, value) => {
             Type::Map(Box::new(lower_type(key)), Box::new(lower_type(value)))
         }
-        hir::Type::Array(inner) => Type::Array(Box::new(lower_type(inner))),
+        hir::Type::Array(inner, _) => Type::Array(Box::new(lower_type(inner))),
         hir::Type::Task(inner) => Type::Task(Box::new(lower_type(inner))),
         hir::Type::JoinHandle(inner) => Type::JoinHandle(Box::new(lower_type(inner))),
         hir::Type::AsyncChannel(inner) => Type::AsyncChannel(Box::new(lower_type(inner))),

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -3912,14 +3912,17 @@ fn rewrite_type_name(
                 column,
             )?),
         )),
-        syntax::TypeName::Array(inner) => Ok(syntax::TypeName::Array(Box::new(rewrite_type_name(
-            inner,
-            visible_types,
-            private_imported_types,
-            module_path,
-            line,
-            column,
-        )?))),
+        syntax::TypeName::Array(inner, len) => Ok(syntax::TypeName::Array(
+            Box::new(rewrite_type_name(
+                inner,
+                visible_types,
+                private_imported_types,
+                module_path,
+                line,
+                column,
+            )?),
+            len.clone(),
+        )),
     }
 }
 

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -2135,6 +2135,7 @@ fn flatten_modules(
     }
 
     let mut flattened_functions = Vec::new();
+    let mut flattened_consts = Vec::new();
     let mut flattened_type_aliases = Vec::new();
     let mut flattened_structs = Vec::new();
     let mut flattened_enums = Vec::new();
@@ -2473,6 +2474,7 @@ fn flatten_modules(
                 &module.path,
                 &mut HashSet::new(),
             )?;
+            flattened_consts.push(const_decl.clone());
         }
 
         for type_alias in &module.program.type_aliases {
@@ -2541,7 +2543,7 @@ fn flatten_modules(
             .map(|module| module.path.display().to_string())
             .unwrap_or_default(),
         imports: Vec::new(),
-        consts: Vec::new(),
+        consts: flattened_consts,
         type_aliases: flattened_type_aliases,
         structs: flattened_structs,
         enums: flattened_enums,

--- a/stage1/crates/axiomc/src/syntax.rs
+++ b/stage1/crates/axiomc/src/syntax.rs
@@ -198,7 +198,7 @@ pub enum TypeName {
     Result(Box<TypeName>, Box<TypeName>),
     Tuple(Vec<TypeName>),
     Map(Box<TypeName>, Box<TypeName>),
-    Array(Box<TypeName>),
+    Array(Box<TypeName>, Option<String>),
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -437,6 +437,9 @@ pub fn parse_program_with_recovery(source: &str, path: &Path) -> Result<Program,
         if trimmed.starts_with("const ")
             || trimmed.starts_with("pub const ")
             || trimmed.starts_with("pub(pkg) const ")
+            || trimmed.starts_with("static ")
+            || trimmed.starts_with("pub static ")
+            || trimmed.starts_with("pub(pkg) static ")
         {
             match parse_const_decl(trimmed, path, line_no) {
                 Ok(const_decl) => consts.push(const_decl),
@@ -1331,31 +1334,30 @@ fn parse_type_alias(
 
 fn parse_const_decl(trimmed: &str, path: &Path, line_no: usize) -> Result<ConstDecl, Diagnostic> {
     let (visibility, rest, visibility_column) = parse_visibility_prefix(trimmed);
-    let header = if let Some(rest) = rest.strip_prefix("const ") {
-        rest
+    let (keyword, header) = if let Some(rest) = rest.strip_prefix("const ") {
+        ("const", rest)
+    } else if let Some(rest) = rest.strip_prefix("static ") {
+        ("static", rest)
     } else {
-        let _ = rest.strip_prefix("const ").ok_or_else(|| {
-            Diagnostic::new("parse", "invalid const declaration")
-                .with_path(path.display().to_string())
-                .with_span(line_no, 1)
-        })?;
-        unreachable!()
+        return Err(Diagnostic::new("parse", "invalid const/static declaration")
+            .with_path(path.display().to_string())
+            .with_span(line_no, 1));
     };
-    let column = visibility_column + 6;
+    let column = visibility_column + keyword.len() + 1;
     let colon = find_top_level_char(header, ':').ok_or_else(|| {
-        Diagnostic::new("parse", "const declaration is missing ':'")
+        Diagnostic::new("parse", "const/static declaration is missing ':'")
             .with_path(path.display().to_string())
             .with_span(line_no, column)
     })?;
     let equals = find_top_level_char(header, '=').ok_or_else(|| {
-        Diagnostic::new("parse", "const declaration is missing '='")
+        Diagnostic::new("parse", "const/static declaration is missing '='")
             .with_path(path.display().to_string())
             .with_span(line_no, column)
     })?;
     if equals <= colon {
         return Err(Diagnostic::new(
             "parse",
-            "const declaration must use `const NAME: Type = expr` syntax",
+            "const/static declaration must use `const NAME: Type = expr` or `static NAME: Type = expr` syntax",
         )
         .with_path(path.display().to_string())
         .with_span(line_no, column));
@@ -1365,18 +1367,19 @@ fn parse_const_decl(trimmed: &str, path: &Path, line_no: usize) -> Result<ConstD
     let ty_text = header[colon + 1..equals].trim();
     if ty_text.is_empty() {
         return Err(
-            Diagnostic::new("parse", "const declaration is missing a type")
+            Diagnostic::new("parse", "const/static declaration is missing a type")
                 .with_path(path.display().to_string())
                 .with_span(line_no, column + colon + 1),
         );
     }
     let expr_text = header[equals + 1..].trim();
     if expr_text.is_empty() {
-        return Err(
-            Diagnostic::new("parse", "const declaration is missing an initializer")
-                .with_path(path.display().to_string())
-                .with_span(line_no, column + equals + 1),
-        );
+        return Err(Diagnostic::new(
+            "parse",
+            "const/static declaration is missing an initializer",
+        )
+        .with_path(path.display().to_string())
+        .with_span(line_no, column + equals + 1));
     }
     Ok(ConstDecl {
         name: name.to_string(),
@@ -2090,12 +2093,32 @@ fn parse_type_name(
                     .with_span(line_no, column),
             );
         }
-        return Ok(TypeName::Array(Box::new(parse_type_name(
-            inner,
-            path,
-            line_no,
-            column + 1,
-        )?)));
+        let (element_raw, len_raw) = if let Some(semi) = find_top_level_char(inner, ';') {
+            let element_raw = inner[..semi].trim();
+            let len_raw = inner[semi + 1..].trim();
+            if element_raw.is_empty() {
+                return Err(
+                    Diagnostic::new("parse", "array type is missing an element type")
+                        .with_path(path.display().to_string())
+                        .with_span(line_no, column + 1),
+                );
+            }
+            if len_raw.is_empty() {
+                return Err(
+                    Diagnostic::new("parse", "array type is missing a length expression")
+                        .with_path(path.display().to_string())
+                        .with_span(line_no, column + semi + 2),
+                );
+            }
+            parse_expr(len_raw, path, line_no, column + semi + 2)?;
+            (element_raw, Some(len_raw.to_string()))
+        } else {
+            (inner, None)
+        };
+        return Ok(TypeName::Array(
+            Box::new(parse_type_name(element_raw, path, line_no, column + 1)?),
+            len_raw,
+        ));
     }
     if let Some(open_angle) = find_top_level_char(raw, '<') {
         if !raw.ends_with('>')


### PR DESCRIPTION
Closes #222

## Summary
- Adds compile-time constant/static language support in the stage1 compiler path.
- Updates syntax, HIR, MIR, diagnostics, JSON contract handling, project logic, and library wiring for const/static handling.
- Establishes the compiler-side foundation for const expressions used by language features such as array sizing and named constants.

## Scope and conformance
- Issue: Language: `const` / `static` compile-time evaluation.
- Primary implementation paths: `stage1/crates/axiomc/src/{syntax,hir,mir,diagnostics,json_contract,lib,project}.rs`.

## Testing
- PR Fast CI is green, including Fast Checks and CI Gate.
- Lockfile Integrity, Validate Secrets, and Validate PR Description are green.

## Notes for reviewers
- This is the Daedalus-assigned implementation slice for #222.
- Please focus review on evaluator boundaries, diagnostics, and whether the implemented compile-time behavior matches the issue scope.
