### PR TITLE
feat(stage1): add deterministic service test fixtures

### DIFF
--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -6004,6 +6004,7 @@ print serve_once("127.0.0.1:18080", "hello")
                 stderr: None,
                 kind: TestKind::Unit,
                 expected_error: None,
+                http: None,
                 capabilities: Vec::new(),
                 package: None,
             }]
@@ -6132,6 +6133,47 @@ print serve_once("127.0.0.1:18080", "hello")
                 .iter()
                 .any(|case| case.entry == "src/main_test.ax")
         );
+    }
+
+    #[test]
+    fn run_project_tests_supports_local_http_fixture_runner() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("service-runner");
+        create_project(&project, Some("service-runner-app")).expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            format!(
+                "{}\n[[tests]]\nname = \"service-smoke\"\nentry = \"src/service_test.ax\"\nstdout = \"true\\n\"\ncapabilities = [\"net\", \"env\"]\nhttp = {{ path = \"/health\", expected_body = \"ok\" }}\n",
+                render_manifest("service-runner-app")
+            ),
+        )
+        .expect("write manifest");
+        fs::write(
+            project.join("src/service_test.ax"),
+            r#"import "std/env.ax"
+import "std/http.ax"
+
+match get_env("AXIOM_TEST_BIND") {
+Some(bind) {
+print serve_once(bind, "ok")
+}
+None {
+print false
+}
+}
+"#,
+        )
+        .expect("write service test");
+
+        let output = run_project_tests(&project).expect("run tests");
+        let service_case = output
+            .cases
+            .iter()
+            .find(|case| case.name == "service-smoke")
+            .expect("service case");
+        assert!(service_case.ok, "service case failed: {service_case:?}");
+        assert_eq!(service_case.stdout, "true\n");
+        assert_eq!(output.failed, 0);
     }
 
     #[test]

--- a/stage1/crates/axiomc/src/manifest.rs
+++ b/stage1/crates/axiomc/src/manifest.rs
@@ -68,8 +68,15 @@ pub struct TestTarget {
     pub stderr: Option<String>,
     pub kind: TestKind,
     pub expected_error: Option<ExpectedDiagnostic>,
+    pub http: Option<HttpTestFixture>,
     pub capabilities: Vec<CapabilityKind>,
     pub package: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HttpTestFixture {
+    pub path: String,
+    pub expected_body: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -214,6 +221,7 @@ struct RawTestTarget {
     stderr: Option<String>,
     kind: Option<String>,
     expected_error: Option<ExpectedDiagnostic>,
+    http: Option<HttpTestFixture>,
     capabilities: Option<Vec<CapabilityKind>>,
     package: Option<String>,
 }
@@ -947,6 +955,7 @@ fn normalize_tests(
             stderr: raw_test.stderr,
             kind: normalize_test_kind(raw_test.kind, path, &format!("{field_prefix}.kind"))?,
             expected_error: raw_test.expected_error,
+            http: raw_test.http,
             capabilities,
             package,
         });

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -17,10 +17,10 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::env;
 use std::fs;
-use std::io;
+use std::io::{self, Read, Write};
 use std::path::{Component, Path, PathBuf};
-use std::process::Command;
-use std::time::Instant;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
 
 const BUILD_CACHE_VERSION: u32 = 1;
 const BUILD_CACHE_COMPILER: &str = concat!("axiomc-stage1-", env!("CARGO_PKG_VERSION"));
@@ -748,6 +748,7 @@ fn collect_discovered_tests(
             stderr,
             kind,
             expected_error: None,
+            http: None,
             capabilities: Vec::new(),
             package: None,
         });
@@ -1948,9 +1949,14 @@ fn run_test_case(
     }
 
     let build_output_dir = out_dir_path(project_root, manifest);
-    match command_for_build_output(&binary, &build_output_dir)
-        .and_then(|mut command| command.output())
-    {
+    let command_result = if test.http.is_some() {
+        run_http_fixture_case(&binary, &build_output_dir, test)
+    } else {
+        command_for_build_output(&binary, &build_output_dir)
+            .and_then(|mut command| command.output())
+    };
+
+    match command_result {
         Ok(output) => {
             let stdout = String::from_utf8_lossy(&output.stdout).to_string();
             let stderr = String::from_utf8_lossy(&output.stderr).to_string();
@@ -2061,6 +2067,63 @@ fn run_test_case(
             ),
         },
     }
+}
+
+fn run_http_fixture_case(
+    binary: &Path,
+    build_output_dir: &Path,
+    test: &crate::manifest::TestTarget,
+) -> io::Result<std::process::Output> {
+    let fixture = test.http.as_ref().expect("http fixture present");
+    let listener = std::net::TcpListener::bind(("127.0.0.1", 0))?;
+    let port = listener.local_addr()?.port();
+    drop(listener);
+
+    let mut command = command_for_build_output(binary, build_output_dir)?;
+    command
+        .env("AXIOM_TEST_BIND", format!("127.0.0.1:{port}"))
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = command.spawn()?;
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut stream = loop {
+        match std::net::TcpStream::connect(("127.0.0.1", port)) {
+            Ok(stream) => break stream,
+            Err(err) if Instant::now() < deadline => {
+                let _ = err;
+                std::thread::sleep(Duration::from_millis(25));
+            }
+            Err(err) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    format!("http fixture service never became ready: {err}"),
+                ));
+            }
+        }
+    };
+
+    let path = if fixture.path.starts_with('/') {
+        fixture.path.clone()
+    } else {
+        format!("/{}", fixture.path)
+    };
+    stream.write_all(format!("GET {path} HTTP/1.0\r\nHost: 127.0.0.1\r\n\r\n").as_bytes())?;
+    let mut response = String::new();
+    stream.read_to_string(&mut response)?;
+    let body = response.split("\r\n\r\n").nth(1).unwrap_or("");
+    if body != fixture.expected_body {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(io::Error::other(format!(
+            "http response body expected {:?}, got {:?}",
+            fixture.expected_body, body
+        )));
+    }
+
+    child.wait_with_output()
 }
 
 fn run_compile_fail_case(
@@ -5670,6 +5733,7 @@ mod tests {
                 stderr: None,
                 kind: TestKind::Unit,
                 expected_error: None,
+                http: None,
                 capabilities: Vec::new(),
                 package: None,
             },
@@ -5680,6 +5744,7 @@ mod tests {
                 stderr: None,
                 kind: TestKind::Benchmark,
                 expected_error: None,
+                http: None,
                 capabilities: Vec::new(),
                 package: None,
             },


### PR DESCRIPTION
## Summary
- add an `http` test fixture contract for `axiomc test` manifest cases
- run service tests on ephemeral `127.0.0.1` ports via `AXIOM_TEST_BIND`
- issue one deterministic local HTTP request, assert the response body, then wait for clean service shutdown

Closes #399.

## Checks
- `cargo check --manifest-path stage1/Cargo.toml -p axiomc --lib`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc run_project_tests_supports_local_http_fixture_runner --lib` *(blocked by pre-existing duplicate lib test definitions on `origin/main`: static-global tests are defined twice)*

## Merge Automation
Auto-merge requested where GitHub permits it.
