### PR TITLE
Codegen: complete debug source mapping for defers

### DIFF
--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -3215,12 +3215,19 @@ fn render_stmt_block(
             &mut local_defers,
         );
     }
-    render_deferred_exprs(out, indent, &local_defers);
+    render_deferred_exprs(out, indent, source_path, debug, &local_defers);
 }
 
-fn render_deferred_exprs(out: &mut String, indent: usize, defers: &[(String, SourceSpan)]) {
+fn render_deferred_exprs(
+    out: &mut String,
+    indent: usize,
+    source_path: &str,
+    debug: bool,
+    defers: &[(String, SourceSpan)],
+) {
     let pad = "    ".repeat(indent);
-    for (expr, _) in defers.iter().rev() {
+    for (expr, span) in defers.iter().rev() {
+        render_source_marker(source_path, *span, out, indent, debug);
         out.push_str(&format!(
             "{pad}let _ = {expr};
 "
@@ -3269,8 +3276,8 @@ fn render_stmt(
         }
         Stmt::Panic { message, span } => {
             render_source_marker(source_path, *span, out, indent, debug);
-            render_deferred_exprs(out, indent, local_defers);
-            render_deferred_exprs(out, indent, active_defers);
+            render_deferred_exprs(out, indent, source_path, debug, local_defers);
+            render_deferred_exprs(out, indent, source_path, debug, active_defers);
             out.push_str(&format!(
                 "{pad}axiom_panic({});
 ",
@@ -3387,8 +3394,8 @@ fn render_stmt(
         }
         Stmt::Return { expr, span } => {
             render_source_marker(source_path, *span, out, indent, debug);
-            render_deferred_exprs(out, indent, local_defers);
-            render_deferred_exprs(out, indent, active_defers);
+            render_deferred_exprs(out, indent, source_path, debug, local_defers);
+            render_deferred_exprs(out, indent, source_path, debug, active_defers);
             if in_async_function {
                 out.push_str(&format!(
                     "{pad}return axiom_task_ready({});

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -16,7 +16,7 @@ pub mod syntax;
 
 #[cfg(test)]
 mod tests {
-    use crate::codegen::{NativeBackendKind, render_rust};
+    use crate::codegen::{NativeBackendKind, render_rust, render_rust_with_debug};
     use crate::hir;
     use crate::json_contract;
     use crate::lockfile::{render_lockfile, render_lockfile_for_project};
@@ -671,6 +671,13 @@ print demo()
         assert!(
             cleanup < ret,
             "defer should render before return: {rendered}"
+        );
+
+        let debug_rendered = render_rust_with_debug(&mir, true);
+        let marker = "// axiom-source: main.ax:7:1\n    let _ = trace(String::from(\"cleanup\"));";
+        assert!(
+            debug_rendered.contains(marker),
+            "generated defer cleanup should carry the defer source span: {debug_rendered}"
         );
     }
 


### PR DESCRIPTION
## Summary
- Map generated `defer` cleanup statements back to the original Axiom source span in debug source maps.
- Keep debug markers disabled for release codegen.
- Add regression coverage ensuring generated defer cleanup carries the defer statement source marker.

Closes #359.

## Checks
- `cargo test --lib parser_lowers_defer_statement -- --nocapture`
- `cargo test --lib build_project_debug_mode_emits_source_markers_and_uses_separate_cache_key -- --nocapture`

## Merge Automation
Auto-merge requested with `gh pr merge --auto --squash`.
