### PR TITLE
Add process command capability allowlists

### DIFF
--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -7574,6 +7574,7 @@ fn lower_expr_with_expected_inner(
                     .with_span(*line, *column));
                 }
                 let lowered = lower_expr_with_expected(&args[0], Some(&Type::String), env, ctx)?;
+                validate_process_command_allowlist_hir(ctx.capabilities, &lowered, *line, *column)?;
                 if lowered.ty() != &Type::String {
                     return Err(Diagnostic::new(
                         "type",
@@ -9734,6 +9735,37 @@ fn validate_ffi_type(ty: &Type, line: usize, column: usize) -> Result<(), Diagno
         _ => Err(Diagnostic::new(
             "type",
             "FFI signatures only support int, bool, string, ptr<T>, and mutptr<T> in stage1",
+        )
+        .with_span(line, column)),
+    }
+}
+
+
+fn validate_process_command_allowlist_hir(
+    capabilities: &CapabilityConfig,
+    command: &Expr,
+    line: usize,
+    column: usize,
+) -> Result<(), Diagnostic> {
+    if capabilities.process_commands.is_empty() {
+        return Ok(());
+    }
+    match command {
+        Expr::Literal {
+            value: LiteralValue::String(value),
+            ..
+        } if capabilities.process_commands.iter().any(|allowed| allowed == value) => Ok(()),
+        Expr::Literal {
+            value: LiteralValue::String(value),
+            ..
+        } => Err(Diagnostic::new(
+            "capability",
+            format!("call to \"process_status\" requires [capabilities].process to include {value:?}"),
+        )
+        .with_span(line, column)),
+        _ => Err(Diagnostic::new(
+            "capability",
+            "call to \"process_status\" requires a string literal listed in [capabilities].process",
         )
         .with_span(line, column)),
     }

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -3838,6 +3838,42 @@ process = ["/bin/true"]
     }
 
     #[test]
+    fn load_manifest_rejects_empty_process_allowlist() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("process-empty-allowlist");
+        create_project(&project, Some("process-empty-allowlist-app")).expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            r#"[package]
+name = "process-empty-allowlist-app"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+process = []
+"#,
+        )
+        .expect("write manifest");
+        fs::write(
+            project.join("src/main.ax"),
+            "print process_status(\"/bin/true\")\n",
+        )
+        .expect("write source");
+
+        let error = load_manifest(&project).expect_err("empty process allowlist should fail closed");
+        assert_eq!(error.kind, "manifest");
+        assert!(
+            error
+                .message
+                .contains("capabilities.process must list at least one allowed command"),
+            "unexpected diagnostic: {error:?}",
+        );
+    }
+
+    #[test]
     fn check_project_rejects_process_command_missing_from_manifest_allowlist() {
         let dir = tempdir().expect("tempdir");
         let project = dir.path().join("process-not-allowlisted");

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -3645,6 +3645,105 @@ print strlen("hello")
     }
 
     #[test]
+    fn check_project_accepts_process_command_in_manifest_allowlist() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("process-allowlisted");
+        create_project(&project, Some("process-allowlisted-app")).expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            r#"[package]
+name = "process-allowlisted-app"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+process = ["/bin/true"]
+"#,
+        )
+        .expect("write manifest");
+        fs::write(
+            project.join("src/main.ax"),
+            "print process_status(\"/bin/true\")\n",
+        )
+        .expect("write source");
+
+        check_project(&project).expect("allowlisted process command should be accepted");
+    }
+
+    #[test]
+    fn check_project_rejects_process_command_missing_from_manifest_allowlist() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("process-not-allowlisted");
+        create_project(&project, Some("process-not-allowlisted-app")).expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            r#"[package]
+name = "process-not-allowlisted-app"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+process = ["/bin/true"]
+"#,
+        )
+        .expect("write manifest");
+        fs::write(
+            project.join("src/main.ax"),
+            "print process_status(\"/bin/false\")\n",
+        )
+        .expect("write source");
+
+        let error = check_project(&project).expect_err("unlisted process command should fail");
+        assert_eq!(error.kind, "capability");
+        assert!(
+            error
+                .message
+                .contains("requires [capabilities].process to include \"/bin/false\"")
+        );
+    }
+
+    #[test]
+    fn check_project_rejects_dynamic_process_command_with_manifest_allowlist() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("process-dynamic-denied");
+        create_project(&project, Some("process-dynamic-denied-app")).expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            r#"[package]
+name = "process-dynamic-denied-app"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+process = ["/bin/true"]
+"#,
+        )
+        .expect("write manifest");
+        fs::write(
+            project.join("src/main.ax"),
+            "let command: string = \"/bin/true\"\nprint process_status(command)\n",
+        )
+        .expect("write source");
+
+        let error = check_project(&project).expect_err("dynamic process command should fail");
+        assert_eq!(error.kind, "capability");
+        assert!(
+            error
+                .message
+                .contains("requires a string literal listed in [capabilities].process")
+        );
+    }
+
+    #[test]
     fn check_project_rejects_crypto_intrinsic_without_capability() {
         let dir = tempdir().expect("tempdir");
         let project = dir.path().join("crypto-denied");

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -3709,6 +3709,43 @@ process = ["/bin/true"]
     }
 
     #[test]
+    fn check_project_rejects_stdlib_process_command_missing_from_manifest_allowlist() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("stdlib-process-not-allowlisted");
+        create_project(&project, Some("stdlib-process-not-allowlisted-app")).expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            r#"[package]
+name = "stdlib-process-not-allowlisted-app"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+process = ["/bin/true"]
+"#,
+        )
+        .expect("write manifest");
+        fs::write(
+            project.join("src/main.ax"),
+            r#"import "std/process.ax"
+print run_status("/bin/false")
+"#,
+        )
+        .expect("write source");
+
+        let error = check_project(&project).expect_err("unlisted stdlib process command should fail");
+        assert_eq!(error.kind, "capability");
+        assert!(
+            error
+                .message
+                .contains(r#"requires [capabilities].process to include "/bin/false""#)
+        );
+    }
+
+    #[test]
     fn check_project_rejects_dynamic_process_command_with_manifest_allowlist() {
         let dir = tempdir().expect("tempdir");
         let project = dir.path().join("process-dynamic-denied");

--- a/stage1/crates/axiomc/src/manifest.rs
+++ b/stage1/crates/axiomc/src/manifest.rs
@@ -107,6 +107,7 @@ pub struct CapabilityConfig {
     pub fs_root: Option<String>,
     pub net: bool,
     pub process: bool,
+    pub process_commands: Vec<String>,
     pub env: bool,
     pub env_vars: Vec<String>,
     pub env_unrestricted: bool,
@@ -241,7 +242,7 @@ struct RawCapabilityConfig {
     fs_write: Option<bool>,
     fs_root: Option<String>,
     net: Option<bool>,
-    process: Option<bool>,
+    process: Option<RawProcessCapability>,
     env: Option<RawEnvCapability>,
     env_unrestricted: Option<bool>,
     unsafe_rationale: Option<String>,
@@ -254,6 +255,13 @@ struct RawCapabilityConfig {
     unsafe_opt_ins: Option<Vec<String>>,
     owners: Option<BTreeMap<String, String>>,
     rationale: Option<BTreeMap<String, String>>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum RawProcessCapability {
+    LegacyBool(bool),
+    AllowList(Vec<String>),
 }
 
 #[derive(Debug, Deserialize)]
@@ -336,10 +344,10 @@ pub fn capability_descriptors(config: &CapabilityConfig) -> Vec<CapabilityDescri
             enabled: config.enabled(*kind),
             description: kind.description(),
             deny_by_default: config.deny_by_default,
-            allowed: if *kind == CapabilityKind::Env {
-                config.env_vars.clone()
-            } else {
-                Vec::new()
+            allowed: match *kind {
+                CapabilityKind::Env => config.env_vars.clone(),
+                CapabilityKind::Process => config.process_commands.clone(),
+                _ => Vec::new(),
             },
             configured_root: None,
             effective_root: None,
@@ -459,6 +467,7 @@ fn normalize_manifest(raw: RawManifest, path: &Path) -> Result<Manifest, Diagnos
     let capabilities = raw.capabilities.unwrap_or_default();
     let fs_root =
         normalize_optional_relative_path(path, "capabilities.fs_root", capabilities.fs_root)?;
+    let (process, process_commands) = normalize_process_capability(path, capabilities.process)?;
     let explicit_env_unrestricted = capabilities.env_unrestricted.unwrap_or(false);
     let (env, env_vars, env_unrestricted, env_legacy_unrestricted) =
         normalize_env_capability(path, capabilities.env, explicit_env_unrestricted)?;
@@ -494,7 +503,8 @@ fn normalize_manifest(raw: RawManifest, path: &Path) -> Result<Manifest, Diagnos
             fs_write: capabilities.fs_write.unwrap_or(false),
             fs_root,
             net: capabilities.net.unwrap_or(false),
-            process: capabilities.process.unwrap_or(false),
+            process,
+            process_commands,
             env,
             env_vars,
             env_unrestricted,
@@ -671,6 +681,52 @@ fn normalize_capability_name(
         .with_path(path.display().to_string()));
     }
     Ok(name)
+}
+
+fn normalize_process_capability(
+    path: &Path,
+    raw_process: Option<RawProcessCapability>,
+) -> Result<(bool, Vec<String>), Diagnostic> {
+    match raw_process {
+        Some(RawProcessCapability::LegacyBool(enabled)) => Ok((enabled, Vec::new())),
+        Some(RawProcessCapability::AllowList(values)) => {
+            let commands = normalize_process_allowlist(path, values)?;
+            Ok((true, commands))
+        }
+        None => Ok((false, Vec::new())),
+    }
+}
+
+fn normalize_process_allowlist(
+    path: &Path,
+    values: Vec<String>,
+) -> Result<Vec<String>, Diagnostic> {
+    let mut commands = Vec::new();
+    let mut seen = std::collections::BTreeSet::new();
+    for (index, value) in values.into_iter().enumerate() {
+        let field_name = format!("capabilities.process[{index}]");
+        if value.trim().is_empty() {
+            return Err(
+                Diagnostic::new("manifest", format!("{field_name} must not be empty"))
+                    .with_path(path.display().to_string()),
+            );
+        }
+        if value.chars().any(char::is_whitespace) {
+            return Err(
+                Diagnostic::new("manifest", format!("{field_name} must be a single command path or binary name, not a shell command line"))
+                    .with_path(path.display().to_string()),
+            );
+        }
+        if !seen.insert(value.clone()) {
+            return Err(Diagnostic::new(
+                "manifest",
+                format!("duplicate process command {value:?}"),
+            )
+            .with_path(path.display().to_string()));
+        }
+        commands.push(value);
+    }
+    Ok(commands)
 }
 
 fn normalize_env_capability(

--- a/stage1/crates/axiomc/src/manifest.rs
+++ b/stage1/crates/axiomc/src/manifest.rs
@@ -701,6 +701,12 @@ fn normalize_process_allowlist(
     path: &Path,
     values: Vec<String>,
 ) -> Result<Vec<String>, Diagnostic> {
+    if values.is_empty() {
+        return Err(
+            Diagnostic::new("manifest", "capabilities.process must list at least one allowed command or use false to disable process execution")
+                .with_path(path.display().to_string()),
+        );
+    }
     let mut commands = Vec::new();
     let mut seen = std::collections::BTreeSet::new();
     for (index, value) in values.into_iter().enumerate() {

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -1134,6 +1134,7 @@ fn register_stdlib_package(graph: &mut PackageGraph) {
             fs_root: None,
             net: true,
             process: true,
+            process_commands: Vec::new(),
             env: true,
             env_vars: Vec::new(),
             env_unrestricted: true,
@@ -2748,6 +2749,9 @@ fn validate_expr_capabilities(
                 .with_path(module_path.display().to_string())
                 .with_span(*line, *column));
             }
+            if name == "process_status" {
+                validate_process_command_allowlist(module_path, args, capabilities, *line, *column)?;
+            }
             for arg in args {
                 validate_expr_capabilities(module_path, arg, capabilities)?;
             }
@@ -2812,6 +2816,35 @@ fn validate_expr_capabilities(
         syntax::Expr::Closure { body, .. } => {
             validate_expr_capabilities(module_path, body, capabilities)
         }
+    }
+}
+
+
+fn validate_process_command_allowlist(
+    module_path: &Path,
+    args: &[syntax::Expr],
+    capabilities: &CapabilityConfig,
+    line: usize,
+    column: usize,
+) -> Result<(), Diagnostic> {
+    if capabilities.process_commands.is_empty() {
+        return Ok(());
+    }
+    match args.first() {
+        Some(syntax::Expr::Literal(syntax::Literal::String(command)))
+            if capabilities.process_commands.iter().any(|allowed| allowed == command) => Ok(()),
+        Some(syntax::Expr::Literal(syntax::Literal::String(command))) => Err(Diagnostic::new(
+            "capability",
+            format!("call to \"process_status\" requires [capabilities].process to include {command:?}"),
+        )
+        .with_path(module_path.display().to_string())
+        .with_span(line, column)),
+        _ => Err(Diagnostic::new(
+            "capability",
+            "call to \"process_status\" requires a string literal listed in [capabilities].process",
+        )
+        .with_path(module_path.display().to_string())
+        .with_span(line, column)),
     }
 }
 

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -2749,8 +2749,8 @@ fn validate_expr_capabilities(
                 .with_path(module_path.display().to_string())
                 .with_span(*line, *column));
             }
-            if name == "process_status" {
-                validate_process_command_allowlist(module_path, args, capabilities, *line, *column)?;
+            if name == "process_status" || name == "run_status" {
+                validate_process_command_allowlist(module_path, name, args, capabilities, *line, *column)?;
             }
             for arg in args {
                 validate_expr_capabilities(module_path, arg, capabilities)?;
@@ -2822,6 +2822,7 @@ fn validate_expr_capabilities(
 
 fn validate_process_command_allowlist(
     module_path: &Path,
+    call_name: &str,
     args: &[syntax::Expr],
     capabilities: &CapabilityConfig,
     line: usize,
@@ -2835,13 +2836,13 @@ fn validate_process_command_allowlist(
             if capabilities.process_commands.iter().any(|allowed| allowed == command) => Ok(()),
         Some(syntax::Expr::Literal(syntax::Literal::String(command))) => Err(Diagnostic::new(
             "capability",
-            format!("call to \"process_status\" requires [capabilities].process to include {command:?}"),
+            format!("call to {call_name:?} requires [capabilities].process to include {command:?}"),
         )
         .with_path(module_path.display().to_string())
         .with_span(line, column)),
         _ => Err(Diagnostic::new(
             "capability",
-            "call to \"process_status\" requires a string literal listed in [capabilities].process",
+            format!("call to {call_name:?} requires a string literal listed in [capabilities].process"),
         )
         .with_path(module_path.display().to_string())
         .with_span(line, column)),

--- a/stage1/schemas/axiom.toml.schema.json
+++ b/stage1/schemas/axiom.toml.schema.json
@@ -193,6 +193,7 @@
             },
             {
               "type": "array",
+              "minItems": 1,
               "items": {
                 "type": "string",
                 "minLength": 1,

--- a/stage1/schemas/axiom.toml.schema.json
+++ b/stage1/schemas/axiom.toml.schema.json
@@ -187,8 +187,20 @@
           "default": false
         },
         "process": {
-          "type": "boolean",
-          "default": false
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1,
+                "pattern": "^\\S+$"
+              },
+              "uniqueItems": true
+            }
+          ]
         },
         "env": {
           "oneOf": [


### PR DESCRIPTION
## Summary
- Add manifest-scoped process command allowlists via `[capabilities] process = [\"...\"]`.
- Surface allowlisted process commands in capability descriptors/contracts.
- Reject `process_status` calls at project check time when the command is not listed, and reject dynamic process command expressions when an allowlist is configured.
- Preserve current generated runtime behavior of `std::process::Command::new(program)`, avoiding shell interpolation by default.

Closes #393

## Checks
- `cargo test -p axiomc process_command -- --nocapture` attempted on Daedalus; blocked by pre-existing/unrelated compile failures in current branch/base: duplicate static-global tests in `crates/axiomc/src/lib.rs`, missing `create_project` test helper references in `crates/axiomc/src/main.rs`, and missing `http` field in a `TestTarget` initializer in `crates/axiomc/src/project.rs`.
- `cargo test -p axiomc --lib process_command -- --nocapture` attempted on Daedalus; hit the same unrelated compile blockers.
- `cargo fmt --check` attempted on Daedalus; blocked by broad pre-existing formatting drift outside this slice, including `axiom-lsp`, `axiomc/src/main.rs`, and other files not touched for this issue.

## Merge Automation
Auto-merge not enabled yet because the local validation commands cannot compile due to unrelated current-tree blockers described above.
