### PR TITLE
feat(stage1): add typed HTTP service values

### DIFF
--- a/stage1/crates/axiomc/src/stdlib.rs
+++ b/stage1/crates/axiomc/src/stdlib.rs
@@ -299,12 +299,55 @@ pub fn snapshot(name: string, actual: string, expected: string): int {\nreturn a
     ),
     (
         "http.ax",
-        "pub struct HttpRoute {\npath: string\nbody: string\n}\n\
-pub fn get(url: string): Option<string> {\nreturn http_get(url)\n}\n\
-pub fn route(path: string, body: string): HttpRoute {\nreturn HttpRoute { path: path, body: body }\n}\n\
-pub fn respond(body: string): HttpRoute {\nreturn route(\"/\", body)\n}\n\
-pub fn serve(bind: string, selected_route: HttpRoute, max_requests: int): bool {\nreturn http_serve_route(bind, selected_route.path, selected_route.body, max_requests)\n}\n\
-pub fn serve_once(bind: string, body: string): bool {\nreturn http_serve_once(bind, body)\n}\n",
+        "pub struct HttpHeader {
+name: string
+value: string
+}
+pub struct HttpRequest {
+method: string
+path: string
+body: string
+}
+pub struct HttpResponse {
+status: int
+body: string
+headers: [HttpHeader]
+}
+pub struct HttpRoute {
+path: string
+response: HttpResponse
+}
+pub fn get(url: string): Option<string> {
+return http_get(url)
+}
+pub fn header(name: string, value: string): HttpHeader {
+return HttpHeader { name: name, value: value }
+}
+pub fn request(method: string, path: string, body: string): HttpRequest {
+return HttpRequest { method: method, path: path, body: body }
+}
+pub fn response(status: int, body: string, headers: [HttpHeader]): HttpResponse {
+return HttpResponse { status: status, body: body, headers: headers }
+}
+pub fn text_response(status: int, body: string): HttpResponse {
+return response(status, body, [header(\"content-type\", \"text/plain; charset=utf-8\")])
+}
+pub fn route(path: string, body: string): HttpRoute {
+return HttpRoute { path: path, response: text_response(200, body) }
+}
+pub fn route_response(path: string, selected_response: HttpResponse): HttpRoute {
+return HttpRoute { path: path, response: selected_response }
+}
+pub fn respond(body: string): HttpRoute {
+return route(\"/\", body)
+}
+pub fn serve(bind: string, selected_route: HttpRoute, max_requests: int): bool {
+return http_serve_route(bind, selected_route.path, selected_route.response.body, max_requests)
+}
+pub fn serve_once(bind: string, body: string): bool {
+return http_serve_once(bind, body)
+}
+",
     ),
     (
         "regex.ax",

--- a/stage1/examples/proof_http_service/src/main.ax
+++ b/stage1/examples/proof_http_service/src/main.ax
@@ -1,10 +1,20 @@
 import "std/env.ax"
+import "std/http.ax"
 import "std/time.ax"
 import "request.ax"
 import "response.ax"
 
 let started: bool = now_ms() > 0
+let method: string = request_method(get_env("REQUEST_METHOD"))
+let path: string = request_path(get_env("REQUEST_PATH"))
+let req_path: string = request_path(get_env("REQUEST_PATH"))
+let req: HttpRequest = request(method, req_path, "")
+let res: HttpResponse = json_response(req, started)
+let status: int = res.status
+let body_text: string = res.body
+let headers: [HttpHeader] = res.headers
+let content_type: HttpHeader = headers[0]
 
-print status_line(request_method(get_env("REQUEST_METHOD")), request_path(get_env("REQUEST_PATH")))
-print "content-type: application/json"
-print body(request_path(get_env("REQUEST_PATH")), started)
+print status_line(status, path)
+print content_type.name + ": " + content_type.value
+print body_text

--- a/stage1/examples/proof_http_service/src/main_test.ax
+++ b/stage1/examples/proof_http_service/src/main_test.ax
@@ -1,10 +1,20 @@
 import "std/env.ax"
+import "std/http.ax"
 import "std/time.ax"
 import "request.ax"
 import "response.ax"
 
 let started: bool = now_ms() > 0
+let method: string = request_method(get_env("REQUEST_METHOD"))
+let path: string = request_path(get_env("REQUEST_PATH"))
+let req_path: string = request_path(get_env("REQUEST_PATH"))
+let req: HttpRequest = request(method, req_path, "")
+let res: HttpResponse = json_response(req, started)
+let status: int = res.status
+let body_text: string = res.body
+let headers: [HttpHeader] = res.headers
+let content_type: HttpHeader = headers[0]
 
-print status_line(request_method(get_env("REQUEST_METHOD")), request_path(get_env("REQUEST_PATH")))
-print "content-type: application/json"
-print body(request_path(get_env("REQUEST_PATH")), started)
+print status_line(status, path)
+print content_type.name + ": " + content_type.value
+print body_text

--- a/stage1/examples/proof_http_service/src/request.ax
+++ b/stage1/examples/proof_http_service/src/request.ax
@@ -1,3 +1,5 @@
+import "std/http.ax"
+
 pub fn request_method(raw: Option<string>): string {
 match raw {
 Some(value) {
@@ -18,4 +20,8 @@ None {
 return "/health"
 }
 }
+}
+
+pub fn current_request(raw_method: Option<string>, raw_path: Option<string>): HttpRequest {
+return request(request_method(raw_method), request_path(raw_path), "")
 }

--- a/stage1/examples/proof_http_service/src/response.ax
+++ b/stage1/examples/proof_http_service/src/response.ax
@@ -1,7 +1,15 @@
+import "std/http.ax"
 import "std/json.ax"
 
-pub fn status_line(method: string, path: string): string {
+pub fn status_for(method: string): int {
 if method == "GET" {
+return 200
+}
+return 405
+}
+
+pub fn status_line(status: int, path: string): string {
+if status == 200 {
 return "HTTP/1.1 200 OK " + path
 }
 return "HTTP/1.1 405 METHOD_NOT_ALLOWED " + path
@@ -9,4 +17,8 @@ return "HTTP/1.1 405 METHOD_NOT_ALLOWED " + path
 
 pub fn body(path: string, started: bool): string {
 return "{\"path\":" + stringify_string(path) + ",\"ok\":" + stringify_bool(started) + "}"
+}
+
+pub fn json_response(request: HttpRequest, started: bool): HttpResponse {
+return response(status_for(request.method), body(request.path, started), [header("content-type", "application/json")])
 }

--- a/stage1/examples/proof_http_service/src/server.ax
+++ b/stage1/examples/proof_http_service/src/server.ax
@@ -4,7 +4,9 @@ import "response.ax"
 
 pub fn health_route(started: bool): HttpRoute {
 let path: string = path_join_segment("", "health")
-return route("/" + path, body("/" + path, started))
+let req: HttpRequest = request("GET", "/" + path, "")
+let selected_response: HttpResponse = json_response(req, started)
+return route_response(req.path, selected_response)
 }
 
 pub fn serve_health(bind: string, max_requests: int, started: bool): bool {


### PR DESCRIPTION
## Summary
- Add typed `HttpRequest`, `HttpResponse`, and `HttpHeader` stdlib structs plus constructors for stage1 HTTP workloads.
- Update the proof HTTP service example to inspect typed request method/path values and emit status, body, and header data through a typed response.
- Preserve existing `route`/`serve` helpers by routing through typed `HttpResponse` while keeping the runtime slice narrow.

Closes #398.

## Checks
- `cargo check -p axiomc`
- `cargo run -q -p axiomc -- check examples/proof_http_service`
- `cargo run -q -p axiomc -- run examples/proof_http_service`

Note: targeted `cargo test -p axiomc checked_in_proof_http_service -- --nocapture` currently hits pre-existing compile blockers on `main` in the test target: duplicate static-global test definitions and a missing `http` field in a `TestTarget` initializer. The library/bin checks and proof HTTP example check/run pass for this slice.

## Merge Automation
Auto-merge requested with squash where GitHub permits it.
