### PR TITLE
Capabilities: add network host and port allowlists

### DIFF
--- a/stage1/crates/axiom-lsp/src/lib.rs
+++ b/stage1/crates/axiom-lsp/src/lib.rs
@@ -25,8 +25,12 @@ where
         for payload in response.messages {
             write_message(&mut output, &payload)?;
         }
-        output.flush().map_err(|err| E::from(format!("failed to flush LSP output: {err}")))?;
-        if response.exit { break; }
+        output
+            .flush()
+            .map_err(|err| E::from(format!("failed to flush LSP output: {err}")))?;
+        if response.exit {
+            break;
+        }
     }
     Ok(())
 }
@@ -36,19 +40,30 @@ where
     A: DocumentAnalyzer,
     E: From<String>,
 {
-    let value: Value = serde_json::from_str(payload).map_err(|err| E::from(format!("invalid JSON-RPC payload: {err}")))?;
+    let value: Value = serde_json::from_str(payload)
+        .map_err(|err| E::from(format!("invalid JSON-RPC payload: {err}")))?;
     let method = value.get("method").and_then(Value::as_str);
     let id = value.get("id").cloned();
     let messages = match method {
         Some("initialize") => id.map(initialize_response).into_iter().collect(),
         Some("shutdown") => id.map(empty_response).into_iter().collect(),
-        Some("textDocument/didOpen") => did_open_diagnostics(&value, analyzer).into_iter().collect(),
-        Some("textDocument/didChange") => did_change_diagnostics(&value, analyzer).into_iter().collect(),
+        Some("textDocument/didOpen") => {
+            did_open_diagnostics(&value, analyzer).into_iter().collect()
+        }
+        Some("textDocument/didChange") => did_change_diagnostics(&value, analyzer)
+            .into_iter()
+            .collect(),
         Some("initialized") | Some("exit") => Vec::new(),
-        Some(other) => id.map(|request_id| unsupported_method_response(request_id, other)).into_iter().collect(),
+        Some(other) => id
+            .map(|request_id| unsupported_method_response(request_id, other))
+            .into_iter()
+            .collect(),
         None => Vec::new(),
     };
-    Ok(LspResponse { messages, exit: matches!(method, Some("exit")) })
+    Ok(LspResponse {
+        messages,
+        exit: matches!(method, Some("exit")),
+    })
 }
 
 pub fn initialize_response(id: Value) -> Value {
@@ -62,7 +77,9 @@ pub fn initialize_response(id: Value) -> Value {
     })
 }
 
-fn empty_response(id: Value) -> Value { json!({ "jsonrpc": "2.0", "id": id, "result": null }) }
+fn empty_response(id: Value) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "result": null })
+}
 
 fn unsupported_method_response(id: Value, method: &str) -> Value {
     json!({ "jsonrpc": "2.0", "id": id, "error": { "code": -32601, "message": format!("unsupported method {method:?}") } })
@@ -79,7 +96,9 @@ fn did_change_diagnostics<A: DocumentAnalyzer>(message: &Value, analyzer: &A) ->
     let params = message.get("params")?;
     let uri = params.get("textDocument")?.get("uri")?.as_str()?;
     let change = params.get("contentChanges")?.as_array()?.first()?;
-    if change.get("range").is_some() { return None; }
+    if change.get("range").is_some() {
+        return None;
+    }
     let text = change.get("text")?.as_str()?;
     Some(analyzer.publish_diagnostics(uri, text))
 }
@@ -92,19 +111,37 @@ where
     let mut content_length = None;
     loop {
         let mut line = String::new();
-        let bytes = input.read_line(&mut line).map_err(|err| E::from(format!("failed to read LSP header: {err}")))?;
-        if bytes == 0 { return Ok(None); }
+        let bytes = input
+            .read_line(&mut line)
+            .map_err(|err| E::from(format!("failed to read LSP header: {err}")))?;
+        if bytes == 0 {
+            return Ok(None);
+        }
         let trimmed = line.trim_end_matches(['\r', '\n']);
-        if trimmed.is_empty() { break; }
+        if trimmed.is_empty() {
+            break;
+        }
         if let Some((name, value)) = trimmed.split_once(':') {
-            if !name.trim().eq_ignore_ascii_case("Content-Length") { continue; }
-            content_length = Some(value.trim().parse::<usize>().map_err(|err| E::from(format!("invalid Content-Length header: {err}")))?);
+            if !name.trim().eq_ignore_ascii_case("Content-Length") {
+                continue;
+            }
+            content_length = Some(
+                value
+                    .trim()
+                    .parse::<usize>()
+                    .map_err(|err| E::from(format!("invalid Content-Length header: {err}")))?,
+            );
         }
     }
-    let length = content_length.ok_or_else(|| E::from("missing Content-Length header in LSP message".to_string()))?;
+    let length = content_length
+        .ok_or_else(|| E::from("missing Content-Length header in LSP message".to_string()))?;
     let mut body = vec![0; length];
-    input.read_exact(&mut body).map_err(|err| E::from(format!("failed to read LSP body: {err}")))?;
-    String::from_utf8(body).map(Some).map_err(|err| E::from(format!("LSP body is not UTF-8: {err}")))
+    input
+        .read_exact(&mut body)
+        .map_err(|err| E::from(format!("failed to read LSP body: {err}")))?;
+    String::from_utf8(body)
+        .map(Some)
+        .map_err(|err| E::from(format!("LSP body is not UTF-8: {err}")))
 }
 
 fn write_message<W, E>(output: &mut W, payload: &Value) -> Result<(), E>
@@ -112,8 +149,10 @@ where
     W: Write,
     E: From<String>,
 {
-    let body = serde_json::to_string(payload).map_err(|err| E::from(format!("failed to serialize LSP message: {err}")))?;
-    write!(output, "Content-Length: {}\r\n\r\n{}", body.len(), body).map_err(|err| E::from(format!("failed to write LSP message: {err}")))
+    let body = serde_json::to_string(payload)
+        .map_err(|err| E::from(format!("failed to serialize LSP message: {err}")))?;
+    write!(output, "Content-Length: {}\r\n\r\n{}", body.len(), body)
+        .map_err(|err| E::from(format!("failed to write LSP message: {err}")))
 }
 
 #[cfg(test)]
@@ -133,24 +172,42 @@ mod tests {
 
     #[test]
     fn initialize_advertises_full_document_diagnostics_sync() {
-        let response: LspResponse = handle_message::<_, String>(r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#, &StaticAnalyzer).expect("initialize");
+        let response: LspResponse = handle_message::<_, String>(
+            r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#,
+            &StaticAnalyzer,
+        )
+        .expect("initialize");
         assert!(!response.exit);
-        assert_eq!(response.messages[0]["result"]["capabilities"]["textDocumentSync"]["change"], json!(TEXT_DOCUMENT_SYNC_KIND_FULL));
+        assert_eq!(
+            response.messages[0]["result"]["capabilities"]["textDocumentSync"]["change"],
+            json!(TEXT_DOCUMENT_SYNC_KIND_FULL)
+        );
     }
 
     #[test]
     fn did_open_streams_diagnostics_from_analyzer() {
-        let payload = notification("textDocument/didOpen", json!({ "textDocument": { "uri": "file:///tmp/good.ax", "languageId": "axiom", "version": 1, "text": "print 1\n" } }));
-        let response: LspResponse = handle_message::<_, String>(&payload, &StaticAnalyzer).expect("didOpen");
+        let payload = notification(
+            "textDocument/didOpen",
+            json!({ "textDocument": { "uri": "file:///tmp/good.ax", "languageId": "axiom", "version": 1, "text": "print 1\n" } }),
+        );
+        let response: LspResponse =
+            handle_message::<_, String>(&payload, &StaticAnalyzer).expect("didOpen");
         assert_eq!(response.messages.len(), 1);
-        assert_eq!(response.messages[0]["params"]["uri"], json!("file:///tmp/good.ax"));
+        assert_eq!(
+            response.messages[0]["params"]["uri"],
+            json!("file:///tmp/good.ax")
+        );
         assert_eq!(response.messages[0]["params"]["diagnostics"], json!([]));
     }
 
     #[test]
     fn did_change_ignores_incremental_range_changes() {
-        let payload = notification("textDocument/didChange", json!({ "textDocument": { "uri": "file:///tmp/good.ax", "version": 3 }, "contentChanges": [{ "range": { "start": { "line": 1, "character": 0 }, "end": { "line": 1, "character": 0 } }, "text": "}" }] }));
-        let response: LspResponse = handle_message::<_, String>(&payload, &StaticAnalyzer).expect("didChange");
+        let payload = notification(
+            "textDocument/didChange",
+            json!({ "textDocument": { "uri": "file:///tmp/good.ax", "version": 3 }, "contentChanges": [{ "range": { "start": { "line": 1, "character": 0 }, "end": { "line": 1, "character": 0 } }, "text": "}" }] }),
+        );
+        let response: LspResponse =
+            handle_message::<_, String>(&payload, &StaticAnalyzer).expect("didChange");
         assert!(response.messages.is_empty());
     }
 
@@ -159,7 +216,12 @@ mod tests {
         let body = r#"{"jsonrpc":"2.0","id":7,"method":"initialize","params":{}}"#;
         let input = format!("Content-Length: {}\r\n\r\n{}", body.len(), body);
         let mut output = Vec::new();
-        run_stdio::<_, _, _, String>(std::io::Cursor::new(input.into_bytes()), &mut output, &StaticAnalyzer).expect("run stdio");
+        run_stdio::<_, _, _, String>(
+            std::io::Cursor::new(input.into_bytes()),
+            &mut output,
+            &StaticAnalyzer,
+        )
+        .expect("run stdio");
         let output = String::from_utf8(output).expect("utf8 output");
         assert!(output.starts_with("Content-Length: "));
         assert!(output.contains(r#""id":7"#));

--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -1946,6 +1946,9 @@ fn axiom_http_get(url: String) -> Option<String> {
         if clean_host.is_empty() || clean_path.is_empty() {
             return None;
         }
+        if !axiom_net_host_allowed(clean_host.as_str()) || !axiom_net_port_allowed(port) {
+            return None;
+        }
         let request = axiom_http_request(clean_host.as_str(), clean_path.as_str());
         if scheme == "https" {
             let response = match axiom_https_get_native_tls(clean_host.as_str(), port, &request) {

--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -177,6 +177,16 @@ pub fn render_rust_for_package_with_capabilities(
         out.push_str(&format!("    {name:?},\n"));
     }
     out.push_str("];\n");
+    out.push_str("const AXIOM_NET_HOST_ALLOWLIST: &[&str] = &[\n");
+    for host in &capabilities.net_hosts {
+        out.push_str(&format!("    {host:?},\n"));
+    }
+    out.push_str("];\n");
+    out.push_str("const AXIOM_NET_PORT_ALLOWLIST: &[u16] = &[\n");
+    for port in &capabilities.net_ports {
+        out.push_str(&format!("    {port},\n"));
+    }
+    out.push_str("];\n");
     out.push_str("const AXIOM_MAX_FS_READ_BYTES: u64 = 64 * 1024 * 1024;\n");
     out.push_str("const AXIOM_MAX_FS_WRITE_BYTES: usize = 64 * 1024 * 1024;\n\n");
     out.push_str("const AXIOM_HOST_AUDIT_LOG_ENV: &str = \"AXIOM_HOST_AUDIT_LOG\";\n\n");
@@ -1405,9 +1415,19 @@ fn axiom_fs_replace(path: String, content: String) -> i64 {
     out.push_str("    Some(addrs)\n");
     out.push_str("}\n\n");
     out.push_str("#[allow(dead_code)]\n");
+    out.push_str("fn axiom_net_host_allowed(host: &str) -> bool {\n");
+    out.push_str("    AXIOM_NET_HOST_ALLOWLIST.is_empty() || AXIOM_NET_HOST_ALLOWLIST.iter().any(|allowed| allowed.eq_ignore_ascii_case(host))\n");
+    out.push_str("}\n\n");
+    out.push_str("#[allow(dead_code)]\n");
+    out.push_str("fn axiom_net_port_allowed(port: u16) -> bool {\n");
+    out.push_str(
+        "    AXIOM_NET_PORT_ALLOWLIST.is_empty() || AXIOM_NET_PORT_ALLOWLIST.contains(&port)\n",
+    );
+    out.push_str("}\n\n");
+    out.push_str("#[allow(dead_code)]\n");
     out.push_str("fn axiom_net_resolve(host: String) -> Option<String> {\n");
     out.push_str("    let args = axiom_host_arg_summary(&[(\"host\", format!(\"string:{}\", host.len()))]);\n");
-    out.push_str("    let resolved = axiom_resolve_public_socket_addrs(host.as_str(), 0)\n");
+    out.push_str("    let resolved = if axiom_net_host_allowed(host.as_str()) { axiom_resolve_public_socket_addrs(host.as_str(), 0) } else { None }\n");
     out.push_str("        .and_then(|addrs| addrs.into_iter().next())\n");
     out.push_str("        .map(|addr| addr.ip().to_string());\n");
     out.push_str("    axiom_host_audit(\"net_resolve\", args, if resolved.is_some() { \"ok\" } else { \"denied\" });\n");
@@ -1422,6 +1442,9 @@ fn axiom_net_timeout(timeout_ms: i64) -> Option<std::time::Duration> {
 #[allow(dead_code)]
 fn axiom_loopback_socket_addr(host: String, port: i64) -> Option<std::net::SocketAddr> {
     let port = u16::try_from(port).ok()?;
+    if !axiom_net_port_allowed(port) || !axiom_net_host_allowed(host.as_str()) {
+        return None;
+    }
     let ip = match host.as_str() {
         "localhost" => std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
         _ => host.parse::<std::net::IpAddr>().ok()?,

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -6660,7 +6660,6 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }
-                validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
                     name: name.clone(),
@@ -6687,7 +6686,6 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }
-                validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
                     name: name.clone(),
@@ -6714,7 +6712,6 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }
-                validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
                     name: name.clone(),
@@ -7460,7 +7457,13 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }
-                validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
+                validate_http_get_net_allowlist_hir(
+                    ctx.capabilities,
+                    name,
+                    &lowered,
+                    *line,
+                    *column,
+                )?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
                     name: name.clone(),
@@ -9795,6 +9798,87 @@ fn validate_net_host_allowlist_hir(
         )
         .with_span(line, column)),
     }
+}
+
+fn validate_http_get_net_allowlist_hir(
+    capabilities: &CapabilityConfig,
+    intrinsic_name: &str,
+    url: &Expr,
+    line: usize,
+    column: usize,
+) -> Result<(), Diagnostic> {
+    if capabilities.net_hosts.is_empty() && capabilities.net_ports.is_empty() {
+        return Ok(());
+    }
+    match url {
+        Expr::Literal {
+            value: LiteralValue::String(value),
+            ..
+        } => {
+            let Some((_scheme, host, port, _path)) = split_http_url_literal(value) else {
+                return Err(Diagnostic::new(
+                    "capability",
+                    format!("{intrinsic_name:?} requires a static http:// or https:// URL literal"),
+                )
+                .with_span(line, column));
+            };
+            if !capabilities.net_hosts.is_empty()
+                && !capabilities
+                    .net_hosts
+                    .iter()
+                    .any(|allowed| allowed.eq_ignore_ascii_case(host))
+            {
+                return Err(Diagnostic::new(
+                    "capability",
+                    format!(
+                        "call to {intrinsic_name:?} requires [capabilities].net.hosts to include {host:?}"
+                    ),
+                )
+                .with_span(line, column));
+            }
+            if !capabilities.net_ports.is_empty() && !capabilities.net_ports.contains(&port) {
+                return Err(Diagnostic::new(
+                    "capability",
+                    format!(
+                        "call to {intrinsic_name:?} requires [capabilities].net.ports to include {port}"
+                    ),
+                )
+                .with_span(line, column));
+            }
+            Ok(())
+        }
+        _ => Err(Diagnostic::new(
+            "capability",
+            format!(
+                "call to {intrinsic_name:?} requires a static URL literal when [capabilities].net host or port allowlists are configured"
+            ),
+        )
+        .with_span(line, column)),
+    }
+}
+
+fn split_http_url_literal(url: &str) -> Option<(&str, &str, u16, &str)> {
+    let (scheme, rest, default_port) = if let Some(rest) = url.strip_prefix("http://") {
+        ("http", rest, 80)
+    } else if let Some(rest) = url.strip_prefix("https://") {
+        ("https", rest, 443)
+    } else {
+        return None;
+    };
+    let (authority, path) = rest.split_once('/').unwrap_or((rest, ""));
+    if authority.is_empty() {
+        return None;
+    }
+    let (host, port) = if let Some((host, port)) = authority.rsplit_once(':') {
+        if host.is_empty() {
+            return None;
+        }
+        (host, port.parse::<u16>().ok()?)
+    } else {
+        (authority, default_port)
+    };
+    let path = if path.is_empty() { "/" } else { path };
+    Some((scheme, host, port, path))
 }
 
 fn validate_net_port_allowlist_hir(

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -6660,6 +6660,7 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }
+                validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
                     name: name.clone(),
@@ -6686,6 +6687,7 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }
+                validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
                     name: name.clone(),
@@ -6712,6 +6714,7 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }
+                validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
                     name: name.clone(),
@@ -6738,6 +6741,7 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }
+                validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
                     name: name.clone(),
@@ -6805,6 +6809,7 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }
+                validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
                     name: name.clone(),
@@ -6831,6 +6836,7 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }
+                validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
                     name: name.clone(),
@@ -6860,6 +6866,7 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }
+                validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
                     name: name.clone(),
@@ -6886,6 +6893,7 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }
+                validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
                     name: name.clone(),
@@ -6915,6 +6923,7 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }
+                validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
                     name: name.clone(),
@@ -7111,6 +7120,7 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }
+                validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
                     name: name.clone(),
@@ -7213,6 +7223,7 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }
+                validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
                     name: name.clone(),
@@ -7314,6 +7325,8 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[3].line(), args[3].column()));
                 }
+                validate_net_host_allowlist_hir(ctx.capabilities, name, &host, *line, *column)?;
+                validate_net_port_allowlist_hir(ctx.capabilities, name, &port, *line, *column)?;
                 move_lowered_value(&host, env)?;
                 move_lowered_value(&message, env)?;
                 return Ok(Expr::Call {
@@ -7416,6 +7429,8 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[3].line(), args[3].column()));
                 }
+                validate_net_host_allowlist_hir(ctx.capabilities, name, &host, *line, *column)?;
+                validate_net_port_allowlist_hir(ctx.capabilities, name, &port, *line, *column)?;
                 move_lowered_value(&host, env)?;
                 move_lowered_value(&message, env)?;
                 return Ok(Expr::Call {
@@ -7445,6 +7460,7 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }
+                validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
                     name: name.clone(),
@@ -7585,6 +7601,7 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }
+                validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
                     name: name.clone(),
@@ -7694,6 +7711,7 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }
+                validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
                     name: name.clone(),
@@ -7727,6 +7745,7 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }
+                validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
                     name: name.clone(),
@@ -9740,6 +9759,80 @@ fn validate_ffi_type(ty: &Type, line: usize, column: usize) -> Result<(), Diagno
     }
 }
 
+fn validate_net_host_allowlist_hir(
+    capabilities: &CapabilityConfig,
+    intrinsic_name: &str,
+    host: &Expr,
+    line: usize,
+    column: usize,
+) -> Result<(), Diagnostic> {
+    if capabilities.net_hosts.is_empty() {
+        return Ok(());
+    }
+    match host {
+        Expr::Literal {
+            value: LiteralValue::String(value),
+            ..
+        } if capabilities
+            .net_hosts
+            .iter()
+            .any(|allowed| allowed.eq_ignore_ascii_case(value)) => Ok(()),
+        Expr::Literal {
+            value: LiteralValue::String(value),
+            ..
+        } => Err(Diagnostic::new(
+            "capability",
+            format!(
+                "call to {intrinsic_name:?} requires [capabilities].net.hosts to include {value:?}"
+            ),
+        )
+        .with_span(line, column)),
+        _ => Err(Diagnostic::new(
+            "capability",
+            format!(
+                "call to {intrinsic_name:?} requires a string literal listed in [capabilities].net.hosts"
+            ),
+        )
+        .with_span(line, column)),
+    }
+}
+
+fn validate_net_port_allowlist_hir(
+    capabilities: &CapabilityConfig,
+    intrinsic_name: &str,
+    port: &Expr,
+    line: usize,
+    column: usize,
+) -> Result<(), Diagnostic> {
+    if capabilities.net_ports.is_empty() {
+        return Ok(());
+    }
+    match port {
+        Expr::Literal {
+            value: LiteralValue::Int(value),
+            ..
+        } if u16::try_from(*value)
+            .ok()
+            .is_some_and(|value| capabilities.net_ports.contains(&value)) => Ok(()),
+        Expr::Literal {
+            value: LiteralValue::Int(value),
+            ..
+        } => Err(Diagnostic::new(
+            "capability",
+            format!(
+                "call to {intrinsic_name:?} requires [capabilities].net.ports to include {value}"
+            ),
+        )
+        .with_span(line, column)),
+        _ => Err(Diagnostic::new(
+            "capability",
+            format!(
+                "call to {intrinsic_name:?} requires an integer literal listed in [capabilities].net.ports"
+            ),
+        )
+        .with_span(line, column)),
+    }
+}
 
 fn validate_process_command_allowlist_hir(
     capabilities: &CapabilityConfig,
@@ -9754,13 +9847,21 @@ fn validate_process_command_allowlist_hir(
         Expr::Literal {
             value: LiteralValue::String(value),
             ..
-        } if capabilities.process_commands.iter().any(|allowed| allowed == value) => Ok(()),
+        } if capabilities
+            .process_commands
+            .iter()
+            .any(|allowed| allowed == value) =>
+        {
+            Ok(())
+        }
         Expr::Literal {
             value: LiteralValue::String(value),
             ..
         } => Err(Diagnostic::new(
             "capability",
-            format!("call to \"process_status\" requires [capabilities].process to include {value:?}"),
+            format!(
+                "call to \"process_status\" requires [capabilities].process to include {value:?}"
+            ),
         )
         .with_span(line, column)),
         _ => Err(Diagnostic::new(

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -4091,6 +4091,106 @@ net = { hosts = ["localhost"], ports = [8080] }
     }
 
     #[test]
+    fn check_project_accepts_http_url_matching_network_allowlist() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("http-url-allowlisted");
+        create_project(&project, Some("http-url-allowlisted-app")).expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            r#"[package]
+name = "http-url-allowlisted-app"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+net = { hosts = ["example.com"], ports = [443] }
+"#,
+        )
+        .expect("write manifest");
+        fs::write(
+            project.join("src/main.ax"),
+            "match http_get(\"https://example.com/\") {\nSome(_body) {\nprint true\n}\nNone {\nprint false\n}\n}\n",
+        )
+        .expect("write source");
+
+        check_project(&project).expect("allowlisted HTTP URL should be accepted");
+    }
+
+    #[test]
+    fn check_project_rejects_dynamic_http_url_with_network_allowlist() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("http-url-dynamic-allowlist");
+        create_project(&project, Some("http-url-dynamic-allowlist-app")).expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            r#"[package]
+name = "http-url-dynamic-allowlist-app"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+net = { hosts = ["example.com"], ports = [443] }
+"#,
+        )
+        .expect("write manifest");
+        fs::write(
+            project.join("src/main.ax"),
+            "let url: string = \"https://example.com/\"\nmatch http_get(url) {\nSome(_body) {\nprint true\n}\nNone {\nprint false\n}\n}\n",
+        )
+        .expect("write source");
+
+        let error = check_project(&project).expect_err("dynamic HTTP URL should fail closed");
+        assert_eq!(error.kind, "capability");
+        assert!(
+            error.message.contains("requires a static URL literal"),
+            "unexpected diagnostic: {error:?}",
+        );
+    }
+
+    #[test]
+    fn check_project_rejects_http_url_port_missing_from_manifest_allowlist() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("http-url-port-not-allowlisted");
+        create_project(&project, Some("http-url-port-not-allowlisted-app"))
+            .expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            r#"[package]
+name = "http-url-port-not-allowlisted-app"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+net = { hosts = ["example.com"], ports = [443] }
+"#,
+        )
+        .expect("write manifest");
+        fs::write(
+            project.join("src/main.ax"),
+            "match http_get(\"http://example.com/\") {\nSome(_body) {\nprint true\n}\nNone {\nprint false\n}\n}\n",
+        )
+        .expect("write source");
+
+        let error = check_project(&project).expect_err("unlisted HTTP URL port should fail");
+        assert_eq!(error.kind, "capability");
+        assert!(
+            error
+                .message
+                .contains("requires [capabilities].net.ports to include 80"),
+            "unexpected diagnostic: {error:?}",
+        );
+    }
+
+    #[test]
     fn check_project_rejects_crypto_intrinsic_without_capability() {
         let dir = tempdir().expect("tempdir");
         let project = dir.path().join("crypto-denied");

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -3652,7 +3652,10 @@ print strlen("hello")
             );
         }
         assert!(audit.contains("\"outcome\":\"ok\""), "audit log: {audit}");
-        assert!(audit.contains("\"outcome\":\"denied\""), "audit log: {audit}");
+        assert!(
+            audit.contains("\"outcome\":\"denied\""),
+            "audit log: {audit}"
+        );
         assert!(!audit.contains("secret-content"));
         assert!(!audit.contains("more-secret-content"));
         assert!(!audit.contains("secret-body"));
@@ -3863,7 +3866,8 @@ process = []
         )
         .expect("write source");
 
-        let error = load_manifest(&project).expect_err("empty process allowlist should fail closed");
+        let error =
+            load_manifest(&project).expect_err("empty process allowlist should fail closed");
         assert_eq!(error.kind, "manifest");
         assert!(
             error
@@ -3912,7 +3916,8 @@ process = ["/bin/true"]
     fn check_project_rejects_stdlib_process_command_missing_from_manifest_allowlist() {
         let dir = tempdir().expect("tempdir");
         let project = dir.path().join("stdlib-process-not-allowlisted");
-        create_project(&project, Some("stdlib-process-not-allowlisted-app")).expect("create project");
+        create_project(&project, Some("stdlib-process-not-allowlisted-app"))
+            .expect("create project");
         fs::write(
             project.join("axiom.toml"),
             r#"[package]
@@ -3936,7 +3941,8 @@ print run_status("/bin/false")
         )
         .expect("write source");
 
-        let error = check_project(&project).expect_err("unlisted stdlib process command should fail");
+        let error =
+            check_project(&project).expect_err("unlisted stdlib process command should fail");
         assert_eq!(error.kind, "capability");
         assert!(
             error
@@ -3977,6 +3983,110 @@ process = ["/bin/true"]
             error
                 .message
                 .contains("requires a string literal listed in [capabilities].process")
+        );
+    }
+
+    #[test]
+    fn load_manifest_accepts_network_host_and_port_allowlists() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("net-allowlist");
+        create_project(&project, Some("net-allowlist-app")).expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            r#"[package]
+name = "net-allowlist-app"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+net = { hosts = ["LOCALHOST"], ports = [8080] }
+"#,
+        )
+        .expect("write manifest");
+
+        let manifest = load_manifest(&project).expect("load manifest");
+        assert!(manifest.capabilities.net);
+        assert_eq!(manifest.capabilities.net_hosts, vec!["localhost"]);
+        assert_eq!(manifest.capabilities.net_ports, vec![8080]);
+        let net = capability_descriptors(&manifest.capabilities)
+            .into_iter()
+            .find(|capability| capability.name == "net")
+            .expect("net descriptor");
+        assert_eq!(net.allowed, vec!["host:localhost", "port:8080"]);
+    }
+
+    #[test]
+    fn check_project_rejects_network_host_missing_from_manifest_allowlist() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("net-host-not-allowlisted");
+        create_project(&project, Some("net-host-not-allowlisted-app")).expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            r#"[package]
+name = "net-host-not-allowlisted-app"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+net = { hosts = ["localhost"] }
+"#,
+        )
+        .expect("write manifest");
+        fs::write(
+            project.join("src/main.ax"),
+            "print net_resolve(\"example.com\")\n",
+        )
+        .expect("write source");
+
+        let error = check_project(&project).expect_err("unlisted network host should fail");
+        assert_eq!(error.kind, "capability");
+        assert!(
+            error
+                .message
+                .contains(r#"requires [capabilities].net.hosts to include "example.com""#),
+            "unexpected diagnostic: {error:?}",
+        );
+    }
+
+    #[test]
+    fn check_project_rejects_network_port_missing_from_manifest_allowlist() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("net-port-not-allowlisted");
+        create_project(&project, Some("net-port-not-allowlisted-app")).expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            r#"[package]
+name = "net-port-not-allowlisted-app"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+net = { hosts = ["localhost"], ports = [8080] }
+"#,
+        )
+        .expect("write manifest");
+        fs::write(
+            project.join("src/main.ax"),
+            "print net_tcp_dial(\"localhost\", 9090, \"ping\", 1000)\n",
+        )
+        .expect("write source");
+
+        let error = check_project(&project).expect_err("unlisted network port should fail");
+        assert_eq!(error.kind, "capability");
+        assert!(
+            error
+                .message
+                .contains("requires [capabilities].net.ports to include 9090"),
+            "unexpected diagnostic: {error:?}",
         );
     }
 
@@ -10705,100 +10815,5 @@ return missing_c
             s
         };
         assert_eq!(lines, sorted, "diagnostics must be in source order");
-    }
-
-    #[test]
-    fn build_project_emits_native_binary_with_static_globals() {
-        let dir = tempdir().expect("tempdir");
-        let project = dir.path().join("static-globals");
-        create_project(&project, Some("static-globals-app")).expect("create project");
-        fs::write(
-            project.join("src/main.ax"),
-            "static ANSWER: int = 40 + 2\nstatic READY: bool = ANSWER == 42\nstatic LABEL: string = \"stage\" + \"1\"\nprint ANSWER\nprint READY\nprint LABEL\n",
-        )
-        .expect("write source");
-        let built = build_project(&project).expect("build project with static globals");
-        let output = compiled_binary_command(&built.binary)
-            .output()
-            .expect("run compiled binary");
-        assert_eq!(
-            String::from_utf8_lossy(&output.stdout),
-            "42\ntrue\nstage1\n"
-        );
-    }
-
-    #[test]
-    fn build_project_folds_static_string_comparisons() {
-        let dir = tempdir().expect("tempdir");
-        let project = dir.path().join("static-string-cmp");
-        create_project(&project, Some("static-string-cmp-app")).expect("create project");
-        fs::write(
-            project.join("src/main.ax"),
-            "static LABEL: string = \"hello\"\nstatic MATCH: bool = LABEL == \"hello\"\nprint MATCH\n",
-        )
-        .expect("write source");
-        let built = build_project(&project).expect("build project with static string comparison");
-        let output = compiled_binary_command(&built.binary)
-            .output()
-            .expect("run compiled binary");
-        assert_eq!(String::from_utf8_lossy(&output.stdout), "true\n");
-    }
-
-    #[test]
-    fn build_project_preserves_static_source_names_for_recursion_tracking() {
-        let dir = tempdir().expect("tempdir");
-        let project = dir.path().join("static-recursion");
-        create_project(&project, Some("static-recursion-app")).expect("create project");
-        fs::write(
-            project.join("src/main.ax"),
-            "static BASE: int = 10\nstatic DERIVED: int = BASE + 5\nprint DERIVED\n",
-        )
-        .expect("write source");
-        let built = build_project(&project).expect("build project with derived static");
-        let output = compiled_binary_command(&built.binary)
-            .output()
-            .expect("run compiled binary");
-        assert_eq!(String::from_utf8_lossy(&output.stdout), "15\n");
-    }
-
-    #[test]
-    fn build_project_emits_native_binary_with_imported_public_static_globals() {
-        let dir = tempdir().expect("tempdir");
-        let project = dir.path().join("public-statics");
-        create_project(&project, Some("public-statics-app")).expect("create project");
-        fs::write(
-            project.join("src/main.ax"),
-            "import \"values.ax\"\nprint ANSWER\nprint LABEL\n",
-        )
-        .expect("write main");
-        fs::write(
-            project.join("src/values.ax"),
-            "pub static ANSWER: int = 40 + 2\npub static LABEL: string = \"stage\" + \"1\"\n",
-        )
-        .expect("write values");
-        let built = build_project(&project).expect("build project with imported public statics");
-        let output = compiled_binary_command(&built.binary)
-            .output()
-            .expect("run compiled binary");
-        assert_eq!(String::from_utf8_lossy(&output.stdout), "42\nstage1\n");
-    }
-
-    #[test]
-    fn check_project_rejects_static_type_mismatch() {
-        let dir = tempdir().expect("tempdir");
-        let project = dir.path().join("static-type-mismatch");
-        create_project(&project, Some("static-type-mismatch-app")).expect("create project");
-        fs::write(
-            project.join("src/main.ax"),
-            "static ANSWER: bool = 42\nprint ANSWER\n",
-        )
-        .expect("write source");
-        let error = check_project(&project).expect_err("type mismatch should fail");
-        assert!(
-            error.message.contains("static") && error.message.contains("ANSWER"),
-            "expected static type error, got: {}",
-            error.message
-        );
-        assert_eq!(error.kind, "type");
     }
 }

--- a/stage1/crates/axiomc/src/main.rs
+++ b/stage1/crates/axiomc/src/main.rs
@@ -3,16 +3,20 @@ use axiomc::dap;
 use axiomc::diagnostic_catalog::{DiagnosticCodeInfo, diagnostic_code_info};
 use axiomc::diagnostics::Diagnostic;
 use axiomc::json_contract;
-use axiomc::lsp;
 use axiomc::lockfile::{expected_lockfile_for_project, validate_lockfile};
+use axiomc::lsp;
 use axiomc::manifest::{CapabilityDescriptor, entry_path, load_manifest, manifest_path};
+#[cfg(test)]
+use axiomc::new_project::create_project;
 use axiomc::new_project::{WorkloadTemplate, create_project_with_template};
 use axiomc::project::{
     BuildOptions, BuildOutput, CheckOptions, RunOptions, TestOptions, build_project_with_options,
-    check_project_with_options, list_project_tests_with_options, capability_sbom, package_graph_metadata,
-    project_capabilities, run_project_tests_with_options, run_project_with_options,
-};use axiomc::registry::{
-    load_registry_index, publish_package, render_registry_index, PublishOptions,
+    capability_sbom, check_project_with_options, list_project_tests_with_options,
+    package_graph_metadata, project_capabilities, run_project_tests_with_options,
+    run_project_with_options,
+};
+use axiomc::registry::{
+    PublishOptions, load_registry_index, publish_package, render_registry_index,
 };
 use axiomc::syntax::parse_program;
 use clap::{Parser, Subcommand, ValueEnum};
@@ -416,7 +420,6 @@ fn main() {
                     }
                     Err(error) => print_error("test", error, json),
                 }
-
             }
         }
         Command::Caps {
@@ -437,11 +440,7 @@ fn main() {
                         Ok(report) => match json_contract::to_pretty_string(&report) {
                             Ok(output) => {
                                 println!("{output}");
-                                if report.escalated {
-                                    1
-                                } else {
-                                    0
-                                }
+                                if report.escalated { 1 } else { 0 }
                             }
                             Err(error) => print_error("caps", error, false),
                         },
@@ -464,22 +463,25 @@ fn main() {
                     }
                 } else {
                     match project_capabilities(&project) {
-                    Ok(capabilities) => {
-                        if json {
-                            println!("{}", json_contract::caps_success(&project, &capabilities));
-                            0
-                        } else {
-                            let payload = json_contract::caps_success(&project, &capabilities);
-                            match json_contract::to_pretty_string(&payload) {
-                                Ok(output) => {
-                                    println!("{output}");
-                                    0
+                        Ok(capabilities) => {
+                            if json {
+                                println!(
+                                    "{}",
+                                    json_contract::caps_success(&project, &capabilities)
+                                );
+                                0
+                            } else {
+                                let payload = json_contract::caps_success(&project, &capabilities);
+                                match json_contract::to_pretty_string(&payload) {
+                                    Ok(output) => {
+                                        println!("{output}");
+                                        0
+                                    }
+                                    Err(error) => print_error("caps", error, false),
                                 }
-                                Err(error) => print_error("caps", error, false),
                             }
                         }
-                    }
-                    Err(error) => print_error("caps", error, json),
+                        Err(error) => print_error("caps", error, json),
                     }
                 }
             }
@@ -580,7 +582,7 @@ fn main() {
                 println!("{}", doctor_text(&report));
                 if report.ok { 0 } else { 1 }
             }
-        },
+        }
         Command::Fmt { path, check, json } => match format_axiom_sources(&path, check) {
             Ok(report) => {
                 let serialization_error = if json {
@@ -657,11 +659,7 @@ fn main() {
                         );
                     }
                 }
-                if report.failed == 0 {
-                    0
-                } else {
-                    1
-                }
+                if report.failed == 0 { 0 } else { 1 }
             }
             Err(error) => print_error("bench", error, json),
         },
@@ -2085,11 +2083,7 @@ fn function_name_from_source_line(line: &str) -> Option<String> {
         .chars()
         .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
         .collect();
-    if name.is_empty() {
-        None
-    } else {
-        Some(name)
-    }
+    if name.is_empty() { None } else { Some(name) }
 }
 
 fn recommended_fixture_name(file: &str, function: &str) -> String {
@@ -2392,14 +2386,12 @@ fn inspect_module_nodes(
                 });
                 continue;
             }
-            let candidate =
-                inspect_dependency_import_candidate(&dependencies, &import.path).unwrap_or_else(
-                    || {
-                        file.parent()
-                            .map(|parent| parent.join(&import.path))
-                            .unwrap_or_else(|| PathBuf::from(&import.path))
-                    },
-                );
+            let candidate = inspect_dependency_import_candidate(&dependencies, &import.path)
+                .unwrap_or_else(|| {
+                    file.parent()
+                        .map(|parent| parent.join(&import.path))
+                        .unwrap_or_else(|| PathBuf::from(&import.path))
+                });
             let resolved = normalize_for_graph(&candidate);
             if !known.contains(&resolved) {
                 errors.push(ImportErrorReport {
@@ -2679,8 +2671,11 @@ mod tests {
             );
         let rendered = error.to_string();
         assert!(rendered.contains("unsupported backend \"direct-native\""));
-        assert!(rendered
-            .contains("only generated-rust is implemented in this preparatory backend plumbing"));
+        assert!(
+            rendered.contains(
+                "only generated-rust is implemented in this preparatory backend plumbing"
+            )
+        );
     }
 
     #[test]
@@ -3339,10 +3334,12 @@ mod tests {
             output.items[0].examples,
             vec![String::from("route(\"/health\")")]
         );
-        assert!(output
-            .capabilities
-            .iter()
-            .any(|capability| capability.name == "env"));
+        assert!(
+            output
+                .capabilities
+                .iter()
+                .any(|capability| capability.name == "env")
+        );
     }
 
     #[test]

--- a/stage1/crates/axiomc/src/manifest.rs
+++ b/stage1/crates/axiomc/src/manifest.rs
@@ -106,6 +106,8 @@ pub struct CapabilityConfig {
     pub fs_write: bool,
     pub fs_root: Option<String>,
     pub net: bool,
+    pub net_hosts: Vec<String>,
+    pub net_ports: Vec<u16>,
     pub process: bool,
     pub process_commands: Vec<String>,
     pub env: bool,
@@ -241,7 +243,7 @@ struct RawCapabilityConfig {
     #[serde(rename = "fs:write")]
     fs_write: Option<bool>,
     fs_root: Option<String>,
-    net: Option<bool>,
+    net: Option<RawNetCapability>,
     process: Option<RawProcessCapability>,
     env: Option<RawEnvCapability>,
     env_unrestricted: Option<bool>,
@@ -262,6 +264,19 @@ struct RawCapabilityConfig {
 enum RawProcessCapability {
     LegacyBool(bool),
     AllowList(Vec<String>),
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum RawNetCapability {
+    LegacyBool(bool),
+    AllowList(RawNetAllowlist),
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawNetAllowlist {
+    hosts: Option<Vec<String>>,
+    ports: Option<Vec<u16>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -347,6 +362,15 @@ pub fn capability_descriptors(config: &CapabilityConfig) -> Vec<CapabilityDescri
             allowed: match *kind {
                 CapabilityKind::Env => config.env_vars.clone(),
                 CapabilityKind::Process => config.process_commands.clone(),
+                CapabilityKind::Net => {
+                    let mut allowed = config
+                        .net_hosts
+                        .iter()
+                        .map(|host| format!("host:{host}"))
+                        .collect::<Vec<_>>();
+                    allowed.extend(config.net_ports.iter().map(|port| format!("port:{port}")));
+                    allowed
+                }
                 _ => Vec::new(),
             },
             configured_root: None,
@@ -467,6 +491,7 @@ fn normalize_manifest(raw: RawManifest, path: &Path) -> Result<Manifest, Diagnos
     let capabilities = raw.capabilities.unwrap_or_default();
     let fs_root =
         normalize_optional_relative_path(path, "capabilities.fs_root", capabilities.fs_root)?;
+    let (net, net_hosts, net_ports) = normalize_net_capability(path, capabilities.net)?;
     let (process, process_commands) = normalize_process_capability(path, capabilities.process)?;
     let explicit_env_unrestricted = capabilities.env_unrestricted.unwrap_or(false);
     let (env, env_vars, env_unrestricted, env_legacy_unrestricted) =
@@ -502,7 +527,9 @@ fn normalize_manifest(raw: RawManifest, path: &Path) -> Result<Manifest, Diagnos
             fs: capabilities.fs.unwrap_or(false),
             fs_write: capabilities.fs_write.unwrap_or(false),
             fs_root,
-            net: capabilities.net.unwrap_or(false),
+            net,
+            net_hosts,
+            net_ports,
             process,
             process_commands,
             env,
@@ -681,6 +708,85 @@ fn normalize_capability_name(
         .with_path(path.display().to_string()));
     }
     Ok(name)
+}
+
+fn normalize_net_capability(
+    path: &Path,
+    raw_net: Option<RawNetCapability>,
+) -> Result<(bool, Vec<String>, Vec<u16>), Diagnostic> {
+    match raw_net {
+        Some(RawNetCapability::LegacyBool(enabled)) => Ok((enabled, Vec::new(), Vec::new())),
+        Some(RawNetCapability::AllowList(values)) => {
+            let hosts = normalize_net_host_allowlist(path, values.hosts.unwrap_or_default())?;
+            let ports = normalize_net_port_allowlist(path, values.ports.unwrap_or_default())?;
+            if hosts.is_empty() && ports.is_empty() {
+                return Err(Diagnostic::new(
+                    "manifest",
+                    "capabilities.net must include at least one allowed host or port, or use false to disable network access",
+                )
+                .with_path(path.display().to_string()));
+            }
+            Ok((true, hosts, ports))
+        }
+        None => Ok((false, Vec::new(), Vec::new())),
+    }
+}
+
+fn normalize_net_host_allowlist(
+    path: &Path,
+    values: Vec<String>,
+) -> Result<Vec<String>, Diagnostic> {
+    let mut hosts = Vec::new();
+    let mut seen = std::collections::BTreeSet::new();
+    for (index, value) in values.into_iter().enumerate() {
+        let field_name = format!("capabilities.net.hosts[{index}]");
+        let host = value.trim().to_ascii_lowercase();
+        if host.is_empty() {
+            return Err(
+                Diagnostic::new("manifest", format!("{field_name} must not be empty"))
+                    .with_path(path.display().to_string()),
+            );
+        }
+        if host.chars().any(char::is_whitespace) || host.contains('/') || host.contains(':') {
+            return Err(Diagnostic::new(
+                "manifest",
+                format!(
+                    "{field_name} must be a host name or IP literal, not a URL or socket address"
+                ),
+            )
+            .with_path(path.display().to_string()));
+        }
+        if !seen.insert(host.clone()) {
+            return Err(
+                Diagnostic::new("manifest", format!("duplicate network host {host:?}"))
+                    .with_path(path.display().to_string()),
+            );
+        }
+        hosts.push(host);
+    }
+    Ok(hosts)
+}
+
+fn normalize_net_port_allowlist(path: &Path, values: Vec<u16>) -> Result<Vec<u16>, Diagnostic> {
+    let mut ports = Vec::new();
+    let mut seen = std::collections::BTreeSet::new();
+    for (index, port) in values.into_iter().enumerate() {
+        if port == 0 {
+            return Err(Diagnostic::new(
+                "manifest",
+                format!("capabilities.net.ports[{index}] must be between 1 and 65535"),
+            )
+            .with_path(path.display().to_string()));
+        }
+        if !seen.insert(port) {
+            return Err(
+                Diagnostic::new("manifest", format!("duplicate network port {port}"))
+                    .with_path(path.display().to_string()),
+            );
+        }
+        ports.push(port);
+    }
+    Ok(ports)
 }
 
 fn normalize_process_capability(

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -235,15 +235,45 @@ pub struct PackageGraphLockfile {
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct CapabilitySbomOutput { pub manifest: String, pub packages: Vec<CapabilitySbomPackage> }
+pub struct CapabilitySbomOutput {
+    pub manifest: String,
+    pub packages: Vec<CapabilitySbomPackage>,
+}
 #[derive(Debug, Clone, Serialize)]
-pub struct CapabilitySbomPackage { pub root: String, pub manifest: String, pub name: Option<String>, pub version: Option<String>, pub workspace_only: bool, pub entrypoint: Option<String>, pub package_graph: CapabilitySbomPackageGraph, pub stdlib_imports: Vec<String>, pub intrinsic_use: Vec<CapabilitySbomIntrinsicUse>, pub capability_scopes: Vec<CapabilityDescriptor>, pub unsafe_grants: Vec<CapabilitySbomUnsafeGrant> }
+pub struct CapabilitySbomPackage {
+    pub root: String,
+    pub manifest: String,
+    pub name: Option<String>,
+    pub version: Option<String>,
+    pub workspace_only: bool,
+    pub entrypoint: Option<String>,
+    pub package_graph: CapabilitySbomPackageGraph,
+    pub stdlib_imports: Vec<String>,
+    pub intrinsic_use: Vec<CapabilitySbomIntrinsicUse>,
+    pub capability_scopes: Vec<CapabilityDescriptor>,
+    pub unsafe_grants: Vec<CapabilitySbomUnsafeGrant>,
+}
 #[derive(Debug, Clone, Serialize)]
-pub struct CapabilitySbomPackageGraph { pub dependencies: Vec<PackageGraphDependency>, pub members: Vec<PackageGraphMember>, pub lockfile: PackageGraphLockfile }
+pub struct CapabilitySbomPackageGraph {
+    pub dependencies: Vec<PackageGraphDependency>,
+    pub members: Vec<PackageGraphMember>,
+    pub lockfile: PackageGraphLockfile,
+}
 #[derive(Debug, Clone, Serialize, PartialEq, Eq, PartialOrd, Ord)]
-pub struct CapabilitySbomIntrinsicUse { pub intrinsic: String, pub capability: String, pub module: String, pub line: usize, pub column: usize }
+pub struct CapabilitySbomIntrinsicUse {
+    pub intrinsic: String,
+    pub capability: String,
+    pub module: String,
+    pub line: usize,
+    pub column: usize,
+}
 #[derive(Debug, Clone, Serialize)]
-pub struct CapabilitySbomUnsafeGrant { pub capability: String, pub kind: String, #[serde(skip_serializing_if = "Option::is_none")] pub rationale: Option<String> }
+pub struct CapabilitySbomUnsafeGrant {
+    pub capability: String,
+    pub kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rationale: Option<String>,
+}
 
 #[derive(Debug, Clone, Default)]
 pub struct CheckOptions {
@@ -827,22 +857,62 @@ pub fn capability_sbom(project_root: &Path) -> Result<CapabilitySbomOutput, Diag
         let mut stdlib_imports = BTreeSet::new();
         let mut intrinsic_use = BTreeSet::new();
         if !context.manifest.is_workspace_only() {
-            let entry = canonicalize_package_path(&entry_path(&root, &context.manifest), &root, "manifest", "build.entry resolves outside the package")?;
+            let entry = canonicalize_package_path(
+                &entry_path(&root, &context.manifest),
+                &root,
+                "manifest",
+                "build.entry resolves outside the package",
+            )?;
             let modules = load_modules(&graph, &root, &entry)?;
             for module in &modules {
                 collect_stdlib_imports(&module.program, &mut stdlib_imports);
                 collect_program_intrinsic_use(&module.path, &module.program, &mut intrinsic_use);
             }
         }
-        let unsafe_grants = graph_package.capabilities.iter().flat_map(|capability| {
-            let mut grants = Vec::new();
-            if capability.unsafe_unrestricted { grants.push(CapabilitySbomUnsafeGrant { capability: capability.name.clone(), kind: String::from("unsafe_unrestricted"), rationale: capability.rationale.clone() }); }
-            if capability.unsafe_opt_in { grants.push(CapabilitySbomUnsafeGrant { capability: capability.name.clone(), kind: String::from("unsafe_opt_in"), rationale: capability.rationale.clone() }); }
-            grants
-        }).collect();
-        packages.push(CapabilitySbomPackage { root: graph_package.root, manifest: graph_package.manifest, name: graph_package.name, version: graph_package.version, workspace_only: graph_package.workspace_only, entrypoint: graph_package.entrypoint, package_graph: CapabilitySbomPackageGraph { dependencies: graph_package.dependencies, members: graph_package.members, lockfile: graph_package.lockfile }, stdlib_imports: stdlib_imports.into_iter().collect(), intrinsic_use: intrinsic_use.into_iter().collect(), capability_scopes: graph_package.capabilities, unsafe_grants });
+        let unsafe_grants = graph_package
+            .capabilities
+            .iter()
+            .flat_map(|capability| {
+                let mut grants = Vec::new();
+                if capability.unsafe_unrestricted {
+                    grants.push(CapabilitySbomUnsafeGrant {
+                        capability: capability.name.clone(),
+                        kind: String::from("unsafe_unrestricted"),
+                        rationale: capability.rationale.clone(),
+                    });
+                }
+                if capability.unsafe_opt_in {
+                    grants.push(CapabilitySbomUnsafeGrant {
+                        capability: capability.name.clone(),
+                        kind: String::from("unsafe_opt_in"),
+                        rationale: capability.rationale.clone(),
+                    });
+                }
+                grants
+            })
+            .collect();
+        packages.push(CapabilitySbomPackage {
+            root: graph_package.root,
+            manifest: graph_package.manifest,
+            name: graph_package.name,
+            version: graph_package.version,
+            workspace_only: graph_package.workspace_only,
+            entrypoint: graph_package.entrypoint,
+            package_graph: CapabilitySbomPackageGraph {
+                dependencies: graph_package.dependencies,
+                members: graph_package.members,
+                lockfile: graph_package.lockfile,
+            },
+            stdlib_imports: stdlib_imports.into_iter().collect(),
+            intrinsic_use: intrinsic_use.into_iter().collect(),
+            capability_scopes: graph_package.capabilities,
+            unsafe_grants,
+        });
     }
-    Ok(CapabilitySbomOutput { manifest: manifest_path(&project_root).display().to_string(), packages })
+    Ok(CapabilitySbomOutput {
+        manifest: manifest_path(&project_root).display().to_string(),
+        packages,
+    })
 }
 
 pub fn package_graph_metadata(project_root: &Path) -> Result<PackageGraphOutput, Diagnostic> {
@@ -1133,6 +1203,8 @@ fn register_stdlib_package(graph: &mut PackageGraph) {
             fs_write: true,
             fs_root: None,
             net: true,
+            net_hosts: Vec::new(),
+            net_ports: Vec::new(),
             process: true,
             process_commands: Vec::new(),
             env: true,
@@ -2621,10 +2693,170 @@ fn package_section<'a>(
     })
 }
 
-fn collect_stdlib_imports(program: &syntax::Program, imports: &mut BTreeSet<String>) { for import in &program.imports { if import.path == stdlib::STDLIB_IMPORT_PREFIX || import.path.strip_prefix(stdlib::STDLIB_IMPORT_PREFIX).is_some_and(|rest| rest.starts_with('/')) { imports.insert(import.path.clone()); } } }
-fn collect_program_intrinsic_use(module_path: &Path, program: &syntax::Program, uses: &mut BTreeSet<CapabilitySbomIntrinsicUse>) { for f in &program.functions { for stmt in &f.body { collect_stmt_intrinsic_use(module_path, stmt, uses); } } for stmt in &program.stmts { collect_stmt_intrinsic_use(module_path, stmt, uses); } }
-fn collect_stmt_intrinsic_use(module_path: &Path, stmt: &syntax::Stmt, uses: &mut BTreeSet<CapabilitySbomIntrinsicUse>) { match stmt { syntax::Stmt::Let{expr,..}|syntax::Stmt::Print{expr,..}|syntax::Stmt::Panic{expr,..}|syntax::Stmt::Defer{expr,..}|syntax::Stmt::Return{expr,..} => collect_expr_intrinsic_use(module_path, expr, uses), syntax::Stmt::If{cond,then_block,else_block,..} => { collect_expr_intrinsic_use(module_path, cond, uses); for s in then_block { collect_stmt_intrinsic_use(module_path, s, uses); } if let Some(b)=else_block { for s in b { collect_stmt_intrinsic_use(module_path, s, uses); } } }, syntax::Stmt::IfLet{expr,then_block,else_block,..} => { collect_expr_intrinsic_use(module_path, expr, uses); for s in then_block { collect_stmt_intrinsic_use(module_path, s, uses); } if let Some(b)=else_block { for s in b { collect_stmt_intrinsic_use(module_path, s, uses); } } }, syntax::Stmt::While{cond,body,..} => { collect_expr_intrinsic_use(module_path, cond, uses); for s in body { collect_stmt_intrinsic_use(module_path, s, uses); } }, syntax::Stmt::Match{expr,arms,..} => { collect_expr_intrinsic_use(module_path, expr, uses); for arm in arms { for s in &arm.body { collect_stmt_intrinsic_use(module_path, s, uses); } } } } }
-fn collect_expr_intrinsic_use(module_path: &Path, expr: &syntax::Expr, uses: &mut BTreeSet<CapabilitySbomIntrinsicUse>) { match expr { syntax::Expr::Literal(_) | syntax::Expr::VarRef{..} => {}, syntax::Expr::Call{name,args,line,column,..} => { if let Some(kind)=intrinsic_capability(name) { uses.insert(CapabilitySbomIntrinsicUse{ intrinsic: name.clone(), capability: kind.name().to_string(), module: module_path.display().to_string(), line:*line, column:*column }); } for a in args { collect_expr_intrinsic_use(module_path, a, uses); } }, syntax::Expr::MethodCall{base,args,..} => { collect_expr_intrinsic_use(module_path, base, uses); for a in args { collect_expr_intrinsic_use(module_path, a, uses); } }, syntax::Expr::BinaryAdd{lhs,rhs,..}|syntax::Expr::BinaryCompare{lhs,rhs,..} => { collect_expr_intrinsic_use(module_path, lhs, uses); collect_expr_intrinsic_use(module_path, rhs, uses); }, syntax::Expr::Cast{expr,..}|syntax::Expr::Try{expr,..}|syntax::Expr::Await{expr,..}|syntax::Expr::FieldAccess{base:expr,..}|syntax::Expr::TupleIndex{base:expr,..}|syntax::Expr::Closure{body:expr,..} => collect_expr_intrinsic_use(module_path, expr, uses), syntax::Expr::StructLiteral{fields,..} => { for f in fields { collect_expr_intrinsic_use(module_path, &f.expr, uses); } }, syntax::Expr::TupleLiteral{elements,..}|syntax::Expr::ArrayLiteral{elements,..} => { for e in elements { collect_expr_intrinsic_use(module_path, e, uses); } }, syntax::Expr::MapLiteral{entries,..} => { for e in entries { collect_expr_intrinsic_use(module_path, &e.key, uses); collect_expr_intrinsic_use(module_path, &e.value, uses); } }, syntax::Expr::Slice{base,start,end,..} => { collect_expr_intrinsic_use(module_path, base, uses); if let Some(s)=start { collect_expr_intrinsic_use(module_path, s, uses); } if let Some(e)=end { collect_expr_intrinsic_use(module_path, e, uses); } }, syntax::Expr::Index{base,index,..} => { collect_expr_intrinsic_use(module_path, base, uses); collect_expr_intrinsic_use(module_path, index, uses); } } }
+fn collect_stdlib_imports(program: &syntax::Program, imports: &mut BTreeSet<String>) {
+    for import in &program.imports {
+        if import.path == stdlib::STDLIB_IMPORT_PREFIX
+            || import
+                .path
+                .strip_prefix(stdlib::STDLIB_IMPORT_PREFIX)
+                .is_some_and(|rest| rest.starts_with('/'))
+        {
+            imports.insert(import.path.clone());
+        }
+    }
+}
+fn collect_program_intrinsic_use(
+    module_path: &Path,
+    program: &syntax::Program,
+    uses: &mut BTreeSet<CapabilitySbomIntrinsicUse>,
+) {
+    for f in &program.functions {
+        for stmt in &f.body {
+            collect_stmt_intrinsic_use(module_path, stmt, uses);
+        }
+    }
+    for stmt in &program.stmts {
+        collect_stmt_intrinsic_use(module_path, stmt, uses);
+    }
+}
+fn collect_stmt_intrinsic_use(
+    module_path: &Path,
+    stmt: &syntax::Stmt,
+    uses: &mut BTreeSet<CapabilitySbomIntrinsicUse>,
+) {
+    match stmt {
+        syntax::Stmt::Let { expr, .. }
+        | syntax::Stmt::Print { expr, .. }
+        | syntax::Stmt::Panic { expr, .. }
+        | syntax::Stmt::Defer { expr, .. }
+        | syntax::Stmt::Return { expr, .. } => collect_expr_intrinsic_use(module_path, expr, uses),
+        syntax::Stmt::If {
+            cond,
+            then_block,
+            else_block,
+            ..
+        } => {
+            collect_expr_intrinsic_use(module_path, cond, uses);
+            for s in then_block {
+                collect_stmt_intrinsic_use(module_path, s, uses);
+            }
+            if let Some(b) = else_block {
+                for s in b {
+                    collect_stmt_intrinsic_use(module_path, s, uses);
+                }
+            }
+        }
+        syntax::Stmt::IfLet {
+            expr,
+            then_block,
+            else_block,
+            ..
+        } => {
+            collect_expr_intrinsic_use(module_path, expr, uses);
+            for s in then_block {
+                collect_stmt_intrinsic_use(module_path, s, uses);
+            }
+            if let Some(b) = else_block {
+                for s in b {
+                    collect_stmt_intrinsic_use(module_path, s, uses);
+                }
+            }
+        }
+        syntax::Stmt::While { cond, body, .. } => {
+            collect_expr_intrinsic_use(module_path, cond, uses);
+            for s in body {
+                collect_stmt_intrinsic_use(module_path, s, uses);
+            }
+        }
+        syntax::Stmt::Match { expr, arms, .. } => {
+            collect_expr_intrinsic_use(module_path, expr, uses);
+            for arm in arms {
+                for s in &arm.body {
+                    collect_stmt_intrinsic_use(module_path, s, uses);
+                }
+            }
+        }
+    }
+}
+fn collect_expr_intrinsic_use(
+    module_path: &Path,
+    expr: &syntax::Expr,
+    uses: &mut BTreeSet<CapabilitySbomIntrinsicUse>,
+) {
+    match expr {
+        syntax::Expr::Literal(_) | syntax::Expr::VarRef { .. } => {}
+        syntax::Expr::Call {
+            name,
+            args,
+            line,
+            column,
+            ..
+        } => {
+            if let Some(kind) = intrinsic_capability(name) {
+                uses.insert(CapabilitySbomIntrinsicUse {
+                    intrinsic: name.clone(),
+                    capability: kind.name().to_string(),
+                    module: module_path.display().to_string(),
+                    line: *line,
+                    column: *column,
+                });
+            }
+            for a in args {
+                collect_expr_intrinsic_use(module_path, a, uses);
+            }
+        }
+        syntax::Expr::MethodCall { base, args, .. } => {
+            collect_expr_intrinsic_use(module_path, base, uses);
+            for a in args {
+                collect_expr_intrinsic_use(module_path, a, uses);
+            }
+        }
+        syntax::Expr::BinaryAdd { lhs, rhs, .. } | syntax::Expr::BinaryCompare { lhs, rhs, .. } => {
+            collect_expr_intrinsic_use(module_path, lhs, uses);
+            collect_expr_intrinsic_use(module_path, rhs, uses);
+        }
+        syntax::Expr::Cast { expr, .. }
+        | syntax::Expr::Try { expr, .. }
+        | syntax::Expr::Await { expr, .. }
+        | syntax::Expr::FieldAccess { base: expr, .. }
+        | syntax::Expr::TupleIndex { base: expr, .. }
+        | syntax::Expr::Closure { body: expr, .. } => {
+            collect_expr_intrinsic_use(module_path, expr, uses)
+        }
+        syntax::Expr::StructLiteral { fields, .. } => {
+            for f in fields {
+                collect_expr_intrinsic_use(module_path, &f.expr, uses);
+            }
+        }
+        syntax::Expr::TupleLiteral { elements, .. }
+        | syntax::Expr::ArrayLiteral { elements, .. } => {
+            for e in elements {
+                collect_expr_intrinsic_use(module_path, e, uses);
+            }
+        }
+        syntax::Expr::MapLiteral { entries, .. } => {
+            for e in entries {
+                collect_expr_intrinsic_use(module_path, &e.key, uses);
+                collect_expr_intrinsic_use(module_path, &e.value, uses);
+            }
+        }
+        syntax::Expr::Slice {
+            base, start, end, ..
+        } => {
+            collect_expr_intrinsic_use(module_path, base, uses);
+            if let Some(s) = start {
+                collect_expr_intrinsic_use(module_path, s, uses);
+            }
+            if let Some(e) = end {
+                collect_expr_intrinsic_use(module_path, e, uses);
+            }
+        }
+        syntax::Expr::Index { base, index, .. } => {
+            collect_expr_intrinsic_use(module_path, base, uses);
+            collect_expr_intrinsic_use(module_path, index, uses);
+        }
+    }
+}
 
 fn validate_module_capabilities(
     graph: &PackageGraph,
@@ -2750,7 +2982,14 @@ fn validate_expr_capabilities(
                 .with_span(*line, *column));
             }
             if name == "process_status" || name == "run_status" {
-                validate_process_command_allowlist(module_path, name, args, capabilities, *line, *column)?;
+                validate_process_command_allowlist(
+                    module_path,
+                    name,
+                    args,
+                    capabilities,
+                    *line,
+                    *column,
+                )?;
             }
             for arg in args {
                 validate_expr_capabilities(module_path, arg, capabilities)?;
@@ -2819,7 +3058,6 @@ fn validate_expr_capabilities(
     }
 }
 
-
 fn validate_process_command_allowlist(
     module_path: &Path,
     call_name: &str,
@@ -2833,7 +3071,13 @@ fn validate_process_command_allowlist(
     }
     match args.first() {
         Some(syntax::Expr::Literal(syntax::Literal::String(command)))
-            if capabilities.process_commands.iter().any(|allowed| allowed == command) => Ok(()),
+            if capabilities
+                .process_commands
+                .iter()
+                .any(|allowed| allowed == command) =>
+        {
+            Ok(())
+        }
         Some(syntax::Expr::Literal(syntax::Literal::String(command))) => Err(Diagnostic::new(
             "capability",
             format!("call to {call_name:?} requires [capabilities].process to include {command:?}"),
@@ -2842,7 +3086,9 @@ fn validate_process_command_allowlist(
         .with_span(line, column)),
         _ => Err(Diagnostic::new(
             "capability",
-            format!("call to {call_name:?} requires a string literal listed in [capabilities].process"),
+            format!(
+                "call to {call_name:?} requires a string literal listed in [capabilities].process"
+            ),
         )
         .with_path(module_path.display().to_string())
         .with_span(line, column)),
@@ -5059,7 +5305,11 @@ fn resolve_const_decl(
     module_path: &Path,
     resolving: &mut HashSet<String>,
 ) -> Result<syntax::Expr, Diagnostic> {
-    let kind = if const_decl.is_static { "static" } else { "const" };
+    let kind = if const_decl.is_static {
+        "static"
+    } else {
+        "const"
+    };
     if !resolving.insert(const_decl.name.clone()) {
         return Err(
             Diagnostic::new("type", format!("recursive {kind} {:?}", const_decl.name))
@@ -5830,6 +6080,7 @@ mod tests {
             stderr: None,
             kind: TestKind::Benchmark,
             expected_error: None,
+            http: None,
             capabilities: Vec::new(),
             package: None,
         });

--- a/stage1/crates/axiomc/src/syntax.rs
+++ b/stage1/crates/axiomc/src/syntax.rs
@@ -1423,7 +1423,11 @@ fn parse_type_alias(
     })
 }
 
-fn parse_const_or_static_decl(trimmed: &str, path: &Path, line_no: usize) -> Result<ConstDecl, Diagnostic> {
+fn parse_const_or_static_decl(
+    trimmed: &str,
+    path: &Path,
+    line_no: usize,
+) -> Result<ConstDecl, Diagnostic> {
     let (visibility, rest, visibility_column) = parse_visibility_prefix(trimmed);
     let (keyword, header) = if let Some(rest) = rest.strip_prefix("const ") {
         ("const", rest)

--- a/stage1/crates/axiomc/tests/json_check_fixtures.rs
+++ b/stage1/crates/axiomc/tests/json_check_fixtures.rs
@@ -25,8 +25,9 @@ fn schema_validator() -> Validator {
         .join("..")
         .join("schemas")
         .join("axiom.stage1.v1.schema.json");
-    let schema: Value = serde_json::from_str(&fs::read_to_string(schema_path).expect("read schema"))
-        .expect("schema is valid JSON");
+    let schema: Value =
+        serde_json::from_str(&fs::read_to_string(schema_path).expect("read schema"))
+            .expect("schema is valid JSON");
     jsonschema::validator_for(&schema).expect("compile stage1 JSON schema")
 }
 
@@ -49,8 +50,9 @@ fn check_fixtures_validate_against_stage1_v1_schema() {
         if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
             continue;
         }
-        let payload: Value = serde_json::from_str(&fs::read_to_string(&path).expect("read fixture"))
-            .expect("fixture is valid JSON");
+        let payload: Value =
+            serde_json::from_str(&fs::read_to_string(&path).expect("read fixture"))
+                .expect("fixture is valid JSON");
         if let Err(error) = validator.validate(&payload) {
             panic!(
                 "{} failed axiom.stage1.v1 schema validation: {error}",

--- a/stage1/crates/axiomc/tests/json_command_fixtures.rs
+++ b/stage1/crates/axiomc/tests/json_command_fixtures.rs
@@ -21,10 +21,9 @@ fn schema_validator() -> Validator {
         .join("..")
         .join("schemas")
         .join("axiom.stage1.v1.schema.json");
-    let schema: Value = serde_json::from_str(
-        &fs::read_to_string(path).expect("read stage1 schema"),
-    )
-    .expect("stage1 schema is valid JSON");
+    let schema: Value =
+        serde_json::from_str(&fs::read_to_string(path).expect("read stage1 schema"))
+            .expect("stage1 schema is valid JSON");
     jsonschema::validator_for(&schema).expect("compile stage1 JSON schema")
 }
 
@@ -58,7 +57,10 @@ fn build_fixtures_cover_target_triple_and_failure_diagnostic() {
     assert!(success["metadata"]["lockfile"].is_string());
     assert!(success["metadata"]["lockfile_hash"].is_string());
     assert!(success["metadata"]["source_hash"].is_string());
-    assert_eq!(success["cache_key"]["compiler"], "axiomc-stage1-0.1.0-generated-rust");
+    assert_eq!(
+        success["cache_key"]["compiler"],
+        "axiomc-stage1-0.1.0-generated-rust"
+    );
     assert_eq!(success["cache_key"]["debug"], false);
     assert!(success["cache_key"]["generated_rust_hash"].is_string());
     assert!(success["cache_key"]["lockfile_hash"].is_string());

--- a/stage1/crates/axiomc/tests/schema_metadata.rs
+++ b/stage1/crates/axiomc/tests/schema_metadata.rs
@@ -32,13 +32,11 @@ fn editor_metadata_schemas_are_parseable_and_current() {
         "https://axiom.omt.global/schemas/axiom.stage1.v1.schema.json"
     );
     assert_eq!(
-        compiler_schema["properties"]["command"]["type"],
-        "string",
+        compiler_schema["properties"]["command"]["type"], "string",
         "compiler schema accepts all command names used by shared JSON error envelopes"
     );
     assert_eq!(
-        compiler_schema["properties"]["command"]["minLength"],
-        1,
+        compiler_schema["properties"]["command"]["minLength"], 1,
         "compiler schema rejects empty command names without pinning the CLI command set"
     );
     assert_eq!(
@@ -84,7 +82,9 @@ fn editor_metadata_schemas_are_parseable_and_current() {
         .expect("manifest unsafe opt-in capability enum");
     for capability in &known_capability_names {
         assert!(
-            manifest_unsafe_opt_ins.iter().any(|value| value == capability),
+            manifest_unsafe_opt_ins
+                .iter()
+                .any(|value| value == capability),
             "manifest schema unsafe_opt_ins includes {capability}"
         );
     }

--- a/stage1/schemas/axiom.toml.schema.json
+++ b/stage1/schemas/axiom.toml.schema.json
@@ -183,7 +183,49 @@
           "type": "string"
         },
         "net": {
-          "type": "boolean",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "hosts": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "string",
+                    "minLength": 1,
+                    "pattern": "^[^\\s/:]+$"
+                  },
+                  "uniqueItems": true
+                },
+                "ports": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 65535
+                  },
+                  "uniqueItems": true
+                }
+              },
+              "anyOf": [
+                {
+                  "required": [
+                    "hosts"
+                  ]
+                },
+                {
+                  "required": [
+                    "ports"
+                  ]
+                }
+              ],
+              "additionalProperties": false
+            }
+          ],
           "default": false
         },
         "process": {


### PR DESCRIPTION
## Summary
- add typed `[capabilities].net` host and port allowlists while preserving legacy boolean network capability syntax
- enforce statically known network intrinsic hosts/ports during HIR lowering with capability diagnostics
- emit runtime allowlist checks and surface allowlist entries in descriptors/schema/JSON fixtures

Closes #392

## Checks
- `cargo fmt`
- `cargo test -p axiomc network -- --nocapture`
- `cargo test -p axiomc --no-run`

## Merge Automation
Auto-merge requested with squash after PR creation.