### PR TITLE
Salvage reserved registry manifest validation

### DIFF
--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -5349,6 +5349,51 @@ print serve_once("127.0.0.1:18080", "hello")
     }
 
     #[test]
+    fn manifest_rejects_reserved_registry_publish_fields() {
+        let dir = tempdir().expect("tempdir");
+
+        let root_registry = dir.path().join("root-registry");
+        create_project(&root_registry, Some("root-registry-app")).expect("create project");
+        fs::write(
+            root_registry.join("axiom.toml"),
+            format!(
+                "{}\n[registry]\nsource = \"https://registry.example\"\n",
+                render_manifest("root-registry-app")
+            ),
+        )
+        .expect("write manifest");
+        let err = load_manifest(&root_registry).expect_err("reserved registry should fail");
+        assert!(err.message.contains("[registry] is reserved"));
+
+        let package_checksum = dir.path().join("package-checksum");
+        create_project(&package_checksum, Some("package-checksum-app")).expect("create project");
+        fs::write(
+            package_checksum.join("axiom.toml"),
+            "[package]\nname = \"package-checksum-app\"\nversion = \"0.1.0\"\nchecksum = \"sha256:abc\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n",
+        )
+        .expect("write manifest");
+        let err = load_manifest(&package_checksum).expect_err("reserved checksum should fail");
+        assert!(err.message.contains("package.checksum is reserved"));
+
+        let dependency_version = dir.path().join("dependency-version");
+        create_project(&dependency_version, Some("dependency-version-app"))
+            .expect("create project");
+        fs::write(
+            dependency_version.join("axiom.toml"),
+            format!(
+                "{}\n[dependencies]\ncore = {{ version = \"1.0.0\", registry = \"default\" }}\n",
+                render_manifest("dependency-version-app")
+            ),
+        )
+        .expect("write manifest");
+        let err = load_manifest(&dependency_version).expect_err("reserved dependency should fail");
+        assert!(
+            err.message
+                .contains("dependencies.core.version is reserved")
+        );
+    }
+
+    #[test]
     fn run_project_tests_executes_manifest_cases() {
         let dir = tempdir().expect("tempdir");
         let project = dir.path().join("runner");

--- a/stage1/crates/axiomc/src/manifest.rs
+++ b/stage1/crates/axiomc/src/manifest.rs
@@ -131,12 +131,17 @@ struct RawManifest {
     build: Option<RawBuildSection>,
     tests: Option<Vec<RawTestTarget>>,
     capabilities: Option<RawCapabilityConfig>,
+    registry: Option<toml::Value>,
+    publish: Option<toml::Value>,
 }
 
 #[derive(Debug, Deserialize)]
 struct RawPackageSection {
     name: Option<String>,
     version: Option<String>,
+    checksum: Option<toml::Value>,
+    registry: Option<toml::Value>,
+    source: Option<toml::Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -160,6 +165,10 @@ enum RawDependencySpec {
 #[derive(Debug, Deserialize)]
 struct RawDependencyDetail {
     path: Option<String>,
+    version: Option<toml::Value>,
+    checksum: Option<toml::Value>,
+    registry: Option<toml::Value>,
+    source: Option<toml::Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -364,6 +373,7 @@ impl CapabilityKind {
 }
 
 fn normalize_manifest(raw: RawManifest, path: &Path) -> Result<Manifest, Diagnostic> {
+    validate_reserved_root_publish_fields(&raw, path)?;
     let workspace = normalize_workspace(raw.workspace, path)?;
     let package = normalize_package(raw.package, workspace.is_some(), path)?;
     let raw_build = raw.build;
@@ -432,6 +442,25 @@ fn normalize_manifest(raw: RawManifest, path: &Path) -> Result<Manifest, Diagnos
             rationale,
         },
     })
+}
+
+
+fn validate_reserved_root_publish_fields(raw: &RawManifest, path: &Path) -> Result<(), Diagnostic> {
+    if raw.registry.is_some() {
+        return Err(reserved_manifest_field(path, "[registry]"));
+    }
+    if raw.publish.is_some() {
+        return Err(reserved_manifest_field(path, "[publish]"));
+    }
+    Ok(())
+}
+
+fn reserved_manifest_field(path: &Path, field_name: &str) -> Diagnostic {
+    Diagnostic::new(
+        "manifest",
+        format!("{field_name} is reserved for future registry publishing"),
+    )
+    .with_path(path.display().to_string())
 }
 
 fn normalize_capability_name_list(
@@ -553,6 +582,15 @@ fn normalize_package(
         return Err(Diagnostic::new("manifest", "missing [package] section")
             .with_path(path.display().to_string()));
     };
+    if package.checksum.is_some() {
+        return Err(reserved_manifest_field(path, "package.checksum"));
+    }
+    if package.registry.is_some() {
+        return Err(reserved_manifest_field(path, "package.registry"));
+    }
+    if package.source.is_some() {
+        return Err(reserved_manifest_field(path, "package.source"));
+    }
     let package_name = required_field(package.name, path, "package.name")?;
     let package_version = required_field(package.version, path, "package.version")?;
     Ok(Some(PackageSection {
@@ -620,6 +658,30 @@ fn normalize_dependencies(
         let raw_path = match raw_spec {
             RawDependencySpec::Path(value) => value,
             RawDependencySpec::Detailed(detail) => {
+                if detail.version.is_some() {
+                    return Err(reserved_manifest_field(
+                        path,
+                        &format!("dependencies.{name}.version"),
+                    ));
+                }
+                if detail.checksum.is_some() {
+                    return Err(reserved_manifest_field(
+                        path,
+                        &format!("dependencies.{name}.checksum"),
+                    ));
+                }
+                if detail.registry.is_some() {
+                    return Err(reserved_manifest_field(
+                        path,
+                        &format!("dependencies.{name}.registry"),
+                    ));
+                }
+                if detail.source.is_some() {
+                    return Err(reserved_manifest_field(
+                        path,
+                        &format!("dependencies.{name}.source"),
+                    ));
+                }
                 required_field(detail.path, path, &format!("dependencies.{name}.path"))?
             }
         };


### PR DESCRIPTION
## Summary
- salvage the reserved registry/publish manifest validation from #436 onto current `main`
- reject `[registry]`, `[publish]`, reserved package source/checksum fields, and reserved dependency registry/version/checksum/source fields
- keep docs unchanged where the current `main` already carries the explanatory package/stage1 text

Supersedes #436 once merged.

## Validation
- `cargo check --manifest-path stage1/Cargo.toml -p axiomc`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc manifest_rejects_reserved_registry_publish_fields`
- `bash scripts/ci/run-fast-checks.sh`