### PR TITLE
Add full axiomc caps manifest

### DIFF
--- a/stage1/compiler-contracts/schemas/axiom.stage1.command.schema.json
+++ b/stage1/compiler-contracts/schemas/axiom.stage1.command.schema.json
@@ -44,7 +44,17 @@
       "properties": {
         "name": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "fs",
+            "fs:write",
+            "net",
+            "process",
+            "env",
+            "clock",
+            "crypto",
+            "ffi",
+            "async"
+          ]
         },
         "description": {
           "type": "string"

--- a/stage1/compiler-contracts/schemas/axiom.stage1.command.schema.json
+++ b/stage1/compiler-contracts/schemas/axiom.stage1.command.schema.json
@@ -69,6 +69,26 @@
         "package_root": {
           "type": "string",
           "minLength": 1
+        },
+        "deny_by_default": {
+          "type": "boolean"
+        },
+        "unsafe_unrestricted": {
+          "type": "boolean"
+        },
+        "unsafe_opt_in": {
+          "type": "boolean"
+        },
+        "unsafe_rationale": {
+          "type": "string"
+        },
+        "owner": {
+          "type": "string",
+          "minLength": 1
+        },
+        "rationale": {
+          "type": "string",
+          "minLength": 1
         }
       }
     },
@@ -523,7 +543,14 @@
         "ok",
         "command",
         "project",
-        "capabilities"
+        "capabilities",
+        "manifest",
+        "requested",
+        "granted",
+        "denied",
+        "unsafe",
+        "transitive_package_usage",
+        "stdlib_modules"
       ],
       "properties": {
         "schema_version": {
@@ -542,6 +569,173 @@
           "type": "array",
           "items": {
             "$ref": "#/$defs/capability"
+          }
+        },
+        "manifest": {
+          "$ref": "#/$defs/path"
+        },
+        "requested": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "name",
+              "granted",
+              "triggers"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "minLength": 1
+              },
+              "granted": {
+                "type": "boolean"
+              },
+              "triggers": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          }
+        },
+        "granted": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/capability"
+          }
+        },
+        "denied": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        },
+        "unsafe": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "package",
+              "capability",
+              "kind",
+              "rationale"
+            ],
+            "properties": {
+              "package": {
+                "$ref": "#/$defs/path"
+              },
+              "capability": {
+                "type": "string",
+                "minLength": 1
+              },
+              "kind": {
+                "type": "string",
+                "minLength": 1
+              },
+              "rationale": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        },
+        "transitive_package_usage": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "root",
+              "manifest",
+              "name",
+              "version",
+              "workspace_only",
+              "entrypoint",
+              "dependencies",
+              "members",
+              "capability_scopes"
+            ],
+            "properties": {
+              "root": {
+                "$ref": "#/$defs/path"
+              },
+              "manifest": {
+                "$ref": "#/$defs/path"
+              },
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "version": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "workspace_only": {
+                "type": "boolean"
+              },
+              "entrypoint": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "dependencies": {
+                "type": "array"
+              },
+              "members": {
+                "type": "array"
+              },
+              "capability_scopes": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/$defs/capability"
+                }
+              }
+            }
+          }
+        },
+        "stdlib_modules": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "capability",
+              "modules"
+            ],
+            "properties": {
+              "capability": {
+                "type": "string",
+                "minLength": 1
+              },
+              "modules": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/$defs/path"
+                }
+              }
+            }
           }
         }
       }

--- a/stage1/compiler-contracts/schemas/axiom.stage1.command.schema.json
+++ b/stage1/compiler-contracts/schemas/axiom.stage1.command.schema.json
@@ -742,7 +742,24 @@
               "modules": {
                 "type": "array",
                 "items": {
-                  "$ref": "#/$defs/path"
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "module",
+                    "triggers"
+                  ],
+                  "properties": {
+                    "module": {
+                      "$ref": "#/$defs/path"
+                    },
+                    "triggers": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    }
+                  }
                 }
               }
             }

--- a/stage1/compiler-contracts/snapshots/caps.json
+++ b/stage1/compiler-contracts/snapshots/caps.json
@@ -47,7 +47,72 @@
     }
   ],
   "command": "caps",
+  "denied": [],
+  "granted": [],
+  "manifest": "<project>/axiom.toml",
   "ok": true,
   "project": "<project>",
-  "schema_version": "axiom.stage1.v1"
+  "requested": [],
+  "schema_version": "axiom.stage1.v1",
+  "stdlib_modules": [],
+  "transitive_package_usage": [
+    {
+      "capability_scopes": [
+        {
+          "description": "filesystem read access",
+          "enabled": false,
+          "name": "fs"
+        },
+        {
+          "description": "filesystem write access",
+          "enabled": false,
+          "name": "fs:write"
+        },
+        {
+          "description": "network access",
+          "enabled": false,
+          "name": "net"
+        },
+        {
+          "description": "child process execution",
+          "enabled": false,
+          "name": "process"
+        },
+        {
+          "description": "environment variable access",
+          "enabled": false,
+          "name": "env"
+        },
+        {
+          "description": "wall-clock time access",
+          "enabled": false,
+          "name": "clock"
+        },
+        {
+          "description": "hashing and cryptography primitives",
+          "enabled": false,
+          "name": "crypto"
+        },
+        {
+          "description": "foreign function interface access",
+          "enabled": false,
+          "name": "ffi"
+        },
+        {
+          "description": "host async runtime access",
+          "enabled": false,
+          "name": "async"
+        }
+      ],
+      "dependencies": [],
+      "entrypoint": "<project>/src/main.ax",
+      "manifest": "<project>/axiom.toml",
+      "members": [],
+      "name": "contract-app",
+      "root": "<project>",
+      "version": "0.1.0",
+      "workspace_only": false
+    }
+  ],
+  "unsafe": []
 }

--- a/stage1/crates/axiomc/src/json_contract.rs
+++ b/stage1/crates/axiomc/src/json_contract.rs
@@ -1,8 +1,9 @@
 use crate::diagnostics::Diagnostic;
 use crate::manifest::CapabilityDescriptor;
-use crate::project::{BuildOutput, CheckOutput, TestListOutput, TestOutput};
+use crate::project::{BuildOutput, CapabilitySbomOutput, CheckOutput, TestListOutput, TestOutput};
 use serde::Serialize;
 use serde_json::{Value, json};
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
 pub const JSON_SCHEMA_VERSION: &str = "axiom.stage1.v1";
@@ -90,6 +91,117 @@ pub fn caps_success(project: &Path, capabilities: &[CapabilityDescriptor]) -> Va
         "command": "caps",
         "project": project.display().to_string(),
         "capabilities": capabilities,
+    })
+}
+
+pub fn caps_manifest_success(
+    project: &Path,
+    capabilities: &[CapabilityDescriptor],
+    sbom: &CapabilitySbomOutput,
+) -> Value {
+    let by_name: BTreeMap<&str, &CapabilityDescriptor> = capabilities
+        .iter()
+        .map(|capability| (capability.name.as_str(), capability))
+        .collect();
+    let mut requested_by_capability: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for package in &sbom.packages {
+        for use_site in &package.intrinsic_use {
+            requested_by_capability
+                .entry(use_site.capability.clone())
+                .or_default()
+                .insert(format!(
+                    "{}:{}:{}:{}",
+                    use_site.module, use_site.line, use_site.column, use_site.intrinsic
+                ));
+        }
+    }
+
+    let requested: Vec<Value> = requested_by_capability
+        .iter()
+        .map(|(name, triggers)| {
+            json!({
+                "name": name,
+                "granted": by_name.get(name.as_str()).is_some_and(|capability| capability.enabled),
+                "triggers": triggers.iter().cloned().collect::<Vec<_>>(),
+            })
+        })
+        .collect();
+    let granted: Vec<&CapabilityDescriptor> = capabilities
+        .iter()
+        .filter(|capability| capability.enabled)
+        .collect();
+    let denied: Vec<Value> = requested_by_capability
+        .keys()
+        .filter(|name| {
+            !by_name
+                .get(name.as_str())
+                .is_some_and(|capability| capability.enabled)
+        })
+        .map(|name| json!({ "name": name }))
+        .collect();
+    let unsafe_entries: Vec<Value> = sbom
+        .packages
+        .iter()
+        .flat_map(|package| {
+            package.unsafe_grants.iter().map(move |grant| {
+                json!({
+                    "package": package.root,
+                    "capability": grant.capability,
+                    "kind": grant.kind,
+                    "rationale": grant.rationale,
+                })
+            })
+        })
+        .collect();
+    let transitive_package_usage: Vec<Value> = sbom
+        .packages
+        .iter()
+        .map(|package| {
+            json!({
+                "root": package.root,
+                "manifest": package.manifest,
+                "name": package.name,
+                "version": package.version,
+                "workspace_only": package.workspace_only,
+                "entrypoint": package.entrypoint,
+                "dependencies": package.package_graph.dependencies,
+                "members": package.package_graph.members,
+                "capability_scopes": package.capability_scopes,
+            })
+        })
+        .collect();
+    let mut stdlib_modules_by_capability: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for package in &sbom.packages {
+        for use_site in &package.intrinsic_use {
+            stdlib_modules_by_capability
+                .entry(use_site.capability.clone())
+                .or_default()
+                .insert(use_site.module.clone());
+        }
+    }
+    let stdlib_modules: Vec<Value> = stdlib_modules_by_capability
+        .into_iter()
+        .map(|(capability, modules)| {
+            json!({
+                "capability": capability,
+                "modules": modules.into_iter().collect::<Vec<_>>(),
+            })
+        })
+        .collect();
+
+    json!({
+        "schema_version": JSON_SCHEMA_VERSION,
+        "ok": true,
+        "command": "caps",
+        "project": project.display().to_string(),
+        "manifest": sbom.manifest,
+        "capabilities": capabilities,
+        "requested": requested,
+        "granted": granted,
+        "denied": denied,
+        "unsafe": unsafe_entries,
+        "transitive_package_usage": transitive_package_usage,
+        "stdlib_modules": stdlib_modules,
     })
 }
 

--- a/stage1/crates/axiomc/src/json_contract.rs
+++ b/stage1/crates/axiomc/src/json_contract.rs
@@ -170,21 +170,36 @@ pub fn caps_manifest_success(
             })
         })
         .collect();
-    let mut stdlib_modules_by_capability: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    let mut stdlib_modules_by_capability: BTreeMap<String, BTreeMap<String, BTreeSet<String>>> =
+        BTreeMap::new();
     for package in &sbom.packages {
         for use_site in &package.intrinsic_use {
             stdlib_modules_by_capability
                 .entry(use_site.capability.clone())
                 .or_default()
-                .insert(use_site.module.clone());
+                .entry(use_site.module.clone())
+                .or_default()
+                .insert(format!(
+                    "{}:{}:{}",
+                    use_site.line, use_site.column, use_site.intrinsic
+                ));
         }
     }
     let stdlib_modules: Vec<Value> = stdlib_modules_by_capability
         .into_iter()
         .map(|(capability, modules)| {
+            let modules = modules
+                .into_iter()
+                .map(|(module, triggers)| {
+                    json!({
+                        "module": module,
+                        "triggers": triggers.into_iter().collect::<Vec<_>>(),
+                    })
+                })
+                .collect::<Vec<_>>();
             json!({
                 "capability": capability,
-                "modules": modules.into_iter().collect::<Vec<_>>(),
+                "modules": modules,
             })
         })
         .collect();

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -2036,6 +2036,7 @@ out_dir = "dist"
 [capabilities]
 clock = true
 env_unrestricted = true
+unsafe_rationale = "test fixture intentionally exercises unrestricted env reporting"
 "#,
         )
         .expect("write manifest");
@@ -2043,9 +2044,7 @@ env_unrestricted = true
             project.join("src/main.ax"),
             r#"import "std/time.ax"
 
-fn main() {
-    let _now = clock_now_ms();
-}
+let now: int = clock_now_ms()
 "#,
         )
         .expect("write source");
@@ -3233,6 +3232,7 @@ out_dir = "dist"
 [capabilities]
 clock = true
 env_unrestricted = true
+unsafe_rationale = "test fixture intentionally exercises unrestricted env reporting"
 "#,
         )
         .expect("write manifest");
@@ -3240,9 +3240,7 @@ env_unrestricted = true
             project.join("src/main.ax"),
             r#"import "std/time.ax"
 
-fn main() {
-    let _now = clock_now_ms();
-}
+let now: int = clock_now_ms()
 "#,
         )
         .expect("write source");
@@ -3281,6 +3279,36 @@ fn main() {
                 .unsafe_grants
                 .iter()
                 .any(|grant| grant.capability == "env" && grant.kind == "unsafe_unrestricted")
+        );
+
+        let caps = project_capabilities(&project).expect("project capabilities");
+        let payload = json_contract::caps_manifest_success(&project, &caps, &sbom);
+        let clock_modules = payload["stdlib_modules"]
+            .as_array()
+            .expect("stdlib module capability entries")
+            .iter()
+            .find(|entry| entry["capability"] == "clock")
+            .expect("clock stdlib module entry");
+        let module = clock_modules["modules"]
+            .as_array()
+            .expect("clock modules")
+            .first()
+            .expect("clock module trigger entry");
+        assert!(
+            module["module"]
+                .as_str()
+                .expect("module path")
+                .ends_with("src/main.ax")
+        );
+        assert!(
+            module["triggers"]
+                .as_array()
+                .expect("module triggers")
+                .iter()
+                .any(|trigger| trigger
+                    .as_str()
+                    .expect("trigger string")
+                    .ends_with("clock_now_ms"))
         );
     }
 

--- a/stage1/crates/axiomc/src/main.rs
+++ b/stage1/crates/axiomc/src/main.rs
@@ -461,14 +461,14 @@ fn main() {
                         },
                         Err(error) => print_error("caps", error, json),
                     }
-                } else {
+                } else if json {
                     match (project_capabilities(&project), capability_sbom(&project)) {
                         (Ok(capabilities), Ok(sbom)) => {
-                            let payload = if json {
-                                json_contract::caps_manifest_success(&project, &capabilities, &sbom)
-                            } else {
-                                json_contract::caps_success(&project, &capabilities)
-                            };
+                            let payload = json_contract::caps_manifest_success(
+                                &project,
+                                &capabilities,
+                                &sbom,
+                            );
                             match json_contract::to_pretty_string(&payload) {
                                 Ok(output) => {
                                     println!("{output}");
@@ -478,6 +478,20 @@ fn main() {
                             }
                         }
                         (Err(error), _) | (_, Err(error)) => print_error("caps", error, json),
+                    }
+                } else {
+                    match project_capabilities(&project) {
+                        Ok(capabilities) => {
+                            let payload = json_contract::caps_success(&project, &capabilities);
+                            match json_contract::to_pretty_string(&payload) {
+                                Ok(output) => {
+                                    println!("{output}");
+                                    0
+                                }
+                                Err(error) => print_error("caps", error, false),
+                            }
+                        }
+                        Err(error) => print_error("caps", error, json),
                     }
                 }
             }

--- a/stage1/crates/axiomc/src/main.rs
+++ b/stage1/crates/axiomc/src/main.rs
@@ -462,26 +462,22 @@ fn main() {
                         Err(error) => print_error("caps", error, json),
                     }
                 } else {
-                    match project_capabilities(&project) {
-                        Ok(capabilities) => {
-                            if json {
-                                println!(
-                                    "{}",
-                                    json_contract::caps_success(&project, &capabilities)
-                                );
-                                0
+                    match (project_capabilities(&project), capability_sbom(&project)) {
+                        (Ok(capabilities), Ok(sbom)) => {
+                            let payload = if json {
+                                json_contract::caps_manifest_success(&project, &capabilities, &sbom)
                             } else {
-                                let payload = json_contract::caps_success(&project, &capabilities);
-                                match json_contract::to_pretty_string(&payload) {
-                                    Ok(output) => {
-                                        println!("{output}");
-                                        0
-                                    }
-                                    Err(error) => print_error("caps", error, false),
+                                json_contract::caps_success(&project, &capabilities)
+                            };
+                            match json_contract::to_pretty_string(&payload) {
+                                Ok(output) => {
+                                    println!("{output}");
+                                    0
                                 }
+                                Err(error) => print_error("caps", error, false),
                             }
                         }
-                        Err(error) => print_error("caps", error, json),
+                        (Err(error), _) | (_, Err(error)) => print_error("caps", error, json),
                     }
                 }
             }

--- a/stage1/json-fixtures/caps/unsafe-env.json
+++ b/stage1/json-fixtures/caps/unsafe-env.json
@@ -9,7 +9,10 @@
       "description": "environment variable access",
       "enabled": true,
       "name": "env",
-      "allowed": ["AXIOM_SAFE", "AXIOM_SECRET"],
+      "allowed": [
+        "AXIOM_SAFE",
+        "AXIOM_SECRET"
+      ],
       "unsafe_unrestricted": true,
       "unsafe_opt_in": true,
       "unsafe_rationale": "legacy environment bridge"
@@ -24,7 +27,9 @@
     {
       "name": "env",
       "granted": true,
-      "triggers": ["manifest:capabilities.env"]
+      "triggers": [
+        "manifest:capabilities.env"
+      ]
     },
     {
       "name": "net",
@@ -37,7 +42,10 @@
       "description": "environment variable access",
       "enabled": true,
       "name": "env",
-      "allowed": ["AXIOM_SAFE", "AXIOM_SECRET"],
+      "allowed": [
+        "AXIOM_SAFE",
+        "AXIOM_SECRET"
+      ],
       "unsafe_unrestricted": true,
       "unsafe_opt_in": true,
       "unsafe_rationale": "legacy environment bridge"
@@ -71,7 +79,10 @@
           "description": "environment variable access",
           "enabled": true,
           "name": "env",
-          "allowed": ["AXIOM_SAFE", "AXIOM_SECRET"],
+          "allowed": [
+            "AXIOM_SAFE",
+            "AXIOM_SECRET"
+          ],
           "unsafe_unrestricted": true,
           "unsafe_opt_in": true,
           "unsafe_rationale": "legacy environment bridge"
@@ -87,7 +98,14 @@
   "stdlib_modules": [
     {
       "capability": "env",
-      "modules": ["std/env"]
+      "modules": [
+        {
+          "module": "std/env",
+          "triggers": [
+            "1:1:env_get"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/stage1/json-fixtures/caps/unsafe-env.json
+++ b/stage1/json-fixtures/caps/unsafe-env.json
@@ -3,18 +3,91 @@
   "ok": true,
   "command": "caps",
   "project": "<project>",
+  "manifest": "<project>/axiom.toml",
   "capabilities": [
     {
       "description": "environment variable access",
       "enabled": true,
       "name": "env",
       "allowed": ["AXIOM_SAFE", "AXIOM_SECRET"],
-      "unsafe_unrestricted": true
+      "unsafe_unrestricted": true,
+      "unsafe_opt_in": true,
+      "unsafe_rationale": "legacy environment bridge"
     },
     {
       "description": "network access",
       "enabled": false,
       "name": "net"
+    }
+  ],
+  "requested": [
+    {
+      "name": "env",
+      "granted": true,
+      "triggers": ["manifest:capabilities.env"]
+    },
+    {
+      "name": "net",
+      "granted": false,
+      "triggers": []
+    }
+  ],
+  "granted": [
+    {
+      "description": "environment variable access",
+      "enabled": true,
+      "name": "env",
+      "allowed": ["AXIOM_SAFE", "AXIOM_SECRET"],
+      "unsafe_unrestricted": true,
+      "unsafe_opt_in": true,
+      "unsafe_rationale": "legacy environment bridge"
+    }
+  ],
+  "denied": [
+    {
+      "name": "net"
+    }
+  ],
+  "unsafe": [
+    {
+      "package": "<project>",
+      "capability": "env",
+      "kind": "unsafe_unrestricted",
+      "rationale": "legacy environment bridge"
+    }
+  ],
+  "transitive_package_usage": [
+    {
+      "root": "<project>",
+      "manifest": "<project>/axiom.toml",
+      "name": "caps-env-app",
+      "version": "0.1.0",
+      "workspace_only": false,
+      "entrypoint": "<project>/src/main.ax",
+      "dependencies": [],
+      "members": [],
+      "capability_scopes": [
+        {
+          "description": "environment variable access",
+          "enabled": true,
+          "name": "env",
+          "allowed": ["AXIOM_SAFE", "AXIOM_SECRET"],
+          "unsafe_unrestricted": true,
+          "unsafe_opt_in": true,
+          "unsafe_rationale": "legacy environment bridge"
+        },
+        {
+          "description": "network access",
+          "enabled": false,
+          "name": "net"
+        }
+      ]
+    }
+  ],
+  "stdlib_modules": [
+    {
+      "capability": "env",
+      "modules": ["std/env"]
     }
   ]
 }

--- a/stage1/schemas/axiom.stage1.v1.schema.json
+++ b/stage1/schemas/axiom.stage1.v1.schema.json
@@ -257,7 +257,24 @@
           "modules": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/path"
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "module",
+                "triggers"
+              ],
+              "properties": {
+                "module": {
+                  "$ref": "#/$defs/path"
+                },
+                "triggers": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              }
             }
           }
         }
@@ -595,7 +612,24 @@
                 "modules": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/$defs/path"
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "module",
+                      "triggers"
+                    ],
+                    "properties": {
+                      "module": {
+                        "$ref": "#/$defs/path"
+                      },
+                      "triggers": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      }
+                    }
                   }
                 }
               }

--- a/stage1/schemas/axiom.stage1.v1.schema.json
+++ b/stage1/schemas/axiom.stage1.v1.schema.json
@@ -24,7 +24,7 @@
       "type": "string"
     },
     "manifest": {
-      "type": "string"
+      "$ref": "#/$defs/path"
     },
     "entry": {
       "type": "string"
@@ -98,58 +98,197 @@
     },
     "error": {
       "$ref": "#/$defs/diagnostic"
+    },
+    "requested": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "granted",
+          "triggers"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "granted": {
+            "type": "boolean"
+          },
+          "triggers": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "granted": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/capability"
+      }
+    },
+    "denied": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "unsafe": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "package",
+          "capability",
+          "kind",
+          "rationale"
+        ],
+        "properties": {
+          "package": {
+            "$ref": "#/$defs/path"
+          },
+          "capability": {
+            "type": "string",
+            "minLength": 1
+          },
+          "kind": {
+            "type": "string",
+            "minLength": 1
+          },
+          "rationale": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      }
+    },
+    "transitive_package_usage": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "root",
+          "manifest",
+          "name",
+          "version",
+          "workspace_only",
+          "entrypoint",
+          "dependencies",
+          "members",
+          "capability_scopes"
+        ],
+        "properties": {
+          "root": {
+            "$ref": "#/$defs/path"
+          },
+          "manifest": {
+            "$ref": "#/$defs/path"
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "version": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "workspace_only": {
+            "type": "boolean"
+          },
+          "entrypoint": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "dependencies": {
+            "type": "array"
+          },
+          "members": {
+            "type": "array"
+          },
+          "capability_scopes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/$defs/capability"
+            }
+          }
+        }
+      }
+    },
+    "stdlib_modules": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "capability",
+          "modules"
+        ],
+        "properties": {
+          "capability": {
+            "type": "string",
+            "minLength": 1
+          },
+          "modules": {
+            "type": "array",
+            "items": {
+              "$ref": "#/$defs/path"
+            }
+          }
+        }
+      }
     }
   },
   "$defs": {
     "capability": {
       "type": "object",
+      "additionalProperties": false,
       "required": [
         "name",
-        "enabled",
-        "description"
+        "description",
+        "enabled"
       ],
       "properties": {
         "name": {
-          "enum": [
-            "fs",
-            "fs:write",
-            "net",
-            "process",
-            "env",
-            "clock",
-            "crypto",
-            "ffi",
-            "async"
-          ]
-        },
-        "enabled": {
-          "type": "boolean"
+          "type": "string",
+          "minLength": 1
         },
         "description": {
           "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
         },
         "allowed": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "unsafe_unrestricted": {
-          "type": "boolean"
-        },
-        "deny_by_default": {
-          "type": "boolean"
-        },
-        "unsafe_opt_in": {
-          "type": "boolean"
-        },
-        "owner": {
-          "type": "string",
-          "minLength": 1
-        },
-        "rationale": {
-          "type": "string",
-          "minLength": 1
         },
         "configured_root": {
           "type": "string",
@@ -162,9 +301,28 @@
         "package_root": {
           "type": "string",
           "minLength": 1
+        },
+        "deny_by_default": {
+          "type": "boolean"
+        },
+        "unsafe_unrestricted": {
+          "type": "boolean"
+        },
+        "unsafe_opt_in": {
+          "type": "boolean"
+        },
+        "unsafe_rationale": {
+          "type": "string"
+        },
+        "owner": {
+          "type": "string",
+          "minLength": 1
+        },
+        "rationale": {
+          "type": "string",
+          "minLength": 1
         }
-      },
-      "additionalProperties": false
+      }
     },
     "diagnostic": {
       "type": "object",
@@ -210,7 +368,231 @@
         }
       },
       "additionalProperties": false
+    },
+    "path": {
+      "type": "string",
+      "minLength": 1
+    },
+    "schemaVersion": {
+      "const": "axiom.stage1.v1"
     }
   },
-  "additionalProperties": true
+  "additionalProperties": true,
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "command": {
+            "const": "caps"
+          }
+        },
+        "required": [
+          "command"
+        ]
+      },
+      "then": {
+        "required": [
+          "schema_version",
+          "ok",
+          "command",
+          "project",
+          "capabilities",
+          "manifest",
+          "requested",
+          "granted",
+          "denied",
+          "unsafe",
+          "transitive_package_usage",
+          "stdlib_modules"
+        ],
+        "properties": {
+          "schema_version": {
+            "$ref": "#/$defs/schemaVersion"
+          },
+          "project": {
+            "$ref": "#/$defs/path"
+          },
+          "ok": {
+            "const": true
+          },
+          "command": {
+            "const": "caps"
+          },
+          "capabilities": {
+            "type": "array",
+            "items": {
+              "$ref": "#/$defs/capability"
+            }
+          },
+          "manifest": {
+            "$ref": "#/$defs/path"
+          },
+          "requested": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "name",
+                "granted",
+                "triggers"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "granted": {
+                  "type": "boolean"
+                },
+                "triggers": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              }
+            }
+          },
+          "granted": {
+            "type": "array",
+            "items": {
+              "$ref": "#/$defs/capability"
+            }
+          },
+          "denied": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "name"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          },
+          "unsafe": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "package",
+                "capability",
+                "kind",
+                "rationale"
+              ],
+              "properties": {
+                "package": {
+                  "$ref": "#/$defs/path"
+                },
+                "capability": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "kind": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "rationale": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            }
+          },
+          "transitive_package_usage": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "root",
+                "manifest",
+                "name",
+                "version",
+                "workspace_only",
+                "entrypoint",
+                "dependencies",
+                "members",
+                "capability_scopes"
+              ],
+              "properties": {
+                "root": {
+                  "$ref": "#/$defs/path"
+                },
+                "manifest": {
+                  "$ref": "#/$defs/path"
+                },
+                "name": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "version": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "workspace_only": {
+                  "type": "boolean"
+                },
+                "entrypoint": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "dependencies": {
+                  "type": "array"
+                },
+                "members": {
+                  "type": "array"
+                },
+                "capability_scopes": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/$defs/capability"
+                  }
+                }
+              }
+            }
+          },
+          "stdlib_modules": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "capability",
+                "modules"
+              ],
+              "properties": {
+                "capability": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "modules": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/$defs/path"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
 }

--- a/stage1/schemas/axiom.stage1.v1.schema.json
+++ b/stage1/schemas/axiom.stage1.v1.schema.json
@@ -276,7 +276,17 @@
       "properties": {
         "name": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "fs",
+            "fs:write",
+            "net",
+            "process",
+            "env",
+            "clock",
+            "crypto",
+            "ffi",
+            "async"
+          ]
         },
         "description": {
           "type": "string"


### PR DESCRIPTION
## Summary

- extend `axiomc caps --json` into a full capability manifest with requested, granted, denied, unsafe, transitive package usage, and stdlib trigger sections
- reuse the capability SBOM/package graph walk to attach intrinsic use sites, stdlib modules, unsafe grants, package members/dependencies, and scoped capability metadata
- update stage1 JSON schemas, fixtures, snapshots, and LSP/schema metadata expectations
- repair the reviewed schema/fixture mismatch so `stdlib_modules[].modules[]` carries `{ module, triggers }` entries instead of plain strings

## Checks

- `cargo test -p axiomc --manifest-path stage1/Cargo.toml --test json_command_fixtures`
- `cargo test -p axiomc --manifest-path stage1/Cargo.toml --test schema_metadata --test json_check_fixtures`
- `cargo test -p axiomc --test schema_metadata --test json_check_fixtures && cargo test -p axiomc --test json_command_fixtures && cargo test -p axiomc --test json_contract_snapshots`
- `git diff --check`



Daedalus follow-up verification (2026-05-13):
- `cargo check --manifest-path ./stage1/Cargo.toml -p axiomc`
- `cargo test --manifest-path ./stage1/Cargo.toml -p axiomc caps -- --nocapture`

## Merge Automation

Auto-merge was requested with `gh pr merge --auto --squash`, but the PR remains blocked by the existing `CHANGES_REQUESTED` review state until reviewers re-check the updated branch.

Closes #384



Daedalus rebase verification (2026-05-13 01:10 UTC):
- merged latest `origin/main` into `daedalus/issue-384` (`4b27705`)
- `git diff --check`
- `cargo check -p axiomc`
- `cargo test -p axiomc --test json_contract_snapshots`
- `cargo test -p axiomc caps --lib --tests`



Daedalus final verification (2026-05-13 01:43 UTC):
- confirmed cwd and git toplevel are `/openclaw-data/src/_worktrees/daedalus/omt-global/axiom/issue-384`
- `git diff --check`
- `cargo test -p axiomc --manifest-path stage1/Cargo.toml --test schema_metadata --test json_check_fixtures`
- `cargo test -p axiomc --manifest-path stage1/Cargo.toml --test json_command_fixtures`
- `cargo test -p axiomc --manifest-path stage1/Cargo.toml --test json_contract_snapshots`

Merge automation current status: auto-merge is enabled with squash, but GitHub currently reports `reviewDecision: REVIEW_REQUIRED` / `mergeStateStatus: BLOCKED` after the latest main merge. No code/test blocker found by Daedalus; this is waiting on required review state.
