### PR TITLE
fix: add first-class JSON values

### DIFF
--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -551,6 +551,12 @@ fn axiom_async_timeout<T: Send + 'static>(task: AxiomTask<T>, timeout_ms: i64) -
     out.push_str("    axiom_json_parse_int(axiom_json_object_field(text, key)?)\n");
     out.push_str("}\n\n");
     out.push_str("#[allow(dead_code)]\n");
+    out.push_str("fn axiom_json_parse_value(text: String) -> Option<String> {\n");
+    out.push_str("    let text = text.trim();\n");
+    out.push_str("    let end = axiom_json_scan_value_end(text, 0)?;\n");
+    out.push_str("    if axiom_json_skip_ws(text, end) == text.len() { Some(text.to_string()) } else { None }\n");
+    out.push_str("}\n\n");
+    out.push_str("#[allow(dead_code)]\n");
     out.push_str("fn axiom_json_parse_field_bool(text: String, key: String) -> Option<bool> {\n");
     out.push_str("    axiom_json_parse_bool(axiom_json_object_field(text, key)?)\n");
     out.push_str("}\n\n");
@@ -559,6 +565,12 @@ fn axiom_async_timeout<T: Send + 'static>(task: AxiomTask<T>, timeout_ms: i64) -
         "fn axiom_json_parse_field_string(text: String, key: String) -> Option<String> {\n",
     );
     out.push_str("    axiom_json_parse_string(axiom_json_object_field(text, key)?)\n");
+    out.push_str("}\n\n");
+    out.push_str("#[allow(dead_code)]\n");
+    out.push_str(
+        "fn axiom_json_parse_field_value(text: String, key: String) -> Option<String> {\n",
+    );
+    out.push_str("    axiom_json_parse_value(axiom_json_object_field(text, key)?)\n");
     out.push_str("}\n\n");
     out.push_str("#[allow(dead_code)]\n");
     out.push_str("fn axiom_json_escape_string(value: &str) -> String {\n");
@@ -590,6 +602,10 @@ fn axiom_async_timeout<T: Send + 'static>(task: AxiomTask<T>, timeout_ms: i64) -
     out.push_str("#[allow(dead_code)]\n");
     out.push_str("fn axiom_json_stringify_string(value: String) -> String {\n");
     out.push_str("    axiom_json_escape_string(&value)\n");
+    out.push_str("}\n\n");
+    out.push_str("#[allow(dead_code)]\n");
+    out.push_str("fn axiom_json_stringify_value(value: String) -> String {\n");
+    out.push_str("    axiom_json_parse_value(value.clone()).unwrap_or(value)\n");
     out.push_str("}\n\n");
     out.push_str(r#"#[derive(Clone, Debug, PartialEq, Eq)]
 enum AxiomRegexAtom {
@@ -3334,8 +3350,21 @@ fn render_expr(expr: &Expr) -> String {
         Expr::Call { name, args, .. } if name == "json_stringify_bool" => {
             format!("axiom_json_stringify_bool({})", render_expr(&args[0]))
         }
+        Expr::Call { name, args, .. } if name == "json_parse_value" => {
+            format!("axiom_json_parse_value({})", render_expr(&args[0]))
+        }
+        Expr::Call { name, args, .. } if name == "json_parse_field_value" => {
+            format!(
+                "axiom_json_parse_field_value({}, {})",
+                render_expr(&args[0]),
+                render_expr(&args[1])
+            )
+        }
         Expr::Call { name, args, .. } if name == "json_stringify_string" => {
             format!("axiom_json_stringify_string({})", render_expr(&args[0]))
+        }
+        Expr::Call { name, args, .. } if name == "json_stringify_value" => {
+            format!("axiom_json_stringify_value({})", render_expr(&args[0]))
         }
         Expr::Call { name, .. } if name == "cli_args" => String::from("axiom_cli_args()"),
         Expr::Call { name, .. } if name == "cli_arg_count" => String::from("axiom_cli_arg_count()"),

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -4825,7 +4825,15 @@ fn lower_static_decls(
 ) -> Result<Vec<StaticDef>, Diagnostic> {
     let mut lowered = Vec::new();
     for decl in consts.iter().filter(|decl| decl.is_static) {
-        let ty = lower_type(&decl.ty, structs, enums, aliases, ctx.consts, decl.line, decl.column)?;
+        let ty = lower_type(
+            &decl.ty,
+            structs,
+            enums,
+            aliases,
+            ctx.consts,
+            decl.line,
+            decl.column,
+        )?;
         let mut env = HashMap::new();
         let mut expr = lower_expr_with_expected(&decl.expr, Some(&ty), &mut env, ctx)?;
         if expr.ty() != &ty {
@@ -6857,6 +6865,102 @@ fn lower_expr_with_expected_inner(
                     name: name.clone(),
                     args: vec![lowered],
                     ty: Type::String,
+                });
+            }
+            if name == "json_parse_value" {
+                if args.len() != 1 {
+                    return Err(Diagnostic::new(
+                        "type",
+                        format!("json_parse_value expects 1 argument, got {}", args.len()),
+                    )
+                    .with_span(*line, *column));
+                }
+                let lowered = lower_expr_with_expected(&args[0], Some(&Type::String), env, ctx)?;
+                if lowered.ty() != &Type::String {
+                    return Err(Diagnostic::new(
+                        "type",
+                        format!(
+                            "json_parse_value expects a string argument, got {}",
+                            lowered.ty()
+                        ),
+                    )
+                    .with_span(args[0].line(), args[0].column()));
+                }
+                move_lowered_value(&lowered, env)?;
+                return Ok(Expr::Call {
+                    name: name.clone(),
+                    args: vec![lowered],
+                    ty: Type::Option(Box::new(Type::String)),
+                });
+            }
+            if name == "json_stringify_value" {
+                if args.len() != 1 {
+                    return Err(Diagnostic::new(
+                        "type",
+                        format!(
+                            "json_stringify_value expects 1 argument, got {}",
+                            args.len()
+                        ),
+                    )
+                    .with_span(*line, *column));
+                }
+                let lowered = lower_expr_with_expected(&args[0], Some(&Type::String), env, ctx)?;
+                if lowered.ty() != &Type::String {
+                    return Err(Diagnostic::new(
+                        "type",
+                        format!(
+                            "json_stringify_value expects a string argument, got {}",
+                            lowered.ty()
+                        ),
+                    )
+                    .with_span(args[0].line(), args[0].column()));
+                }
+                move_lowered_value(&lowered, env)?;
+                return Ok(Expr::Call {
+                    name: name.clone(),
+                    args: vec![lowered],
+                    ty: Type::String,
+                });
+            }
+            if name == "json_parse_field_value" {
+                if args.len() != 2 {
+                    return Err(Diagnostic::new(
+                        "type",
+                        format!(
+                            "json_parse_field_value expects 2 arguments, got {}",
+                            args.len()
+                        ),
+                    )
+                    .with_span(*line, *column));
+                }
+                let text = lower_expr_with_expected(&args[0], Some(&Type::String), env, ctx)?;
+                if text.ty() != &Type::String {
+                    return Err(Diagnostic::new(
+                        "type",
+                        format!(
+                            "json_parse_field_value expects a string JSON argument, got {}",
+                            text.ty()
+                        ),
+                    )
+                    .with_span(args[0].line(), args[0].column()));
+                }
+                let key = lower_expr_with_expected(&args[1], Some(&Type::String), env, ctx)?;
+                if key.ty() != &Type::String {
+                    return Err(Diagnostic::new(
+                        "type",
+                        format!(
+                            "json_parse_field_value expects a string key argument, got {}",
+                            key.ty()
+                        ),
+                    )
+                    .with_span(args[1].line(), args[1].column()));
+                }
+                move_lowered_value(&text, env)?;
+                move_lowered_value(&key, env)?;
+                return Ok(Expr::Call {
+                    name: name.clone(),
+                    args: vec![text, key],
+                    ty: Type::Option(Box::new(Type::String)),
                 });
             }
             if name == "regex_is_match" || name == "regex_find" || name == "regex_replace_all" {

--- a/stage1/crates/axiomc/src/stdlib.rs
+++ b/stage1/crates/axiomc/src/stdlib.rs
@@ -48,8 +48,9 @@
 //!
 //! * `std/io.ax` — `eprintln(text)` on top of the new ungated `io_eprintln`
 //!   intrinsic (writes a line to stderr and returns bytes written).
-//! * `std/json.ax` — scalar/string JSON parsing and serialization helpers on
-//!   top of new ungated `json_parse_*` / `json_stringify_*` intrinsics.
+//! * `std/json.ax` — scalar/string JSON parsing plus first-class `JsonValue`
+//!   parsing, composition, nested field lookup, and serialization helpers on
+//!   top of ungated `json_parse_*` / `json_stringify_*` intrinsics.
 //! * `std/collections.ax` — generic borrowed-slice helpers built on the
 //!   existing polymorphic collection primitives and AG2 generic functions.
 //! * `std/string_builder.ax` — an owned string accumulator implemented with
@@ -170,18 +171,26 @@ pub fn constant_time_eq(left: string, right: string): bool {\nreturn crypto_cons
     ),
     (
         "json.ax",
-        "pub fn parse_int(text: string): Option<int> {\nreturn json_parse_int(text)\n}\n\
+        "pub struct JsonValue {\nsource: string\n}\n\
+pub fn parse_value(text: string): Option<JsonValue> {\nmatch json_parse_value(text) {\nSome(source) {\nreturn Some(JsonValue { source: source })\n}\nNone {\nreturn None\n}\n}\n}\n\
+pub fn stringify_value(value: JsonValue): string {\nreturn json_stringify_value(value.source)\n}\n\
+pub fn parse_int(text: string): Option<int> {\nreturn json_parse_int(text)\n}\n\
 pub fn parse_bool(text: string): Option<bool> {\nreturn json_parse_bool(text)\n}\n\
 pub fn parse_string(text: string): Option<string> {\nreturn json_parse_string(text)\n}\n\
 pub fn parse_field_int(text: string, key: string): Option<int> {\nreturn json_parse_field_int(text, key)\n}\n\
 pub fn parse_field_bool(text: string, key: string): Option<bool> {\nreturn json_parse_field_bool(text, key)\n}\n\
 pub fn parse_field_string(text: string, key: string): Option<string> {\nreturn json_parse_field_string(text, key)\n}\n\
+pub fn parse_field_value(value: JsonValue, key: string): Option<JsonValue> {\nmatch json_parse_field_value(value.source, key) {\nSome(source) {\nreturn Some(JsonValue { source: source })\n}\nNone {\nreturn None\n}\n}\n}\n\
 pub fn stringify_int(value: int): string {\nreturn json_stringify_int(value)\n}\n\
 pub fn stringify_bool(value: bool): string {\nreturn json_stringify_bool(value)\n}\n\
 pub fn stringify_string(value: string): string {\nreturn json_stringify_string(value)\n}\n\
+pub fn value_string(value: string): JsonValue {\nreturn JsonValue { source: json_stringify_string(value) }\n}\n\
+pub fn value_int(value: int): JsonValue {\nreturn JsonValue { source: json_stringify_int(value) }\n}\n\
+pub fn value_bool(value: bool): JsonValue {\nreturn JsonValue { source: json_stringify_bool(value) }\n}\n\
 pub fn field_string(key: string, value: string): string {\nreturn json_stringify_string(key) + \":\" + json_stringify_string(value)\n}\n\
 pub fn field_int(key: string, value: int): string {\nreturn json_stringify_string(key) + \":\" + json_stringify_int(value)\n}\n\
 pub fn field_bool(key: string, value: bool): string {\nreturn json_stringify_string(key) + \":\" + json_stringify_bool(value)\n}\n\
+pub fn field_value(key: string, value: JsonValue): string {\nreturn json_stringify_string(key) + \":\" + json_stringify_value(value.source)\n}\n\
 pub fn schema_field_string(key: string): string {\nreturn json_stringify_string(key) + \":{\\\"type\\\":\\\"string\\\"}\"\n}\n\
 pub fn schema_field_int(key: string): string {\nreturn json_stringify_string(key) + \":{\\\"type\\\":\\\"integer\\\"}\"\n}\n\
 pub fn schema_field_bool(key: string): string {\nreturn json_stringify_string(key) + \":{\\\"type\\\":\\\"boolean\\\"}\"\n}\n\
@@ -190,7 +199,13 @@ pub fn schema_object2(first_field: string, second_field: string): string {\nretu
 pub fn schema_object3(first_field: string, second_field: string, third_field: string): string {\nreturn \"{\\\"type\\\":\\\"object\\\",\\\"properties\\\":{\" + first_field + \",\" + second_field + \",\" + third_field + \"}}\"\n}\n\
 pub fn object1(field: string): string {\nreturn \"{\" + field + \"}\"\n}\n\
 pub fn object2(first_field: string, second_field: string): string {\nreturn \"{\" + first_field + \",\" + second_field + \"}\"\n}\n\
-pub fn object3(first_field: string, second_field: string, third_field: string): string {\nreturn \"{\" + first_field + \",\" + second_field + \",\" + third_field + \"}\"\n}\n",
+pub fn object3(first_field: string, second_field: string, third_field: string): string {\nreturn \"{\" + first_field + \",\" + second_field + \",\" + third_field + \"}\"\n}\n\
+pub fn value_object1(field: string): JsonValue {\nreturn JsonValue { source: object1(field) }\n}\n\
+pub fn value_object2(first_field: string, second_field: string): JsonValue {\nreturn JsonValue { source: object2(first_field, second_field) }\n}\n\
+pub fn value_object3(first_field: string, second_field: string, third_field: string): JsonValue {\nreturn JsonValue { source: object3(first_field, second_field, third_field) }\n}\n\
+pub fn array1(first: JsonValue): JsonValue {\nreturn JsonValue { source: \"[\" + json_stringify_value(first.source) + \"]\" }\n}\n\
+pub fn array2(first: JsonValue, second: JsonValue): JsonValue {\nreturn JsonValue { source: \"[\" + json_stringify_value(first.source) + \",\" + json_stringify_value(second.source) + \"]\" }\n}\n\
+pub fn array3(first: JsonValue, second: JsonValue, third: JsonValue): JsonValue {\nreturn JsonValue { source: \"[\" + json_stringify_value(first.source) + \",\" + json_stringify_value(second.source) + \",\" + json_stringify_value(third.source) + \"]\" }\n}\n",
     ),
     (
         "collections.ax",

--- a/stage1/examples/stdlib_json_value/axiom.lock
+++ b/stage1/examples/stdlib_json_value/axiom.lock
@@ -1,0 +1,6 @@
+version = 1
+
+[[package]]
+name = "stdlib-json-value"
+version = "0.1.0"
+source = "path"

--- a/stage1/examples/stdlib_json_value/axiom.toml
+++ b/stage1/examples/stdlib_json_value/axiom.toml
@@ -1,0 +1,3 @@
+[package]
+name = "stdlib-json-value"
+version = "0.1.0"

--- a/stage1/examples/stdlib_json_value/src/main.ax
+++ b/stage1/examples/stdlib_json_value/src/main.ax
@@ -1,0 +1,31 @@
+import "std/json.ax"
+
+let item: JsonValue = value_object2(field_string("id", "worker"), field_int("attempts", 2))
+let tags: JsonValue = array2(value_string("cli"), value_string("worker"))
+let payload: JsonValue = value_object3(field_value("item", item), field_value("tags", tags), field_bool("ready", true))
+print stringify_value(payload)
+
+match parse_value("{\"item\":{\"id\":\"worker\",\"attempts\":2},\"tags\":[\"cli\",\"worker\"],\"ready\":true}") {
+Some(parsed) {
+print stringify_value(parsed)
+}
+None {
+print "invalid"
+}
+}
+
+match parse_value("{\"item\":{\"id\":\"worker\",\"attempts\":2},\"tags\":[\"cli\",\"worker\"],\"ready\":true}") {
+Some(parsed) {
+match parse_field_value(parsed, "item") {
+Some(nested) {
+print stringify_value(nested)
+}
+None {
+print "missing"
+}
+}
+}
+None {
+print "invalid"
+}
+}

--- a/stage1/examples/stdlib_json_value/src/main_test.ax
+++ b/stage1/examples/stdlib_json_value/src/main_test.ax
@@ -1,0 +1,31 @@
+import "std/json.ax"
+
+let item: JsonValue = value_object2(field_string("id", "worker"), field_int("attempts", 2))
+let tags: JsonValue = array2(value_string("cli"), value_string("worker"))
+let payload: JsonValue = value_object3(field_value("item", item), field_value("tags", tags), field_bool("ready", true))
+print stringify_value(payload)
+
+match parse_value("{\"item\":{\"id\":\"worker\",\"attempts\":2},\"tags\":[\"cli\",\"worker\"],\"ready\":true}") {
+Some(parsed) {
+print stringify_value(parsed)
+}
+None {
+print "invalid"
+}
+}
+
+match parse_value("{\"item\":{\"id\":\"worker\",\"attempts\":2},\"tags\":[\"cli\",\"worker\"],\"ready\":true}") {
+Some(parsed) {
+match parse_field_value(parsed, "item") {
+Some(nested) {
+print stringify_value(nested)
+}
+None {
+print "missing"
+}
+}
+}
+None {
+print "invalid"
+}
+}

--- a/stage1/examples/stdlib_json_value/src/main_test.stdout
+++ b/stage1/examples/stdlib_json_value/src/main_test.stdout
@@ -1,0 +1,3 @@
+{"item":{"id":"worker","attempts":2},"tags":["cli","worker"],"ready":true}
+{"item":{"id":"worker","attempts":2},"tags":["cli","worker"],"ready":true}
+{"id":"worker","attempts":2}


### PR DESCRIPTION
$## Summary\n\nAdds first-class `JsonValue` support to `std/json.ax` so stage1 programs can parse, compose, inspect, and stringify nested JSON objects and arrays while keeping existing scalar helpers intact.\n\n## Changes\n\n- Adds `JsonValue` plus `parse_value`, `stringify_value`, nested field parsing, value constructors, object value constructors, and array helpers to `std/json.ax`.\n- Adds compiler typing/codegen support for `json_parse_value`, `json_parse_field_value`, and `json_stringify_value` intrinsics.\n- Adds a `stdlib_json_value` fixture covering nested CLI/worker-style object + array round-trips.\n\n## Testing\n\n- `cargo check -p axiomc --lib` (passes; existing warning: unused variable `relative` in `project.rs`)\n- `cargo test -p axiomc stdlib_json -- --nocapture` (blocked by pre-existing duplicate test definitions in `lib.rs` and missing `create_project` test helper in `main.rs`, unrelated to this change)\n\nFixes OMT-Global/axiom#404\n\n## Merge Automation\n\nPending: auto-merge will be enabled after PR creation if GitHub permits it.