### PR TITLE
fix: address issue #221

### DIFF
--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -2167,6 +2167,7 @@ fn expr_uses_call(expr: &Expr, name: &str) -> bool {
             expr_uses_call(base, name) || expr_uses_call(index, name)
         }
         Expr::Literal(_) | Expr::VarRef { .. } => false,
+        Expr::StringBorrow { expr, .. } => expr_uses_call(expr, name),
     }
 }
 
@@ -2211,6 +2212,7 @@ impl<'a> TypeContext<'a> {
     ) -> bool {
         match ty {
             Type::Int | Type::Bool | Type::String | Type::Ptr(_) | Type::MutPtr(_) => false,
+            Type::Str => true,
             Type::Slice(_) | Type::MutSlice(_) => true,
             Type::Struct(name) => {
                 if !visiting_structs.insert(name.clone()) {
@@ -2784,6 +2786,8 @@ fn render_expr(expr: &Expr) -> String {
         Expr::Literal(LiteralValue::Int(value)) => value.to_string(),
         Expr::Literal(LiteralValue::Bool(value)) => value.to_string(),
         Expr::Literal(LiteralValue::String(value)) => format!("String::from({value:?})"),
+        Expr::Literal(LiteralValue::Str(value)) => format!("{value:?}"),
+        Expr::StringBorrow { expr, .. } => format!("{}.as_str()", render_expr(expr)),
         Expr::VarRef { name, .. } if name == "self" => String::from("self_"),
         Expr::VarRef { name, .. } => name.clone(),
         Expr::Call { name, args, .. } if name == "assert_true" => {
@@ -3106,7 +3110,7 @@ fn render_expr(expr: &Expr) -> String {
         }
         Expr::BinaryAdd { lhs, rhs, ty } => match ty {
             Type::Int => format!("{} + {}", render_expr(lhs), render_expr(rhs)),
-            Type::String => format!(
+            Type::String | Type::Str => format!(
                 "format!(\"{{}}{{}}\", {}, {})",
                 render_expr(lhs),
                 render_expr(rhs)
@@ -3311,6 +3315,10 @@ fn rust_type_inner(ty: &Type, lifetime: Option<&str>, type_context: &TypeContext
         Type::Int => String::from("i64"),
         Type::Bool => String::from("bool"),
         Type::String => String::from("String"),
+        Type::Str => match lifetime {
+            Some(lifetime) => format!("&{lifetime} str"),
+            None => String::from("&str"),
+        },
         Type::Struct(name) => {
             if type_context.struct_uses_borrowed_slice(name) {
                 format!("{name}<{}>", lifetime.unwrap_or("'_"))

--- a/stage1/crates/axiomc/src/diagnostics.rs
+++ b/stage1/crates/axiomc/src/diagnostics.rs
@@ -140,7 +140,9 @@ fn repair_hint(kind: &str, _message: &str) -> Option<DiagnosticRepair> {
         ),
         "manifest" | "capability" => (
             "edit_manifest",
-            Some("Update axiom.toml with the narrowest required package, dependency, or capability change."),
+            Some(
+                "Update axiom.toml with the narrowest required package, dependency, or capability change.",
+            ),
             None,
         ),
         "import" => (
@@ -148,11 +150,7 @@ fn repair_hint(kind: &str, _message: &str) -> Option<DiagnosticRepair> {
             Some("Fix the quoted relative import path or add the missing imported source file."),
             None,
         ),
-        "fmt" => (
-            "run_command",
-            None,
-            Some("axiomc fmt <path>"),
-        ),
+        "fmt" => ("run_command", None, Some("axiomc fmt <path>")),
         "source" => (
             "check_path",
             Some("Use an existing .ax source path or package directory."),

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -5208,7 +5208,7 @@ fn coerce_expr_to_expected(
 }
 
 fn is_stable_string_borrow_owner(expr: &Expr) -> bool {
-    matches!(expr, Expr::VarRef { .. } | Expr::FieldAccess { .. } | Expr::Index { .. })
+    matches!(expr, Expr::VarRef { .. } | Expr::FieldAccess { .. })
 }
 
 fn lower_expr_with_expected(
@@ -8670,12 +8670,9 @@ fn contains_borrowed_slice_type_inner(
             visiting_enums.remove(name);
             contains
         }
-        Type::Error
-        | Type::Int
-        | Type::Bool
-        | Type::String
-        | Type::Ptr(_)
-        | Type::MutPtr(_) => false,
+        Type::Error | Type::Int | Type::Bool | Type::String | Type::Ptr(_) | Type::MutPtr(_) => {
+            false
+        }
     }
 }
 

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -5226,9 +5226,11 @@ fn lower_call_arg_with_expected(
     expected: Option<&Type>,
     env: &mut HashMap<String, Binding>,
     ctx: &LowerContext<'_>,
+    allow_temporary_string_borrow: bool,
 ) -> Result<Expr, Diagnostic> {
-    lower_expr_with_expected_inner(expr, expected, env, ctx)
-        .and_then(|lowered| coerce_expr_to_expected(lowered, expected, true))
+    lower_expr_with_expected_inner(expr, expected, env, ctx).and_then(|lowered| {
+        coerce_expr_to_expected(lowered, expected, allow_temporary_string_borrow)
+    })
 }
 
 fn lower_expr_with_expected_inner(
@@ -6599,8 +6601,17 @@ fn lower_expr_with_expected_inner(
                 }
                 let mut lowered_args = Vec::new();
                 let mut temporary_borrows = Vec::new();
-                for (arg, expected) in args.iter().zip(signature.params.iter()) {
-                    let lowered = lower_call_arg_with_expected(arg, Some(expected), env, ctx)?;
+                for (index, (arg, expected)) in args.iter().zip(signature.params.iter()).enumerate()
+                {
+                    let allow_temporary_string_borrow =
+                        !signature.borrow_return_params.contains(&index);
+                    let lowered = lower_call_arg_with_expected(
+                        arg,
+                        Some(expected),
+                        env,
+                        ctx,
+                        allow_temporary_string_borrow,
+                    )?;
                     if lowered.ty() != expected {
                         return Err(Diagnostic::new(
                             "type",
@@ -6794,8 +6805,17 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(*line, *column));
                 }
-                for (arg, expected) in args.iter().zip(signature.params.iter()) {
-                    let lowered = lower_call_arg_with_expected(arg, Some(expected), env, ctx)?;
+                for (index, (arg, expected)) in args.iter().zip(signature.params.iter()).enumerate()
+                {
+                    let allow_temporary_string_borrow =
+                        !signature.borrow_return_params.contains(&index);
+                    let lowered = lower_call_arg_with_expected(
+                        arg,
+                        Some(expected),
+                        env,
+                        ctx,
+                        allow_temporary_string_borrow,
+                    )?;
                     if lowered.ty() != expected {
                         return Err(Diagnostic::new(
                             "type",

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -202,6 +202,10 @@ pub enum Expr {
         index: Box<Expr>,
         ty: Type,
     },
+    StringBorrow {
+        expr: Box<Expr>,
+        ty: Type,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -210,6 +214,7 @@ pub enum Type {
     Int,
     Bool,
     String,
+    Str,
     Struct(String),
     Enum(String),
     Ptr(Box<Type>),
@@ -673,9 +678,13 @@ fn type_has_unboxed_recursive_path(
     visiting: &mut HashSet<AggregateRef>,
 ) -> bool {
     match ty {
-        Type::Error | Type::Int | Type::Bool | Type::String | Type::Ptr(_) | Type::MutPtr(_) => {
-            false
-        }
+        Type::Error
+        | Type::Int
+        | Type::Bool
+        | Type::String
+        | Type::Str
+        | Type::Ptr(_)
+        | Type::MutPtr(_) => false,
         Type::Struct(name) => {
             let current = AggregateRef::Struct(name.clone());
             if &current == owner {
@@ -1969,7 +1978,10 @@ fn collect_type_params(ty: &syntax::TypeName, type_params: &[String], found: &mu
                 collect_type_params(element, type_params, found);
             }
         }
-        syntax::TypeName::Int | syntax::TypeName::Bool | syntax::TypeName::String => {}
+        syntax::TypeName::Int
+        | syntax::TypeName::Bool
+        | syntax::TypeName::String
+        | syntax::TypeName::Str => {}
     }
 }
 
@@ -2358,6 +2370,7 @@ fn rewrite_aggregate_type_name(
         syntax::TypeName::Int => syntax::TypeName::Int,
         syntax::TypeName::Bool => syntax::TypeName::Bool,
         syntax::TypeName::String => syntax::TypeName::String,
+        syntax::TypeName::Str => syntax::TypeName::Str,
     })
 }
 
@@ -3563,6 +3576,7 @@ fn substitute_type_name(
         syntax::TypeName::Int => syntax::TypeName::Int,
         syntax::TypeName::Bool => syntax::TypeName::Bool,
         syntax::TypeName::String => syntax::TypeName::String,
+        syntax::TypeName::Str => syntax::TypeName::Str,
     }
 }
 
@@ -3613,6 +3627,7 @@ fn type_name_monomorph_suffix(ty: &syntax::TypeName) -> String {
         syntax::TypeName::Int => String::from("int"),
         syntax::TypeName::Bool => String::from("bool"),
         syntax::TypeName::String => String::from("string"),
+        syntax::TypeName::Str => String::from("str"),
         syntax::TypeName::Named(name, args) if args.is_empty() => name.clone(),
         syntax::TypeName::Named(name, args) => monomorphized_type_name(name, args),
         syntax::TypeName::Ptr(inner) => format!("ptr_{}", type_name_monomorph_suffix(inner)),
@@ -3662,6 +3677,7 @@ impl Type {
             Type::Error
             | Type::Int
             | Type::Bool
+            | Type::Str
             | Type::Ptr(_)
             | Type::MutPtr(_)
             | Type::Slice(_) => true,
@@ -3683,7 +3699,7 @@ impl Type {
 
     fn supports_map_key(&self) -> bool {
         match self {
-            Type::Int | Type::Bool | Type::String => true,
+            Type::Int | Type::Bool | Type::String | Type::Str => true,
             Type::Tuple(elements) => elements.iter().all(Type::supports_map_key),
             Type::Error
             | Type::Struct(_)
@@ -4411,11 +4427,14 @@ fn lower_stmt(
             let lowered = lower_expr(expr, env, ctx)?;
             if !matches!(
                 lowered.ty(),
-                Type::Error | Type::Int | Type::Bool | Type::String
+                Type::Error | Type::Int | Type::Bool | Type::String | Type::Str
             ) {
                 return Err(Diagnostic::new(
                     "type",
-                    format!("print expects int, bool, or string, got {}", lowered.ty()),
+                    format!(
+                        "print expects int, bool, String, or &str, got {}",
+                        lowered.ty()
+                    ),
                 )
                 .with_span(*line, *column));
             }
@@ -5156,14 +5175,38 @@ fn lower_expr(
     lower_expr_with_expected(expr, None, env, ctx)
 }
 
+fn is_string_like_type(ty: &Type) -> bool {
+    matches!(ty, Type::String | Type::Str)
+}
+
+fn coerce_expr_to_expected(expr: Expr, expected: Option<&Type>) -> Expr {
+    match expected {
+        Some(Type::Str) if expr.ty() == &Type::String => Expr::StringBorrow {
+            expr: Box::new(expr),
+            ty: Type::Str,
+        },
+        _ => expr,
+    }
+}
+
 fn lower_expr_with_expected(
     expr: &syntax::Expr,
     expected: Option<&Type>,
     env: &mut HashMap<String, Binding>,
     ctx: &LowerContext<'_>,
 ) -> Result<Expr, Diagnostic> {
+    lower_expr_with_expected_inner(expr, expected, env, ctx)
+        .map(|lowered| coerce_expr_to_expected(lowered, expected))
+}
+
+fn lower_expr_with_expected_inner(
+    expr: &syntax::Expr,
+    expected: Option<&Type>,
+    env: &mut HashMap<String, Binding>,
+    ctx: &LowerContext<'_>,
+) -> Result<Expr, Diagnostic> {
     match expr {
-        syntax::Expr::Literal(literal) => Ok(lower_literal(literal)),
+        syntax::Expr::Literal(literal) => Ok(lower_literal(literal, expected)),
         syntax::Expr::VarRef { name, line, column } => {
             if let Some(binding) = env.get(name) {
                 if binding.moved {
@@ -5404,7 +5447,7 @@ fn lower_expr_with_expected(
                     0
                 };
                 let lhs = lower_expr(&args[value_start], env, ctx)?;
-                if !matches!(lhs.ty(), Type::Int | Type::Bool | Type::String) {
+                if !matches!(lhs.ty(), Type::Int | Type::Bool | Type::String | Type::Str) {
                     return Err(Diagnostic::new(
                         "type",
                         format!(
@@ -6844,7 +6887,11 @@ fn lower_expr_with_expected(
             let rhs = lower_expr(rhs, env, ctx)?;
             let lhs_ty = lhs.ty().clone();
             let rhs_ty = rhs.ty().clone();
-            if lhs_ty != rhs_ty || !matches!(lhs_ty, Type::Int | Type::String) {
+            let result_ty = if lhs_ty == Type::Int && rhs_ty == Type::Int {
+                Type::Int
+            } else if is_string_like_type(&lhs_ty) && is_string_like_type(&rhs_ty) {
+                Type::String
+            } else {
                 return Err(
                     Diagnostic::new(
                         "type",
@@ -6854,11 +6901,11 @@ fn lower_expr_with_expected(
                     )
                     .with_span(*line, *column),
                 );
-            }
+            };
             Ok(Expr::BinaryAdd {
                 lhs: Box::new(lhs),
                 rhs: Box::new(rhs),
-                ty: lhs_ty,
+                ty: result_ty,
             })
         }
         syntax::Expr::BinaryCompare {
@@ -6874,7 +6921,9 @@ fn lower_expr_with_expected(
             let rhs_ty = rhs.ty().clone();
             match op {
                 syntax::CompareOp::Eq | syntax::CompareOp::Ne => {
-                    if lhs_ty != rhs_ty {
+                    if lhs_ty != rhs_ty
+                        && !(is_string_like_type(&lhs_ty) && is_string_like_type(&rhs_ty))
+                    {
                         return Err(
                             Diagnostic::new(
                                 "type",
@@ -7254,13 +7303,27 @@ fn lower_expr_with_expected(
                 )
                 .with_span(*line, *column));
             }
+            let expected_key_value = match expected {
+                Some(Type::Map(key, value)) => Some((key.as_ref(), value.as_ref())),
+                _ => None,
+            };
             let mut lowered_entries = Vec::new();
             let mut key_ty = None;
             let mut value_ty = None;
             let mut temporary_borrows = Vec::new();
             for entry in entries {
-                let lowered_key = lower_expr(&entry.key, env, ctx)?;
-                let lowered_value = lower_expr(&entry.value, env, ctx)?;
+                let lowered_key = lower_expr_with_expected(
+                    &entry.key,
+                    expected_key_value.map(|(key, _)| key),
+                    env,
+                    ctx,
+                )?;
+                let lowered_value = lower_expr_with_expected(
+                    &entry.value,
+                    expected_key_value.map(|(_, value)| value),
+                    env,
+                    ctx,
+                )?;
                 if let Some(expected) = key_ty.as_ref() {
                     if lowered_key.ty() != expected {
                         return Err(Diagnostic::new(
@@ -7329,11 +7392,15 @@ fn lower_expr_with_expected(
                 )
                 .with_span(*line, *column));
             }
+            let expected_element = match expected {
+                Some(Type::Array(element_ty)) => Some(element_ty.as_ref()),
+                _ => None,
+            };
             let mut lowered_elements = Vec::new();
             let mut element_ty = None;
             let mut temporary_borrows = Vec::new();
             for element in elements {
-                let lowered = lower_expr(element, env, ctx)?;
+                let lowered = lower_expr_with_expected(element, expected_element, env, ctx)?;
                 if let Some(expected) = element_ty.as_ref() {
                     if lowered.ty() != expected {
                         return Err(Diagnostic::new(
@@ -7438,7 +7505,11 @@ fn lower_expr_with_expected(
             column,
         } => {
             let lowered_base = lower_projection_base_expr(base, env, ctx)?;
-            let lowered_index = lower_expr(index, env, ctx)?;
+            let index_expected_ty = match lowered_base.ty() {
+                Type::Map(key_ty, _) => Some(key_ty.as_ref()),
+                _ => None,
+            };
+            let lowered_index = lower_expr_with_expected(index, index_expected_ty, env, ctx)?;
             let result_ty = match lowered_base.ty() {
                 Type::Array(element_ty) => {
                     if lowered_index.ty() != &Type::Int {
@@ -7820,7 +7891,10 @@ fn validate_ffi_type_name(
     column: usize,
 ) -> Result<(), Diagnostic> {
     match ty {
-        syntax::TypeName::Int | syntax::TypeName::Bool | syntax::TypeName::String => Ok(()),
+        syntax::TypeName::Int
+        | syntax::TypeName::Bool
+        | syntax::TypeName::String
+        | syntax::TypeName::Str => Ok(()),
         syntax::TypeName::Ptr(inner) | syntax::TypeName::MutPtr(inner) => {
             validate_ffi_type_name(inner, line, column)
         }
@@ -7834,7 +7908,7 @@ fn validate_ffi_type_name(
 
 fn validate_ffi_type(ty: &Type, line: usize, column: usize) -> Result<(), Diagnostic> {
     match ty {
-        Type::Int | Type::Bool | Type::String => Ok(()),
+        Type::Int | Type::Bool | Type::String | Type::Str => Ok(()),
         Type::Ptr(inner) | Type::MutPtr(inner) => validate_ffi_type(inner, line, column),
         _ => Err(Diagnostic::new(
             "type",
@@ -8276,6 +8350,7 @@ fn expr_borrow_origin(
         ),
         Expr::Index { base, .. } => expr_borrow_origin(base, env, ctx),
         Expr::Literal { .. } | Expr::BinaryAdd { .. } | Expr::BinaryCompare { .. } => None,
+        Expr::StringBorrow { expr, .. } => expr_borrow_origin(expr, env, ctx),
     }
 }
 
@@ -8408,6 +8483,7 @@ fn expr_borrowed_owners(
         Expr::Literal { .. } | Expr::BinaryAdd { .. } | Expr::BinaryCompare { .. } => {
             HashSet::new()
         }
+        Expr::StringBorrow { expr, .. } => expr_borrowed_owners(expr, env, ctx),
         Expr::StructLiteral { fields, .. } => {
             let mut owners = HashSet::new();
             for field in fields {
@@ -8562,9 +8638,13 @@ fn contains_borrowed_slice_type_inner(
             visiting_enums.remove(name);
             contains
         }
-        Type::Error | Type::Int | Type::Bool | Type::String | Type::Ptr(_) | Type::MutPtr(_) => {
-            false
-        }
+        Type::Error
+        | Type::Int
+        | Type::Bool
+        | Type::String
+        | Type::Str
+        | Type::Ptr(_)
+        | Type::MutPtr(_) => false,
     }
 }
 
@@ -8582,6 +8662,7 @@ fn contains_mut_borrowed_slice_type_inner(
         | Type::Int
         | Type::Bool
         | Type::String
+        | Type::Str
         | Type::Ptr(_)
         | Type::MutPtr(_) => false,
         Type::Option(inner) => contains_mut_borrowed_slice_type_inner(
@@ -8871,7 +8952,7 @@ fn merge_borrow_count(
     then_count.max(else_count)
 }
 
-fn lower_literal(literal: &syntax::Literal) -> Expr {
+fn lower_literal(literal: &syntax::Literal, expected: Option<&Type>) -> Expr {
     match literal {
         syntax::Literal::Int(value) => Expr::Literal {
             ty: Type::Int,
@@ -8882,7 +8963,11 @@ fn lower_literal(literal: &syntax::Literal) -> Expr {
             value: LiteralValue::Bool(*value),
         },
         syntax::Literal::String(value) => Expr::Literal {
-            ty: Type::String,
+            ty: if matches!(expected, Some(Type::String)) {
+                Type::String
+            } else {
+                Type::Str
+            },
             value: LiteralValue::String(value.clone()),
         },
     }
@@ -8913,6 +8998,7 @@ fn lower_type_inner<T, U>(
         syntax::TypeName::Int => Ok(Type::Int),
         syntax::TypeName::Bool => Ok(Type::Bool),
         syntax::TypeName::String => Ok(Type::String),
+        syntax::TypeName::Str => Ok(Type::Str),
         syntax::TypeName::Named(name, args) => {
             if is_async_runtime_type(name) {
                 if args.len() != 1 {
@@ -9106,6 +9192,7 @@ impl Expr {
             Expr::ArrayLiteral { ty, .. } => ty,
             Expr::Slice { ty, .. } => ty,
             Expr::Index { ty, .. } => ty,
+            Expr::StringBorrow { ty, .. } => ty,
         }
     }
 }
@@ -9235,7 +9322,8 @@ impl std::fmt::Display for Type {
             Type::Error => write!(f, "<type-error>"),
             Type::Int => write!(f, "int"),
             Type::Bool => write!(f, "bool"),
-            Type::String => write!(f, "string"),
+            Type::String => write!(f, "String"),
+            Type::Str => write!(f, "&str"),
             Type::Struct(name) => write!(f, "{name}"),
             Type::Enum(name) => write!(f, "{name}"),
             Type::Ptr(inner) => write!(f, "ptr<{inner}>"),

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -1439,7 +1439,10 @@ fn contains_generic_type_param(ty: &syntax::TypeName, type_params: &HashSet<Stri
         syntax::TypeName::Tuple(elements) => elements
             .iter()
             .any(|element| contains_generic_type_param(element, type_params)),
-        syntax::TypeName::Int | syntax::TypeName::Bool | syntax::TypeName::String => false,
+        syntax::TypeName::Int
+        | syntax::TypeName::Bool
+        | syntax::TypeName::String
+        | syntax::TypeName::Str => false,
     }
 }
 
@@ -1568,7 +1571,10 @@ fn unify_generic_type_name(
                 Ok(())
             }
         }
-        syntax::TypeName::Int | syntax::TypeName::Bool | syntax::TypeName::String => Ok(()),
+        syntax::TypeName::Int
+        | syntax::TypeName::Bool
+        | syntax::TypeName::String
+        | syntax::TypeName::Str => Ok(()),
     }
 }
 
@@ -5179,14 +5185,30 @@ fn is_string_like_type(ty: &Type) -> bool {
     matches!(ty, Type::String | Type::Str)
 }
 
-fn coerce_expr_to_expected(expr: Expr, expected: Option<&Type>) -> Expr {
+fn coerce_expr_to_expected(
+    expr: Expr,
+    expected: Option<&Type>,
+    allow_temporary_string_borrow: bool,
+) -> Result<Expr, Diagnostic> {
     match expected {
-        Some(Type::Str) if expr.ty() == &Type::String => Expr::StringBorrow {
-            expr: Box::new(expr),
-            ty: Type::Str,
-        },
-        _ => expr,
+        Some(Type::Str) if expr.ty() == &Type::String => {
+            if !allow_temporary_string_borrow && !is_stable_string_borrow_owner(&expr) {
+                return Err(Diagnostic::new(
+                    "ownership",
+                    "cannot borrow a temporary String as &str; bind the String to a local first",
+                ));
+            }
+            Ok(Expr::StringBorrow {
+                expr: Box::new(expr),
+                ty: Type::Str,
+            })
+        }
+        _ => Ok(expr),
     }
+}
+
+fn is_stable_string_borrow_owner(expr: &Expr) -> bool {
+    matches!(expr, Expr::VarRef { .. } | Expr::FieldAccess { .. } | Expr::Index { .. })
 }
 
 fn lower_expr_with_expected(
@@ -5196,7 +5218,17 @@ fn lower_expr_with_expected(
     ctx: &LowerContext<'_>,
 ) -> Result<Expr, Diagnostic> {
     lower_expr_with_expected_inner(expr, expected, env, ctx)
-        .map(|lowered| coerce_expr_to_expected(lowered, expected))
+        .and_then(|lowered| coerce_expr_to_expected(lowered, expected, false))
+}
+
+fn lower_call_arg_with_expected(
+    expr: &syntax::Expr,
+    expected: Option<&Type>,
+    env: &mut HashMap<String, Binding>,
+    ctx: &LowerContext<'_>,
+) -> Result<Expr, Diagnostic> {
+    lower_expr_with_expected_inner(expr, expected, env, ctx)
+        .and_then(|lowered| coerce_expr_to_expected(lowered, expected, true))
 }
 
 fn lower_expr_with_expected_inner(
@@ -6568,7 +6600,7 @@ fn lower_expr_with_expected_inner(
                 let mut lowered_args = Vec::new();
                 let mut temporary_borrows = Vec::new();
                 for (arg, expected) in args.iter().zip(signature.params.iter()) {
-                    let lowered = lower_expr_with_expected(arg, Some(expected), env, ctx)?;
+                    let lowered = lower_call_arg_with_expected(arg, Some(expected), env, ctx)?;
                     if lowered.ty() != expected {
                         return Err(Diagnostic::new(
                             "type",
@@ -6763,7 +6795,7 @@ fn lower_expr_with_expected_inner(
                     .with_span(*line, *column));
                 }
                 for (arg, expected) in args.iter().zip(signature.params.iter()) {
-                    let lowered = lower_expr_with_expected(arg, Some(expected), env, ctx)?;
+                    let lowered = lower_call_arg_with_expected(arg, Some(expected), env, ctx)?;
                     if lowered.ty() != expected {
                         return Err(Diagnostic::new(
                             "type",
@@ -6852,7 +6884,7 @@ fn lower_expr_with_expected_inner(
             }
             lowered_args.push(lowered_base);
             for (arg, expected) in args.iter().zip(signature.params.iter().skip(1)) {
-                let lowered = lower_expr_with_expected(arg, Some(expected), env, ctx)?;
+                let lowered = lower_call_arg_with_expected(arg, Some(expected), env, ctx)?;
                 if lowered.ty() != expected {
                     return Err(Diagnostic::new(
                         "type",
@@ -8001,7 +8033,7 @@ fn lower_variant_constructor(
     }
     let mut lowered_payloads = Vec::new();
     for (arg, expected) in args.iter().zip(variant.payload_tys.iter()) {
-        let lowered = lower_expr_with_expected(arg, Some(expected), env, ctx)?;
+        let lowered = lower_call_arg_with_expected(arg, Some(expected), env, ctx)?;
         if lowered.ty() != expected {
             return Err(Diagnostic::new(
                 "type",
@@ -8963,10 +8995,10 @@ fn lower_literal(literal: &syntax::Literal, expected: Option<&Type>) -> Expr {
             value: LiteralValue::Bool(*value),
         },
         syntax::Literal::String(value) => Expr::Literal {
-            ty: if matches!(expected, Some(Type::String)) {
-                Type::String
-            } else {
+            ty: if matches!(expected, Some(Type::Str)) {
                 Type::Str
+            } else {
+                Type::String
             },
             value: LiteralValue::String(value.clone()),
         },
@@ -9322,7 +9354,7 @@ impl std::fmt::Display for Type {
             Type::Error => write!(f, "<type-error>"),
             Type::Int => write!(f, "int"),
             Type::Bool => write!(f, "bool"),
-            Type::String => write!(f, "String"),
+            Type::String => write!(f, "string"),
             Type::Str => write!(f, "&str"),
             Type::Struct(name) => write!(f, "{name}"),
             Type::Enum(name) => write!(f, "{name}"),

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -8515,7 +8515,7 @@ fn expr_borrowed_owners(
         Expr::Literal { .. } | Expr::BinaryAdd { .. } | Expr::BinaryCompare { .. } => {
             HashSet::new()
         }
-        Expr::StringBorrow { expr, .. } => expr_borrowed_owners(expr, env, ctx),
+        Expr::StringBorrow { expr, .. } => owned_borrow_root(expr).into_iter().collect(),
         Expr::StructLiteral { fields, .. } => {
             let mut owners = HashSet::new();
             for field in fields {
@@ -8579,7 +8579,7 @@ fn contains_borrowed_slice_type_inner(
     visiting_enums: &mut HashSet<String>,
 ) -> bool {
     match ty {
-        Type::Slice(_) | Type::MutSlice(_) => true,
+        Type::Slice(_) | Type::MutSlice(_) | Type::Str => true,
         Type::Option(inner) => contains_borrowed_slice_type_inner(
             inner,
             structs,
@@ -8674,7 +8674,6 @@ fn contains_borrowed_slice_type_inner(
         | Type::Int
         | Type::Bool
         | Type::String
-        | Type::Str
         | Type::Ptr(_)
         | Type::MutPtr(_) => false,
     }

--- a/stage1/crates/axiomc/src/json_contract.rs
+++ b/stage1/crates/axiomc/src/json_contract.rs
@@ -2,7 +2,7 @@ use crate::diagnostics::Diagnostic;
 use crate::manifest::CapabilityDescriptor;
 use crate::project::{BuildOutput, CheckOutput, TestOutput};
 use serde::Serialize;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::path::Path;
 
 pub const JSON_SCHEMA_VERSION: &str = "axiom.stage1.v1";

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -5311,6 +5311,11 @@ print serve_once("127.0.0.1:18080", "hello")
                 "cannot create mutable borrow of value",
             ),
             (
+                "move_string_while_str_borrow_live",
+                "move_while_borrowed",
+                "cannot move value",
+            ),
+            (
                 "loop_move_outer_non_copy",
                 "loop_move_outer_non_copy",
                 "cannot move non-copy value",

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -314,6 +314,46 @@ print read(make())
     }
 
     #[test]
+    fn parser_rejects_borrow_return_from_temporary_string_call_arg() {
+        let source = r#"fn echo(value: &str): &str {
+return value
+}
+
+fn make(): String {
+return "owned"
+}
+
+let borrowed: &str = echo(make())
+print borrowed
+"#;
+        let parsed = parse_program(source, Path::new("main.ax")).expect("parse");
+        let err = hir::lower(&parsed)
+            .expect_err("lower should reject escaping borrow from temporary String call arg");
+        assert!(
+            err.message
+                .contains("cannot borrow a temporary String as &str")
+        );
+    }
+
+    #[test]
+    fn parser_rejects_borrow_return_from_temporary_concat_call_arg() {
+        let source = r#"fn echo(value: &str): &str {
+return value
+}
+
+let borrowed: &str = echo("own" + "ed")
+print borrowed
+"#;
+        let parsed = parse_program(source, Path::new("main.ax")).expect("parse");
+        let err = hir::lower(&parsed)
+            .expect_err("lower should reject escaping borrow from temporary concat call arg");
+        assert!(
+            err.message
+                .contains("cannot borrow a temporary String as &str")
+        );
+    }
+
+    #[test]
     fn parser_expands_declarative_statement_macros_before_lowering() {
         let source = r#"macro_rules! answer {
 ($value:expr) => {

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -260,7 +260,10 @@ print borrowed
 "#;
         let parsed = parse_program(source, Path::new("main.ax")).expect("parse");
         let err = hir::lower(&parsed).expect_err("lower should reject borrowed temporary String");
-        assert!(err.message.contains("cannot borrow a temporary String as &str"));
+        assert!(
+            err.message
+                .contains("cannot borrow a temporary String as &str")
+        );
     }
 
     #[test]
@@ -270,7 +273,24 @@ print borrowed
 "#;
         let parsed = parse_program(source, Path::new("main.ax")).expect("parse");
         let err = hir::lower(&parsed).expect_err("lower should reject borrowed temporary concat");
-        assert!(err.message.contains("cannot borrow a temporary String as &str"));
+        assert!(
+            err.message
+                .contains("cannot borrow a temporary String as &str")
+        );
+    }
+
+    #[test]
+    fn parser_rejects_borrowed_str_from_indexed_string() {
+        let source = r#"let values: [string] = ["hello"]
+let borrowed: &str = values[0]
+print borrowed
+"#;
+        let parsed = parse_program(source, Path::new("main.ax")).expect("parse");
+        let err = hir::lower(&parsed).expect_err("lower should reject indexed String borrow");
+        assert!(
+            err.message
+                .contains("cannot borrow a temporary String as &str")
+        );
     }
 
     #[test]
@@ -7670,15 +7690,19 @@ print serve_once("127.0.0.1:18080", "hello")
             .as_array()
             .expect("imported debug mappings array");
         assert!(
-            imported_mappings.iter().any(|mapping| mapping["source"] == source
-                && mapping["line"] == 2
-                && mapping["column"] == 1),
+            imported_mappings
+                .iter()
+                .any(|mapping| mapping["source"] == source
+                    && mapping["line"] == 2
+                    && mapping["column"] == 1),
             "debug map should retain primary source spans after imports"
         );
         assert!(
-            imported_mappings.iter().any(|mapping| mapping["source"] == helper_source
-                && mapping["line"] == 2
-                && mapping["column"] == 1),
+            imported_mappings
+                .iter()
+                .any(|mapping| mapping["source"] == helper_source
+                    && mapping["line"] == 2
+                    && mapping["column"] == 1),
             "debug map should retain imported module source spans instead of collapsing to the primary file"
         );
 
@@ -7913,11 +7937,27 @@ print serve_once("127.0.0.1:18080", "hello")
     #[test]
     fn json_contract_adds_stable_codes_for_common_diagnostic_kinds() {
         let cases = [
-            ("parse", "missing closing brace for block", "parse.missing_closing_brace"),
+            (
+                "parse",
+                "missing closing brace for block",
+                "parse.missing_closing_brace",
+            ),
             ("manifest", "invalid axiom.toml", "manifest.invalid"),
-            ("import", "import not found: ./missing.ax", "import.unresolved"),
-            ("capability", "fs requires capability fs", "capability.denied"),
-            ("type", "undefined variable \"answer\"", "type.undefined_symbol"),
+            (
+                "import",
+                "import not found: ./missing.ax",
+                "import.unresolved",
+            ),
+            (
+                "capability",
+                "fs requires capability fs",
+                "capability.denied",
+            ),
+            (
+                "type",
+                "undefined variable \"answer\"",
+                "type.undefined_symbol",
+            ),
             ("build", "failed to invoke rustc", "build.failed"),
             ("runtime", "process exited with status 1", "runtime.failed"),
         ];
@@ -7941,16 +7981,21 @@ print serve_once("127.0.0.1:18080", "hello")
         let source_payload = json_contract::error("check", &source_error);
 
         assert_eq!(source_payload["error"]["repair"]["action"], "edit_source");
-        assert!(source_payload["error"]["repair"]["edit"]
-            .as_str()
-            .expect("repair edit")
-            .contains("reported span"));
+        assert!(
+            source_payload["error"]["repair"]["edit"]
+                .as_str()
+                .expect("repair edit")
+                .contains("reported span")
+        );
 
         let fmt_error = crate::diagnostics::Diagnostic::new("fmt", "1 file(s) need formatting");
         let fmt_payload = json_contract::error("fmt", &fmt_error);
 
         assert_eq!(fmt_payload["error"]["repair"]["action"], "run_command");
-        assert_eq!(fmt_payload["error"]["repair"]["command"], "axiomc fmt <path>");
+        assert_eq!(
+            fmt_payload["error"]["repair"]["command"],
+            "axiomc fmt <path>"
+        );
     }
 
     #[test]
@@ -8174,7 +8219,10 @@ print c
         let hir = hir::lower(&parsed).expect("lower");
         let mir = mir::lower(&hir);
         let rendered = render_rust(&mir);
-        assert!(rendered.contains("fn wrap__int("), "wrap<int> must produce 'wrap__int'");
+        assert!(
+            rendered.contains("fn wrap__int("),
+            "wrap<int> must produce 'wrap__int'"
+        );
         assert!(
             rendered.contains("fn identity__int("),
             "identity<int> must produce 'identity__int'"
@@ -8252,10 +8300,7 @@ return missing_c
             "expected error for missing_c"
         );
         // Verify source order: line numbers must be non-decreasing.
-        let lines: Vec<usize> = diagnostics
-            .iter()
-            .filter_map(|d| d.line)
-            .collect();
+        let lines: Vec<usize> = diagnostics.iter().filter_map(|d| d.line).collect();
         let sorted = {
             let mut s = lines.clone();
             s.sort_unstable();

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -227,6 +227,73 @@ mod tests {
     }
 
     #[test]
+    fn parser_distinguishes_owned_string_from_borrowed_str() {
+        let source = r#"fn read(label: &str): int {
+print label
+return 1
+}
+
+let literal: &str = "borrowed"
+let owned: String = "owned"
+print read(literal)
+print read(owned)
+"#;
+        let parsed = parse_program(source, Path::new("main.ax")).expect("parse");
+        let hir = hir::lower(&parsed).expect("lower");
+        let mir = mir::lower(&hir);
+        let rendered = render_rust(&mir);
+        assert!(rendered.contains("fn read<'a>(label: &'a str) -> i64 {"));
+        assert!(rendered.contains(r#"let literal: &str = "borrowed";"#));
+        assert!(rendered.contains(r#"let owned: String = String::from("owned");"#));
+        assert!(rendered.contains(r#"println!("{}", read(literal));"#));
+        assert!(rendered.contains(r#"println!("{}", read(owned.as_str()));"#));
+    }
+
+    #[test]
+    fn parser_rejects_borrowed_str_from_temporary_string() {
+        let source = r#"fn make(): String {
+return "owned"
+}
+
+let borrowed: &str = make()
+print borrowed
+"#;
+        let parsed = parse_program(source, Path::new("main.ax")).expect("parse");
+        let err = hir::lower(&parsed).expect_err("lower should reject borrowed temporary String");
+        assert!(err.message.contains("cannot borrow a temporary String as &str"));
+    }
+
+    #[test]
+    fn parser_rejects_borrowed_str_from_temporary_concat() {
+        let source = r#"let borrowed: &str = "own" + "ed"
+print borrowed
+"#;
+        let parsed = parse_program(source, Path::new("main.ax")).expect("parse");
+        let err = hir::lower(&parsed).expect_err("lower should reject borrowed temporary concat");
+        assert!(err.message.contains("cannot borrow a temporary String as &str"));
+    }
+
+    #[test]
+    fn parser_allows_borrowed_str_call_arg_from_temporary_string() {
+        let source = r#"fn read(label: &str): int {
+print label
+return 1
+}
+
+fn make(): String {
+return "owned"
+}
+
+print read(make())
+"#;
+        let parsed = parse_program(source, Path::new("main.ax")).expect("parse");
+        let hir = hir::lower(&parsed).expect("lower");
+        let mir = mir::lower(&hir);
+        let rendered = render_rust(&mir);
+        assert!(rendered.contains(r#"println!("{}", read(make().as_str()));"#));
+    }
+
+    #[test]
     fn parser_expands_declarative_statement_macros_before_lowering() {
         let source = r#"macro_rules! answer {
 ($value:expr) => {

--- a/stage1/crates/axiomc/src/lsp.rs
+++ b/stage1/crates/axiomc/src/lsp.rs
@@ -402,7 +402,7 @@ mod tests {
         );
         assert_eq!(
             diagnostics[1]["message"],
-            json!("let binding \"answer\" expects int, got string")
+            json!("let binding \"answer\" expects int, got &str")
         );
         assert_eq!(
             diagnostics[2]["range"]["start"],

--- a/stage1/crates/axiomc/src/lsp.rs
+++ b/stage1/crates/axiomc/src/lsp.rs
@@ -402,7 +402,7 @@ mod tests {
         );
         assert_eq!(
             diagnostics[1]["message"],
-            json!("let binding \"answer\" expects int, got &str")
+            json!("let binding \"answer\" expects int, got string")
         );
         assert_eq!(
             diagnostics[2]["range"]["start"],

--- a/stage1/crates/axiomc/src/mir.rs
+++ b/stage1/crates/axiomc/src/mir.rs
@@ -196,6 +196,10 @@ pub enum Expr {
         index: Box<Expr>,
         ty: Type,
     },
+    StringBorrow {
+        expr: Box<Expr>,
+        ty: Type,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -203,6 +207,7 @@ pub enum LiteralValue {
     Int(i64),
     Bool(bool),
     String(String),
+    Str(String),
 }
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
@@ -220,6 +225,7 @@ pub enum Type {
     Int,
     Bool,
     String,
+    Str,
     Struct(String),
     Enum(String),
     Ptr(Box<Type>),
@@ -240,7 +246,12 @@ pub enum Type {
 impl Type {
     pub fn is_copy(&self) -> bool {
         match self {
-            Type::Int | Type::Bool | Type::Ptr(_) | Type::MutPtr(_) | Type::Slice(_) => true,
+            Type::Int
+            | Type::Bool
+            | Type::Str
+            | Type::Ptr(_)
+            | Type::MutPtr(_)
+            | Type::Slice(_) => true,
             Type::MutSlice(_) => false,
             Type::Option(inner) => inner.is_copy(),
             Type::Result(ok, err) => ok.is_copy() && err.is_copy(),
@@ -290,6 +301,7 @@ impl Expr {
             Expr::Literal(LiteralValue::Int(_)) => Type::Int,
             Expr::Literal(LiteralValue::Bool(_)) => Type::Bool,
             Expr::Literal(LiteralValue::String(_)) => Type::String,
+            Expr::Literal(LiteralValue::Str(_)) => Type::Str,
             Expr::VarRef { ty, .. } => ty.clone(),
             Expr::Call { ty, .. } => ty.clone(),
             Expr::BinaryAdd { ty, .. } => ty.clone(),
@@ -305,6 +317,7 @@ impl Expr {
             Expr::ArrayLiteral { ty, .. } => ty.clone(),
             Expr::Slice { ty, .. } => ty.clone(),
             Expr::Index { ty, .. } => ty.clone(),
+            Expr::StringBorrow { ty, .. } => ty.clone(),
         }
     }
 }
@@ -463,10 +476,16 @@ fn lower_source_span(span: &hir::SourceSpan) -> SourceSpan {
 
 fn lower_expr(expr: &hir::Expr) -> Expr {
     match expr {
-        hir::Expr::Literal { value, .. } => Expr::Literal(match value {
+        hir::Expr::Literal { ty, value } => Expr::Literal(match value {
             hir::LiteralValue::Int(value) => LiteralValue::Int(*value),
             hir::LiteralValue::Bool(value) => LiteralValue::Bool(*value),
-            hir::LiteralValue::String(value) => LiteralValue::String(value.clone()),
+            hir::LiteralValue::String(value) => {
+                if matches!(ty, hir::Type::Str) {
+                    LiteralValue::Str(value.clone())
+                } else {
+                    LiteralValue::String(value.clone())
+                }
+            }
         }),
         hir::Expr::VarRef { name, ty } => Expr::VarRef {
             name: name.clone(),
@@ -564,6 +583,10 @@ fn lower_expr(expr: &hir::Expr) -> Expr {
             index: Box::new(lower_expr(index)),
             ty: lower_type(ty),
         },
+        hir::Expr::StringBorrow { expr, ty } => Expr::StringBorrow {
+            expr: Box::new(lower_expr(expr)),
+            ty: lower_type(ty),
+        },
     }
 }
 
@@ -573,6 +596,7 @@ fn lower_type(ty: &hir::Type) -> Type {
         hir::Type::Int => Type::Int,
         hir::Type::Bool => Type::Bool,
         hir::Type::String => Type::String,
+        hir::Type::Str => Type::Str,
         hir::Type::Struct(name) => Type::Struct(name.clone()),
         hir::Type::Enum(name) => Type::Enum(name.clone()),
         hir::Type::Ptr(inner) => Type::Ptr(Box::new(lower_type(inner))),

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -3787,6 +3787,7 @@ fn rewrite_type_name(
         syntax::TypeName::Int => Ok(syntax::TypeName::Int),
         syntax::TypeName::Bool => Ok(syntax::TypeName::Bool),
         syntax::TypeName::String => Ok(syntax::TypeName::String),
+        syntax::TypeName::Str => Ok(syntax::TypeName::Str),
         syntax::TypeName::Named(name, args) => {
             if !visible_types.contains_key(name) && private_imported_types.contains(name) {
                 return Err(Diagnostic::new(

--- a/stage1/crates/axiomc/src/syntax.rs
+++ b/stage1/crates/axiomc/src/syntax.rs
@@ -189,6 +189,7 @@ pub enum TypeName {
     Int,
     Bool,
     String,
+    Str,
     Named(String, Vec<TypeName>),
     Ptr(Box<TypeName>),
     MutPtr(Box<TypeName>),
@@ -2152,7 +2153,8 @@ fn parse_type_name(
     match raw {
         "int" => Ok(TypeName::Int),
         "bool" => Ok(TypeName::Bool),
-        "string" => Ok(TypeName::String),
+        "string" | "String" => Ok(TypeName::String),
+        "&str" => Ok(TypeName::Str),
         _ => {
             validate_ident(raw, path, line_no, column)?;
             Ok(TypeName::Named(raw.to_string(), Vec::new()))

--- a/stage1/crates/axiomc/tests/ownership_failures/move_string_while_str_borrow_live/axiom.lock
+++ b/stage1/crates/axiomc/tests/ownership_failures/move_string_while_str_borrow_live/axiom.lock
@@ -1,0 +1,6 @@
+version = 1
+
+[[package]]
+name = "move-string-while-str-borrow-live"
+version = "0.1.0"
+source = "path"

--- a/stage1/crates/axiomc/tests/ownership_failures/move_string_while_str_borrow_live/axiom.toml
+++ b/stage1/crates/axiomc/tests/ownership_failures/move_string_while_str_borrow_live/axiom.toml
@@ -1,0 +1,15 @@
+[package]
+name = "move-string-while-str-borrow-live"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false

--- a/stage1/crates/axiomc/tests/ownership_failures/move_string_while_str_borrow_live/src/main.ax
+++ b/stage1/crates/axiomc/tests/ownership_failures/move_string_while_str_borrow_live/src/main.ax
@@ -1,0 +1,4 @@
+let owned: string = "hello"
+let borrowed: &str = owned
+let moved: string = owned
+print borrowed


### PR DESCRIPTION
Closes #221

## Summary
- Distinguishes owned `String` from borrowed `&str` in the stage1 compiler model.
- Updates syntax, HIR, MIR, diagnostics, JSON contract handling, project logic, and codegen for string ownership semantics.
- Adds an ownership failure fixture for moving an owned string while an `&str` borrow remains live.

## Scope and conformance
- Issue: Language: Distinguish owned `String` from borrowed `&str`.
- Primary implementation paths: `stage1/crates/axiomc/src/{syntax,hir,mir,codegen,diagnostics,json_contract,lib,project}.rs`.
- Test fixture: `stage1/crates/axiomc/tests/ownership_failures/move_string_while_str_borrow_live/`.

## Testing
- PR Fast CI is green, including Fast Checks and CI Gate.
- Lockfile Integrity, Validate Secrets, and Validate PR Description are green.

## Notes for reviewers
- This is the Daedalus-assigned implementation slice for #221.
- Please focus review on borrow/move interactions, string literal treatment, and consistency with the mutable/lifetime work in adjacent PRs.
