### PR TITLE
test: add negative runtime conformance cases

### DIFF
--- a/stage1/conformance/README.md
+++ b/stage1/conformance/README.md
@@ -50,6 +50,8 @@ Current executable fixtures cover:
 - `parser_type_slice`: migrated parser/type coverage for type aliases,
   borrowed slices, enum payload patterns, typed aggregate literals, and
   return-type checking through parsed control flow.
+- `runtime_negative_diagnostics`: executable negative runtime coverage for
+  structured `panic(...)` diagnostics and array bounds runtime diagnostics.
 
 Packages under `fail/` are compile-fail fixtures. Each package is a complete
 stage1 project with `axiom.toml`, `axiom.lock`, source, and

--- a/stage1/conformance/axiom.lock
+++ b/stage1/conformance/axiom.lock
@@ -295,6 +295,11 @@ version = "0.1.0"
 source = "path:pass/package_visibility"
 
 [[package]]
+name = "conformance-runtime-negative-diagnostics"
+version = "0.1.0"
+source = "path:pass/runtime_negative_diagnostics"
+
+[[package]]
 name = "conformance-slice-type-alias-in-option"
 version = "0.1.0"
 source = "path:pass/slice_type_alias_in_option"

--- a/stage1/conformance/axiom.toml
+++ b/stage1/conformance/axiom.toml
@@ -52,6 +52,7 @@ members = [
   "pass/functions_across_modules",
   "pass/legacy_core_programs",
   "pass/outcome_control_flow",
+  "pass/runtime_negative_diagnostics",
   "pass/ownership_borrowing",
   "pass/package_local_modules",
   "pass/package_visibility",

--- a/stage1/conformance/pass/runtime_negative_diagnostics/axiom.lock
+++ b/stage1/conformance/pass/runtime_negative_diagnostics/axiom.lock
@@ -1,0 +1,6 @@
+version = 1
+
+[[package]]
+name = "conformance-runtime-negative-diagnostics"
+version = "0.1.0"
+source = "path"

--- a/stage1/conformance/pass/runtime_negative_diagnostics/axiom.toml
+++ b/stage1/conformance/pass/runtime_negative_diagnostics/axiom.toml
@@ -1,0 +1,25 @@
+[package]
+name = "conformance-runtime-negative-diagnostics"
+version = "0.1.0"
+
+[build]
+entry = "src/panic_test.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false
+
+[[tests]]
+name = "panic_runtime_diagnostic"
+entry = "src/panic_test.ax"
+stderr = "{\"kind\":\"panic\",\"message\":\"conformance panic\"}\n"
+
+[[tests]]
+name = "array_bounds_runtime_diagnostic"
+entry = "src/array_bounds_test.ax"
+stderr = "{\"kind\":\"runtime\",\"message\":\"array index out of bounds\"}\n"

--- a/stage1/conformance/pass/runtime_negative_diagnostics/src/array_bounds_test.ax
+++ b/stage1/conformance/pass/runtime_negative_diagnostics/src/array_bounds_test.ax
@@ -1,0 +1,2 @@
+let values: [int] = [1]
+print values[2]

--- a/stage1/conformance/pass/runtime_negative_diagnostics/src/panic_test.ax
+++ b/stage1/conformance/pass/runtime_negative_diagnostics/src/panic_test.ax
@@ -1,0 +1,1 @@
+panic("conformance panic")

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -6377,8 +6377,8 @@ print serve_health("127.0.0.1:18080", 1, started)
     fn conformance_corpus_reports_stable_results() {
         let output =
             run_project_tests(&conformance_fixture()).expect("run stage1 conformance corpus");
-        assert_eq!(output.cases.len(), 60);
-        assert_eq!(output.passed, 60);
+        assert_eq!(output.cases.len(), 63);
+        assert_eq!(output.passed, 63);
         let failures: Vec<_> = output
             .cases
             .iter()
@@ -6400,7 +6400,15 @@ print serve_health("127.0.0.1:18080", 1, started)
                 .iter()
                 .filter(|case| case.expected_stdout.is_some())
                 .count(),
-            17
+            18
+        );
+        assert_eq!(
+            output
+                .cases
+                .iter()
+                .filter(|case| case.expected_stderr.is_some())
+                .count(),
+            2
         );
     }
 

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -1904,48 +1904,57 @@ fn run_test_case(
             let stdout = String::from_utf8_lossy(&output.stdout).to_string();
             let stderr = String::from_utf8_lossy(&output.stderr).to_string();
             let exit_code = output.status.code();
-            let error = if !output.status.success() {
-                let detail = stderr.trim();
-                Some(
-                    Diagnostic::new(
-                        "test",
-                        if detail.is_empty() {
-                            format!(
-                                "test {:?} exited with status {}",
-                                test.name,
-                                exit_code.unwrap_or(1)
-                            )
-                        } else {
-                            format!(
-                                "test {:?} exited with status {}: {}",
-                                test.name,
-                                exit_code.unwrap_or(1),
-                                detail
-                            )
-                        },
-                    )
-                    .with_path(entry_path.display().to_string()),
-                )
-            } else {
-                let mut mismatches = Vec::new();
-                if let Some(expected_stdout) = &test.stdout {
-                    if &stdout != expected_stdout {
-                        mismatches.push(format!(
-                            "stdout expected {:?}, got {:?}",
-                            expected_stdout, stdout
-                        ));
-                    }
+            let mut mismatches = Vec::new();
+            if let Some(expected_stdout) = &test.stdout {
+                if &stdout != expected_stdout {
+                    mismatches.push(format!(
+                        "stdout expected {:?}, got {:?}",
+                        expected_stdout, stdout
+                    ));
                 }
-                if let Some(expected_stderr) = &test.stderr {
-                    if &stderr != expected_stderr {
-                        mismatches.push(format!(
-                            "stderr expected {:?}, got {:?}",
-                            expected_stderr, stderr
-                        ));
-                    }
+            }
+            if let Some(expected_stderr) = &test.stderr {
+                if &stderr != expected_stderr {
+                    mismatches.push(format!(
+                        "stderr expected {:?}, got {:?}",
+                        expected_stderr, stderr
+                    ));
                 }
-                if mismatches.is_empty() {
+            }
+            let expected_runtime_failure = !output.status.success() && test.stderr.is_some();
+            let error =
+                if mismatches.is_empty() && (output.status.success() || expected_runtime_failure) {
                     None
+                } else if !output.status.success() {
+                    let detail = stderr.trim();
+                    Some(
+                        Diagnostic::new(
+                            "test",
+                            if detail.is_empty() {
+                                format!(
+                                    "test {:?} exited with status {}",
+                                    test.name,
+                                    exit_code.unwrap_or(1)
+                                )
+                            } else if mismatches.is_empty() {
+                                format!(
+                                    "test {:?} exited with status {}: {}",
+                                    test.name,
+                                    exit_code.unwrap_or(1),
+                                    detail
+                                )
+                            } else {
+                                format!(
+                                    "test {:?} exited with status {}: {}; {}",
+                                    test.name,
+                                    exit_code.unwrap_or(1),
+                                    detail,
+                                    mismatches.join("; ")
+                                )
+                            },
+                        )
+                        .with_path(entry_path.display().to_string()),
+                    )
                 } else {
                     Some(
                         Diagnostic::new(
@@ -1958,8 +1967,7 @@ fn run_test_case(
                         )
                         .with_path(entry_path.display().to_string()),
                     )
-                }
-            };
+                };
             TestCaseResult {
                 package_root: project_root.display().to_string(),
                 name: test.name.clone(),


### PR DESCRIPTION
## Summary

Adds executable negative runtime conformance coverage for structured panic and runtime diagnostics, and teaches `axiomc test` to treat a non-zero test process as expected when a manifest test declares matching stderr.

## Changes

- Added `runtime_negative_diagnostics` conformance fixture with panic and array-bounds runtime cases.
- Registered the fixture in the conformance workspace and lockfile.
- Updated conformance stability assertions for stderr-backed runtime-negative cases.
- Preserved existing compile-fail ownership/capability behavior while allowing explicit runtime-negative execution cases.

## Testing

- `make stage1-conformance` ✅
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc conformance_corpus_reports_stable_results` ✅
- PR checks passing: CI Gate, Fast Checks, lockfile/SBOM, PR description, secrets validation ✅

Fixes OMT-Global/axiom#368

## Merge Automation

Auto-merge requested with squash after PR creation; currently waiting on branch protection/merge queue because GitHub reports `mergeStateStatus: BLOCKED` while required checks are otherwise passing.