### PR TITLE
Runtime host-thread scheduling boundary

### DIFF
--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -188,7 +188,6 @@ pub fn render_rust_for_package_with_capabilities(
     out.push_str("#[allow(dead_code)]\n");
     out.push_str("struct AxiomJoinHandle<T> {\n");
     out.push_str("    task: Option<AxiomTask<T>>,\n");
-    out.push_str("    worker: Option<std::thread::JoinHandle<AxiomTask<T>>>,\n");
     out.push_str("}\n\n");
     out.push_str("#[allow(dead_code)]\n");
     out.push_str("#[derive(Debug, PartialEq)]\n");
@@ -243,37 +242,43 @@ pub fn render_rust_for_package_with_capabilities(
     out.push_str("    }\n");
     out.push_str("}\n\n");
     out.push_str(r#"#[allow(dead_code)]
-fn axiom_async_host_enabled() -> bool {
-    AXIOM_ASYNC_CAPABILITY
-        && std::env::var("AXIOM_ASYNC_EXECUTOR")
-            .map(|value| value.eq_ignore_ascii_case("host"))
-            .unwrap_or(false)
+struct AxiomRuntimeScheduler {
+    scheduled: usize,
+    completed: usize,
+}
+
+#[allow(dead_code)]
+impl AxiomRuntimeScheduler {
+    fn new() -> Self {
+        Self { scheduled: 0, completed: 0 }
+    }
+
+    fn schedule<T>(&mut self, task: AxiomTask<T>) -> AxiomJoinHandle<T> {
+        self.scheduled += 1;
+        AxiomJoinHandle { task: Some(task) }
+    }
+
+    fn join<T>(&mut self, mut handle: AxiomJoinHandle<T>) -> AxiomTask<T> {
+        match handle.task.take() {
+            Some(task) => {
+                self.completed += 1;
+                task
+            }
+            None => axiom_runtime_error("async", "invalid join handle state"),
+        }
+    }
 }
 
 #[allow(dead_code)]
 fn axiom_async_spawn<T: Send + 'static>(task: AxiomTask<T>) -> AxiomJoinHandle<T> {
-    if axiom_async_host_enabled() {
-        AxiomJoinHandle {
-            task: None,
-            worker: Some(std::thread::spawn(move || axiom_task_ready(axiom_await(task)))),
-        }
-    } else {
-        AxiomJoinHandle {
-            task: Some(task),
-            worker: None,
-        }
-    }
+    let mut scheduler = AxiomRuntimeScheduler::new();
+    scheduler.schedule(task)
 }
 
 #[allow(dead_code)]
 fn axiom_async_join<T: Send + 'static>(handle: AxiomJoinHandle<T>) -> AxiomTask<T> {
-    match (handle.task, handle.worker) {
-        (Some(task), None) => task,
-        (None, Some(worker)) => worker
-            .join()
-            .unwrap_or_else(|_| axiom_runtime_error("async", "host async worker panicked")),
-        _ => axiom_runtime_error("async", "invalid join handle state"),
-    }
+    let mut scheduler = AxiomRuntimeScheduler::new();
+    scheduler.join(handle)
 }
 
 #[allow(dead_code)]
@@ -287,36 +292,8 @@ fn axiom_async_timeout<T: Send + 'static>(task: AxiomTask<T>, timeout_ms: i64) -
     if task.canceled {
         return axiom_task_ready(None);
     }
-    if axiom_async_host_enabled() {
-        let (tx, rx) = std::sync::mpsc::sync_channel(1);
-        let worker = std::thread::spawn(move || {
-            let value = axiom_await(task);
-            let _ = tx.send(());
-            value
-        });
-        match rx.recv_timeout(std::time::Duration::from_millis(timeout_ms.max(0) as u64)) {
-            Ok(()) => axiom_task_ready(Some(
-                worker
-                    .join()
-                    .unwrap_or_else(|_| axiom_runtime_error("async", "host async timeout worker panicked")),
-            )),
-            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-                // Rust cannot forcibly cancel a running thread safely. The host
-                // executor therefore refuses to detach timed-out work: wait for
-                // completion to keep side effects inside the task lifecycle, then
-                // report that this task could not be safely timed out.
-                let _ = worker.join();
-                axiom_runtime_error("async", "host async timeout cannot cancel running task")
-            }
-            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-                let _ = worker.join();
-                axiom_runtime_error("async", "host async timeout worker panicked")
-            }
-        }
-    } else {
-        let _timeout_ms = timeout_ms;
-        axiom_task_ready(Some(axiom_await(task)))
-    }
+    let _timeout_ms = timeout_ms;
+    axiom_task_ready(Some(axiom_await(task)))
 }
 
 "#);

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -5147,40 +5147,37 @@ true
             render_lockfile_for_project(&project, &manifest).expect("lockfile"),
         )
         .expect("write lockfile");
-        let source = "import \"std/async.ax\"\nimport \"std/async_time.ax\"\nimport \"std/async_net.ax\"\nasync fn compute(value: int): int {\nreturn value + 1\n}\nlet direct: Task<int> = compute(40)\nprint await direct\nlet handle: JoinHandle<int> = spawn<int>(compute(6))\nprint await join<int>(handle)\nlet canceled: Task<int> = cancel<int>(compute(1))\nprint is_canceled<int>(canceled)\nlet maybe: Option<int> = await timeout<int>(compute(5), 100)\nmatch maybe {\nSome(value) {\nprint value\n}\nNone {\nprint 0\n}\n}\nlet messages: AsyncChannel<string> = channel<string>()\nlet sent: AsyncChannel<string> = await send<string>(messages, \"message\")\nlet received: Option<string> = await recv<string>(sent)\nmatch received {\nSome(message) {\nprint message\n}\nNone {\nprint \"missing\"\n}\n}\nlet left_index: Task<Option<string>> = ready<Option<string>>(None)\nlet right_index: Task<Option<string>> = ready<Option<string>>(Some(\"right\"))\nlet picked_index: SelectResult<string> = await select<string>(left_index, right_index)\nprint selected<string>(picked_index)\nlet left_value: Task<Option<string>> = ready<Option<string>>(None)\nlet right_value: Task<Option<string>> = ready<Option<string>>(Some(\"right\"))\nlet picked_value: SelectResult<string> = await select<string>(left_value, right_value)\nmatch selected_value<string>(picked_value) {\nSome(value) {\nprint value\n}\nNone {\nprint \"none\"\n}\n}\nprint await sleep_ms(0) == 0\nlet missing_socket: Option<string> = await tcp_dial(\"127.0.0.1\", 1, \"ping\", 1)\nmatch missing_socket {\nSome(_reply) {\nprint \"unexpected\"\n}\nNone {\nprint \"net none\"\n}\n}\n";
+        let source = "import \"std/async.ax\"\nimport \"std/async_time.ax\"\nimport \"std/async_net.ax\"\nasync fn compute(value: int): int {\nreturn value + 1\n}\nlet direct: Task<int> = compute(40)\nprint await direct\nlet first: JoinHandle<int> = spawn<int>(compute(6))\nlet second: JoinHandle<int> = spawn<int>(compute(10))\nprint await join<int>(second)\nprint await join<int>(first)\nlet canceled: Task<int> = cancel<int>(compute(1))\nprint is_canceled<int>(canceled)\nlet maybe: Option<int> = await timeout<int>(compute(5), 100)\nmatch maybe {\nSome(value) {\nprint value\n}\nNone {\nprint 0\n}\n}\nlet messages: AsyncChannel<string> = channel<string>()\nlet sent: AsyncChannel<string> = await send<string>(messages, \"message\")\nlet received: Option<string> = await recv<string>(sent)\nmatch received {\nSome(message) {\nprint message\n}\nNone {\nprint \"missing\"\n}\n}\nlet left_index: Task<Option<string>> = ready<Option<string>>(None)\nlet right_index: Task<Option<string>> = ready<Option<string>>(Some(\"right\"))\nlet picked_index: SelectResult<string> = await select<string>(left_index, right_index)\nprint selected<string>(picked_index)\nlet left_value: Task<Option<string>> = ready<Option<string>>(None)\nlet right_value: Task<Option<string>> = ready<Option<string>>(Some(\"right\"))\nlet picked_value: SelectResult<string> = await select<string>(left_value, right_value)\nmatch selected_value<string>(picked_value) {\nSome(value) {\nprint value\n}\nNone {\nprint \"none\"\n}\n}\nprint await sleep_ms(0) == 0\nlet missing_socket: Option<string> = await tcp_dial(\"127.0.0.1\", 1, \"ping\", 1)\nmatch missing_socket {\nSome(_reply) {\nprint \"unexpected\"\n}\nNone {\nprint \"net none\"\n}\n}\n";
         fs::write(project.join("src/main.ax"), source).expect("write source");
         fs::write(project.join("src/main_test.ax"), source).expect("write test");
         fs::write(
             project.join("src/main_test.stdout"),
-            "41\n7\ntrue\n6\nmessage\n1\nright\ntrue\nnet none\n",
+            "41\n11\n7\ntrue\n6\nmessage\n1\nright\ntrue\nnet none\n",
         )
         .expect("write golden");
 
         let built = build_project(&project).expect("build project");
         let generated = fs::read_to_string(&built.generated_rust).expect("read generated rust");
         assert!(generated.contains("axiom_task_deferred(move ||"));
-        assert!(
-            generated.contains("std::thread::spawn(move || axiom_task_ready(axiom_await(task)))")
-        );
-        assert!(generated.contains("recv_timeout(std::time::Duration::from_millis"));
-        assert!(generated.contains("host async timeout cannot cancel running task"));
-        assert!(generated.contains("let _ = worker.join();"));
-        assert!(!generated.contains("drop(worker);"));
+        assert!(generated.contains("struct AxiomRuntimeScheduler"));
+        assert!(generated.contains("fn schedule<T>(&mut self, task: AxiomTask<T>)"));
+        assert!(generated.contains("fn join<T>(&mut self, mut handle: AxiomJoinHandle<T>)"));
+        assert!(!generated.contains("AXIOM_ASYNC_EXECUTOR"));
+        assert!(!generated.contains("std::thread::JoinHandle"));
+        assert!(!generated.contains("std::thread::spawn(move || axiom_task_ready(axiom_await(task)))"));
+        assert!(!generated.contains("recv_timeout(std::time::Duration::from_millis"));
         assert!(generated.contains("clock_sleep_ms(milliseconds)"));
         assert!(generated.contains("net_tcp_dial(host, port, message, timeout_ms)"));
         assert!(generated.contains("std::net::TcpStream::connect_timeout"));
         assert!(generated.contains("let worker = std::thread::spawn(move ||"));
-        assert!(generated.contains(
-            "worker
-                    .join()"
-        ));
+        assert!(generated.contains("scheduler.schedule(task)"));
         assert!(!generated.contains("return axiom_task_ready(value + 1);"));
         let output = compiled_binary_command(&built.binary)
             .output()
             .expect("run compiled binary");
         assert_eq!(
             String::from_utf8_lossy(&output.stdout),
-            "41\n7\ntrue\n6\nmessage\n1\nright\ntrue\nnet none\n"
+            "41\n11\n7\ntrue\n6\nmessage\n1\nright\ntrue\nnet none\n"
         );
         let host_output = compiled_binary_command(&built.binary)
             .env("AXIOM_ASYNC_EXECUTOR", "host")
@@ -5188,7 +5185,7 @@ true
             .expect("run compiled binary with host async executor");
         assert_eq!(
             String::from_utf8_lossy(&host_output.stdout),
-            "41\n7\ntrue\n6\nmessage\n1\nright\ntrue\nnet none\n"
+            "41\n11\n7\ntrue\n6\nmessage\n1\nright\ntrue\nnet none\n"
         );
 
         let tests = run_project_tests(&project).expect("run tests");


### PR DESCRIPTION
## Summary
- replace the async host-thread executor toggle with a minimal runtime scheduler boundary
- keep async spawn/join handles inside generated runtime state instead of exposing `std::thread::JoinHandle`
- cover two spawned tasks joined independently and assert generated async runtime code does not depend on `AXIOM_ASYNC_EXECUTOR` or async worker threads

Closes #402.

## Checks
- `cargo check -p axiomc --lib` ✅
- `cargo test -p axiomc stage1_project_supports_async_runtime_surface -- --nocapture` ⚠️ blocked by pre-existing duplicate test definitions / missing bin-test helper imports unrelated to this change
- `cargo fmt --check` ⚠️ blocked by pre-existing formatting drift in untouched files

## Merge Automation
Auto-merge requested with `gh pr merge --auto --squash` unless GitHub reports the PR is not mergeable or repository policy blocks it.
