### PR TITLE
feat(stage1): add publish manifest contract

### DIFF
--- a/docs/package.md
+++ b/docs/package.md
@@ -103,38 +103,27 @@ analysis.
 The generated index records per-release capability manifests, archive/signature URLs,
 and yanked status so a simple static host can serve lockfile-friendly package metadata. This is publish and registry-index groundwork for a future hosted registry service, not the hosted service itself.
 
-and yanked status so a simple static host can serve lockfile-friendly package metadata. This is registry-index groundwork for a future hosted registry service, not the hosted service itself.
-
 ## Registry And Publish Contract
 
-The local manifest contract reserves the package-registry surface without
-implementing remote publishing yet. Today, `axiomc` accepts local path
-dependencies only:
+The local manifest contract exposes publish metadata for future registry tooling while keeping dependency resolution local-only. Today, `axiomc` accepts local path dependencies and rejects registry dependency selectors:
 
 ```toml
 [dependencies]
 core = { path = "deps/core" }
 ```
 
-Package identity is the pair in `[package]`:
+Package identity is the pair in `[package]`. Publish metadata is optional and declarative only:
 
 ```toml
 [package]
 name = "agent-worker"
 version = "0.1.0"
+
+[publish]
+registry = "https://registry.example.test/index"
+checksum = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+include = ["src/**", "axiom.toml", "axiom.lock"]
+exclude = ["dist/**"]
 ```
 
-Future registry packages will need stable source and integrity metadata:
-
-- Package identity: `package.name` plus `package.version`.
-- Registry source: a named registry or URL source for non-local packages.
-- Checksums: content-addressed package archives, expected to use a tagged form
-  such as `sha256:<hex>`.
-- Publish metadata: include/exclude rules, target registry, archive checksum,
-  and provenance or signature references.
-
-Those fields are intentionally reserved. Until `axiomc publish` and registry
-resolution exist, manifests must not contain `[registry]`, `[publish]`,
-`package.checksum`, `package.registry`, `package.source`, or dependency
-`version`/`checksum`/`registry`/`source` fields. The parser rejects them instead
-of silently treating a registry package as a local package.
+Parser validation enforces the reserved boundary: root `[registry]`, `package.checksum`, `package.registry`, `package.source`, and dependency `version`/`checksum`/`registry`/`source` fields are rejected instead of silently treating a registry package as a local package. `[publish]` is accepted only as metadata; it does not make `axiomc` contact or upload to a remote registry.

--- a/stage1/crates/axiomc/src/manifest.rs
+++ b/stage1/crates/axiomc/src/manifest.rs
@@ -20,6 +20,7 @@ pub const KNOWN_CAPABILITIES: [CapabilityKind; 9] = [
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct Manifest {
     pub package: Option<PackageSection>,
+    pub publish: Option<PublishSection>,
     pub dependencies: BTreeMap<String, DependencySpec>,
     pub workspace: Option<WorkspaceSection>,
     pub build: BuildSection,
@@ -31,6 +32,14 @@ pub struct Manifest {
 pub struct PackageSection {
     pub name: String,
     pub version: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct PublishSection {
+    pub registry: String,
+    pub checksum: Option<String>,
+    pub include: Vec<String>,
+    pub exclude: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -146,7 +155,15 @@ struct RawManifest {
     tests: Option<Vec<RawTestTarget>>,
     capabilities: Option<RawCapabilityConfig>,
     registry: Option<toml::Value>,
-    publish: Option<toml::Value>,
+    publish: Option<RawPublishSection>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawPublishSection {
+    registry: Option<String>,
+    checksum: Option<String>,
+    include: Option<Vec<String>>,
+    exclude: Option<Vec<String>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -392,6 +409,7 @@ impl CapabilityKind {
 
 fn normalize_manifest(raw: RawManifest, path: &Path) -> Result<Manifest, Diagnostic> {
     validate_reserved_root_publish_fields(&raw, path)?;
+    let publish = normalize_publish(raw.publish, path)?;
     let workspace = normalize_workspace(raw.workspace, path)?;
     let package = normalize_package(raw.package, workspace.is_some(), path)?;
     let raw_build = raw.build;
@@ -436,6 +454,7 @@ fn normalize_manifest(raw: RawManifest, path: &Path) -> Result<Manifest, Diagnos
     )?;
     Ok(Manifest {
         package,
+        publish,
         dependencies,
         workspace,
         build: BuildSection { entry, out_dir },
@@ -466,10 +485,95 @@ fn validate_reserved_root_publish_fields(raw: &RawManifest, path: &Path) -> Resu
     if raw.registry.is_some() {
         return Err(reserved_manifest_field(path, "[registry]"));
     }
-    if raw.publish.is_some() {
-        return Err(reserved_manifest_field(path, "[publish]"));
-    }
     Ok(())
+}
+
+fn normalize_publish(
+    raw_publish: Option<RawPublishSection>,
+    path: &Path,
+) -> Result<Option<PublishSection>, Diagnostic> {
+    let Some(raw_publish) = raw_publish else {
+        return Ok(None);
+    };
+    let registry = required_field(raw_publish.registry, path, "publish.registry")?;
+    validate_registry_source(path, "publish.registry", &registry)?;
+    let checksum = match raw_publish.checksum {
+        Some(value) => {
+            let checksum = required_field(Some(value), path, "publish.checksum")?;
+            validate_sha256_checksum(path, "publish.checksum", &checksum)?;
+            Some(checksum)
+        }
+        None => None,
+    };
+    let include = normalize_publish_globs(
+        path,
+        "publish.include",
+        raw_publish.include.unwrap_or_default(),
+    )?;
+    let exclude = normalize_publish_globs(
+        path,
+        "publish.exclude",
+        raw_publish.exclude.unwrap_or_default(),
+    )?;
+    Ok(Some(PublishSection {
+        registry,
+        checksum,
+        include,
+        exclude,
+    }))
+}
+
+fn validate_registry_source(path: &Path, field_name: &str, value: &str) -> Result<(), Diagnostic> {
+    if value.starts_with("https://") || value.starts_with("file:") {
+        return Ok(());
+    }
+    Err(Diagnostic::new(
+        "manifest",
+        format!("{field_name} must be an https:// URL or file: registry source"),
+    )
+    .with_path(path.display().to_string()))
+}
+
+fn validate_sha256_checksum(path: &Path, field_name: &str, value: &str) -> Result<(), Diagnostic> {
+    let Some(hex) = value.strip_prefix("sha256:") else {
+        return Err(Diagnostic::new(
+            "manifest",
+            format!("{field_name} must use sha256:<64 hex characters>"),
+        )
+        .with_path(path.display().to_string()));
+    };
+    if hex.len() == 64 && hex.chars().all(|ch| ch.is_ascii_hexdigit()) {
+        Ok(())
+    } else {
+        Err(Diagnostic::new(
+            "manifest",
+            format!("{field_name} must use sha256:<64 hex characters>"),
+        )
+        .with_path(path.display().to_string()))
+    }
+}
+
+fn normalize_publish_globs(
+    path: &Path,
+    field_name: &str,
+    values: Vec<String>,
+) -> Result<Vec<String>, Diagnostic> {
+    let mut normalized = Vec::new();
+    let mut seen = std::collections::BTreeSet::new();
+    for (index, value) in values.into_iter().enumerate() {
+        let item_field = format!("{field_name}[{index}]");
+        let value = required_field(Some(value), path, &item_field)?;
+        validate_relative_path(path, &item_field, &value)?;
+        if !seen.insert(value.clone()) {
+            return Err(Diagnostic::new(
+                "manifest",
+                format!("duplicate publish pattern {value:?}"),
+            )
+            .with_path(path.display().to_string()));
+        }
+        normalized.push(value);
+    }
+    Ok(normalized)
 }
 
 fn reserved_manifest_field(path: &Path, field_name: &str) -> Diagnostic {
@@ -843,4 +947,73 @@ fn validate_dependency_path(path: &Path, field_name: &str, value: &str) -> Resul
         );
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod registry_publish_manifest_tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn write_manifest(text: &str) -> tempfile::TempDir {
+        let dir = tempdir().unwrap_or_else(|err| panic!("tempdir: {err}"));
+        std::fs::write(dir.path().join(MANIFEST_FILENAME), text)
+            .unwrap_or_else(|err| panic!("write manifest: {err}"));
+        dir
+    }
+
+    #[test]
+    fn accepts_publish_manifest_contract_without_remote_publishing() {
+        let dir = write_manifest(
+            r#"
+[package]
+name = "demo"
+version = "0.1.0"
+
+[publish]
+registry = "https://registry.example.test/index"
+checksum = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+include = ["src/**", "axiom.toml"]
+exclude = ["dist/**"]
+"#,
+        );
+        let manifest = load_manifest(dir.path()).expect("manifest should load");
+        let publish = manifest.publish.expect("publish metadata");
+        assert_eq!(publish.registry, "https://registry.example.test/index");
+        assert_eq!(publish.include, vec!["src/**", "axiom.toml"]);
+        assert_eq!(publish.exclude, vec!["dist/**"]);
+    }
+
+    #[test]
+    fn rejects_invalid_publish_checksum() {
+        let dir = write_manifest(
+            r#"
+[package]
+name = "demo"
+version = "0.1.0"
+
+[publish]
+registry = "https://registry.example.test/index"
+checksum = "sha256:not-a-digest"
+"#,
+        );
+        let error = load_manifest(dir.path()).expect_err("checksum should be rejected");
+        assert!(error.message.contains("publish.checksum must use sha256"));
+    }
+
+    #[test]
+    fn still_reserves_dependency_registry_resolution_fields() {
+        let dir = write_manifest(
+            r#"
+[package]
+name = "demo"
+version = "0.1.0"
+
+[dependencies.dep]
+path = "dep"
+registry = "https://registry.example.test/index"
+"#,
+        );
+        let error = load_manifest(dir.path()).expect_err("dependency registry should be reserved");
+        assert!(error.message.contains("dependencies.dep.registry is reserved"));
+    }
 }

--- a/stage1/crates/axiomc/src/new_project.rs
+++ b/stage1/crates/axiomc/src/new_project.rs
@@ -82,6 +82,7 @@ pub fn create_project_with_template(
             name: project_name.clone(),
             version: String::from("0.1.0"),
         }),
+        publish: None,
         dependencies: BTreeMap::new(),
         workspace: None,
         build: BuildSection {

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -833,6 +833,7 @@ fn register_stdlib_package(graph: &mut PackageGraph) {
             name: stdlib::STDLIB_PACKAGE_NAME.to_string(),
             version: stdlib::STDLIB_PACKAGE_VERSION.to_string(),
         }),
+        publish: None,
         dependencies: BTreeMap::new(),
         workspace: None,
         build: BuildSection {
@@ -5009,6 +5010,7 @@ mod tests {
     fn workspace_only_manifest() -> Manifest {
         Manifest {
             package: None,
+            publish: None,
             dependencies: BTreeMap::new(),
             workspace: None,
             build: BuildSection {
@@ -5026,6 +5028,7 @@ mod tests {
                 name: "demo".to_string(),
                 version: "0.1.0".to_string(),
             }),
+            publish: None,
             dependencies: BTreeMap::new(),
             workspace: None,
             build: BuildSection {

--- a/stage1/schemas/axiom.toml.schema.json
+++ b/stage1/schemas/axiom.toml.schema.json
@@ -156,6 +156,39 @@
         }
       },
       "additionalProperties": false
+    },
+    "publish": {
+      "type": "object",
+      "required": [
+        "registry"
+      ],
+      "properties": {
+        "registry": {
+          "type": "string",
+          "pattern": "^(https://|file:).+"
+        },
+        "checksum": {
+          "type": "string",
+          "pattern": "^sha256:[0-9A-Fa-f]{64}$"
+        },
+        "include": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "exclude": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        }
+      },
+      "additionalProperties": false
     }
   },
   "anyOf": [


### PR DESCRIPTION
## Summary

Defines the stage1 manifest contract for package identity, future registry sources, checksums, and publish metadata while keeping remote dependency resolution reserved.

## Changes

- Add typed optional `[publish]` metadata to manifest parsing without contacting/uploading to a remote registry.
- Validate publish registry sources (`https://` or `file:`), `sha256:<64 hex>` checksums, and relative include/exclude patterns.
- Preserve parser rejection for reserved registry-resolution fields on root/package/dependency surfaces.
- Update the editor schema and package docs for the publish contract.

## Testing

- `cargo test --manifest-path stage1/Cargo.toml -p axiomc registry_publish_manifest_tests -- --nocapture`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test schema_metadata -- --nocapture`
- `cargo check --manifest-path stage1/Cargo.toml -p axiomc` (passes with existing `mutation_report_from_json_str` dead-code warning)
- `cargo fmt --manifest-path stage1/Cargo.toml` could not run because `cargo-fmt`/rustfmt is not installed in the worker toolchain.

Fixes OMT-Global/axiom#416

## Merge Automation

Auto-merge requested with squash merge.