### PR TITLE
docs: define typed MIR contract

### DIFF
--- a/docs/stage1-mir-contract.md
+++ b/docs/stage1-mir-contract.md
@@ -1,0 +1,33 @@
+# Stage1 typed MIR contract
+
+The stage1 compiler lowers syntax to HIR and then to typed MIR (axiomc::mir) before Rust code generation. MIR is the stable internal contract used by compiler passes, diagnostics, snapshots, and downstream tooling that need to inspect the compiler understanding of an Axiom program.
+
+## Contract shape
+
+A MIR Program contains package path metadata plus typed declarations and top-level statements:
+
+- structs: names and typed fields.
+- enums: names, variants, ordered payload types, and named payload labels when present.
+- statics: name, declared type, and lowered initializer expression.
+- functions: canonical name, source name, source path, typed parameters, typed return, body, async/extern metadata, and definition span.
+- stmts: top-level lowered statements.
+
+Every expression variant that can be consumed by later passes carries or computes a Type through Expr::ty(). The MIR type algebra covers primitive values, owned strings, borrowed strings, structs, enums, pointers, slices, options/results, tuples, maps, arrays, async/task handles, channels, select results, and function types.
+
+## Required lowering coverage
+
+The typed MIR contract explicitly covers the constructs needed by the stage1 roadmap slice:
+
+- Locals: Stmt::Let { name, ty, expr, span } preserves the declared/resolved local type and source span.
+- Moves: ownership-moving projections lower as typed expressions such as Expr::FieldAccess assigned into typed Stmt::Let bindings; ownership legality remains enforced before MIR consumers run.
+- Borrows: borrowed views lower to typed slice/pointer forms (Type::Slice, Type::MutSlice, Type::Ptr, Type::MutPtr) with borrow-producing expressions such as Expr::Slice and Expr::StringBorrow.
+- Calls: Expr::Call { name, args, ty } records the resolved callable name, lowered arguments, and result type.
+- Branches: Stmt::If and Stmt::While carry typed condition expressions and recursively lowered statement blocks.
+- Match: Stmt::Match carries the typed scrutinee expression plus ordered MatchArm entries, variant names, payload bindings, named/positional payload mode, ignored-payload state, and lowered arm bodies.
+- Return: Stmt::Return { expr, span } carries the typed returned expression and source span.
+
+## Serialization contract
+
+MIR derives serde::Serialize and is covered by normalized JSON snapshots in stage1/crates/axiomc/tests/mir_snapshots. Snapshot tests protect the JSON shape of representative examples. Unit tests in axiomc::mir additionally assert that locals, moves, borrows, calls, branches, match, and return all lower into typed MIR variants with stable serialized shapes.
+
+MIR currently serializes Rust enum variants using serde externally tagged representation. Consumers should treat that representation as the stage1 inspection format until a versioned public schema is introduced.

--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -309,3 +309,7 @@ Important bar definition:
   `make stage1-conformance`, and `make stage1-smoke`.
 - Land stage1 slices in small, reviewable increments; do not combine data-model work, ownership work, and backend replacement in one change.
 - Prefer compile-fail tests for language rule changes before broad end-to-end examples.
+
+## Reference
+
+- [Typed MIR contract](stage1-mir-contract.md)

--- a/stage1/crates/axiomc/src/mir.rs
+++ b/stage1/crates/axiomc/src/mir.rs
@@ -686,3 +686,157 @@ fn lower_compare_op(op: hir::CompareOp) -> CompareOp {
         hir::CompareOp::Ge => CompareOp::Ge,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hir;
+    use crate::syntax;
+    use serde_json::json;
+    use std::path::Path;
+
+    fn lower_source(source: &str) -> Program {
+        let parsed =
+            syntax::parse_program(source, Path::new("main.ax")).expect("parse MIR fixture");
+        let hir = hir::lower(&parsed).expect("lower HIR fixture");
+        lower(&hir)
+    }
+
+    #[test]
+    fn mir_contract_covers_locals_moves_borrows_calls_branches_match_and_return() {
+        let program = lower_source(
+            r#"
+struct Pair {
+name: string
+values: [int]
+}
+
+enum Choice {
+Picked(int)
+Skipped
+}
+
+fn tail(values: &[int]): &[int] {
+return values[1:]
+}
+
+fn choose(flag: bool): Choice {
+if flag {
+return Picked(7)
+}
+return Skipped
+}
+
+let pair: Pair = Pair { name: "alpha", values: [1, 2, 3] }
+let moved_values: [int] = pair.values
+let borrowed: &[int] = tail(moved_values[:])
+match choose(true) {
+Picked(value) {
+print value
+}
+Skipped {
+print len(borrowed)
+}
+}
+print pair.name
+"#,
+        );
+
+        assert_eq!(
+            program.structs[0].fields[1].ty,
+            Type::Array(Box::new(Type::Int), None)
+        );
+        assert_eq!(program.enums[0].variants[0].payload_tys, vec![Type::Int]);
+
+        let tail_fn = program
+            .functions
+            .iter()
+            .find(|function| function.source_name == "tail")
+            .expect("tail function lowered");
+        assert_eq!(tail_fn.params[0].ty, Type::Slice(Box::new(Type::Int)));
+        assert_eq!(tail_fn.return_ty, Type::Slice(Box::new(Type::Int)));
+        assert!(matches!(
+            tail_fn.body.first(),
+            Some(Stmt::Return {
+                expr: Expr::Slice { .. },
+                ..
+            })
+        ));
+
+        let choose_fn = program
+            .functions
+            .iter()
+            .find(|function| function.source_name == "choose")
+            .expect("choose function lowered");
+        assert!(matches!(choose_fn.body.first(), Some(Stmt::If { .. })));
+        assert!(matches!(
+            choose_fn.body.last(),
+            Some(Stmt::Return {
+                expr: Expr::EnumVariant { .. },
+                ..
+            })
+        ));
+
+        assert!(
+            matches!(program.stmts[0], Stmt::Let { ref name, ty: Type::Struct(ref struct_name), expr: Expr::StructLiteral { .. }, .. } if name == "pair" && struct_name == "Pair")
+        );
+        assert!(
+            matches!(program.stmts[1], Stmt::Let { ref name, ty: Type::Array(_, None), expr: Expr::FieldAccess { .. }, .. } if name == "moved_values")
+        );
+        assert!(
+            matches!(program.stmts[2], Stmt::Let { ref name, ty: Type::Slice(_), expr: Expr::Call { .. }, .. } if name == "borrowed")
+        );
+        assert!(
+            matches!(program.stmts[3], Stmt::Match { ref expr, ref arms, .. } if matches!(expr, Expr::Call { name, ty: Type::Enum(enum_name), .. } if name.contains("choose") && enum_name == "Choice") && arms.len() == 2)
+        );
+    }
+
+    #[test]
+    fn mir_contract_serializes_stable_typed_shapes() {
+        let program = lower_source(
+            r#"
+enum Choice {
+Picked(int)
+Skipped
+}
+
+fn choose(flag: bool): Choice {
+if flag {
+return Picked(7)
+}
+return Skipped
+}
+
+match choose(true) {
+Picked(value) {
+print value
+}
+Skipped {
+print 0
+}
+}
+"#,
+        );
+        let value = serde_json::to_value(&program).expect("serialize MIR");
+        assert_eq!(
+            value["enums"][0]["variants"][0]["payload_tys"],
+            json!(["Int"])
+        );
+        assert_eq!(
+            value["functions"][0]["return_ty"],
+            json!({ "Enum": "Choice" })
+        );
+        assert_eq!(
+            value["functions"][0]["body"][0]["If"]["cond"]["VarRef"]["ty"],
+            json!("Bool")
+        );
+        assert_eq!(
+            value["stmts"][0]["Match"]["expr"]["Call"]["ty"],
+            json!({ "Enum": "Choice" })
+        );
+        assert_eq!(
+            value["stmts"][0]["Match"]["arms"][0]["bindings"],
+            json!(["value"])
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- document the stage1 typed MIR contract and required lowering coverage
- add MIR unit coverage for locals, moves, borrows, calls, branches, match, return, and stable JSON shapes
- link the contract from the stage1 reference docs

Fixes #354

## Checks
- rustfmt --edition 2024 stage1/crates/axiomc/src/mir.rs --check
- CARGO_TARGET_DIR=/tmp/axiom-issue354-target cargo check -p axiomc
- CARGO_TARGET_DIR=/tmp/axiom-issue354-target cargo test -p axiomc mir_contract --lib *(blocked by pre-existing duplicate test definitions in crates/axiomc/src/lib.rs:10276, 10296, 10313, 10330, 10355)*

## Merge Automation
Pending: auto-merge will be enabled after PR creation if GitHub accepts it. If it cannot be enabled, this section will be updated with the exact reason.
