### PR TITLE
fix: address issue #220

### DIFF
--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -2140,6 +2140,7 @@ fn expr_uses_call(expr: &Expr, name: &str) -> bool {
         Expr::BinaryAdd { lhs, rhs, .. } | Expr::BinaryCompare { lhs, rhs, .. } => {
             expr_uses_call(lhs, name) || expr_uses_call(rhs, name)
         }
+        Expr::Cast { expr, .. } => expr_uses_call(expr, name),
         Expr::Try { expr, .. }
         | Expr::Await { expr, .. }
         | Expr::FieldAccess { base: expr, .. } => expr_uses_call(expr, name),
@@ -2176,6 +2177,13 @@ struct TypeContext<'a> {
 }
 
 impl<'a> TypeContext<'a> {
+    fn empty() -> Self {
+        Self {
+            structs: HashMap::new(),
+            enums: HashMap::new(),
+        }
+    }
+
     fn new(program: &'a Program) -> Self {
         Self {
             structs: program
@@ -2210,7 +2218,12 @@ impl<'a> TypeContext<'a> {
         visiting_enums: &mut HashSet<String>,
     ) -> bool {
         match ty {
-            Type::Int | Type::Bool | Type::String | Type::Ptr(_) | Type::MutPtr(_) => false,
+            Type::Int
+            | Type::Numeric(_)
+            | Type::Bool
+            | Type::String
+            | Type::Ptr(_)
+            | Type::MutPtr(_) => false,
             Type::Slice(_) | Type::MutSlice(_) => true,
             Type::Struct(name) => {
                 if !visiting_structs.insert(name.clone()) {
@@ -2782,6 +2795,7 @@ fn render_source_marker(
 fn render_expr(expr: &Expr) -> String {
     match expr {
         Expr::Literal(LiteralValue::Int(value)) => value.to_string(),
+        Expr::Literal(LiteralValue::Numeric { raw, ty }) => format!("{raw}{}", ty.as_str()),
         Expr::Literal(LiteralValue::Bool(value)) => value.to_string(),
         Expr::Literal(LiteralValue::String(value)) => format!("String::from({value:?})"),
         Expr::VarRef { name, .. } if name == "self" => String::from("self_"),
@@ -3105,7 +3119,7 @@ fn render_expr(expr: &Expr) -> String {
             format!("{name}({rendered_args})")
         }
         Expr::BinaryAdd { lhs, rhs, ty } => match ty {
-            Type::Int => format!("{} + {}", render_expr(lhs), render_expr(rhs)),
+            Type::Int | Type::Numeric(_) => format!("{} + {}", render_expr(lhs), render_expr(rhs)),
             Type::String => format!(
                 "format!(\"{{}}{{}}\", {}, {})",
                 render_expr(lhs),
@@ -3130,6 +3144,11 @@ fn render_expr(expr: &Expr) -> String {
         Expr::BinaryCompare { op, lhs, rhs, .. } => {
             format!("{} {} {}", render_expr(lhs), op.lexeme(), render_expr(rhs))
         }
+        Expr::Cast { expr, ty } => format!(
+            "({}) as {}",
+            render_expr(expr),
+            rust_type(ty, &TypeContext::empty())
+        ),
         Expr::Try { expr, .. } => format!("({})?", render_expr(expr)),
         Expr::Await { expr, .. } => format!("axiom_await({})", render_expr(expr)),
         Expr::StructLiteral { name, fields, .. } => {
@@ -3309,6 +3328,7 @@ fn rust_type_in_signature(
 fn rust_type_inner(ty: &Type, lifetime: Option<&str>, type_context: &TypeContext<'_>) -> String {
     match ty {
         Type::Int => String::from("i64"),
+        Type::Numeric(numeric) => numeric.as_str().to_string(),
         Type::Bool => String::from("bool"),
         Type::String => String::from("String"),
         Type::Struct(name) => {

--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -3114,6 +3114,10 @@ fn render_expr(expr: &Expr) -> String {
         Expr::Call { name, args, ty } if name == "last" => {
             render_collection_edge(&args[0], ty, true)
         }
+        Expr::Call { name, args, .. } if name.starts_with("__axiom_numeric_") => {
+            let method = name.trim_start_matches("__axiom_numeric_");
+            format!("({}).{}({})", render_expr(&args[0]), method, render_expr(&args[1]))
+        }
         Expr::Call { name, args, .. } => {
             let rendered_args = args.iter().map(render_expr).collect::<Vec<_>>().join(", ");
             format!("{name}({rendered_args})")

--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -3116,7 +3116,12 @@ fn render_expr(expr: &Expr) -> String {
         }
         Expr::Call { name, args, .. } if name.starts_with("__axiom_numeric_") => {
             let method = name.trim_start_matches("__axiom_numeric_");
-            format!("({}).{}({})", render_expr(&args[0]), method, render_expr(&args[1]))
+            format!(
+                "({}).{}({})",
+                render_expr(&args[0]),
+                method,
+                render_expr(&args[1])
+            )
         }
         Expr::Call { name, args, .. } => {
             let rendered_args = args.iter().map(render_expr).collect::<Vec<_>>().join(", ");

--- a/stage1/crates/axiomc/src/diagnostics.rs
+++ b/stage1/crates/axiomc/src/diagnostics.rs
@@ -140,7 +140,9 @@ fn repair_hint(kind: &str, _message: &str) -> Option<DiagnosticRepair> {
         ),
         "manifest" | "capability" => (
             "edit_manifest",
-            Some("Update axiom.toml with the narrowest required package, dependency, or capability change."),
+            Some(
+                "Update axiom.toml with the narrowest required package, dependency, or capability change.",
+            ),
             None,
         ),
         "import" => (
@@ -148,11 +150,7 @@ fn repair_hint(kind: &str, _message: &str) -> Option<DiagnosticRepair> {
             Some("Fix the quoted relative import path or add the missing imported source file."),
             None,
         ),
-        "fmt" => (
-            "run_command",
-            None,
-            Some("axiomc fmt <path>"),
-        ),
+        "fmt" => ("run_command", None, Some("axiomc fmt <path>")),
         "source" => (
             "check_path",
             Some("Use an existing .ax source path or package directory."),

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -1088,6 +1088,22 @@ fn infer_generic_calls_in_expr(
             line: *line,
             column: *column,
         },
+        syntax::Expr::Cast {
+            expr,
+            ty,
+            line,
+            column,
+        } => syntax::Expr::Cast {
+            expr: Box::new(infer_generic_calls_in_expr(
+                expr,
+                Some(ty),
+                env,
+                generic_functions,
+            )?),
+            ty: ty.clone(),
+            line: *line,
+            column: *column,
+        },
         syntax::Expr::Try { expr, line, column } => syntax::Expr::Try {
             expr: Box::new(infer_generic_calls_in_expr(
                 expr,
@@ -1457,7 +1473,10 @@ fn contains_generic_type_param(ty: &syntax::TypeName, type_params: &HashSet<Stri
         syntax::TypeName::Tuple(elements) => elements
             .iter()
             .any(|element| contains_generic_type_param(element, type_params)),
-        syntax::TypeName::Int | syntax::TypeName::Bool | syntax::TypeName::String => false,
+        syntax::TypeName::Int
+        | syntax::TypeName::Numeric(_)
+        | syntax::TypeName::Bool
+        | syntax::TypeName::String => false,
     }
 }
 
@@ -1586,7 +1605,10 @@ fn unify_generic_type_name(
                 Ok(())
             }
         }
-        syntax::TypeName::Int | syntax::TypeName::Bool | syntax::TypeName::String => Ok(()),
+        syntax::TypeName::Int
+        | syntax::TypeName::Numeric(_)
+        | syntax::TypeName::Bool
+        | syntax::TypeName::String => Ok(()),
     }
 }
 

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -356,10 +356,9 @@ fn is_addable_numeric(ty: &Type) -> bool {
 fn numeric_method_return_ty(receiver: &Type, method: &str) -> Option<Type> {
     let is_integer = match receiver {
         Type::Int => true,
-        Type::Numeric(numeric) => !matches!(
-            numeric,
-            syntax::NumericType::F32 | syntax::NumericType::F64
-        ),
+        Type::Numeric(numeric) => {
+            !matches!(numeric, syntax::NumericType::F32 | syntax::NumericType::F64)
+        }
         _ => false,
     };
     if !is_integer {

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -353,6 +353,29 @@ fn is_addable_numeric(ty: &Type) -> bool {
     matches!(ty, Type::Int | Type::Numeric(_))
 }
 
+fn numeric_method_return_ty(receiver: &Type, method: &str) -> Option<Type> {
+    let is_integer = match receiver {
+        Type::Int => true,
+        Type::Numeric(numeric) => !matches!(
+            numeric,
+            syntax::NumericType::F32 | syntax::NumericType::F64
+        ),
+        _ => false,
+    };
+    if !is_integer {
+        return None;
+    }
+    match method {
+        "wrapping_add" | "wrapping_sub" | "wrapping_mul" | "wrapping_div" | "wrapping_rem" => {
+            Some(receiver.clone())
+        }
+        "checked_add" | "checked_sub" | "checked_mul" | "checked_div" | "checked_rem" => {
+            Some(Type::Option(Box::new(receiver.clone())))
+        }
+        _ => None,
+    }
+}
+
 fn method_owner_name(ty: &Type) -> Option<&str> {
     match ty {
         Type::Struct(name) | Type::Enum(name) => Some(name.as_str()),
@@ -6844,6 +6867,35 @@ fn lower_expr_with_expected(
                 });
             }
             let lowered_base = lower_expr(base, env, ctx)?;
+            if let Some(return_ty) = numeric_method_return_ty(lowered_base.ty(), method) {
+                if args.len() != 1 {
+                    return Err(Diagnostic::new(
+                        "type",
+                        format!(
+                            "numeric method {method:?} expects 1 argument, got {}",
+                            args.len()
+                        ),
+                    )
+                    .with_span(*line, *column));
+                }
+                let receiver_ty = lowered_base.ty().clone();
+                let lowered_arg = lower_expr_with_expected(&args[0], Some(&receiver_ty), env, ctx)?;
+                if lowered_arg.ty() != &receiver_ty {
+                    return Err(Diagnostic::new(
+                        "type",
+                        format!(
+                            "numeric method {method:?} expects argument type {receiver_ty}, got {}",
+                            lowered_arg.ty()
+                        ),
+                    )
+                    .with_span(args[0].line(), args[0].column()));
+                }
+                return Ok(Expr::Call {
+                    name: format!("__axiom_numeric_{method}"),
+                    args: vec![lowered_base, lowered_arg],
+                    ty: return_ty,
+                });
+            }
             let Some(owner_name) = method_owner_name(lowered_base.ty()) else {
                 return Err(Diagnostic::new(
                     "type",

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -149,6 +149,10 @@ pub enum Expr {
         rhs: Box<Expr>,
         ty: Type,
     },
+    Cast {
+        expr: Box<Expr>,
+        ty: Type,
+    },
     Try {
         expr: Box<Expr>,
         ty: Type,
@@ -208,6 +212,7 @@ pub enum Expr {
 pub enum Type {
     Error,
     Int,
+    Numeric(syntax::NumericType),
     Bool,
     String,
     Struct(String),
@@ -230,6 +235,10 @@ pub enum Type {
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub enum LiteralValue {
     Int(i64),
+    Numeric {
+        raw: String,
+        ty: syntax::NumericType,
+    },
     Bool(bool),
     String(String),
 }
@@ -330,6 +339,18 @@ fn function_symbol_name(function: &syntax::Function) -> String {
         Some(target) => format!("{target}__{}", function.name),
         None => function.name.clone(),
     }
+}
+
+fn is_castable_numeric(ty: &Type) -> bool {
+    matches!(ty, Type::Int | Type::Numeric(_))
+}
+
+fn is_ordered_numeric(ty: &Type) -> bool {
+    matches!(ty, Type::Int | Type::Numeric(_))
+}
+
+fn is_addable_numeric(ty: &Type) -> bool {
+    matches!(ty, Type::Int | Type::Numeric(_))
 }
 
 fn method_owner_name(ty: &Type) -> Option<&str> {
@@ -556,7 +577,9 @@ fn collect_expr_calls(expr: &syntax::Expr, calls: &mut VecDeque<String>) {
             collect_expr_calls(lhs, calls);
             collect_expr_calls(rhs, calls);
         }
-        syntax::Expr::Try { expr, .. } | syntax::Expr::Await { expr, .. } => {
+        syntax::Expr::Try { expr, .. }
+        | syntax::Expr::Await { expr, .. }
+        | syntax::Expr::Cast { expr, .. } => {
             collect_expr_calls(expr, calls);
         }
         syntax::Expr::StructLiteral { fields, .. } => {
@@ -673,9 +696,13 @@ fn type_has_unboxed_recursive_path(
     visiting: &mut HashSet<AggregateRef>,
 ) -> bool {
     match ty {
-        Type::Error | Type::Int | Type::Bool | Type::String | Type::Ptr(_) | Type::MutPtr(_) => {
-            false
-        }
+        Type::Error
+        | Type::Int
+        | Type::Numeric(_)
+        | Type::Bool
+        | Type::String
+        | Type::Ptr(_)
+        | Type::MutPtr(_) => false,
         Type::Struct(name) => {
             let current = AggregateRef::Struct(name.clone());
             if &current == owner {
@@ -1969,7 +1996,10 @@ fn collect_type_params(ty: &syntax::TypeName, type_params: &[String], found: &mu
                 collect_type_params(element, type_params, found);
             }
         }
-        syntax::TypeName::Int | syntax::TypeName::Bool | syntax::TypeName::String => {}
+        syntax::TypeName::Int
+        | syntax::TypeName::Numeric(_)
+        | syntax::TypeName::Bool
+        | syntax::TypeName::String => {}
     }
 }
 
@@ -2356,6 +2386,7 @@ fn rewrite_aggregate_type_name(
             )?))
         }
         syntax::TypeName::Int => syntax::TypeName::Int,
+        syntax::TypeName::Numeric(numeric) => syntax::TypeName::Numeric(*numeric),
         syntax::TypeName::Bool => syntax::TypeName::Bool,
         syntax::TypeName::String => syntax::TypeName::String,
     })
@@ -2700,6 +2731,31 @@ fn rewrite_expr_aggregate_types(
                 queue,
                 queued,
             )?),
+            line: *line,
+            column: *column,
+        },
+        syntax::Expr::Cast {
+            expr,
+            ty,
+            line,
+            column,
+        } => syntax::Expr::Cast {
+            expr: Box::new(rewrite_expr_aggregate_types(
+                expr,
+                generic_structs,
+                generic_enums,
+                queue,
+                queued,
+            )?),
+            ty: rewrite_aggregate_type_name(
+                ty,
+                generic_structs,
+                generic_enums,
+                queue,
+                queued,
+                *line,
+                *column,
+            )?,
             line: *line,
             column: *column,
         },
@@ -3290,6 +3346,23 @@ fn rewrite_expr_generic_calls(
             line: *line,
             column: *column,
         },
+        syntax::Expr::Cast {
+            expr,
+            ty,
+            line,
+            column,
+        } => syntax::Expr::Cast {
+            expr: Box::new(rewrite_expr_generic_calls(
+                expr,
+                type_bindings,
+                generic_functions,
+                queue,
+                queued,
+            )?),
+            ty: substitute_type_name(ty, type_bindings),
+            line: *line,
+            column: *column,
+        },
         syntax::Expr::Try { expr, line, column } => syntax::Expr::Try {
             expr: Box::new(rewrite_expr_generic_calls(
                 expr,
@@ -3561,6 +3634,7 @@ fn substitute_type_name(
             syntax::TypeName::Array(Box::new(substitute_type_name(inner, type_bindings)))
         }
         syntax::TypeName::Int => syntax::TypeName::Int,
+        syntax::TypeName::Numeric(numeric) => syntax::TypeName::Numeric(*numeric),
         syntax::TypeName::Bool => syntax::TypeName::Bool,
         syntax::TypeName::String => syntax::TypeName::String,
     }
@@ -3611,6 +3685,7 @@ fn is_async_runtime_intrinsic(name: &str) -> bool {
 fn type_name_monomorph_suffix(ty: &syntax::TypeName) -> String {
     match ty {
         syntax::TypeName::Int => String::from("int"),
+        syntax::TypeName::Numeric(numeric) => numeric.as_str().to_string(),
         syntax::TypeName::Bool => String::from("bool"),
         syntax::TypeName::String => String::from("string"),
         syntax::TypeName::Named(name, args) if args.is_empty() => name.clone(),
@@ -3661,6 +3736,7 @@ impl Type {
         match self {
             Type::Error
             | Type::Int
+            | Type::Numeric(_)
             | Type::Bool
             | Type::Ptr(_)
             | Type::MutPtr(_)
@@ -3683,7 +3759,7 @@ impl Type {
 
     fn supports_map_key(&self) -> bool {
         match self {
-            Type::Int | Type::Bool | Type::String => true,
+            Type::Int | Type::Numeric(_) | Type::Bool | Type::String => true,
             Type::Tuple(elements) => elements.iter().all(Type::supports_map_key),
             Type::Error
             | Type::Struct(_)
@@ -4411,7 +4487,7 @@ fn lower_stmt(
             let lowered = lower_expr(expr, env, ctx)?;
             if !matches!(
                 lowered.ty(),
-                Type::Error | Type::Int | Type::Bool | Type::String
+                Type::Error | Type::Int | Type::Numeric(_) | Type::Bool | Type::String
             ) {
                 return Err(Diagnostic::new(
                     "type",
@@ -6844,12 +6920,13 @@ fn lower_expr_with_expected(
             let rhs = lower_expr(rhs, env, ctx)?;
             let lhs_ty = lhs.ty().clone();
             let rhs_ty = rhs.ty().clone();
-            if lhs_ty != rhs_ty || !matches!(lhs_ty, Type::Int | Type::String) {
+            if lhs_ty != rhs_ty || !(is_addable_numeric(&lhs_ty) || matches!(lhs_ty, Type::String))
+            {
                 return Err(
                     Diagnostic::new(
                         "type",
                         format!(
-                            "operator '+' expects matching int or string operands, got {lhs_ty} and {rhs_ty}"
+                            "operator '+' expects matching numeric or string operands, got {lhs_ty} and {rhs_ty}"
                         ),
                     )
                     .with_span(*line, *column),
@@ -6891,11 +6968,11 @@ fn lower_expr_with_expected(
                 | syntax::CompareOp::Le
                 | syntax::CompareOp::Gt
                 | syntax::CompareOp::Ge => {
-                    if lhs_ty != Type::Int || rhs_ty != Type::Int {
+                    if lhs_ty != rhs_ty || !is_ordered_numeric(&lhs_ty) {
                         return Err(Diagnostic::new(
                             "type",
                             format!(
-                                "operator '{}' expects int operands, got {lhs_ty} and {rhs_ty}",
+                                "operator '{}' expects matching numeric operands, got {lhs_ty} and {rhs_ty}",
                                 op.lexeme()
                             ),
                         )
@@ -6908,6 +6985,29 @@ fn lower_expr_with_expected(
                 lhs: Box::new(lhs),
                 rhs: Box::new(rhs),
                 ty: Type::Bool,
+            })
+        }
+        syntax::Expr::Cast {
+            expr,
+            ty,
+            line,
+            column,
+        } => {
+            let expr = lower_expr(expr, env, ctx)?;
+            let target = lower_type(ty, ctx.structs, ctx.enums, ctx.aliases, *line, *column)?;
+            if !is_castable_numeric(expr.ty()) || !is_castable_numeric(&target) {
+                return Err(Diagnostic::new(
+                    "type",
+                    format!(
+                        "cast expects numeric source and target types, got {} as {target}",
+                        expr.ty()
+                    ),
+                )
+                .with_span(*line, *column));
+            }
+            Ok(Expr::Cast {
+                expr: Box::new(expr),
+                ty: target,
             })
         }
         syntax::Expr::Try { expr, line, column } => {
@@ -7820,7 +7920,10 @@ fn validate_ffi_type_name(
     column: usize,
 ) -> Result<(), Diagnostic> {
     match ty {
-        syntax::TypeName::Int | syntax::TypeName::Bool | syntax::TypeName::String => Ok(()),
+        syntax::TypeName::Int
+        | syntax::TypeName::Numeric(_)
+        | syntax::TypeName::Bool
+        | syntax::TypeName::String => Ok(()),
         syntax::TypeName::Ptr(inner) | syntax::TypeName::MutPtr(inner) => {
             validate_ffi_type_name(inner, line, column)
         }
@@ -7834,7 +7937,7 @@ fn validate_ffi_type_name(
 
 fn validate_ffi_type(ty: &Type, line: usize, column: usize) -> Result<(), Diagnostic> {
     match ty {
-        Type::Int | Type::Bool | Type::String => Ok(()),
+        Type::Int | Type::Numeric(_) | Type::Bool | Type::String => Ok(()),
         Type::Ptr(inner) | Type::MutPtr(inner) => validate_ffi_type(inner, line, column),
         _ => Err(Diagnostic::new(
             "type",
@@ -8248,7 +8351,9 @@ fn expr_borrow_origin(
                 .iter()
                 .map(|element| expr_borrow_origin(element, env, ctx)),
         ),
-        Expr::Try { expr, .. } | Expr::Await { expr, .. } => expr_borrow_origin(expr, env, ctx),
+        Expr::Try { expr, .. } | Expr::Await { expr, .. } | Expr::Cast { expr, .. } => {
+            expr_borrow_origin(expr, env, ctx)
+        }
         Expr::TupleIndex { base, .. } => expr_borrow_origin(base, env, ctx),
         Expr::MapLiteral { entries, .. } => {
             merge_borrow_origins(entries.iter().flat_map(|entry| {
@@ -8391,7 +8496,9 @@ fn expr_borrowed_owners(
             })
             .unwrap_or_default(),
         Expr::TupleLiteral { elements, .. } => collect_expr_borrowed_owners(elements, env, ctx),
-        Expr::Try { expr, .. } | Expr::Await { expr, .. } => expr_borrowed_owners(expr, env, ctx),
+        Expr::Try { expr, .. } | Expr::Await { expr, .. } | Expr::Cast { expr, .. } => {
+            expr_borrowed_owners(expr, env, ctx)
+        }
         Expr::TupleIndex { base, .. } => expr_borrowed_owners(base, env, ctx),
         Expr::MapLiteral { entries, .. } => {
             let mut owners = HashSet::new();
@@ -8562,9 +8669,13 @@ fn contains_borrowed_slice_type_inner(
             visiting_enums.remove(name);
             contains
         }
-        Type::Error | Type::Int | Type::Bool | Type::String | Type::Ptr(_) | Type::MutPtr(_) => {
-            false
-        }
+        Type::Error
+        | Type::Int
+        | Type::Numeric(_)
+        | Type::Bool
+        | Type::String
+        | Type::Ptr(_)
+        | Type::MutPtr(_) => false,
     }
 }
 
@@ -8580,6 +8691,7 @@ fn contains_mut_borrowed_slice_type_inner(
         Type::Error
         | Type::Slice(_)
         | Type::Int
+        | Type::Numeric(_)
         | Type::Bool
         | Type::String
         | Type::Ptr(_)
@@ -8877,6 +8989,13 @@ fn lower_literal(literal: &syntax::Literal) -> Expr {
             ty: Type::Int,
             value: LiteralValue::Int(*value),
         },
+        syntax::Literal::Numeric { raw, ty } => Expr::Literal {
+            ty: Type::Numeric(*ty),
+            value: LiteralValue::Numeric {
+                raw: raw.clone(),
+                ty: *ty,
+            },
+        },
         syntax::Literal::Bool(value) => Expr::Literal {
             ty: Type::Bool,
             value: LiteralValue::Bool(*value),
@@ -8911,6 +9030,7 @@ fn lower_type_inner<T, U>(
 ) -> Result<Type, Diagnostic> {
     match ty {
         syntax::TypeName::Int => Ok(Type::Int),
+        syntax::TypeName::Numeric(numeric) => Ok(Type::Numeric(*numeric)),
         syntax::TypeName::Bool => Ok(Type::Bool),
         syntax::TypeName::String => Ok(Type::String),
         syntax::TypeName::Named(name, args) => {
@@ -9095,6 +9215,7 @@ impl Expr {
             Expr::Call { ty, .. } => ty,
             Expr::BinaryAdd { ty, .. } => ty,
             Expr::BinaryCompare { ty, .. } => ty,
+            Expr::Cast { ty, .. } => ty,
             Expr::Try { ty, .. } => ty,
             Expr::Await { ty, .. } => ty,
             Expr::StructLiteral { ty, .. } => ty,
@@ -9181,6 +9302,7 @@ impl syntax::Expr {
             | syntax::Expr::MethodCall { line, .. }
             | syntax::Expr::BinaryAdd { line, .. }
             | syntax::Expr::BinaryCompare { line, .. }
+            | syntax::Expr::Cast { line, .. }
             | syntax::Expr::Try { line, .. }
             | syntax::Expr::Await { line, .. }
             | syntax::Expr::StructLiteral { line, .. }
@@ -9202,6 +9324,7 @@ impl syntax::Expr {
             | syntax::Expr::MethodCall { column, .. }
             | syntax::Expr::BinaryAdd { column, .. }
             | syntax::Expr::BinaryCompare { column, .. }
+            | syntax::Expr::Cast { column, .. }
             | syntax::Expr::Try { column, .. }
             | syntax::Expr::Await { column, .. }
             | syntax::Expr::StructLiteral { column, .. }
@@ -9234,6 +9357,7 @@ impl std::fmt::Display for Type {
         match self {
             Type::Error => write!(f, "<type-error>"),
             Type::Int => write!(f, "int"),
+            Type::Numeric(numeric) => write!(f, "{}", numeric.as_str()),
             Type::Bool => write!(f, "bool"),
             Type::String => write!(f, "string"),
             Type::Struct(name) => write!(f, "{name}"),

--- a/stage1/crates/axiomc/src/json_contract.rs
+++ b/stage1/crates/axiomc/src/json_contract.rs
@@ -2,7 +2,7 @@ use crate::diagnostics::Diagnostic;
 use crate::manifest::CapabilityDescriptor;
 use crate::project::{BuildOutput, CheckOutput, TestOutput};
 use serde::Serialize;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::path::Path;
 
 pub const JSON_SCHEMA_VERSION: &str = "axiom.stage1.v1";

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -1084,6 +1084,32 @@ print fail()
     }
 
     #[test]
+    fn parser_lowers_numeric_tower_literals_and_casts() {
+        let source = "fn widen(value: u8): u32 {\nreturn value as u32\n}\n\nlet byte: u8 = 255u8\nlet word: u32 = widen(byte) + 1u32\nlet signed: i16 = -1i16\nlet big: i64 = signed as i64\nlet ratio: f64 = 3.5f64\nlet half: f32 = 0.5f32\nprint word as int\nprint big\n";
+        let parsed = parse_program(source, Path::new("main.ax")).expect("parse");
+        let hir = hir::lower(&parsed).expect("lower");
+        let mir = mir::lower(&hir);
+        let rendered = render_rust(&mir);
+        assert!(rendered.contains("fn widen(value: u8) -> u32 {"));
+        assert!(rendered.contains("return (value) as u32;"));
+        assert!(rendered.contains("let byte: u8 = 255u8;"));
+        assert!(rendered.contains("let word: u32 = widen(byte) + 1u32;"));
+        assert!(rendered.contains("let signed: i16 = -1i16;"));
+        assert!(rendered.contains("let big: i64 = (signed) as i64;"));
+        assert!(rendered.contains("let ratio: f64 = 3.5f64;"));
+        assert!(rendered.contains("let half: f32 = 0.5f32;"));
+        assert!(rendered.contains("println!(\"{}\", (word) as i64);"));
+    }
+
+    #[test]
+    fn checker_rejects_mixed_numeric_width_arithmetic_without_cast() {
+        let source = "let byte: u8 = 1u8\nlet word: u32 = 2u32\nlet bad: u32 = byte + word\n";
+        let parsed = parse_program(source, Path::new("main.ax")).expect("parse");
+        let error = hir::lower(&parsed).expect_err("mixed-width arithmetic should fail");
+        assert!(error.message.contains("matching numeric or string operands"));
+    }
+
+    #[test]
     fn parser_lowers_arrays_and_indexing() {
         let source = "fn answer(values: [int]): int {\nreturn values[1]\n}\n\nlet values: [int] = [40, 42]\nprint answer(values)\n";
         let parsed = parse_program(source, Path::new("main.ax")).expect("parse");

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -1126,6 +1126,30 @@ print fail()
     }
 
     #[test]
+    fn parser_lowers_numeric_checked_and_wrapping_methods() {
+        let source = "let byte: u8 = 255u8
+let wrapped: u8 = byte.wrapping_add(1u8)
+let checked: Option<u8> = byte.checked_add(1u8)
+";
+        let parsed = parse_program(source, Path::new("main.ax")).expect("parse");
+        let hir = hir::lower(&parsed).expect("lower");
+        let mir = mir::lower(&hir);
+        let rendered = render_rust(&mir);
+        assert!(rendered.contains("let wrapped: u8 = (byte).wrapping_add(1u8);"));
+        assert!(rendered.contains("let checked: Option<u8> = (byte).checked_add(1u8);"));
+    }
+
+    #[test]
+    fn checker_rejects_numeric_method_argument_type_mismatch() {
+        let source = "let byte: u8 = 1u8
+let bad: u8 = byte.wrapping_add(1u16)
+";
+        let parsed = parse_program(source, Path::new("main.ax")).expect("parse");
+        let error = hir::lower(&parsed).expect_err("numeric method argument width should fail");
+        assert!(error.message.contains("expects argument type u8"));
+    }
+
+    #[test]
     fn parser_lowers_arrays_and_indexing() {
         let source = "fn answer(values: [int]): int {\nreturn values[1]\n}\n\nlet values: [int] = [40, 42]\nprint answer(values)\n";
         let parsed = parse_program(source, Path::new("main.ax")).expect("parse");

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -1110,6 +1110,22 @@ print fail()
     }
 
     #[test]
+    fn parser_rejects_unsigned_negative_numeric_literal() {
+        let source = "let bad: u8 = -1u8\n";
+        let error = parse_program(source, Path::new("main.ax"))
+            .expect_err("unsigned negative numeric literal should fail during parsing");
+        assert!(error.message.contains("invalid identifier"));
+    }
+
+    #[test]
+    fn parser_rejects_out_of_range_numeric_literal() {
+        let source = "let bad: u8 = 300u8\n";
+        let error = parse_program(source, Path::new("main.ax"))
+            .expect_err("out-of-range numeric literal should fail during parsing");
+        assert!(error.message.contains("invalid identifier"));
+    }
+
+    #[test]
     fn parser_lowers_arrays_and_indexing() {
         let source = "fn answer(values: [int]): int {\nreturn values[1]\n}\n\nlet values: [int] = [40, 42]\nprint answer(values)\n";
         let parsed = parse_program(source, Path::new("main.ax")).expect("parse");

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -1106,7 +1106,11 @@ print fail()
         let source = "let byte: u8 = 1u8\nlet word: u32 = 2u32\nlet bad: u32 = byte + word\n";
         let parsed = parse_program(source, Path::new("main.ax")).expect("parse");
         let error = hir::lower(&parsed).expect_err("mixed-width arithmetic should fail");
-        assert!(error.message.contains("matching numeric or string operands"));
+        assert!(
+            error
+                .message
+                .contains("matching numeric or string operands")
+        );
     }
 
     #[test]
@@ -1114,7 +1118,7 @@ print fail()
         let source = "let bad: u8 = -1u8\n";
         let error = parse_program(source, Path::new("main.ax"))
             .expect_err("unsigned negative numeric literal should fail during parsing");
-        assert!(error.message.contains("invalid identifier"));
+        assert!(error.message.contains("invalid numeric literal"));
     }
 
     #[test]
@@ -1122,7 +1126,20 @@ print fail()
         let source = "let bad: u8 = 300u8\n";
         let error = parse_program(source, Path::new("main.ax"))
             .expect_err("out-of-range numeric literal should fail during parsing");
-        assert!(error.message.contains("invalid identifier"));
+        assert!(error.message.contains("invalid numeric literal"));
+    }
+
+    #[test]
+    fn parser_rejects_non_rust_suffixed_float_literals() {
+        for source in [
+            "let bad: f64 = NaNf64\n",
+            "let bad: f32 = inff32\n",
+            "let bad: f32 = 1e39f32\n",
+        ] {
+            let error = parse_program(source, Path::new("main.ax"))
+                .expect_err("non-rust float literal should fail during parsing");
+            assert!(error.message.contains("invalid numeric literal"));
+        }
     }
 
     #[test]
@@ -7664,15 +7681,19 @@ print serve_once("127.0.0.1:18080", "hello")
             .as_array()
             .expect("imported debug mappings array");
         assert!(
-            imported_mappings.iter().any(|mapping| mapping["source"] == source
-                && mapping["line"] == 2
-                && mapping["column"] == 1),
+            imported_mappings
+                .iter()
+                .any(|mapping| mapping["source"] == source
+                    && mapping["line"] == 2
+                    && mapping["column"] == 1),
             "debug map should retain primary source spans after imports"
         );
         assert!(
-            imported_mappings.iter().any(|mapping| mapping["source"] == helper_source
-                && mapping["line"] == 2
-                && mapping["column"] == 1),
+            imported_mappings
+                .iter()
+                .any(|mapping| mapping["source"] == helper_source
+                    && mapping["line"] == 2
+                    && mapping["column"] == 1),
             "debug map should retain imported module source spans instead of collapsing to the primary file"
         );
 
@@ -7907,11 +7928,27 @@ print serve_once("127.0.0.1:18080", "hello")
     #[test]
     fn json_contract_adds_stable_codes_for_common_diagnostic_kinds() {
         let cases = [
-            ("parse", "missing closing brace for block", "parse.missing_closing_brace"),
+            (
+                "parse",
+                "missing closing brace for block",
+                "parse.missing_closing_brace",
+            ),
             ("manifest", "invalid axiom.toml", "manifest.invalid"),
-            ("import", "import not found: ./missing.ax", "import.unresolved"),
-            ("capability", "fs requires capability fs", "capability.denied"),
-            ("type", "undefined variable \"answer\"", "type.undefined_symbol"),
+            (
+                "import",
+                "import not found: ./missing.ax",
+                "import.unresolved",
+            ),
+            (
+                "capability",
+                "fs requires capability fs",
+                "capability.denied",
+            ),
+            (
+                "type",
+                "undefined variable \"answer\"",
+                "type.undefined_symbol",
+            ),
             ("build", "failed to invoke rustc", "build.failed"),
             ("runtime", "process exited with status 1", "runtime.failed"),
         ];
@@ -7935,16 +7972,21 @@ print serve_once("127.0.0.1:18080", "hello")
         let source_payload = json_contract::error("check", &source_error);
 
         assert_eq!(source_payload["error"]["repair"]["action"], "edit_source");
-        assert!(source_payload["error"]["repair"]["edit"]
-            .as_str()
-            .expect("repair edit")
-            .contains("reported span"));
+        assert!(
+            source_payload["error"]["repair"]["edit"]
+                .as_str()
+                .expect("repair edit")
+                .contains("reported span")
+        );
 
         let fmt_error = crate::diagnostics::Diagnostic::new("fmt", "1 file(s) need formatting");
         let fmt_payload = json_contract::error("fmt", &fmt_error);
 
         assert_eq!(fmt_payload["error"]["repair"]["action"], "run_command");
-        assert_eq!(fmt_payload["error"]["repair"]["command"], "axiomc fmt <path>");
+        assert_eq!(
+            fmt_payload["error"]["repair"]["command"],
+            "axiomc fmt <path>"
+        );
     }
 
     #[test]
@@ -8168,7 +8210,10 @@ print c
         let hir = hir::lower(&parsed).expect("lower");
         let mir = mir::lower(&hir);
         let rendered = render_rust(&mir);
-        assert!(rendered.contains("fn wrap__int("), "wrap<int> must produce 'wrap__int'");
+        assert!(
+            rendered.contains("fn wrap__int("),
+            "wrap<int> must produce 'wrap__int'"
+        );
         assert!(
             rendered.contains("fn identity__int("),
             "identity<int> must produce 'identity__int'"
@@ -8246,10 +8291,7 @@ return missing_c
             "expected error for missing_c"
         );
         // Verify source order: line numbers must be non-decreasing.
-        let lines: Vec<usize> = diagnostics
-            .iter()
-            .filter_map(|d| d.line)
-            .collect();
+        let lines: Vec<usize> = diagnostics.iter().filter_map(|d| d.line).collect();
         let sorted = {
             let mut s = lines.clone();
             s.sort_unstable();

--- a/stage1/crates/axiomc/src/mir.rs
+++ b/stage1/crates/axiomc/src/mir.rs
@@ -1,4 +1,4 @@
-use crate::hir;
+use crate::{hir, syntax};
 use serde::Serialize;
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -143,6 +143,10 @@ pub enum Expr {
         rhs: Box<Expr>,
         ty: Type,
     },
+    Cast {
+        expr: Box<Expr>,
+        ty: Type,
+    },
     Try {
         expr: Box<Expr>,
         ty: Type,
@@ -201,6 +205,10 @@ pub enum Expr {
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub enum LiteralValue {
     Int(i64),
+    Numeric {
+        raw: String,
+        ty: syntax::NumericType,
+    },
     Bool(bool),
     String(String),
 }
@@ -218,6 +226,7 @@ pub enum CompareOp {
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub enum Type {
     Int,
+    Numeric(syntax::NumericType),
     Bool,
     String,
     Struct(String),
@@ -240,7 +249,12 @@ pub enum Type {
 impl Type {
     pub fn is_copy(&self) -> bool {
         match self {
-            Type::Int | Type::Bool | Type::Ptr(_) | Type::MutPtr(_) | Type::Slice(_) => true,
+            Type::Int
+            | Type::Numeric(_)
+            | Type::Bool
+            | Type::Ptr(_)
+            | Type::MutPtr(_)
+            | Type::Slice(_) => true,
             Type::MutSlice(_) => false,
             Type::Option(inner) => inner.is_copy(),
             Type::Result(ok, err) => ok.is_copy() && err.is_copy(),
@@ -288,12 +302,14 @@ impl Expr {
     pub fn ty(&self) -> Type {
         match self {
             Expr::Literal(LiteralValue::Int(_)) => Type::Int,
+            Expr::Literal(LiteralValue::Numeric { ty, .. }) => Type::Numeric(*ty),
             Expr::Literal(LiteralValue::Bool(_)) => Type::Bool,
             Expr::Literal(LiteralValue::String(_)) => Type::String,
             Expr::VarRef { ty, .. } => ty.clone(),
             Expr::Call { ty, .. } => ty.clone(),
             Expr::BinaryAdd { ty, .. } => ty.clone(),
             Expr::BinaryCompare { ty, .. } => ty.clone(),
+            Expr::Cast { ty, .. } => ty.clone(),
             Expr::Try { ty, .. } => ty.clone(),
             Expr::Await { ty, .. } => ty.clone(),
             Expr::StructLiteral { ty, .. } => ty.clone(),
@@ -465,6 +481,10 @@ fn lower_expr(expr: &hir::Expr) -> Expr {
     match expr {
         hir::Expr::Literal { value, .. } => Expr::Literal(match value {
             hir::LiteralValue::Int(value) => LiteralValue::Int(*value),
+            hir::LiteralValue::Numeric { raw, ty } => LiteralValue::Numeric {
+                raw: raw.clone(),
+                ty: *ty,
+            },
             hir::LiteralValue::Bool(value) => LiteralValue::Bool(*value),
             hir::LiteralValue::String(value) => LiteralValue::String(value.clone()),
         }),
@@ -486,6 +506,10 @@ fn lower_expr(expr: &hir::Expr) -> Expr {
             op: lower_compare_op(*op),
             lhs: Box::new(lower_expr(lhs)),
             rhs: Box::new(lower_expr(rhs)),
+            ty: lower_type(ty),
+        },
+        hir::Expr::Cast { expr, ty } => Expr::Cast {
+            expr: Box::new(lower_expr(expr)),
             ty: lower_type(ty),
         },
         hir::Expr::Try { expr, ty } => Expr::Try {
@@ -571,6 +595,7 @@ fn lower_type(ty: &hir::Type) -> Type {
     match ty {
         hir::Type::Error => unreachable!("type-error sentinel must not reach MIR lowering"),
         hir::Type::Int => Type::Int,
+        hir::Type::Numeric(numeric) => Type::Numeric(*numeric),
         hir::Type::Bool => Type::Bool,
         hir::Type::String => Type::String,
         hir::Type::Struct(name) => Type::Struct(name.clone()),

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -2055,6 +2055,9 @@ fn validate_expr_capabilities(
             validate_expr_capabilities(module_path, lhs, capabilities)?;
             validate_expr_capabilities(module_path, rhs, capabilities)
         }
+        syntax::Expr::Cast { expr, .. } => {
+            validate_expr_capabilities(module_path, expr, capabilities)
+        }
         syntax::Expr::Try { expr, .. } | syntax::Expr::Await { expr, .. } => {
             validate_expr_capabilities(module_path, expr, capabilities)
         }
@@ -3483,6 +3486,34 @@ fn rewrite_expr(
             line: *line,
             column: *column,
         },
+        syntax::Expr::Cast {
+            expr,
+            ty,
+            line,
+            column,
+        } => syntax::Expr::Cast {
+            expr: Box::new(rewrite_expr(
+                expr,
+                visible_functions,
+                visible_consts,
+                visible_structs,
+                visible_types,
+                private_imported,
+                private_imported_consts,
+                private_imported_types,
+                module_path,
+            )?),
+            ty: rewrite_type_name(
+                ty,
+                visible_types,
+                private_imported_types,
+                module_path,
+                *line,
+                *column,
+            )?,
+            line: *line,
+            column: *column,
+        },
         syntax::Expr::Try { expr, line, column } => syntax::Expr::Try {
             expr: Box::new(rewrite_expr(
                 expr,
@@ -3785,6 +3816,7 @@ fn rewrite_type_name(
 ) -> Result<syntax::TypeName, Diagnostic> {
     match ty {
         syntax::TypeName::Int => Ok(syntax::TypeName::Int),
+        syntax::TypeName::Numeric(numeric) => Ok(syntax::TypeName::Numeric(*numeric)),
         syntax::TypeName::Bool => Ok(syntax::TypeName::Bool),
         syntax::TypeName::String => Ok(syntax::TypeName::String),
         syntax::TypeName::Named(name, args) => {

--- a/stage1/crates/axiomc/src/syntax.rs
+++ b/stage1/crates/axiomc/src/syntax.rs
@@ -184,9 +184,67 @@ pub struct MatchArm {
     pub column: usize,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, Hash)]
+pub enum NumericType {
+    I8,
+    I16,
+    I32,
+    I64,
+    Isize,
+    U8,
+    U16,
+    U32,
+    U64,
+    Usize,
+    F32,
+    F64,
+}
+
+impl NumericType {
+    pub fn parse(raw: &str) -> Option<Self> {
+        match raw {
+            "i8" => Some(Self::I8),
+            "i16" => Some(Self::I16),
+            "i32" => Some(Self::I32),
+            "i64" => Some(Self::I64),
+            "isize" => Some(Self::Isize),
+            "u8" => Some(Self::U8),
+            "u16" => Some(Self::U16),
+            "u32" => Some(Self::U32),
+            "u64" => Some(Self::U64),
+            "usize" => Some(Self::Usize),
+            "f32" => Some(Self::F32),
+            "f64" => Some(Self::F64),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::I8 => "i8",
+            Self::I16 => "i16",
+            Self::I32 => "i32",
+            Self::I64 => "i64",
+            Self::Isize => "isize",
+            Self::U8 => "u8",
+            Self::U16 => "u16",
+            Self::U32 => "u32",
+            Self::U64 => "u64",
+            Self::Usize => "usize",
+            Self::F32 => "f32",
+            Self::F64 => "f64",
+        }
+    }
+
+    pub fn is_float(self) -> bool {
+        matches!(self, Self::F32 | Self::F64)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, PartialEq, Eq, Hash)]
 pub enum TypeName {
     Int,
+    Numeric(NumericType),
     Bool,
     String,
     Named(String, Vec<TypeName>),
@@ -234,6 +292,12 @@ pub enum Expr {
         op: CompareOp,
         lhs: Box<Expr>,
         rhs: Box<Expr>,
+        line: usize,
+        column: usize,
+    },
+    Cast {
+        expr: Box<Expr>,
+        ty: TypeName,
         line: usize,
         column: usize,
     },
@@ -314,6 +378,7 @@ pub struct MapEntry {
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub enum Literal {
     Int(i64),
+    Numeric { raw: String, ty: NumericType },
     Bool(bool),
     String(String),
 }
@@ -2153,7 +2218,10 @@ fn parse_type_name(
         "int" => Ok(TypeName::Int),
         "bool" => Ok(TypeName::Bool),
         "string" => Ok(TypeName::String),
-        _ => {
+        name => {
+            if let Some(numeric) = NumericType::parse(name) {
+                return Ok(TypeName::Numeric(numeric));
+            }
             validate_ident(raw, path, line_no, column)?;
             Ok(TypeName::Named(raw.to_string(), Vec::new()))
         }
@@ -2162,6 +2230,23 @@ fn parse_type_name(
 
 fn parse_expr(raw: &str, path: &Path, line_no: usize, column: usize) -> Result<Expr, Diagnostic> {
     let raw = raw.trim();
+    if let Some(split_index) = find_top_level_as(raw) {
+        let lhs_raw = raw[..split_index].trim();
+        let ty_raw = raw[split_index + 4..].trim();
+        if lhs_raw.is_empty() || ty_raw.is_empty() {
+            return Err(
+                Diagnostic::new("parse", "cast expression must use `expr as Type` syntax")
+                    .with_path(path.display().to_string())
+                    .with_span(line_no, column),
+            );
+        }
+        return Ok(Expr::Cast {
+            expr: Box::new(parse_expr(lhs_raw, path, line_no, column)?),
+            ty: parse_type_name(ty_raw, path, line_no, column + split_index + 5)?,
+            line: line_no,
+            column,
+        });
+    }
     if let Some((op, split_index)) = find_compare_operator(raw) {
         let lhs_raw = raw[..split_index].trim();
         let rhs_offset = split_index + op.lexeme().len();
@@ -2207,6 +2292,10 @@ fn parse_term(raw: &str, path: &Path, line_no: usize, column: usize) -> Result<E
         return Err(Diagnostic::new("parse", "expression is empty")
             .with_path(path.display().to_string())
             .with_span(line_no, column));
+    }
+
+    if let Some(literal) = parse_numeric_literal(raw) {
+        return Ok(Expr::Literal(literal));
     }
     if raw.ends_with('?') {
         let inner = raw[..raw.len() - 1].trim_end();
@@ -2436,6 +2525,61 @@ fn parse_term(raw: &str, path: &Path, line_no: usize, column: usize) -> Result<E
         line: line_no,
         column,
     })
+}
+
+fn parse_numeric_literal(raw: &str) -> Option<Literal> {
+    for suffix in [
+        "isize", "usize", "i8", "i16", "i32", "i64", "u8", "u16", "u32", "u64", "f32", "f64",
+    ] {
+        let Some(number) = raw.strip_suffix(suffix) else {
+            continue;
+        };
+        if number.is_empty() || number == "." {
+            return None;
+        }
+        let ty = NumericType::parse(suffix)?;
+        let valid = if ty.is_float() {
+            number.parse::<f64>().is_ok()
+        } else {
+            number.parse::<u128>().is_ok()
+                || (number.starts_with('-') && number[1..].parse::<u128>().is_ok())
+        };
+        if valid {
+            return Some(Literal::Numeric {
+                raw: number.to_string(),
+                ty,
+            });
+        }
+    }
+    None
+}
+
+fn find_top_level_as(raw: &str) -> Option<usize> {
+    let mut paren = 0usize;
+    let mut square = 0usize;
+    let mut brace = 0usize;
+    let mut angle = 0usize;
+    let bytes = raw.as_bytes();
+    let mut index = 0usize;
+    while index + 4 <= bytes.len() {
+        match bytes[index] as char {
+            '(' => paren += 1,
+            ')' => paren = paren.saturating_sub(1),
+            '[' => square += 1,
+            ']' => square = square.saturating_sub(1),
+            '{' => brace += 1,
+            '}' => brace = brace.saturating_sub(1),
+            '<' => angle += 1,
+            '>' => angle = angle.saturating_sub(1),
+            _ => {}
+        }
+        if paren == 0 && square == 0 && brace == 0 && angle == 0 && raw[index..].starts_with(" as ")
+        {
+            return Some(index);
+        }
+        index += 1;
+    }
+    None
 }
 
 fn parse_function_name<'a>(

--- a/stage1/crates/axiomc/src/syntax.rs
+++ b/stage1/crates/axiomc/src/syntax.rs
@@ -2538,13 +2538,7 @@ fn parse_numeric_literal(raw: &str) -> Option<Literal> {
             return None;
         }
         let ty = NumericType::parse(suffix)?;
-        let valid = if ty.is_float() {
-            number.parse::<f64>().is_ok()
-        } else {
-            number.parse::<u128>().is_ok()
-                || (number.starts_with('-') && number[1..].parse::<u128>().is_ok())
-        };
-        if valid {
+        if numeric_literal_fits(number, ty) {
             return Some(Literal::Numeric {
                 raw: number.to_string(),
                 ty,
@@ -2552,6 +2546,37 @@ fn parse_numeric_literal(raw: &str) -> Option<Literal> {
         }
     }
     None
+}
+
+fn numeric_literal_fits(number: &str, ty: NumericType) -> bool {
+    match ty {
+        NumericType::F32 | NumericType::F64 => number.parse::<f64>().is_ok(),
+        NumericType::I8 => integer_literal_in_range(number, i8::MIN as i128, i8::MAX as i128),
+        NumericType::I16 => integer_literal_in_range(number, i16::MIN as i128, i16::MAX as i128),
+        NumericType::I32 => integer_literal_in_range(number, i32::MIN as i128, i32::MAX as i128),
+        NumericType::I64 | NumericType::Isize => {
+            integer_literal_in_range(number, i64::MIN as i128, i64::MAX as i128)
+        }
+        NumericType::U8 => unsigned_integer_literal_in_range(number, u8::MAX as u128),
+        NumericType::U16 => unsigned_integer_literal_in_range(number, u16::MAX as u128),
+        NumericType::U32 => unsigned_integer_literal_in_range(number, u32::MAX as u128),
+        NumericType::U64 | NumericType::Usize => {
+            unsigned_integer_literal_in_range(number, u64::MAX as u128)
+        }
+    }
+}
+
+fn integer_literal_in_range(number: &str, min: i128, max: i128) -> bool {
+    number
+        .parse::<i128>()
+        .is_ok_and(|value| value >= min && value <= max)
+}
+
+fn unsigned_integer_literal_in_range(number: &str, max: u128) -> bool {
+    if number.starts_with('-') {
+        return false;
+    }
+    number.parse::<u128>().is_ok_and(|value| value <= max)
 }
 
 fn find_top_level_as(raw: &str) -> Option<usize> {

--- a/stage1/crates/axiomc/src/syntax.rs
+++ b/stage1/crates/axiomc/src/syntax.rs
@@ -2297,6 +2297,13 @@ fn parse_term(raw: &str, path: &Path, line_no: usize, column: usize) -> Result<E
     if let Some(literal) = parse_numeric_literal(raw) {
         return Ok(Expr::Literal(literal));
     }
+    if looks_like_invalid_numeric_literal(raw) {
+        return Err(
+            Diagnostic::new("parse", format!("invalid numeric literal {raw:?}"))
+                .with_path(path.display().to_string())
+                .with_span(line_no, column),
+        );
+    }
     if raw.ends_with('?') {
         let inner = raw[..raw.len() - 1].trim_end();
         if inner.is_empty() {
@@ -2527,11 +2534,13 @@ fn parse_term(raw: &str, path: &Path, line_no: usize, column: usize) -> Result<E
     })
 }
 
+const NUMERIC_LITERAL_SUFFIXES: &[&str] = &[
+    "isize", "usize", "i8", "i16", "i32", "i64", "u8", "u16", "u32", "u64", "f32", "f64",
+];
+
 fn parse_numeric_literal(raw: &str) -> Option<Literal> {
-    for suffix in [
-        "isize", "usize", "i8", "i16", "i32", "i64", "u8", "u16", "u32", "u64", "f32", "f64",
-    ] {
-        let Some(number) = raw.strip_suffix(suffix) else {
+    for suffix in NUMERIC_LITERAL_SUFFIXES {
+        let Some(number) = raw.strip_suffix(*suffix) else {
             continue;
         };
         if number.is_empty() || number == "." {
@@ -2548,9 +2557,24 @@ fn parse_numeric_literal(raw: &str) -> Option<Literal> {
     None
 }
 
+fn looks_like_invalid_numeric_literal(raw: &str) -> bool {
+    NUMERIC_LITERAL_SUFFIXES.iter().any(|suffix| {
+        let Some(number) = raw.strip_suffix(suffix) else {
+            return false;
+        };
+        !number.is_empty()
+            && (number.parse::<f64>().is_ok()
+                || number
+                    .chars()
+                    .next()
+                    .is_some_and(|ch| ch.is_ascii_digit() || ch == '-' || ch == '.'))
+    })
+}
+
 fn numeric_literal_fits(number: &str, ty: NumericType) -> bool {
     match ty {
-        NumericType::F32 | NumericType::F64 => number.parse::<f64>().is_ok(),
+        NumericType::F32 => float_literal_fits_f32(number),
+        NumericType::F64 => float_literal_fits_f64(number),
         NumericType::I8 => integer_literal_in_range(number, i8::MIN as i128, i8::MAX as i128),
         NumericType::I16 => integer_literal_in_range(number, i16::MIN as i128, i16::MAX as i128),
         NumericType::I32 => integer_literal_in_range(number, i32::MIN as i128, i32::MAX as i128),
@@ -2564,6 +2588,34 @@ fn numeric_literal_fits(number: &str, ty: NumericType) -> bool {
             unsigned_integer_literal_in_range(number, u64::MAX as u128)
         }
     }
+}
+
+fn float_literal_has_rust_number_shape(number: &str) -> bool {
+    let unsigned = number.strip_prefix('-').unwrap_or(number);
+    let Some(first) = unsigned.chars().next() else {
+        return false;
+    };
+    if !first.is_ascii_digit() {
+        return false;
+    }
+    if !unsigned.chars().any(|ch| ch.is_ascii_digit()) {
+        return false;
+    }
+    if unsigned
+        .chars()
+        .any(|ch| !(ch.is_ascii_digit() || matches!(ch, '_' | '.' | 'e' | 'E' | '+' | '-')))
+    {
+        return false;
+    }
+    true
+}
+
+fn float_literal_fits_f32(number: &str) -> bool {
+    float_literal_has_rust_number_shape(number) && number.parse::<f32>().is_ok_and(f32::is_finite)
+}
+
+fn float_literal_fits_f64(number: &str) -> bool {
+    float_literal_has_rust_number_shape(number) && number.parse::<f64>().is_ok_and(f64::is_finite)
 }
 
 fn integer_literal_in_range(number: &str, min: i128, max: i128) -> bool {


### PR DESCRIPTION
Closes #220

## Summary
- Adds support for the expanded numeric tower beyond `int` and `bool`.
- Updates syntax, HIR, MIR, diagnostics, JSON contract handling, project logic, and codegen for the new numeric forms.
- Preserves explicit typing/casting expectations for mixed-width numeric behavior.

## Scope and conformance
- Issue: Language: Full numeric tower — `i8..i64`, `u8..u64`, `f32`, `f64`.
- Primary implementation paths: `stage1/crates/axiomc/src/{syntax,hir,mir,codegen,diagnostics,json_contract,lib,project}.rs`.

## Testing
- PR Fast CI is green, including Fast Checks and CI Gate.
- Lockfile Integrity, Validate Secrets, and Validate PR Description are green.

## Notes for reviewers
- This is the Daedalus-assigned implementation slice for #220.
- Please focus review on type checking, codegen mapping, and diagnostic behavior for mixed-width or unsupported numeric operations.
