### PR TITLE
test: cover HTTP service proof workload

### DIFF
--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -5805,6 +5805,114 @@ print serve_once("127.0.0.1:18080", "hello")
         }
     }
 
+    fn copy_dir_recursive(from: &std::path::Path, to: &std::path::Path) {
+        fs::create_dir_all(to).expect("create destination directory");
+        for entry in fs::read_dir(from).expect("read source directory") {
+            let entry = entry.expect("read directory entry");
+            let source = entry.path();
+            let dest = to.join(entry.file_name());
+            if source.is_dir() {
+                copy_dir_recursive(&source, &dest);
+            } else {
+                fs::copy(&source, &dest).expect("copy fixture file");
+            }
+        }
+    }
+
+    #[test]
+    fn checked_in_proof_http_service_serves_local_request_response() {
+        use std::io::{Read, Write};
+        use std::net::TcpStream;
+        use std::thread;
+        use std::time::{Duration, Instant};
+
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("proof-http-service");
+        copy_dir_recursive(&checked_in_example_fixture("proof_http_service"), &project);
+
+        let port = find_free_loopback_port();
+        fs::write(
+            project.join("src/main.ax"),
+            format!(
+                r#"import "std/time.ax"
+import "server.ax"
+
+let started: bool = now_ms() > 0
+print serve_health("127.0.0.1:{port}", 1, started)
+"#
+            ),
+        )
+        .expect("write service proof entrypoint");
+
+        check_project(&project).expect("check service proof workload");
+        let built = build_project(&project).expect("build service proof workload");
+        let child = compiled_binary_command(&built.binary)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn service proof workload");
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut stream = loop {
+            match TcpStream::connect(("127.0.0.1", port)) {
+                Ok(stream) => break stream,
+                Err(err) if Instant::now() < deadline => {
+                    let _ = err;
+                    thread::sleep(Duration::from_millis(25));
+                }
+                Err(err) => panic!("service proof workload never became ready: {err}"),
+            }
+        };
+        stream
+            .write_all(b"GET /health HTTP/1.0\r\nHost: 127.0.0.1\r\n\r\n")
+            .expect("write health request");
+        let mut response = String::new();
+        stream.read_to_string(&mut response).expect("read response");
+        assert!(
+            response.starts_with("HTTP/1.0 200 OK\r\n"),
+            "unexpected response: {response:?}"
+        );
+        assert!(
+            response.ends_with(r#"{"path":"/health","ok":true}"#),
+            "unexpected response body: {response:?}"
+        );
+
+        let output = child
+            .wait_with_output()
+            .expect("wait for service proof exit");
+        assert!(output.status.success(), "service proof failed: {output:?}");
+        assert_eq!(String::from_utf8_lossy(&output.stdout), "true\n");
+        assert_eq!(String::from_utf8_lossy(&output.stderr), "");
+    }
+
+    #[test]
+    fn checked_in_proof_http_service_requires_net_capability_for_server() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("proof-http-service-net-denied");
+        copy_dir_recursive(&checked_in_example_fixture("proof_http_service"), &project);
+        let manifest = fs::read_to_string(project.join("axiom.toml"))
+            .expect("read proof service manifest")
+            .replace("net = true", "net = false");
+        fs::write(project.join("axiom.toml"), manifest).expect("write denied manifest");
+        fs::write(
+            project.join("src/main.ax"),
+            r#"import "std/time.ax"
+import "server.ax"
+
+let started: bool = now_ms() > 0
+print serve_health("127.0.0.1:18080", 1, started)
+"#,
+        )
+        .expect("write denied service entrypoint");
+
+        let err = check_project(&project).expect_err("expected net capability denial");
+        assert_eq!(err.kind, "capability");
+        assert!(
+            err.message.contains("requires [capabilities].net = true"),
+            "unexpected diagnostic: {err:?}"
+        );
+    }
+
     #[test]
     fn checked_in_proof_workload_examples_build_run_and_test() {
         std::thread::Builder::new()

--- a/stage1/examples/proof_http_service/axiom.toml
+++ b/stage1/examples/proof_http_service/axiom.toml
@@ -8,7 +8,7 @@ out_dir = "dist"
 
 [capabilities]
 fs = false
-net = false
+net = true
 process = false
 env = ["REQUEST_METHOD", "REQUEST_PATH"]
 clock = true

--- a/stage1/examples/proof_http_service/src/server.ax
+++ b/stage1/examples/proof_http_service/src/server.ax
@@ -1,0 +1,11 @@
+import "std/http.ax"
+import "response.ax"
+
+pub fn health_route(started: bool): HttpRoute {
+return route("/health", body("/health", started))
+}
+
+pub fn serve_health(bind: string, max_requests: int, started: bool): bool {
+let selected_route: HttpRoute = health_route(started)
+return serve(bind, selected_route, max_requests)
+}


### PR DESCRIPTION
## Summary
- Enable the checked-in `proof_http_service` fixture to use the `net` capability through a small `server.ax` wrapper over `std/http.ax`.
- Add a blocking Rust integration test that builds the checked-in proof fixture, starts it as a loopback HTTP service, sends a local `/health` request, and validates the response body.
- Add a regression test that proves the service path is denied when `[capabilities].net` is disabled.

Fixes #411.

## Checks
- `cargo fmt --manifest-path stage1/Cargo.toml --check`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc checked_in_proof_workload_examples_build_run_and_test -- --nocapture`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc checked_in_proof_http_service -- --nocapture`

## Merge Automation
Auto-merge requested with `gh pr merge --auto --squash`.
