### PR TITLE
Add axiomc test list mode

### DIFF
--- a/stage1/crates/axiomc/src/json_contract.rs
+++ b/stage1/crates/axiomc/src/json_contract.rs
@@ -1,6 +1,6 @@
 use crate::diagnostics::Diagnostic;
 use crate::manifest::CapabilityDescriptor;
-use crate::project::{BuildOutput, CheckOutput, TestOutput};
+use crate::project::{BuildOutput, CheckOutput, TestListOutput, TestOutput};
 use serde::Serialize;
 use serde_json::{Value, json};
 use std::path::Path;
@@ -46,6 +46,20 @@ pub fn build_success(project: &Path, output: &BuildOutput) -> Value {
         "cache_misses": output.cache_misses,
         "duration_ms": output.duration_ms,
         "packages": output.packages,
+    })
+}
+
+pub fn test_list_success(project: &Path, filter: Option<&str>, output: &TestListOutput) -> Value {
+    json!({
+        "schema_version": JSON_SCHEMA_VERSION,
+        "ok": true,
+        "command": "test",
+        "mode": "list",
+        "project": project.display().to_string(),
+        "manifest": output.manifest,
+        "packages": output.packages,
+        "filter": filter,
+        "tests": output.tests,
     })
 }
 

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -28,8 +28,9 @@ mod tests {
     use crate::project::{
         BuildCacheStatus, BuildOptions, CheckOptions, RunOptions, TestOptions, build_project,
         build_project_with_options, check_project, check_project_with_options,
-        command_for_build_output, command_for_executable, project_capabilities, run_project_tests,
-        run_project_tests_with_options, run_project_with_options,
+        command_for_build_output, command_for_executable, list_project_tests_with_options,
+        project_capabilities, run_project_tests, run_project_tests_with_options,
+        run_project_with_options,
     };
     use crate::syntax::{Stmt, TypeName, Visibility, parse_program, parse_program_with_recovery};
     use serde::Serialize;
@@ -5709,6 +5710,54 @@ print serve_once("127.0.0.1:18080", "hello")
         assert_eq!(output.kinds.get(&TestKind::Table), Some(&1));
         assert_eq!(output.kinds.get(&TestKind::Property), Some(&1));
         assert_eq!(output.kinds.get(&TestKind::Snapshot), Some(&1));
+    }
+
+    #[test]
+    fn list_project_tests_reports_stable_names_paths_and_package_membership() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("list-tests-discovery");
+        create_project(&project, Some("list-tests-app")).expect("create project");
+        fs::write(project.join("src/main_test.ax"), "print \"unit\"\n").expect("write unit test");
+        fs::create_dir_all(project.join("src/nested")).expect("create nested dir");
+        fs::write(
+            project.join("src/nested/cases_table_test.ax"),
+            "print \"table\"\n",
+        )
+        .expect("write table test");
+
+        let output = list_project_tests_with_options(&project, &TestOptions::default())
+            .expect("list discovered tests");
+
+        assert_eq!(output.packages, vec![project.display().to_string()]);
+        let listed = output
+            .tests
+            .iter()
+            .map(|test| {
+                (
+                    test.package.as_deref(),
+                    test.name.as_str(),
+                    test.entry.as_str(),
+                    test.kind,
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            listed,
+            vec![
+                (
+                    Some("list-tests-app"),
+                    "src/main_test",
+                    "src/main_test.ax",
+                    TestKind::Unit,
+                ),
+                (
+                    Some("list-tests-app"),
+                    "src/nested/cases_table_test",
+                    "src/nested/cases_table_test.ax",
+                    TestKind::Table,
+                ),
+            ]
+        );
     }
 
     #[test]

--- a/stage1/crates/axiomc/src/main.rs
+++ b/stage1/crates/axiomc/src/main.rs
@@ -7,8 +7,8 @@ use axiomc::manifest::{entry_path, load_manifest};
 use axiomc::new_project::{WorkloadTemplate, create_project_with_template};
 use axiomc::project::{
     BuildOptions, BuildOutput, CheckOptions, RunOptions, TestOptions, build_project_with_options,
-    check_project_with_options, project_capabilities, run_project_tests_with_options,
-    run_project_with_options,
+    check_project_with_options, list_project_tests_with_options, project_capabilities,
+    run_project_tests_with_options, run_project_with_options,
 };
 use axiomc::registry::{
     PublishOptions, load_registry_index, publish_package, render_registry_index,
@@ -93,6 +93,8 @@ enum Command {
         filter: Option<String>,
         #[arg(long)]
         include_benchmarks: bool,
+        #[arg(long)]
+        list: bool,
         #[arg(short = 'p', long = "package")]
         package: Option<String>,
     },
@@ -303,40 +305,68 @@ fn main() {
             json,
             filter,
             include_benchmarks,
+            list,
             package,
-        } => match run_project_tests_with_options(
-            &path,
-            &TestOptions {
+        } => {
+            let options = TestOptions {
                 filter: filter.clone(),
                 package: package.clone(),
                 include_benchmarks,
-            },
-        ) {
-            Ok(output) => {
-                let ok = output.failed == 0;
-                if json {
-                    println!(
-                        "{}",
-                        json_contract::test_success(&path, filter.as_deref(), &output)
-                    );
-                } else {
-                    for case in &output.cases {
-                        let status = if case.ok { "PASS" } else { "FAIL" };
-                        eprintln!("{status} {:?} {} ({})", case.kind, case.name, case.entry);
-                        if let Some(error) = &case.error {
-                            eprintln!("  {}", error);
+            };
+            if list {
+                match list_project_tests_with_options(&path, &options) {
+                    Ok(output) => {
+                        if json {
+                            println!(
+                                "{}",
+                                json_contract::test_list_success(&path, filter.as_deref(), &output)
+                            );
+                        } else {
+                            for test in &output.tests {
+                                let package = test.package.as_deref().unwrap_or("<unnamed>");
+                                eprintln!(
+                                    "{:?} {} {} ({})",
+                                    test.kind, package, test.name, test.entry
+                                );
+                            }
+                            eprintln!("discovered: {}", output.tests.len());
                         }
-                        eprintln!("  duration: {} ms", case.duration_ms);
+                        0
                     }
-                    eprintln!(
-                        "passed: {} failed: {} skipped: {} duration: {} ms",
-                        output.passed, output.failed, output.skipped, output.duration_ms
-                    );
+                    Err(error) => print_error("test", error, json),
                 }
-                if ok { 0 } else { 1 }
+            } else {
+                match run_project_tests_with_options(&path, &options) {
+                    Ok(output) => {
+                        let ok = output.failed == 0;
+                        if json {
+                            println!(
+                                "{}",
+                                json_contract::test_success(&path, filter.as_deref(), &output)
+                            );
+                        } else {
+                            for case in &output.cases {
+                                let status = if case.ok { "PASS" } else { "FAIL" };
+                                eprintln!(
+                                    "{status} {:?} {} ({})",
+                                    case.kind, case.name, case.entry
+                                );
+                                if let Some(error) = &case.error {
+                                    eprintln!("  {}", error);
+                                }
+                                eprintln!("  duration: {} ms", case.duration_ms);
+                            }
+                            eprintln!(
+                                "passed: {} failed: {} skipped: {} duration: {} ms",
+                                output.passed, output.failed, output.skipped, output.duration_ms
+                            );
+                        }
+                        if ok { 0 } else { 1 }
+                    }
+                    Err(error) => print_error("test", error, json),
+                }
             }
-            Err(error) => print_error("test", error, json),
-        },
+        }
         Command::Caps {
             path,
             json,
@@ -1895,6 +1925,18 @@ mod tests {
         assert!(help.contains("Pack, sign, and publish a stage1 package"));
         assert!(help.contains("Build a static package-registry index"));
         assert!(help.contains("Validate a static package-registry index JSON file"));
+    }
+
+    #[test]
+    fn test_accepts_list_flag() {
+        let cli = Cli::parse_from(["axiomc", "test", ".", "--list", "--json"]);
+        match cli.command {
+            Command::Test { list, json, .. } => {
+                assert!(list);
+                assert!(json);
+            }
+            other => panic!("expected test command, got {other:?}"),
+        }
     }
 
     #[test]

--- a/stage1/crates/axiomc/src/manifest.rs
+++ b/stage1/crates/axiomc/src/manifest.rs
@@ -1014,6 +1014,10 @@ registry = "https://registry.example.test/index"
 "#,
         );
         let error = load_manifest(dir.path()).expect_err("dependency registry should be reserved");
-        assert!(error.message.contains("dependencies.dep.registry is reserved"));
+        assert!(
+            error
+                .message
+                .contains("dependencies.dep.registry is reserved")
+        );
     }
 }

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -162,6 +162,22 @@ pub struct ExpectedDiagnostic {
 }
 
 #[derive(Debug, Clone, Serialize)]
+pub struct ListedTest {
+    pub package_root: String,
+    pub package: Option<String>,
+    pub name: String,
+    pub kind: TestKind,
+    pub entry: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TestListOutput {
+    pub manifest: String,
+    pub packages: Vec<String>,
+    pub tests: Vec<ListedTest>,
+}
+
+#[derive(Debug, Clone, Serialize)]
 pub struct TestOutput {
     pub manifest: String,
     pub packages: Vec<String>,
@@ -410,6 +426,62 @@ pub fn run_project_with_options(
 
 pub fn run_project_tests(project_root: &Path) -> Result<TestOutput, Diagnostic> {
     run_project_tests_with_options(project_root, &TestOptions::default())
+}
+
+pub fn list_project_tests_with_options(
+    project_root: &Path,
+    options: &TestOptions,
+) -> Result<TestListOutput, Diagnostic> {
+    let project_root = canonicalize_existing_path(&normalize_path(project_root), "project root")?;
+    let graph = load_package_graph(&project_root)?;
+    validate_workspace_root_lockfile(&graph, &project_root)?;
+    let manifest_path_text = manifest_path(&project_root).display().to_string();
+    let mut packages = Vec::new();
+    let mut tests = Vec::new();
+    for package_root in workspace_package_roots(&graph, &project_root, options.package.as_deref())?
+    {
+        let manifest = graph.context(&package_root)?.manifest.clone();
+        validate_lockfile(&package_root, &manifest)?;
+        let discovered = if expected_error_path(&package_root).exists() {
+            Vec::new()
+        } else {
+            collect_test_targets(
+                &package_root,
+                &manifest,
+                options.filter.as_deref(),
+                options.include_benchmarks,
+            )?
+        };
+        if discovered.is_empty() {
+            continue;
+        }
+        packages.push(package_root.display().to_string());
+        let package_name = manifest
+            .package
+            .as_ref()
+            .map(|package| package.name.clone());
+        for test in discovered {
+            tests.push(ListedTest {
+                package_root: package_root.display().to_string(),
+                package: test.package.clone().or_else(|| package_name.clone()),
+                name: test.name,
+                kind: test.kind,
+                entry: test.entry,
+            });
+        }
+    }
+    if tests.is_empty() {
+        return Err(Diagnostic::new(
+            "test",
+            "no tests discovered under src/**/*_test.ax across the workspace and no [[tests]] configured in axiom.toml",
+        )
+        .with_path(manifest_path_text));
+    }
+    Ok(TestListOutput {
+        manifest: manifest_path(&project_root).display().to_string(),
+        packages,
+        tests,
+    })
 }
 
 pub fn run_project_tests_with_options(


### PR DESCRIPTION
## Summary
- add `axiomc test --list` to inspect discovered test targets without executing them
- emit machine-readable JSON with stable test names, entry paths, package roots, and package membership
- preserve existing `axiomc test` execution behavior and JSON output for non-list runs

Closes #381

## Checks
- `cargo fmt --manifest-path stage1/Cargo.toml -- --check`
- `cargo check --manifest-path stage1/Cargo.toml -p axiomc`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc test_accepts_list_flag -- --nocapture`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc list_project_tests_reports_stable_names_paths_and_package_membership -- --nocapture`
- `cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/conformance/pass/legacy_core_programs --list --json`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc`

## Merge Automation
Auto-merge requested with `gh pr merge --auto --squash` if permitted by branch protections.
