### PR TITLE
test: add representative MIR snapshots

### DIFF
--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -1074,6 +1074,14 @@ fn analyze_entry(
     })
 }
 
+/// Return the lowered MIR for a package root. This is primarily used by
+/// snapshot-style regression tests that need the same package analysis path as
+/// normal project builds without rendering native code.
+pub fn lower_project_to_mir(project_root: &Path) -> Result<mir::Program, Diagnostic> {
+    let graph = load_package_graph(project_root)?;
+    Ok(analyze_package(&graph, project_root)?.mir)
+}
+
 fn validate_workspace_root_lockfile(
     graph: &PackageGraph,
     project_root: &Path,

--- a/stage1/crates/axiomc/tests/mir_example_snapshots.rs
+++ b/stage1/crates/axiomc/tests/mir_example_snapshots.rs
@@ -1,0 +1,73 @@
+use axiomc::project::lower_project_to_mir;
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[test]
+fn representative_examples_match_normalized_mir_snapshots() {
+    for example in [
+        "hello",
+        "modules",
+        "borrowed_shapes",
+        "generic_aggregates",
+        "stdlib_collections",
+    ] {
+        assert_example_mir_snapshot(example);
+    }
+}
+
+fn assert_example_mir_snapshot(example: &str) {
+    let project = example_fixture(example)
+        .canonicalize()
+        .unwrap_or_else(|err| panic!("canonicalize {example} fixture: {err}"));
+    let mir = lower_project_to_mir(&project).expect("lower example MIR");
+    let mut actual = serde_json::to_value(&mir).expect("serialize MIR snapshot");
+    normalize_mir_snapshot_value(&mut actual, &project);
+    let actual = serde_json::to_string_pretty(&actual).expect("render MIR snapshot") + "\n";
+
+    let snapshot_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/mir_snapshots")
+        .join(format!("{example}.json"));
+    if std::env::var_os("AXIOM_UPDATE_MIR_SNAPSHOTS").is_some() {
+        fs::create_dir_all(snapshot_path.parent().expect("snapshot dir"))
+            .expect("create MIR snapshot dir");
+        fs::write(&snapshot_path, actual).expect("update MIR snapshot");
+        return;
+    }
+
+    let expected = fs::read_to_string(&snapshot_path)
+        .unwrap_or_else(|err| panic!("read {}: {err}", snapshot_path.display()));
+    assert_eq!(
+        actual, expected,
+        "{example} normalized MIR snapshot drifted"
+    );
+}
+
+fn example_fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("examples")
+        .join(name)
+}
+
+fn normalize_mir_snapshot_value(value: &mut Value, project: &Path) {
+    match value {
+        Value::String(text) => {
+            let project = project.display().to_string();
+            if text.starts_with(&project) {
+                *text = text.replacen(&project, "<example>", 1);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                normalize_mir_snapshot_value(item, project);
+            }
+        }
+        Value::Object(map) => {
+            for value in map.values_mut() {
+                normalize_mir_snapshot_value(value, project);
+            }
+        }
+        _ => {}
+    }
+}

--- a/stage1/crates/axiomc/tests/mir_snapshots/borrowed_shapes.json
+++ b/stage1/crates/axiomc/tests/mir_snapshots/borrowed_shapes.json
@@ -1,0 +1,479 @@
+{
+  "enums": [
+    {
+      "name": "borrowed_shapes_stage1_main_Snapshot",
+      "variants": [
+        {
+          "name": "Window",
+          "payload_names": [],
+          "payload_tys": [
+            {
+              "Struct": "borrowed_shapes_stage1_main_Window"
+            }
+          ]
+        },
+        {
+          "name": "Named",
+          "payload_names": [
+            "window"
+          ],
+          "payload_tys": [
+            {
+              "Struct": "borrowed_shapes_stage1_main_Window"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "functions": [
+    {
+      "body": [
+        {
+          "Return": {
+            "expr": {
+              "StructLiteral": {
+                "fields": [
+                  {
+                    "expr": {
+                      "Slice": {
+                        "base": {
+                          "VarRef": {
+                            "name": "values",
+                            "ty": {
+                              "Slice": "Int"
+                            }
+                          }
+                        },
+                        "end": null,
+                        "start": {
+                          "Literal": {
+                            "Int": 1
+                          }
+                        },
+                        "ty": {
+                          "Slice": "Int"
+                        }
+                      }
+                    },
+                    "name": "view"
+                  }
+                ],
+                "name": "borrowed_shapes_stage1_main_Window",
+                "ty": {
+                  "Struct": "borrowed_shapes_stage1_main_Window"
+                }
+              }
+            },
+            "span": {
+              "column": 1,
+              "line": 11
+            }
+          }
+        }
+      ],
+      "column": 1,
+      "extern_abi": null,
+      "extern_library": null,
+      "is_async": false,
+      "is_extern": false,
+      "line": 10,
+      "name": "borrowed_shapes_stage1_main_tail",
+      "params": [
+        {
+          "name": "values",
+          "ty": {
+            "Slice": "Int"
+          }
+        }
+      ],
+      "path": "<example>/src/main.ax",
+      "return_ty": {
+        "Struct": "borrowed_shapes_stage1_main_Window"
+      },
+      "source_name": "tail"
+    },
+    {
+      "body": [
+        {
+          "Match": {
+            "arms": [
+              {
+                "bindings": [
+                  "window"
+                ],
+                "body": [
+                  {
+                    "Return": {
+                      "expr": {
+                        "Call": {
+                          "args": [
+                            {
+                              "FieldAccess": {
+                                "base": {
+                                  "VarRef": {
+                                    "name": "window",
+                                    "ty": {
+                                      "Struct": "borrowed_shapes_stage1_main_Window"
+                                    }
+                                  }
+                                },
+                                "field": "view",
+                                "ty": {
+                                  "Slice": "Int"
+                                }
+                              }
+                            }
+                          ],
+                          "name": "first",
+                          "ty": "Int"
+                        }
+                      },
+                      "span": {
+                        "column": 1,
+                        "line": 17
+                      }
+                    }
+                  }
+                ],
+                "enum_name": "borrowed_shapes_stage1_main_Snapshot",
+                "ignore_payloads": false,
+                "is_named": false,
+                "variant": "Window"
+              },
+              {
+                "bindings": [
+                  "window"
+                ],
+                "body": [
+                  {
+                    "Return": {
+                      "expr": {
+                        "Call": {
+                          "args": [
+                            {
+                              "FieldAccess": {
+                                "base": {
+                                  "VarRef": {
+                                    "name": "window",
+                                    "ty": {
+                                      "Struct": "borrowed_shapes_stage1_main_Window"
+                                    }
+                                  }
+                                },
+                                "field": "view",
+                                "ty": {
+                                  "Slice": "Int"
+                                }
+                              }
+                            }
+                          ],
+                          "name": "last",
+                          "ty": "Int"
+                        }
+                      },
+                      "span": {
+                        "column": 1,
+                        "line": 20
+                      }
+                    }
+                  }
+                ],
+                "enum_name": "borrowed_shapes_stage1_main_Snapshot",
+                "ignore_payloads": false,
+                "is_named": true,
+                "variant": "Named"
+              }
+            ],
+            "expr": {
+              "VarRef": {
+                "name": "snapshot",
+                "ty": {
+                  "Enum": "borrowed_shapes_stage1_main_Snapshot"
+                }
+              }
+            },
+            "span": {
+              "column": 1,
+              "line": 15
+            }
+          }
+        }
+      ],
+      "column": 1,
+      "extern_abi": null,
+      "extern_library": null,
+      "is_async": false,
+      "is_extern": false,
+      "line": 14,
+      "name": "borrowed_shapes_stage1_main_read",
+      "params": [
+        {
+          "name": "snapshot",
+          "ty": {
+            "Enum": "borrowed_shapes_stage1_main_Snapshot"
+          }
+        }
+      ],
+      "path": "<example>/src/main.ax",
+      "return_ty": "Int",
+      "source_name": "read"
+    }
+  ],
+  "path": "<example>/src/main.ax",
+  "statics": [],
+  "stmts": [
+    {
+      "Let": {
+        "expr": {
+          "ArrayLiteral": {
+            "elements": [
+              {
+                "Literal": {
+                  "Int": 3
+                }
+              },
+              {
+                "Literal": {
+                  "Int": 7
+                }
+              },
+              {
+                "Literal": {
+                  "Int": 9
+                }
+              },
+              {
+                "Literal": {
+                  "Int": 11
+                }
+              }
+            ],
+            "ty": {
+              "Array": [
+                "Int",
+                4
+              ]
+            }
+          }
+        },
+        "name": "numbers",
+        "span": {
+          "column": 1,
+          "line": 25
+        },
+        "ty": {
+          "Array": [
+            "Int",
+            null
+          ]
+        }
+      }
+    },
+    {
+      "Let": {
+        "expr": {
+          "Call": {
+            "args": [
+              {
+                "Slice": {
+                  "base": {
+                    "VarRef": {
+                      "name": "numbers",
+                      "ty": {
+                        "Array": [
+                          "Int",
+                          null
+                        ]
+                      }
+                    }
+                  },
+                  "end": null,
+                  "start": null,
+                  "ty": {
+                    "Slice": "Int"
+                  }
+                }
+              }
+            ],
+            "name": "borrowed_shapes_stage1_main_tail",
+            "ty": {
+              "Struct": "borrowed_shapes_stage1_main_Window"
+            }
+          }
+        },
+        "name": "window",
+        "span": {
+          "column": 1,
+          "line": 26
+        },
+        "ty": {
+          "Struct": "borrowed_shapes_stage1_main_Window"
+        }
+      }
+    },
+    {
+      "Print": {
+        "expr": {
+          "Call": {
+            "args": [
+              {
+                "FieldAccess": {
+                  "base": {
+                    "VarRef": {
+                      "name": "window",
+                      "ty": {
+                        "Struct": "borrowed_shapes_stage1_main_Window"
+                      }
+                    }
+                  },
+                  "field": "view",
+                  "ty": {
+                    "Slice": "Int"
+                  }
+                }
+              }
+            ],
+            "name": "first",
+            "ty": "Int"
+          }
+        },
+        "span": {
+          "column": 1,
+          "line": 27
+        }
+      }
+    },
+    {
+      "Print": {
+        "expr": {
+          "Call": {
+            "args": [
+              {
+                "EnumVariant": {
+                  "enum_name": "borrowed_shapes_stage1_main_Snapshot",
+                  "field_names": [],
+                  "payloads": [
+                    {
+                      "Call": {
+                        "args": [
+                          {
+                            "Slice": {
+                              "base": {
+                                "VarRef": {
+                                  "name": "numbers",
+                                  "ty": {
+                                    "Array": [
+                                      "Int",
+                                      null
+                                    ]
+                                  }
+                                }
+                              },
+                              "end": null,
+                              "start": null,
+                              "ty": {
+                                "Slice": "Int"
+                              }
+                            }
+                          }
+                        ],
+                        "name": "borrowed_shapes_stage1_main_tail",
+                        "ty": {
+                          "Struct": "borrowed_shapes_stage1_main_Window"
+                        }
+                      }
+                    }
+                  ],
+                  "ty": {
+                    "Enum": "borrowed_shapes_stage1_main_Snapshot"
+                  },
+                  "variant": "Window"
+                }
+              }
+            ],
+            "name": "borrowed_shapes_stage1_main_read",
+            "ty": "Int"
+          }
+        },
+        "span": {
+          "column": 1,
+          "line": 28
+        }
+      }
+    },
+    {
+      "Print": {
+        "expr": {
+          "Call": {
+            "args": [
+              {
+                "EnumVariant": {
+                  "enum_name": "borrowed_shapes_stage1_main_Snapshot",
+                  "field_names": [
+                    "window"
+                  ],
+                  "payloads": [
+                    {
+                      "Call": {
+                        "args": [
+                          {
+                            "Slice": {
+                              "base": {
+                                "VarRef": {
+                                  "name": "numbers",
+                                  "ty": {
+                                    "Array": [
+                                      "Int",
+                                      null
+                                    ]
+                                  }
+                                }
+                              },
+                              "end": null,
+                              "start": null,
+                              "ty": {
+                                "Slice": "Int"
+                              }
+                            }
+                          }
+                        ],
+                        "name": "borrowed_shapes_stage1_main_tail",
+                        "ty": {
+                          "Struct": "borrowed_shapes_stage1_main_Window"
+                        }
+                      }
+                    }
+                  ],
+                  "ty": {
+                    "Enum": "borrowed_shapes_stage1_main_Snapshot"
+                  },
+                  "variant": "Named"
+                }
+              }
+            ],
+            "name": "borrowed_shapes_stage1_main_read",
+            "ty": "Int"
+          }
+        },
+        "span": {
+          "column": 1,
+          "line": 29
+        }
+      }
+    }
+  ],
+  "structs": [
+    {
+      "fields": [
+        {
+          "name": "view",
+          "ty": {
+            "Slice": "Int"
+          }
+        }
+      ],
+      "name": "borrowed_shapes_stage1_main_Window"
+    }
+  ]
+}

--- a/stage1/crates/axiomc/tests/mir_snapshots/generic_aggregates.json
+++ b/stage1/crates/axiomc/tests/mir_snapshots/generic_aggregates.json
@@ -1,0 +1,1065 @@
+{
+  "enums": [
+    {
+      "name": "generic_aggregates_stage1_main_Slot__int",
+      "variants": [
+        {
+          "name": "Filled",
+          "payload_names": [],
+          "payload_tys": [
+            "Int"
+          ]
+        },
+        {
+          "name": "Empty",
+          "payload_names": [],
+          "payload_tys": []
+        }
+      ]
+    },
+    {
+      "name": "generic_aggregates_stage1_main_Slot__string",
+      "variants": [
+        {
+          "name": "Filled",
+          "payload_names": [],
+          "payload_tys": [
+            "String"
+          ]
+        },
+        {
+          "name": "Empty",
+          "payload_names": [],
+          "payload_tys": []
+        }
+      ]
+    }
+  ],
+  "functions": [
+    {
+      "body": [
+        {
+          "Return": {
+            "expr": {
+              "StructLiteral": {
+                "fields": [
+                  {
+                    "expr": {
+                      "Call": {
+                        "args": [
+                          {
+                            "VarRef": {
+                              "name": "values",
+                              "ty": {
+                                "Slice": "Int"
+                              }
+                            }
+                          }
+                        ],
+                        "name": "generic_aggregates_stage1_main_tail__int",
+                        "ty": {
+                          "Slice": "Int"
+                        }
+                      }
+                    },
+                    "name": "view"
+                  }
+                ],
+                "name": "generic_aggregates_stage1_main_Window__int",
+                "ty": {
+                  "Struct": "generic_aggregates_stage1_main_Window__int"
+                }
+              }
+            },
+            "span": {
+              "column": 1,
+              "line": 28
+            }
+          }
+        }
+      ],
+      "column": 1,
+      "extern_abi": null,
+      "extern_library": null,
+      "is_async": false,
+      "is_extern": false,
+      "line": 27,
+      "name": "generic_aggregates_stage1_main_make_window__int",
+      "params": [
+        {
+          "name": "values",
+          "ty": {
+            "Slice": "Int"
+          }
+        }
+      ],
+      "path": "<example>/src/main.ax",
+      "return_ty": {
+        "Struct": "generic_aggregates_stage1_main_Window__int"
+      },
+      "source_name": "make_window"
+    },
+    {
+      "body": [
+        {
+          "Return": {
+            "expr": {
+              "Slice": {
+                "base": {
+                  "VarRef": {
+                    "name": "values",
+                    "ty": {
+                      "Slice": "Int"
+                    }
+                  }
+                },
+                "end": null,
+                "start": {
+                  "Literal": {
+                    "Int": 1
+                  }
+                },
+                "ty": {
+                  "Slice": "Int"
+                }
+              }
+            },
+            "span": {
+              "column": 1,
+              "line": 24
+            }
+          }
+        }
+      ],
+      "column": 1,
+      "extern_abi": null,
+      "extern_library": null,
+      "is_async": false,
+      "is_extern": false,
+      "line": 23,
+      "name": "generic_aggregates_stage1_main_tail__int",
+      "params": [
+        {
+          "name": "values",
+          "ty": {
+            "Slice": "Int"
+          }
+        }
+      ],
+      "path": "<example>/src/main.ax",
+      "return_ty": {
+        "Slice": "Int"
+      },
+      "source_name": "tail"
+    }
+  ],
+  "path": "<example>/src/main.ax",
+  "statics": [],
+  "stmts": [
+    {
+      "Let": {
+        "expr": {
+          "ArrayLiteral": {
+            "elements": [
+              {
+                "Literal": {
+                  "Int": 4
+                }
+              },
+              {
+                "Literal": {
+                  "Int": 5
+                }
+              },
+              {
+                "Literal": {
+                  "Int": 6
+                }
+              }
+            ],
+            "ty": {
+              "Array": [
+                "Int",
+                3
+              ]
+            }
+          }
+        },
+        "name": "values",
+        "span": {
+          "column": 1,
+          "line": 31
+        },
+        "ty": {
+          "Array": [
+            "Int",
+            null
+          ]
+        }
+      }
+    },
+    {
+      "Let": {
+        "expr": {
+          "StructLiteral": {
+            "fields": [
+              {
+                "expr": {
+                  "Slice": {
+                    "base": {
+                      "VarRef": {
+                        "name": "values",
+                        "ty": {
+                          "Array": [
+                            "Int",
+                            null
+                          ]
+                        }
+                      }
+                    },
+                    "end": null,
+                    "start": null,
+                    "ty": {
+                      "Slice": "Int"
+                    }
+                  }
+                },
+                "name": "view"
+              }
+            ],
+            "name": "generic_aggregates_stage1_main_Window__int",
+            "ty": {
+              "Struct": "generic_aggregates_stage1_main_Window__int"
+            }
+          }
+        },
+        "name": "window",
+        "span": {
+          "column": 1,
+          "line": 32
+        },
+        "ty": {
+          "Struct": "generic_aggregates_stage1_main_Window__int"
+        }
+      }
+    },
+    {
+      "Print": {
+        "expr": {
+          "Call": {
+            "args": [
+              {
+                "FieldAccess": {
+                  "base": {
+                    "VarRef": {
+                      "name": "window",
+                      "ty": {
+                        "Struct": "generic_aggregates_stage1_main_Window__int"
+                      }
+                    }
+                  },
+                  "field": "view",
+                  "ty": {
+                    "Slice": "Int"
+                  }
+                }
+              }
+            ],
+            "name": "len",
+            "ty": "Int"
+          }
+        },
+        "span": {
+          "column": 1,
+          "line": 33
+        }
+      }
+    },
+    {
+      "Let": {
+        "expr": {
+          "Call": {
+            "args": [
+              {
+                "Slice": {
+                  "base": {
+                    "VarRef": {
+                      "name": "values",
+                      "ty": {
+                        "Array": [
+                          "Int",
+                          null
+                        ]
+                      }
+                    }
+                  },
+                  "end": null,
+                  "start": null,
+                  "ty": {
+                    "Slice": "Int"
+                  }
+                }
+              }
+            ],
+            "name": "generic_aggregates_stage1_main_make_window__int",
+            "ty": {
+              "Struct": "generic_aggregates_stage1_main_Window__int"
+            }
+          }
+        },
+        "name": "tail_window",
+        "span": {
+          "column": 1,
+          "line": 34
+        },
+        "ty": {
+          "Struct": "generic_aggregates_stage1_main_Window__int"
+        }
+      }
+    },
+    {
+      "Print": {
+        "expr": {
+          "Call": {
+            "args": [
+              {
+                "FieldAccess": {
+                  "base": {
+                    "VarRef": {
+                      "name": "tail_window",
+                      "ty": {
+                        "Struct": "generic_aggregates_stage1_main_Window__int"
+                      }
+                    }
+                  },
+                  "field": "view",
+                  "ty": {
+                    "Slice": "Int"
+                  }
+                }
+              }
+            ],
+            "name": "len",
+            "ty": "Int"
+          }
+        },
+        "span": {
+          "column": 1,
+          "line": 35
+        }
+      }
+    },
+    {
+      "Let": {
+        "expr": {
+          "StructLiteral": {
+            "fields": [
+              {
+                "expr": {
+                  "EnumVariant": {
+                    "enum_name": "Option",
+                    "field_names": [],
+                    "payloads": [
+                      {
+                        "Literal": {
+                          "Int": 8
+                        }
+                      }
+                    ],
+                    "ty": {
+                      "Option": "Int"
+                    },
+                    "variant": "Some"
+                  }
+                },
+                "name": "item"
+              }
+            ],
+            "name": "generic_aggregates_stage1_main_MaybeBox__int",
+            "ty": {
+              "Struct": "generic_aggregates_stage1_main_MaybeBox__int"
+            }
+          }
+        },
+        "name": "maybe",
+        "span": {
+          "column": 1,
+          "line": 37
+        },
+        "ty": {
+          "Struct": "generic_aggregates_stage1_main_MaybeBox__int"
+        }
+      }
+    },
+    {
+      "Match": {
+        "arms": [
+          {
+            "bindings": [
+              "value"
+            ],
+            "body": [
+              {
+                "Print": {
+                  "expr": {
+                    "VarRef": {
+                      "name": "value",
+                      "ty": "Int"
+                    }
+                  },
+                  "span": {
+                    "column": 1,
+                    "line": 40
+                  }
+                }
+              }
+            ],
+            "enum_name": "Option",
+            "ignore_payloads": false,
+            "is_named": false,
+            "variant": "Some"
+          },
+          {
+            "bindings": [],
+            "body": [
+              {
+                "Print": {
+                  "expr": {
+                    "Literal": {
+                      "Int": 0
+                    }
+                  },
+                  "span": {
+                    "column": 1,
+                    "line": 43
+                  }
+                }
+              }
+            ],
+            "enum_name": "Option",
+            "ignore_payloads": false,
+            "is_named": false,
+            "variant": "None"
+          }
+        ],
+        "expr": {
+          "FieldAccess": {
+            "base": {
+              "VarRef": {
+                "name": "maybe",
+                "ty": {
+                  "Struct": "generic_aggregates_stage1_main_MaybeBox__int"
+                }
+              }
+            },
+            "field": "item",
+            "ty": {
+              "Option": "Int"
+            }
+          }
+        },
+        "span": {
+          "column": 1,
+          "line": 38
+        }
+      }
+    },
+    {
+      "Let": {
+        "expr": {
+          "StructLiteral": {
+            "fields": [
+              {
+                "expr": {
+                  "EnumVariant": {
+                    "enum_name": "Result",
+                    "field_names": [],
+                    "payloads": [
+                      {
+                        "Literal": {
+                          "String": "ready"
+                        }
+                      }
+                    ],
+                    "ty": {
+                      "Result": [
+                        "String",
+                        "String"
+                      ]
+                    },
+                    "variant": "Ok"
+                  }
+                },
+                "name": "item"
+              }
+            ],
+            "name": "generic_aggregates_stage1_main_ResultBox__string__string",
+            "ty": {
+              "Struct": "generic_aggregates_stage1_main_ResultBox__string__string"
+            }
+          }
+        },
+        "name": "result",
+        "span": {
+          "column": 1,
+          "line": 47
+        },
+        "ty": {
+          "Struct": "generic_aggregates_stage1_main_ResultBox__string__string"
+        }
+      }
+    },
+    {
+      "Match": {
+        "arms": [
+          {
+            "bindings": [
+              "value"
+            ],
+            "body": [
+              {
+                "Print": {
+                  "expr": {
+                    "VarRef": {
+                      "name": "value",
+                      "ty": "String"
+                    }
+                  },
+                  "span": {
+                    "column": 1,
+                    "line": 50
+                  }
+                }
+              }
+            ],
+            "enum_name": "Result",
+            "ignore_payloads": false,
+            "is_named": false,
+            "variant": "Ok"
+          },
+          {
+            "bindings": [
+              "error"
+            ],
+            "body": [
+              {
+                "Print": {
+                  "expr": {
+                    "VarRef": {
+                      "name": "error",
+                      "ty": "String"
+                    }
+                  },
+                  "span": {
+                    "column": 1,
+                    "line": 53
+                  }
+                }
+              }
+            ],
+            "enum_name": "Result",
+            "ignore_payloads": false,
+            "is_named": false,
+            "variant": "Err"
+          }
+        ],
+        "expr": {
+          "FieldAccess": {
+            "base": {
+              "VarRef": {
+                "name": "result",
+                "ty": {
+                  "Struct": "generic_aggregates_stage1_main_ResultBox__string__string"
+                }
+              }
+            },
+            "field": "item",
+            "ty": {
+              "Result": [
+                "String",
+                "String"
+              ]
+            }
+          }
+        },
+        "span": {
+          "column": 1,
+          "line": 48
+        }
+      }
+    },
+    {
+      "Let": {
+        "expr": {
+          "ArrayLiteral": {
+            "elements": [
+              {
+                "Literal": {
+                  "Int": 10
+                }
+              },
+              {
+                "Literal": {
+                  "Int": 20
+                }
+              }
+            ],
+            "ty": {
+              "Array": [
+                "Int",
+                2
+              ]
+            }
+          }
+        },
+        "name": "bucket_values",
+        "span": {
+          "column": 1,
+          "line": 57
+        },
+        "ty": {
+          "Array": [
+            "Int",
+            null
+          ]
+        }
+      }
+    },
+    {
+      "Let": {
+        "expr": {
+          "MapLiteral": {
+            "entries": [
+              {
+                "key": {
+                  "Literal": {
+                    "String": "answer"
+                  }
+                },
+                "value": {
+                  "Literal": {
+                    "Int": 42
+                  }
+                }
+              }
+            ],
+            "ty": {
+              "Map": [
+                "String",
+                "Int"
+              ]
+            }
+          }
+        },
+        "name": "bucket_lookup",
+        "span": {
+          "column": 1,
+          "line": 58
+        },
+        "ty": {
+          "Map": [
+            "String",
+            "Int"
+          ]
+        }
+      }
+    },
+    {
+      "Let": {
+        "expr": {
+          "StructLiteral": {
+            "fields": [
+              {
+                "expr": {
+                  "VarRef": {
+                    "name": "bucket_values",
+                    "ty": {
+                      "Array": [
+                        "Int",
+                        null
+                      ]
+                    }
+                  }
+                },
+                "name": "items"
+              },
+              {
+                "expr": {
+                  "VarRef": {
+                    "name": "bucket_lookup",
+                    "ty": {
+                      "Map": [
+                        "String",
+                        "Int"
+                      ]
+                    }
+                  }
+                },
+                "name": "by_name"
+              }
+            ],
+            "name": "generic_aggregates_stage1_main_Buckets__int",
+            "ty": {
+              "Struct": "generic_aggregates_stage1_main_Buckets__int"
+            }
+          }
+        },
+        "name": "buckets",
+        "span": {
+          "column": 1,
+          "line": 59
+        },
+        "ty": {
+          "Struct": "generic_aggregates_stage1_main_Buckets__int"
+        }
+      }
+    },
+    {
+      "Print": {
+        "expr": {
+          "Call": {
+            "args": [
+              {
+                "FieldAccess": {
+                  "base": {
+                    "VarRef": {
+                      "name": "buckets",
+                      "ty": {
+                        "Struct": "generic_aggregates_stage1_main_Buckets__int"
+                      }
+                    }
+                  },
+                  "field": "items",
+                  "ty": {
+                    "Array": [
+                      "Int",
+                      null
+                    ]
+                  }
+                }
+              }
+            ],
+            "name": "len",
+            "ty": "Int"
+          }
+        },
+        "span": {
+          "column": 1,
+          "line": 60
+        }
+      }
+    },
+    {
+      "Let": {
+        "expr": {
+          "FieldAccess": {
+            "base": {
+              "VarRef": {
+                "name": "buckets",
+                "ty": {
+                  "Struct": "generic_aggregates_stage1_main_Buckets__int"
+                }
+              }
+            },
+            "field": "by_name",
+            "ty": {
+              "Map": [
+                "String",
+                "Int"
+              ]
+            }
+          }
+        },
+        "name": "answers",
+        "span": {
+          "column": 1,
+          "line": 61
+        },
+        "ty": {
+          "Map": [
+            "String",
+            "Int"
+          ]
+        }
+      }
+    },
+    {
+      "Print": {
+        "expr": {
+          "Index": {
+            "base": {
+              "VarRef": {
+                "name": "answers",
+                "ty": {
+                  "Map": [
+                    "String",
+                    "Int"
+                  ]
+                }
+              }
+            },
+            "index": {
+              "Literal": {
+                "String": "answer"
+              }
+            },
+            "ty": "Int"
+          }
+        },
+        "span": {
+          "column": 1,
+          "line": 62
+        }
+      }
+    },
+    {
+      "Let": {
+        "expr": {
+          "EnumVariant": {
+            "enum_name": "generic_aggregates_stage1_main_Slot__int",
+            "field_names": [],
+            "payloads": [
+              {
+                "Literal": {
+                  "Int": 42
+                }
+              }
+            ],
+            "ty": {
+              "Enum": "generic_aggregates_stage1_main_Slot__int"
+            },
+            "variant": "Filled"
+          }
+        },
+        "name": "number",
+        "span": {
+          "column": 1,
+          "line": 64
+        },
+        "ty": {
+          "Enum": "generic_aggregates_stage1_main_Slot__int"
+        }
+      }
+    },
+    {
+      "Match": {
+        "arms": [
+          {
+            "bindings": [
+              "value"
+            ],
+            "body": [
+              {
+                "Print": {
+                  "expr": {
+                    "VarRef": {
+                      "name": "value",
+                      "ty": "Int"
+                    }
+                  },
+                  "span": {
+                    "column": 1,
+                    "line": 67
+                  }
+                }
+              }
+            ],
+            "enum_name": "generic_aggregates_stage1_main_Slot__int",
+            "ignore_payloads": false,
+            "is_named": false,
+            "variant": "Filled"
+          },
+          {
+            "bindings": [],
+            "body": [
+              {
+                "Print": {
+                  "expr": {
+                    "Literal": {
+                      "Int": 0
+                    }
+                  },
+                  "span": {
+                    "column": 1,
+                    "line": 70
+                  }
+                }
+              }
+            ],
+            "enum_name": "generic_aggregates_stage1_main_Slot__int",
+            "ignore_payloads": false,
+            "is_named": false,
+            "variant": "Empty"
+          }
+        ],
+        "expr": {
+          "VarRef": {
+            "name": "number",
+            "ty": {
+              "Enum": "generic_aggregates_stage1_main_Slot__int"
+            }
+          }
+        },
+        "span": {
+          "column": 1,
+          "line": 65
+        }
+      }
+    },
+    {
+      "Let": {
+        "expr": {
+          "EnumVariant": {
+            "enum_name": "generic_aggregates_stage1_main_Slot__string",
+            "field_names": [],
+            "payloads": [
+              {
+                "Literal": {
+                  "String": "done"
+                }
+              }
+            ],
+            "ty": {
+              "Enum": "generic_aggregates_stage1_main_Slot__string"
+            },
+            "variant": "Filled"
+          }
+        },
+        "name": "text",
+        "span": {
+          "column": 1,
+          "line": 74
+        },
+        "ty": {
+          "Enum": "generic_aggregates_stage1_main_Slot__string"
+        }
+      }
+    },
+    {
+      "Match": {
+        "arms": [
+          {
+            "bindings": [
+              "value"
+            ],
+            "body": [
+              {
+                "Print": {
+                  "expr": {
+                    "VarRef": {
+                      "name": "value",
+                      "ty": "String"
+                    }
+                  },
+                  "span": {
+                    "column": 1,
+                    "line": 77
+                  }
+                }
+              }
+            ],
+            "enum_name": "generic_aggregates_stage1_main_Slot__string",
+            "ignore_payloads": false,
+            "is_named": false,
+            "variant": "Filled"
+          },
+          {
+            "bindings": [],
+            "body": [
+              {
+                "Print": {
+                  "expr": {
+                    "Literal": {
+                      "String": "empty"
+                    }
+                  },
+                  "span": {
+                    "column": 1,
+                    "line": 80
+                  }
+                }
+              }
+            ],
+            "enum_name": "generic_aggregates_stage1_main_Slot__string",
+            "ignore_payloads": false,
+            "is_named": false,
+            "variant": "Empty"
+          }
+        ],
+        "expr": {
+          "VarRef": {
+            "name": "text",
+            "ty": {
+              "Enum": "generic_aggregates_stage1_main_Slot__string"
+            }
+          }
+        },
+        "span": {
+          "column": 1,
+          "line": 75
+        }
+      }
+    }
+  ],
+  "structs": [
+    {
+      "fields": [
+        {
+          "name": "items",
+          "ty": {
+            "Array": [
+              "Int",
+              null
+            ]
+          }
+        },
+        {
+          "name": "by_name",
+          "ty": {
+            "Map": [
+              "String",
+              "Int"
+            ]
+          }
+        }
+      ],
+      "name": "generic_aggregates_stage1_main_Buckets__int"
+    },
+    {
+      "fields": [
+        {
+          "name": "item",
+          "ty": {
+            "Option": "Int"
+          }
+        }
+      ],
+      "name": "generic_aggregates_stage1_main_MaybeBox__int"
+    },
+    {
+      "fields": [
+        {
+          "name": "item",
+          "ty": {
+            "Result": [
+              "String",
+              "String"
+            ]
+          }
+        }
+      ],
+      "name": "generic_aggregates_stage1_main_ResultBox__string__string"
+    },
+    {
+      "fields": [
+        {
+          "name": "view",
+          "ty": {
+            "Slice": "Int"
+          }
+        }
+      ],
+      "name": "generic_aggregates_stage1_main_Window__int"
+    }
+  ]
+}

--- a/stage1/crates/axiomc/tests/mir_snapshots/hello.json
+++ b/stage1/crates/axiomc/tests/mir_snapshots/hello.json
@@ -1,0 +1,284 @@
+{
+  "enums": [],
+  "functions": [
+    {
+      "body": [
+        {
+          "Return": {
+            "expr": {
+              "BinaryAdd": {
+                "lhs": {
+                  "Literal": {
+                    "String": "hello "
+                  }
+                },
+                "rhs": {
+                  "VarRef": {
+                    "name": "name",
+                    "ty": "String"
+                  }
+                },
+                "ty": "String"
+              }
+            },
+            "span": {
+              "column": 1,
+              "line": 2
+            }
+          }
+        }
+      ],
+      "column": 1,
+      "extern_abi": null,
+      "extern_library": null,
+      "is_async": false,
+      "is_extern": false,
+      "line": 1,
+      "name": "hello_stage1_main_banner",
+      "params": [
+        {
+          "name": "name",
+          "ty": "String"
+        }
+      ],
+      "path": "<example>/src/main.ax",
+      "return_ty": "String",
+      "source_name": "banner"
+    },
+    {
+      "body": [
+        {
+          "Return": {
+            "expr": {
+              "BinaryAdd": {
+                "lhs": {
+                  "VarRef": {
+                    "name": "base",
+                    "ty": "Int"
+                  }
+                },
+                "rhs": {
+                  "Literal": {
+                    "Int": 2
+                  }
+                },
+                "ty": "Int"
+              }
+            },
+            "span": {
+              "column": 1,
+              "line": 6
+            }
+          }
+        }
+      ],
+      "column": 1,
+      "extern_abi": null,
+      "extern_library": null,
+      "is_async": false,
+      "is_extern": false,
+      "line": 5,
+      "name": "hello_stage1_main_lucky",
+      "params": [
+        {
+          "name": "base",
+          "ty": "Int"
+        }
+      ],
+      "path": "<example>/src/main.ax",
+      "return_ty": "Int",
+      "source_name": "lucky"
+    },
+    {
+      "body": [
+        {
+          "Return": {
+            "expr": {
+              "BinaryCompare": {
+                "lhs": {
+                  "VarRef": {
+                    "name": "value",
+                    "ty": "Int"
+                  }
+                },
+                "op": "Eq",
+                "rhs": {
+                  "Literal": {
+                    "Int": 42
+                  }
+                },
+                "ty": "Bool"
+              }
+            },
+            "span": {
+              "column": 1,
+              "line": 10
+            }
+          }
+        }
+      ],
+      "column": 1,
+      "extern_abi": null,
+      "extern_library": null,
+      "is_async": false,
+      "is_extern": false,
+      "line": 9,
+      "name": "hello_stage1_main_is_ready",
+      "params": [
+        {
+          "name": "value",
+          "ty": "Int"
+        }
+      ],
+      "path": "<example>/src/main.ax",
+      "return_ty": "Bool",
+      "source_name": "is_ready"
+    }
+  ],
+  "path": "<example>/src/main.ax",
+  "statics": [],
+  "stmts": [
+    {
+      "Let": {
+        "expr": {
+          "Call": {
+            "args": [
+              {
+                "Literal": {
+                  "Int": 40
+                }
+              }
+            ],
+            "name": "hello_stage1_main_lucky",
+            "ty": "Int"
+          }
+        },
+        "name": "answer",
+        "span": {
+          "column": 1,
+          "line": 13
+        },
+        "ty": "Int"
+      }
+    },
+    {
+      "Let": {
+        "expr": {
+          "Call": {
+            "args": [
+              {
+                "VarRef": {
+                  "name": "answer",
+                  "ty": "Int"
+                }
+              }
+            ],
+            "name": "hello_stage1_main_is_ready",
+            "ty": "Bool"
+          }
+        },
+        "name": "ready",
+        "span": {
+          "column": 1,
+          "line": 14
+        },
+        "ty": "Bool"
+      }
+    },
+    {
+      "While": {
+        "body": [],
+        "cond": {
+          "Literal": {
+            "Bool": false
+          }
+        },
+        "span": {
+          "column": 1,
+          "line": 16
+        }
+      }
+    },
+    {
+      "If": {
+        "cond": {
+          "VarRef": {
+            "name": "ready",
+            "ty": "Bool"
+          }
+        },
+        "else_block": [
+          {
+            "Print": {
+              "expr": {
+                "Literal": {
+                  "String": "stage1 failed"
+                }
+              },
+              "span": {
+                "column": 1,
+                "line": 23
+              }
+            }
+          }
+        ],
+        "span": {
+          "column": 1,
+          "line": 20
+        },
+        "then_block": [
+          {
+            "Print": {
+              "expr": {
+                "Call": {
+                  "args": [
+                    {
+                      "Literal": {
+                        "String": "from stage1"
+                      }
+                    }
+                  ],
+                  "name": "hello_stage1_main_banner",
+                  "ty": "String"
+                }
+              },
+              "span": {
+                "column": 1,
+                "line": 21
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "Print": {
+        "expr": {
+          "VarRef": {
+            "name": "answer",
+            "ty": "Int"
+          }
+        },
+        "span": {
+          "column": 1,
+          "line": 26
+        }
+      }
+    },
+    {
+      "Print": {
+        "expr": {
+          "VarRef": {
+            "name": "ready",
+            "ty": "Bool"
+          }
+        },
+        "span": {
+          "column": 1,
+          "line": 27
+        }
+      }
+    }
+  ],
+  "structs": []
+}

--- a/stage1/crates/axiomc/tests/mir_snapshots/modules.json
+++ b/stage1/crates/axiomc/tests/mir_snapshots/modules.json
@@ -1,0 +1,342 @@
+{
+  "enums": [],
+  "functions": [
+    {
+      "body": [
+        {
+          "Return": {
+            "expr": {
+              "BinaryAdd": {
+                "lhs": {
+                  "Call": {
+                    "args": [],
+                    "name": "modules_stage1_greetings_prefix",
+                    "ty": "String"
+                  }
+                },
+                "rhs": {
+                  "VarRef": {
+                    "name": "name",
+                    "ty": "String"
+                  }
+                },
+                "ty": "String"
+              }
+            },
+            "span": {
+              "column": 1,
+              "line": 2
+            }
+          }
+        }
+      ],
+      "column": 1,
+      "extern_abi": null,
+      "extern_library": null,
+      "is_async": false,
+      "is_extern": false,
+      "line": 1,
+      "name": "modules_stage1_greetings_banner",
+      "params": [
+        {
+          "name": "name",
+          "ty": "String"
+        }
+      ],
+      "path": "<example>/src/greetings.ax",
+      "return_ty": "String",
+      "source_name": "banner"
+    },
+    {
+      "body": [
+        {
+          "Return": {
+            "expr": {
+              "Literal": {
+                "String": "hello "
+              }
+            },
+            "span": {
+              "column": 1,
+              "line": 6
+            }
+          }
+        }
+      ],
+      "column": 1,
+      "extern_abi": null,
+      "extern_library": null,
+      "is_async": false,
+      "is_extern": false,
+      "line": 5,
+      "name": "modules_stage1_greetings_prefix",
+      "params": [],
+      "path": "<example>/src/greetings.ax",
+      "return_ty": "String",
+      "source_name": "prefix"
+    },
+    {
+      "body": [
+        {
+          "Return": {
+            "expr": {
+              "Call": {
+                "args": [
+                  {
+                    "VarRef": {
+                      "name": "base",
+                      "ty": "Int"
+                    }
+                  }
+                ],
+                "name": "modules_stage1_math_bump",
+                "ty": "Int"
+              }
+            },
+            "span": {
+              "column": 1,
+              "line": 2
+            }
+          }
+        }
+      ],
+      "column": 1,
+      "extern_abi": null,
+      "extern_library": null,
+      "is_async": false,
+      "is_extern": false,
+      "line": 1,
+      "name": "modules_stage1_math_lucky",
+      "params": [
+        {
+          "name": "base",
+          "ty": "Int"
+        }
+      ],
+      "path": "<example>/src/math.ax",
+      "return_ty": "Int",
+      "source_name": "lucky"
+    },
+    {
+      "body": [
+        {
+          "Return": {
+            "expr": {
+              "BinaryAdd": {
+                "lhs": {
+                  "VarRef": {
+                    "name": "base",
+                    "ty": "Int"
+                  }
+                },
+                "rhs": {
+                  "Literal": {
+                    "Int": 2
+                  }
+                },
+                "ty": "Int"
+              }
+            },
+            "span": {
+              "column": 1,
+              "line": 6
+            }
+          }
+        }
+      ],
+      "column": 1,
+      "extern_abi": null,
+      "extern_library": null,
+      "is_async": false,
+      "is_extern": false,
+      "line": 5,
+      "name": "modules_stage1_math_bump",
+      "params": [
+        {
+          "name": "base",
+          "ty": "Int"
+        }
+      ],
+      "path": "<example>/src/math.ax",
+      "return_ty": "Int",
+      "source_name": "bump"
+    },
+    {
+      "body": [
+        {
+          "Return": {
+            "expr": {
+              "BinaryCompare": {
+                "lhs": {
+                  "VarRef": {
+                    "name": "value",
+                    "ty": "Int"
+                  }
+                },
+                "op": "Eq",
+                "rhs": {
+                  "Literal": {
+                    "Int": 42
+                  }
+                },
+                "ty": "Bool"
+              }
+            },
+            "span": {
+              "column": 1,
+              "line": 5
+            }
+          }
+        }
+      ],
+      "column": 1,
+      "extern_abi": null,
+      "extern_library": null,
+      "is_async": false,
+      "is_extern": false,
+      "line": 4,
+      "name": "modules_stage1_main_is_ready",
+      "params": [
+        {
+          "name": "value",
+          "ty": "Int"
+        }
+      ],
+      "path": "<example>/src/main.ax",
+      "return_ty": "Bool",
+      "source_name": "is_ready"
+    }
+  ],
+  "path": "<example>/src/main.ax",
+  "statics": [],
+  "stmts": [
+    {
+      "Let": {
+        "expr": {
+          "Call": {
+            "args": [
+              {
+                "Literal": {
+                  "Int": 40
+                }
+              }
+            ],
+            "name": "modules_stage1_math_lucky",
+            "ty": "Int"
+          }
+        },
+        "name": "answer",
+        "span": {
+          "column": 1,
+          "line": 8
+        },
+        "ty": "Int"
+      }
+    },
+    {
+      "Let": {
+        "expr": {
+          "Call": {
+            "args": [
+              {
+                "VarRef": {
+                  "name": "answer",
+                  "ty": "Int"
+                }
+              }
+            ],
+            "name": "modules_stage1_main_is_ready",
+            "ty": "Bool"
+          }
+        },
+        "name": "ready",
+        "span": {
+          "column": 1,
+          "line": 9
+        },
+        "ty": "Bool"
+      }
+    },
+    {
+      "If": {
+        "cond": {
+          "VarRef": {
+            "name": "ready",
+            "ty": "Bool"
+          }
+        },
+        "else_block": [
+          {
+            "Print": {
+              "expr": {
+                "Literal": {
+                  "String": "stage1 failed"
+                }
+              },
+              "span": {
+                "column": 1,
+                "line": 14
+              }
+            }
+          }
+        ],
+        "span": {
+          "column": 1,
+          "line": 11
+        },
+        "then_block": [
+          {
+            "Print": {
+              "expr": {
+                "Call": {
+                  "args": [
+                    {
+                      "Literal": {
+                        "String": "from modules"
+                      }
+                    }
+                  ],
+                  "name": "modules_stage1_greetings_banner",
+                  "ty": "String"
+                }
+              },
+              "span": {
+                "column": 1,
+                "line": 12
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "Print": {
+        "expr": {
+          "VarRef": {
+            "name": "answer",
+            "ty": "Int"
+          }
+        },
+        "span": {
+          "column": 1,
+          "line": 17
+        }
+      }
+    },
+    {
+      "Print": {
+        "expr": {
+          "VarRef": {
+            "name": "ready",
+            "ty": "Bool"
+          }
+        },
+        "span": {
+          "column": 1,
+          "line": 18
+        }
+      }
+    }
+  ],
+  "structs": []
+}

--- a/stage1/crates/axiomc/tests/mir_snapshots/stdlib_collections.json
+++ b/stage1/crates/axiomc/tests/mir_snapshots/stdlib_collections.json
@@ -1,0 +1,1084 @@
+{
+  "enums": [],
+  "functions": [
+    {
+      "body": [
+        {
+          "Return": {
+            "expr": {
+              "Call": {
+                "args": [
+                  {
+                    "VarRef": {
+                      "name": "values",
+                      "ty": {
+                        "Slice": "Int"
+                      }
+                    }
+                  }
+                ],
+                "name": "len",
+                "ty": "Int"
+              }
+            },
+            "span": {
+              "column": 1,
+              "line": 2
+            }
+          }
+        }
+      ],
+      "column": 1,
+      "extern_abi": null,
+      "extern_library": null,
+      "is_async": false,
+      "is_extern": false,
+      "line": 1,
+      "name": "std_collections_count__int",
+      "params": [
+        {
+          "name": "values",
+          "ty": {
+            "Slice": "Int"
+          }
+        }
+      ],
+      "path": "<stdlib>/collections.ax",
+      "return_ty": "Int",
+      "source_name": "count"
+    },
+    {
+      "body": [
+        {
+          "Return": {
+            "expr": {
+              "BinaryCompare": {
+                "lhs": {
+                  "Call": {
+                    "args": [
+                      {
+                        "VarRef": {
+                          "name": "values",
+                          "ty": {
+                            "Slice": "Int"
+                          }
+                        }
+                      }
+                    ],
+                    "name": "len",
+                    "ty": "Int"
+                  }
+                },
+                "op": "Eq",
+                "rhs": {
+                  "Literal": {
+                    "Int": 0
+                  }
+                },
+                "ty": "Bool"
+              }
+            },
+            "span": {
+              "column": 1,
+              "line": 5
+            }
+          }
+        }
+      ],
+      "column": 1,
+      "extern_abi": null,
+      "extern_library": null,
+      "is_async": false,
+      "is_extern": false,
+      "line": 4,
+      "name": "std_collections_is_empty__int",
+      "params": [
+        {
+          "name": "values",
+          "ty": {
+            "Slice": "Int"
+          }
+        }
+      ],
+      "path": "<stdlib>/collections.ax",
+      "return_ty": "Bool",
+      "source_name": "is_empty"
+    },
+    {
+      "body": [
+        {
+          "Return": {
+            "expr": {
+              "BinaryCompare": {
+                "lhs": {
+                  "Call": {
+                    "args": [
+                      {
+                        "VarRef": {
+                          "name": "values",
+                          "ty": {
+                            "Slice": "Int"
+                          }
+                        }
+                      }
+                    ],
+                    "name": "len",
+                    "ty": "Int"
+                  }
+                },
+                "op": "Gt",
+                "rhs": {
+                  "Literal": {
+                    "Int": 0
+                  }
+                },
+                "ty": "Bool"
+              }
+            },
+            "span": {
+              "column": 1,
+              "line": 8
+            }
+          }
+        }
+      ],
+      "column": 1,
+      "extern_abi": null,
+      "extern_library": null,
+      "is_async": false,
+      "is_extern": false,
+      "line": 7,
+      "name": "std_collections_has_items__int",
+      "params": [
+        {
+          "name": "values",
+          "ty": {
+            "Slice": "Int"
+          }
+        }
+      ],
+      "path": "<stdlib>/collections.ax",
+      "return_ty": "Bool",
+      "source_name": "has_items"
+    },
+    {
+      "body": [
+        {
+          "Return": {
+            "expr": {
+              "Slice": {
+                "base": {
+                  "VarRef": {
+                    "name": "values",
+                    "ty": {
+                      "Slice": "Int"
+                    }
+                  }
+                },
+                "end": {
+                  "VarRef": {
+                    "name": "end",
+                    "ty": "Int"
+                  }
+                },
+                "start": {
+                  "VarRef": {
+                    "name": "start",
+                    "ty": "Int"
+                  }
+                },
+                "ty": {
+                  "Slice": "Int"
+                }
+              }
+            },
+            "span": {
+              "column": 1,
+              "line": 20
+            }
+          }
+        }
+      ],
+      "column": 1,
+      "extern_abi": null,
+      "extern_library": null,
+      "is_async": false,
+      "is_extern": false,
+      "line": 19,
+      "name": "std_collections_window__int",
+      "params": [
+        {
+          "name": "values",
+          "ty": {
+            "Slice": "Int"
+          }
+        },
+        {
+          "name": "start",
+          "ty": "Int"
+        },
+        {
+          "name": "end",
+          "ty": "Int"
+        }
+      ],
+      "path": "<stdlib>/collections.ax",
+      "return_ty": {
+        "Slice": "Int"
+      },
+      "source_name": "window"
+    },
+    {
+      "body": [
+        {
+          "Return": {
+            "expr": {
+              "Slice": {
+                "base": {
+                  "VarRef": {
+                    "name": "values",
+                    "ty": {
+                      "Slice": "Int"
+                    }
+                  }
+                },
+                "end": {
+                  "VarRef": {
+                    "name": "count",
+                    "ty": "Int"
+                  }
+                },
+                "start": null,
+                "ty": {
+                  "Slice": "Int"
+                }
+              }
+            },
+            "span": {
+              "column": 1,
+              "line": 17
+            }
+          }
+        }
+      ],
+      "column": 1,
+      "extern_abi": null,
+      "extern_library": null,
+      "is_async": false,
+      "is_extern": false,
+      "line": 16,
+      "name": "std_collections_take__int",
+      "params": [
+        {
+          "name": "values",
+          "ty": {
+            "Slice": "Int"
+          }
+        },
+        {
+          "name": "count",
+          "ty": "Int"
+        }
+      ],
+      "path": "<stdlib>/collections.ax",
+      "return_ty": {
+        "Slice": "Int"
+      },
+      "source_name": "take"
+    },
+    {
+      "body": [
+        {
+          "Return": {
+            "expr": {
+              "Slice": {
+                "base": {
+                  "VarRef": {
+                    "name": "values",
+                    "ty": {
+                      "Slice": "Int"
+                    }
+                  }
+                },
+                "end": null,
+                "start": {
+                  "VarRef": {
+                    "name": "count",
+                    "ty": "Int"
+                  }
+                },
+                "ty": {
+                  "Slice": "Int"
+                }
+              }
+            },
+            "span": {
+              "column": 1,
+              "line": 14
+            }
+          }
+        }
+      ],
+      "column": 1,
+      "extern_abi": null,
+      "extern_library": null,
+      "is_async": false,
+      "is_extern": false,
+      "line": 13,
+      "name": "std_collections_skip__int",
+      "params": [
+        {
+          "name": "values",
+          "ty": {
+            "Slice": "Int"
+          }
+        },
+        {
+          "name": "count",
+          "ty": "Int"
+        }
+      ],
+      "path": "<stdlib>/collections.ax",
+      "return_ty": {
+        "Slice": "Int"
+      },
+      "source_name": "skip"
+    },
+    {
+      "body": [
+        {
+          "Return": {
+            "expr": {
+              "Call": {
+                "args": [
+                  {
+                    "VarRef": {
+                      "name": "values",
+                      "ty": {
+                        "Slice": "String"
+                      }
+                    }
+                  }
+                ],
+                "name": "len",
+                "ty": "Int"
+              }
+            },
+            "span": {
+              "column": 1,
+              "line": 2
+            }
+          }
+        }
+      ],
+      "column": 1,
+      "extern_abi": null,
+      "extern_library": null,
+      "is_async": false,
+      "is_extern": false,
+      "line": 1,
+      "name": "std_collections_count__string",
+      "params": [
+        {
+          "name": "values",
+          "ty": {
+            "Slice": "String"
+          }
+        }
+      ],
+      "path": "<stdlib>/collections.ax",
+      "return_ty": "Int",
+      "source_name": "count"
+    },
+    {
+      "body": [
+        {
+          "Return": {
+            "expr": {
+              "Slice": {
+                "base": {
+                  "VarRef": {
+                    "name": "values",
+                    "ty": {
+                      "Slice": "String"
+                    }
+                  }
+                },
+                "end": {
+                  "VarRef": {
+                    "name": "count",
+                    "ty": "Int"
+                  }
+                },
+                "start": null,
+                "ty": {
+                  "Slice": "String"
+                }
+              }
+            },
+            "span": {
+              "column": 1,
+              "line": 17
+            }
+          }
+        }
+      ],
+      "column": 1,
+      "extern_abi": null,
+      "extern_library": null,
+      "is_async": false,
+      "is_extern": false,
+      "line": 16,
+      "name": "std_collections_take__string",
+      "params": [
+        {
+          "name": "values",
+          "ty": {
+            "Slice": "String"
+          }
+        },
+        {
+          "name": "count",
+          "ty": "Int"
+        }
+      ],
+      "path": "<stdlib>/collections.ax",
+      "return_ty": {
+        "Slice": "String"
+      },
+      "source_name": "take"
+    },
+    {
+      "body": [
+        {
+          "Return": {
+            "expr": {
+              "BinaryCompare": {
+                "lhs": {
+                  "Call": {
+                    "args": [
+                      {
+                        "VarRef": {
+                          "name": "values",
+                          "ty": {
+                            "Slice": "String"
+                          }
+                        }
+                      }
+                    ],
+                    "name": "len",
+                    "ty": "Int"
+                  }
+                },
+                "op": "Eq",
+                "rhs": {
+                  "Literal": {
+                    "Int": 0
+                  }
+                },
+                "ty": "Bool"
+              }
+            },
+            "span": {
+              "column": 1,
+              "line": 5
+            }
+          }
+        }
+      ],
+      "column": 1,
+      "extern_abi": null,
+      "extern_library": null,
+      "is_async": false,
+      "is_extern": false,
+      "line": 4,
+      "name": "std_collections_is_empty__string",
+      "params": [
+        {
+          "name": "values",
+          "ty": {
+            "Slice": "String"
+          }
+        }
+      ],
+      "path": "<stdlib>/collections.ax",
+      "return_ty": "Bool",
+      "source_name": "is_empty"
+    }
+  ],
+  "path": "<example>/src/main.ax",
+  "statics": [],
+  "stmts": [
+    {
+      "Let": {
+        "expr": {
+          "ArrayLiteral": {
+            "elements": [
+              {
+                "Literal": {
+                  "Int": 4
+                }
+              },
+              {
+                "Literal": {
+                  "Int": 5
+                }
+              },
+              {
+                "Literal": {
+                  "Int": 6
+                }
+              },
+              {
+                "Literal": {
+                  "Int": 7
+                }
+              }
+            ],
+            "ty": {
+              "Array": [
+                "Int",
+                4
+              ]
+            }
+          }
+        },
+        "name": "numbers",
+        "span": {
+          "column": 1,
+          "line": 3
+        },
+        "ty": {
+          "Array": [
+            "Int",
+            null
+          ]
+        }
+      }
+    },
+    {
+      "Print": {
+        "expr": {
+          "Call": {
+            "args": [
+              {
+                "Slice": {
+                  "base": {
+                    "VarRef": {
+                      "name": "numbers",
+                      "ty": {
+                        "Array": [
+                          "Int",
+                          null
+                        ]
+                      }
+                    }
+                  },
+                  "end": null,
+                  "start": null,
+                  "ty": {
+                    "Slice": "Int"
+                  }
+                }
+              }
+            ],
+            "name": "std_collections_count__int",
+            "ty": "Int"
+          }
+        },
+        "span": {
+          "column": 1,
+          "line": 4
+        }
+      }
+    },
+    {
+      "Print": {
+        "expr": {
+          "Call": {
+            "args": [
+              {
+                "Slice": {
+                  "base": {
+                    "VarRef": {
+                      "name": "numbers",
+                      "ty": {
+                        "Array": [
+                          "Int",
+                          null
+                        ]
+                      }
+                    }
+                  },
+                  "end": null,
+                  "start": null,
+                  "ty": {
+                    "Slice": "Int"
+                  }
+                }
+              }
+            ],
+            "name": "std_collections_is_empty__int",
+            "ty": "Bool"
+          }
+        },
+        "span": {
+          "column": 1,
+          "line": 5
+        }
+      }
+    },
+    {
+      "Print": {
+        "expr": {
+          "Call": {
+            "args": [
+              {
+                "Slice": {
+                  "base": {
+                    "VarRef": {
+                      "name": "numbers",
+                      "ty": {
+                        "Array": [
+                          "Int",
+                          null
+                        ]
+                      }
+                    }
+                  },
+                  "end": null,
+                  "start": null,
+                  "ty": {
+                    "Slice": "Int"
+                  }
+                }
+              }
+            ],
+            "name": "std_collections_has_items__int",
+            "ty": "Bool"
+          }
+        },
+        "span": {
+          "column": 1,
+          "line": 6
+        }
+      }
+    },
+    {
+      "Let": {
+        "expr": {
+          "Call": {
+            "args": [
+              {
+                "Slice": {
+                  "base": {
+                    "VarRef": {
+                      "name": "numbers",
+                      "ty": {
+                        "Array": [
+                          "Int",
+                          null
+                        ]
+                      }
+                    }
+                  },
+                  "end": null,
+                  "start": null,
+                  "ty": {
+                    "Slice": "Int"
+                  }
+                }
+              },
+              {
+                "Literal": {
+                  "Int": 1
+                }
+              },
+              {
+                "Literal": {
+                  "Int": 3
+                }
+              }
+            ],
+            "name": "std_collections_window__int",
+            "ty": {
+              "Slice": "Int"
+            }
+          }
+        },
+        "name": "middle",
+        "span": {
+          "column": 1,
+          "line": 8
+        },
+        "ty": {
+          "Slice": "Int"
+        }
+      }
+    },
+    {
+      "Print": {
+        "expr": {
+          "Call": {
+            "args": [
+              {
+                "VarRef": {
+                  "name": "middle",
+                  "ty": {
+                    "Slice": "Int"
+                  }
+                }
+              }
+            ],
+            "name": "std_collections_count__int",
+            "ty": "Int"
+          }
+        },
+        "span": {
+          "column": 1,
+          "line": 9
+        }
+      }
+    },
+    {
+      "Print": {
+        "expr": {
+          "Call": {
+            "args": [
+              {
+                "VarRef": {
+                  "name": "middle",
+                  "ty": {
+                    "Slice": "Int"
+                  }
+                }
+              }
+            ],
+            "name": "first",
+            "ty": "Int"
+          }
+        },
+        "span": {
+          "column": 1,
+          "line": 10
+        }
+      }
+    },
+    {
+      "Print": {
+        "expr": {
+          "Call": {
+            "args": [
+              {
+                "VarRef": {
+                  "name": "middle",
+                  "ty": {
+                    "Slice": "Int"
+                  }
+                }
+              }
+            ],
+            "name": "last",
+            "ty": "Int"
+          }
+        },
+        "span": {
+          "column": 1,
+          "line": 11
+        }
+      }
+    },
+    {
+      "Let": {
+        "expr": {
+          "Call": {
+            "args": [
+              {
+                "Slice": {
+                  "base": {
+                    "VarRef": {
+                      "name": "numbers",
+                      "ty": {
+                        "Array": [
+                          "Int",
+                          null
+                        ]
+                      }
+                    }
+                  },
+                  "end": null,
+                  "start": null,
+                  "ty": {
+                    "Slice": "Int"
+                  }
+                }
+              },
+              {
+                "Literal": {
+                  "Int": 2
+                }
+              }
+            ],
+            "name": "std_collections_take__int",
+            "ty": {
+              "Slice": "Int"
+            }
+          }
+        },
+        "name": "prefix",
+        "span": {
+          "column": 1,
+          "line": 13
+        },
+        "ty": {
+          "Slice": "Int"
+        }
+      }
+    },
+    {
+      "Print": {
+        "expr": {
+          "Call": {
+            "args": [
+              {
+                "VarRef": {
+                  "name": "prefix",
+                  "ty": {
+                    "Slice": "Int"
+                  }
+                }
+              }
+            ],
+            "name": "last",
+            "ty": "Int"
+          }
+        },
+        "span": {
+          "column": 1,
+          "line": 14
+        }
+      }
+    },
+    {
+      "Let": {
+        "expr": {
+          "Call": {
+            "args": [
+              {
+                "Slice": {
+                  "base": {
+                    "VarRef": {
+                      "name": "numbers",
+                      "ty": {
+                        "Array": [
+                          "Int",
+                          null
+                        ]
+                      }
+                    }
+                  },
+                  "end": null,
+                  "start": null,
+                  "ty": {
+                    "Slice": "Int"
+                  }
+                }
+              },
+              {
+                "Literal": {
+                  "Int": 2
+                }
+              }
+            ],
+            "name": "std_collections_skip__int",
+            "ty": {
+              "Slice": "Int"
+            }
+          }
+        },
+        "name": "suffix",
+        "span": {
+          "column": 1,
+          "line": 16
+        },
+        "ty": {
+          "Slice": "Int"
+        }
+      }
+    },
+    {
+      "Print": {
+        "expr": {
+          "Call": {
+            "args": [
+              {
+                "VarRef": {
+                  "name": "suffix",
+                  "ty": {
+                    "Slice": "Int"
+                  }
+                }
+              }
+            ],
+            "name": "first",
+            "ty": "Int"
+          }
+        },
+        "span": {
+          "column": 1,
+          "line": 17
+        }
+      }
+    },
+    {
+      "Let": {
+        "expr": {
+          "ArrayLiteral": {
+            "elements": [
+              {
+                "Literal": {
+                  "String": "build"
+                }
+              },
+              {
+                "Literal": {
+                  "String": "test"
+                }
+              },
+              {
+                "Literal": {
+                  "String": "ship"
+                }
+              }
+            ],
+            "ty": {
+              "Array": [
+                "String",
+                3
+              ]
+            }
+          }
+        },
+        "name": "words",
+        "span": {
+          "column": 1,
+          "line": 19
+        },
+        "ty": {
+          "Array": [
+            "String",
+            null
+          ]
+        }
+      }
+    },
+    {
+      "Print": {
+        "expr": {
+          "Call": {
+            "args": [
+              {
+                "Slice": {
+                  "base": {
+                    "VarRef": {
+                      "name": "words",
+                      "ty": {
+                        "Array": [
+                          "String",
+                          null
+                        ]
+                      }
+                    }
+                  },
+                  "end": null,
+                  "start": null,
+                  "ty": {
+                    "Slice": "String"
+                  }
+                }
+              }
+            ],
+            "name": "std_collections_count__string",
+            "ty": "Int"
+          }
+        },
+        "span": {
+          "column": 1,
+          "line": 20
+        }
+      }
+    },
+    {
+      "Let": {
+        "expr": {
+          "Call": {
+            "args": [
+              {
+                "Slice": {
+                  "base": {
+                    "VarRef": {
+                      "name": "words",
+                      "ty": {
+                        "Array": [
+                          "String",
+                          null
+                        ]
+                      }
+                    }
+                  },
+                  "end": null,
+                  "start": null,
+                  "ty": {
+                    "Slice": "String"
+                  }
+                }
+              },
+              {
+                "Literal": {
+                  "Int": 0
+                }
+              }
+            ],
+            "name": "std_collections_take__string",
+            "ty": {
+              "Slice": "String"
+            }
+          }
+        },
+        "name": "empty_words",
+        "span": {
+          "column": 1,
+          "line": 21
+        },
+        "ty": {
+          "Slice": "String"
+        }
+      }
+    },
+    {
+      "Print": {
+        "expr": {
+          "Call": {
+            "args": [
+              {
+                "VarRef": {
+                  "name": "empty_words",
+                  "ty": {
+                    "Slice": "String"
+                  }
+                }
+              }
+            ],
+            "name": "std_collections_is_empty__string",
+            "ty": "Bool"
+          }
+        },
+        "span": {
+          "column": 1,
+          "line": 22
+        }
+      }
+    }
+  ],
+  "structs": []
+}


### PR DESCRIPTION
## Summary
- add a public project-analysis helper for lowering a package root to MIR without codegen
- add a representative MIR snapshot integration test for hello, modules, borrowed_shapes, generic_aggregates, and stdlib_collections examples
- check in normalized MIR JSON snapshots with example-root paths replaced by `<example>`

Fixes #355

## Checks
- `cargo test -p axiomc --test mir_example_snapshots -- --nocapture`
- after rebase onto latest `origin/main`: `cargo test -p axiomc --test mir_example_snapshots -- --nocapture`

## Merge Automation
- Auto-merge enabled with squash merge.
