### PR TITLE
Guard filesystem read/write capability separation

### DIFF
--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -5652,6 +5652,43 @@ mod tests {
     }
 
     #[test]
+    fn fs_read_and_write_intrinsics_use_separate_capabilities() {
+        assert_eq!(intrinsic_capability("fs_read"), Some(CapabilityKind::Fs));
+
+        for intrinsic in [
+            "fs_write",
+            "fs_create",
+            "fs_append",
+            "fs_mkdir",
+            "fs_mkdir_all",
+            "fs_remove_file",
+            "fs_remove_dir",
+            "fs_replace",
+        ] {
+            assert_eq!(
+                intrinsic_capability(intrinsic),
+                Some(CapabilityKind::FsWrite),
+                "{intrinsic} must require the explicit fs:write capability, not fs"
+            );
+        }
+    }
+
+    #[test]
+    fn fs_read_grant_does_not_enable_write_capability() {
+        let capabilities = CapabilityConfig {
+            fs: true,
+            fs_write: false,
+            ..CapabilityConfig::default()
+        };
+
+        assert!(capabilities.enabled(CapabilityKind::Fs));
+        assert!(
+            !capabilities.enabled(CapabilityKind::FsWrite),
+            "read-only fs grants must not imply future write API access"
+        );
+    }
+
+    #[test]
     fn test_artifact_name_reports_missing_package_manifest() {
         let dir = tempdir().unwrap_or_else(|err| panic!("tempdir: {err}"));
         let error = match test_artifact_name(dir.path(), &workspace_only_manifest(), "main_test") {


### PR DESCRIPTION
## Summary
- Adds regression coverage that `fs_read` maps only to the read-only `fs` capability.
- Adds regression coverage that every current filesystem mutation intrinsic maps to `fs:write`.
- Proves a manifest-level `fs = true` grant does not imply `fs:write`.

Closes #390

## Checks
- `git diff --check`
- `cargo check --manifest-path stage1/crates/axiomc/Cargo.toml` ✅
- `cargo test --manifest-path stage1/crates/axiomc/Cargo.toml fs_read --lib` ⚠️ blocked by existing unrelated lib-test compile failures on `main`: duplicate test definitions in `crates/axiomc/src/lib.rs` and missing `http` field in an existing `TestTarget` initializer.

## Merge Automation
Auto-merge requested with `gh pr merge --auto --squash`.
