### PR TITLE
HIR: audit capability attribution before MIR

### DIFF
--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -172,6 +172,7 @@ pub enum Expr {
         name: String,
         args: Vec<Expr>,
         ty: Type,
+        span: SourceSpan,
     },
     BinaryAdd {
         lhs: Box<Expr>,
@@ -6439,6 +6440,10 @@ fn lower_expr_with_expected_inner(
                 }
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: with_assert_location(vec![lowered], *line, *column),
                     ty: Type::Int,
@@ -6474,6 +6479,10 @@ fn lower_expr_with_expected_inner(
                 move_lowered_value(&label, env)?;
                 move_lowered_value(&holds, env)?;
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: with_assert_location(vec![label, holds], *line, *column),
                     ty: Type::Int,
@@ -6507,6 +6516,10 @@ fn lower_expr_with_expected_inner(
                 move_lowered_value(&actual, env)?;
                 move_lowered_value(&expected, env)?;
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: with_assert_location(vec![label, actual, expected], *line, *column),
                     ty: Type::Int,
@@ -6545,6 +6558,10 @@ fn lower_expr_with_expected_inner(
                 move_lowered_value(&haystack, env)?;
                 move_lowered_value(&needle, env)?;
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: with_assert_location(vec![haystack, needle], *line, *column),
                     ty: Type::Int,
@@ -6604,6 +6621,10 @@ fn lower_expr_with_expected_inner(
                 lowered_args.push(lhs);
                 lowered_args.push(rhs);
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: with_assert_location(lowered_args, *line, *column),
                     ty: Type::Int,
@@ -6629,6 +6650,10 @@ fn lower_expr_with_expected_inner(
                     .with_span(args[0].line(), args[0].column()));
                 }
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: vec![lowered],
                     ty: Type::Int,
@@ -6657,6 +6682,10 @@ fn lower_expr_with_expected_inner(
                 }
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: vec![lowered],
                     ty: Type::Int,
@@ -6683,6 +6712,10 @@ fn lower_expr_with_expected_inner(
                 }
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: vec![lowered],
                     ty: Type::Option(Box::new(Type::Int)),
@@ -6709,6 +6742,10 @@ fn lower_expr_with_expected_inner(
                 }
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: vec![lowered],
                     ty: Type::Option(Box::new(Type::Bool)),
@@ -6736,6 +6773,10 @@ fn lower_expr_with_expected_inner(
                 validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: vec![lowered],
                     ty: Type::Option(Box::new(Type::String)),
@@ -6777,6 +6818,10 @@ fn lower_expr_with_expected_inner(
                     _ => unreachable!(),
                 };
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: vec![text, key],
                     ty,
@@ -6804,6 +6849,10 @@ fn lower_expr_with_expected_inner(
                 validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: vec![lowered],
                     ty: Type::String,
@@ -6831,6 +6880,10 @@ fn lower_expr_with_expected_inner(
                 validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: vec![lowered],
                     ty: Type::String,
@@ -6861,6 +6914,10 @@ fn lower_expr_with_expected_inner(
                 validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: vec![lowered],
                     ty: Type::String,
@@ -6888,6 +6945,10 @@ fn lower_expr_with_expected_inner(
                 validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: vec![lowered],
                     ty: Type::Option(Box::new(Type::String)),
@@ -6918,6 +6979,10 @@ fn lower_expr_with_expected_inner(
                 validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: vec![lowered],
                     ty: Type::String,
@@ -6959,6 +7024,10 @@ fn lower_expr_with_expected_inner(
                 move_lowered_value(&text, env)?;
                 move_lowered_value(&key, env)?;
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: vec![text, key],
                     ty: Type::Option(Box::new(Type::String)),
@@ -7001,6 +7070,10 @@ fn lower_expr_with_expected_inner(
                     Type::String
                 };
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: lowered_args,
                     ty,
@@ -7046,6 +7119,10 @@ fn lower_expr_with_expected_inner(
                     lowered_args.push(lowered);
                 }
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: lowered_args,
                     ty: if name == "encoding_url_component_decode" {
@@ -7064,6 +7141,10 @@ fn lower_expr_with_expected_inner(
                     .with_span(*line, *column));
                 }
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: Vec::new(),
                     ty: if name == "cli_args" {
@@ -7090,6 +7171,10 @@ fn lower_expr_with_expected_inner(
                     .with_span(args[0].line(), args[0].column()));
                 }
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: vec![lowered],
                     ty: Type::Option(Box::new(Type::String)),
@@ -7115,6 +7200,10 @@ fn lower_expr_with_expected_inner(
                 validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: vec![lowered],
                     ty: Type::Option(Box::new(Type::String)),
@@ -7157,6 +7246,10 @@ fn lower_expr_with_expected_inner(
                 move_lowered_value(&path, env)?;
                 move_lowered_value(&content, env)?;
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: vec![path, content],
                     ty: Type::Int,
@@ -7190,6 +7283,10 @@ fn lower_expr_with_expected_inner(
                 }
                 move_lowered_value(&path, env)?;
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: vec![path],
                     ty: Type::Int,
@@ -7218,6 +7315,10 @@ fn lower_expr_with_expected_inner(
                 validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: vec![lowered],
                     ty: Type::Option(Box::new(Type::String)),
@@ -7259,6 +7360,10 @@ fn lower_expr_with_expected_inner(
                 }
                 move_lowered_value(&response, env)?;
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: vec![response, timeout],
                     ty: Type::Option(Box::new(Type::Int)),
@@ -7322,6 +7427,10 @@ fn lower_expr_with_expected_inner(
                 move_lowered_value(&host, env)?;
                 move_lowered_value(&message, env)?;
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: vec![host, port, message, timeout],
                     ty: Type::Option(Box::new(Type::String)),
@@ -7363,6 +7472,10 @@ fn lower_expr_with_expected_inner(
                 }
                 move_lowered_value(&response, env)?;
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: vec![response, timeout],
                     ty: Type::Option(Box::new(Type::Int)),
@@ -7426,6 +7539,10 @@ fn lower_expr_with_expected_inner(
                 move_lowered_value(&host, env)?;
                 move_lowered_value(&message, env)?;
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: vec![host, port, message, timeout],
                     ty: Type::Option(Box::new(Type::String)),
@@ -7461,6 +7578,10 @@ fn lower_expr_with_expected_inner(
                 )?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: vec![lowered],
                     ty: Type::Option(Box::new(Type::String)),
@@ -7503,6 +7624,10 @@ fn lower_expr_with_expected_inner(
                 move_lowered_value(&bind, env)?;
                 move_lowered_value(&body, env)?;
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: vec![bind, body],
                     ty: Type::Bool,
@@ -7567,6 +7692,10 @@ fn lower_expr_with_expected_inner(
                 move_lowered_value(&route_path, env)?;
                 move_lowered_value(&body, env)?;
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: vec![bind, route_path, body, max_requests],
                     ty: Type::Bool,
@@ -7602,6 +7731,10 @@ fn lower_expr_with_expected_inner(
                 validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: vec![lowered],
                     ty: Type::Int,
@@ -7623,6 +7756,10 @@ fn lower_expr_with_expected_inner(
                     .with_span(*line, *column));
                 }
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: Vec::new(),
                     ty: Type::Int,
@@ -7655,6 +7792,10 @@ fn lower_expr_with_expected_inner(
                     .with_span(args[0].line(), args[0].column()));
                 }
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: vec![lowered],
                     ty: Type::Int,
@@ -7687,6 +7828,10 @@ fn lower_expr_with_expected_inner(
                     .with_span(args[0].line(), args[0].column()));
                 }
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: vec![lowered],
                     ty: Type::Int,
@@ -7712,6 +7857,10 @@ fn lower_expr_with_expected_inner(
                 validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: vec![lowered],
                     ty: Type::Option(Box::new(Type::String)),
@@ -7746,6 +7895,10 @@ fn lower_expr_with_expected_inner(
                 validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: vec![lowered],
                     ty: Type::String,
@@ -7788,6 +7941,10 @@ fn lower_expr_with_expected_inner(
                 }
                 move_lowered_value(&message, env)?;
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: vec![key, message],
                     ty: Type::String,
@@ -7836,6 +7993,10 @@ fn lower_expr_with_expected_inner(
                 }
                 move_lowered_value(&right, env)?;
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: vec![left, right],
                     ty: Type::Bool,
@@ -7880,6 +8041,10 @@ fn lower_expr_with_expected_inner(
                     move_lowered_owner_value(&lowered, env)?;
                 }
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: vec![lowered],
                     ty: element_ty,
@@ -7931,6 +8096,10 @@ fn lower_expr_with_expected_inner(
                         lowered_args.push(lowered);
                     }
                     return Ok(Expr::Call {
+                        span: SourceSpan {
+                            line: *line,
+                            column: *column,
+                        },
                         name: name.clone(),
                         args: lowered_args,
                         ty: (*return_ty).clone(),
@@ -7989,6 +8158,10 @@ fn lower_expr_with_expected_inner(
                 }
                 release_temporary_borrows(&temporary_borrows, env);
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: name.clone(),
                     args: lowered_args,
                     ty: signature.return_ty.clone(),
@@ -8194,6 +8367,10 @@ fn lower_expr_with_expected_inner(
                 }
                 release_temporary_borrows(&temporary_borrows, env);
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: signature.function_name.clone(),
                     args: lowered_args,
                     ty: signature.return_ty.clone(),
@@ -8224,6 +8401,10 @@ fn lower_expr_with_expected_inner(
                     .with_span(args[0].line(), args[0].column()));
                 }
                 return Ok(Expr::Call {
+                    span: SourceSpan {
+                        line: *line,
+                        column: *column,
+                    },
                     name: format!("__axiom_numeric_{method}"),
                     args: vec![lowered_base, lowered_arg],
                     ty: return_ty,
@@ -8323,6 +8504,10 @@ fn lower_expr_with_expected_inner(
             }
             release_temporary_borrows(&temporary_borrows, env);
             Ok(Expr::Call {
+                span: SourceSpan {
+                    line: *line,
+                    column: *column,
+                },
                 name: signature.function_name.clone(),
                 args: lowered_args,
                 ty: signature.return_ty.clone(),
@@ -9478,6 +9663,7 @@ fn lower_async_runtime_intrinsic(
         _ => unreachable!("async runtime intrinsic checked before lowering"),
     };
     Ok(Expr::Call {
+        span: SourceSpan { line, column },
         name: name.to_string(),
         args: lowered_args,
         ty,
@@ -9563,6 +9749,10 @@ fn lower_map_lookup_intrinsic(
     if matches!(name, "map_keys" | "keys") {
         move_lowered_value(&lowered_map, env)?;
         return Ok(Expr::Call {
+            span: SourceSpan {
+                line: line,
+                column: column,
+            },
             name: name.to_string(),
             args: vec![lowered_map],
             ty: Type::Array(Box::new(key_ty), None),
@@ -9595,6 +9785,7 @@ fn lower_map_lookup_intrinsic(
     move_lowered_value(&lowered_args[0], env)?;
     move_lowered_value(&lowered_args[1], env)?;
     Ok(Expr::Call {
+        span: SourceSpan { line, column },
         name: name.to_string(),
         args: lowered_args,
         ty: match name {

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -3353,6 +3353,49 @@ let now: int = clock_now_ms()
     }
 
     #[test]
+    fn capability_sbom_records_denied_intrinsic_use() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("caps-sbom-denied");
+        create_project(&project, Some("caps-sbom-denied-app")).expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            r#"[package]
+name = "caps-sbom-denied-app"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+clock = false
+"#,
+        )
+        .expect("write manifest");
+        fs::write(
+            project.join("src/main.ax"),
+            r#"let now: int = clock_now_ms()
+"#,
+        )
+        .expect("write source");
+        let manifest = load_manifest(&project).expect("load manifest");
+        fs::write(
+            project.join("axiom.lock"),
+            render_lockfile_for_project(&project, &manifest).expect("lockfile"),
+        )
+        .expect("write lockfile");
+
+        let sbom = capability_sbom(&project).expect("capability sbom");
+        let package = sbom.packages.first().expect("package");
+        assert!(
+            package
+                .intrinsic_use
+                .iter()
+                .any(|usage| usage.intrinsic == "clock_now_ms" && usage.capability == "clock")
+        );
+    }
+
+    #[test]
     fn capability_view_reports_unsafe_env_grants() {
         let dir = tempdir().expect("tempdir");
         let project = dir.path().join("caps-env-unrestricted");

--- a/stage1/crates/axiomc/src/mir.rs
+++ b/stage1/crates/axiomc/src/mir.rs
@@ -534,7 +534,7 @@ fn lower_expr(expr: &hir::Expr) -> Expr {
             name: name.clone(),
             ty: lower_type(ty),
         },
-        hir::Expr::Call { name, args, ty } => Expr::Call {
+        hir::Expr::Call { name, args, ty, .. } => Expr::Call {
             name: name.clone(),
             args: args.iter().map(lower_expr).collect(),
             ty: lower_type(ty),

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -6007,6 +6007,57 @@ mod tests {
     }
 
     #[test]
+    fn hir_intrinsic_collection_preserves_static_initializer_call_sites() {
+        let static_def = hir::StaticDef {
+            name: "CLOCK_PAIR".to_string(),
+            ty: hir::Type::Tuple(vec![hir::Type::Int, hir::Type::Int]),
+            expr: hir::Expr::TupleLiteral {
+                elements: vec![
+                    hir::Expr::Call {
+                        name: "clock_now_ms".to_string(),
+                        args: Vec::new(),
+                        ty: hir::Type::Int,
+                        span: hir::SourceSpan {
+                            line: 3,
+                            column: 22,
+                        },
+                    },
+                    hir::Expr::Call {
+                        name: "clock_now_ms".to_string(),
+                        args: Vec::new(),
+                        ty: hir::Type::Int,
+                        span: hir::SourceSpan {
+                            line: 3,
+                            column: 38,
+                        },
+                    },
+                ],
+                ty: hir::Type::Tuple(vec![hir::Type::Int, hir::Type::Int]),
+            },
+        };
+        let program = hir::Program {
+            path: "src/main.ax".to_string(),
+            structs: Vec::new(),
+            enums: Vec::new(),
+            statics: vec![static_def],
+            functions: Vec::new(),
+            stmts: Vec::new(),
+        };
+        let mut uses = BTreeSet::new();
+
+        collect_hir_intrinsic_use(&program, &mut uses);
+        let uses = uses.into_iter().collect::<Vec<_>>();
+
+        assert_eq!(uses.len(), 2);
+        assert_eq!(uses[0].intrinsic, "clock_now_ms");
+        assert_eq!(uses[0].line, 3);
+        assert_eq!(uses[0].column, 22);
+        assert_eq!(uses[1].intrinsic, "clock_now_ms");
+        assert_eq!(uses[1].line, 3);
+        assert_eq!(uses[1].column, 38);
+    }
+
+    #[test]
     fn fs_read_grant_does_not_enable_write_capability() {
         let capabilities = CapabilityConfig {
             fs: true,

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -2769,12 +2769,16 @@ fn collect_hir_stmt_intrinsic_use(
 fn collect_hir_expr_intrinsic_use(
     module_path: &str,
     expr: &hir::Expr,
-    line: usize,
-    column: usize,
+    fallback_line: usize,
+    fallback_column: usize,
     uses: &mut BTreeSet<CapabilitySbomIntrinsicUse>,
 ) {
     match expr {
-        hir::Expr::Call { name, args, .. } => {
+        hir::Expr::Call {
+            name, args, span, ..
+        } => {
+            let line = span.line;
+            let column = span.column;
             if let Some(kind) = intrinsic_capability(name) {
                 uses.insert(CapabilitySbomIntrinsicUse {
                     intrinsic: name.clone(),
@@ -2789,56 +2793,104 @@ fn collect_hir_expr_intrinsic_use(
             }
         }
         hir::Expr::BinaryAdd { lhs, rhs, .. } | hir::Expr::BinaryCompare { lhs, rhs, .. } => {
-            collect_hir_expr_intrinsic_use(module_path, lhs, line, column, uses);
-            collect_hir_expr_intrinsic_use(module_path, rhs, line, column, uses);
+            collect_hir_expr_intrinsic_use(module_path, lhs, fallback_line, fallback_column, uses);
+            collect_hir_expr_intrinsic_use(module_path, rhs, fallback_line, fallback_column, uses);
         }
         hir::Expr::Cast { expr, .. }
         | hir::Expr::Try { expr, .. }
         | hir::Expr::Await { expr, .. }
         | hir::Expr::StringBorrow { expr, .. } => {
-            collect_hir_expr_intrinsic_use(module_path, expr, line, column, uses)
+            collect_hir_expr_intrinsic_use(module_path, expr, fallback_line, fallback_column, uses)
         }
         hir::Expr::StructLiteral { fields, .. } => {
             for field in fields {
-                collect_hir_expr_intrinsic_use(module_path, &field.expr, line, column, uses);
+                collect_hir_expr_intrinsic_use(
+                    module_path,
+                    &field.expr,
+                    fallback_line,
+                    fallback_column,
+                    uses,
+                );
             }
         }
         hir::Expr::FieldAccess { base, .. } | hir::Expr::TupleIndex { base, .. } => {
-            collect_hir_expr_intrinsic_use(module_path, base, line, column, uses)
+            collect_hir_expr_intrinsic_use(module_path, base, fallback_line, fallback_column, uses)
         }
         hir::Expr::TupleLiteral { elements, .. } | hir::Expr::ArrayLiteral { elements, .. } => {
             for element in elements {
-                collect_hir_expr_intrinsic_use(module_path, element, line, column, uses);
+                collect_hir_expr_intrinsic_use(
+                    module_path,
+                    element,
+                    fallback_line,
+                    fallback_column,
+                    uses,
+                );
             }
         }
         hir::Expr::MapLiteral { entries, .. } => {
             for entry in entries {
-                collect_hir_expr_intrinsic_use(module_path, &entry.key, line, column, uses);
-                collect_hir_expr_intrinsic_use(module_path, &entry.value, line, column, uses);
+                collect_hir_expr_intrinsic_use(
+                    module_path,
+                    &entry.key,
+                    fallback_line,
+                    fallback_column,
+                    uses,
+                );
+                collect_hir_expr_intrinsic_use(
+                    module_path,
+                    &entry.value,
+                    fallback_line,
+                    fallback_column,
+                    uses,
+                );
             }
         }
         hir::Expr::Index { base, index, .. } => {
-            collect_hir_expr_intrinsic_use(module_path, base, line, column, uses);
-            collect_hir_expr_intrinsic_use(module_path, index, line, column, uses);
+            collect_hir_expr_intrinsic_use(module_path, base, fallback_line, fallback_column, uses);
+            collect_hir_expr_intrinsic_use(
+                module_path,
+                index,
+                fallback_line,
+                fallback_column,
+                uses,
+            );
         }
         hir::Expr::Slice {
             base, start, end, ..
         } => {
-            collect_hir_expr_intrinsic_use(module_path, base, line, column, uses);
+            collect_hir_expr_intrinsic_use(module_path, base, fallback_line, fallback_column, uses);
             if let Some(start) = start {
-                collect_hir_expr_intrinsic_use(module_path, start, line, column, uses);
+                collect_hir_expr_intrinsic_use(
+                    module_path,
+                    start,
+                    fallback_line,
+                    fallback_column,
+                    uses,
+                );
             }
             if let Some(end) = end {
-                collect_hir_expr_intrinsic_use(module_path, end, line, column, uses);
+                collect_hir_expr_intrinsic_use(
+                    module_path,
+                    end,
+                    fallback_line,
+                    fallback_column,
+                    uses,
+                );
             }
         }
         hir::Expr::EnumVariant { payloads, .. } => {
             for payload in payloads {
-                collect_hir_expr_intrinsic_use(module_path, payload, line, column, uses);
+                collect_hir_expr_intrinsic_use(
+                    module_path,
+                    payload,
+                    fallback_line,
+                    fallback_column,
+                    uses,
+                );
             }
         }
         hir::Expr::Closure { body, .. } => {
-            collect_hir_expr_intrinsic_use(module_path, body, line, column, uses);
+            collect_hir_expr_intrinsic_use(module_path, body, fallback_line, fallback_column, uses);
         }
         hir::Expr::Literal { .. } | hir::Expr::VarRef { .. } => {}
     }
@@ -5907,6 +5959,51 @@ mod tests {
                 "{intrinsic} must require the explicit fs:write capability, not fs"
             );
         }
+    }
+
+    #[test]
+    fn hir_intrinsic_collection_preserves_nested_call_sites() {
+        let expr = hir::Expr::TupleLiteral {
+            elements: vec![
+                hir::Expr::Call {
+                    name: "clock_now_ms".to_string(),
+                    args: Vec::new(),
+                    ty: hir::Type::Int,
+                    span: hir::SourceSpan {
+                        line: 7,
+                        column: 21,
+                    },
+                },
+                hir::Expr::Call {
+                    name: "clock_now_ms".to_string(),
+                    args: Vec::new(),
+                    ty: hir::Type::Int,
+                    span: hir::SourceSpan {
+                        line: 7,
+                        column: 38,
+                    },
+                },
+            ],
+            ty: hir::Type::Tuple(vec![hir::Type::Int, hir::Type::Int]),
+        };
+        let stmt = hir::Stmt::Let {
+            name: "pair".to_string(),
+            ty: hir::Type::Tuple(vec![hir::Type::Int, hir::Type::Int]),
+            expr,
+            span: hir::SourceSpan { line: 7, column: 1 },
+        };
+        let mut uses = BTreeSet::new();
+
+        collect_hir_stmt_intrinsic_use("src/main.ax", &stmt, &mut uses);
+        let uses = uses.into_iter().collect::<Vec<_>>();
+
+        assert_eq!(uses.len(), 2);
+        assert_eq!(uses[0].intrinsic, "clock_now_ms");
+        assert_eq!(uses[0].line, 7);
+        assert_eq!(uses[0].column, 21);
+        assert_eq!(uses[1].intrinsic, "clock_now_ms");
+        assert_eq!(uses[1].line, 7);
+        assert_eq!(uses[1].column, 38);
     }
 
     #[test]

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -857,17 +857,11 @@ pub fn capability_sbom(project_root: &Path) -> Result<CapabilitySbomOutput, Diag
         let mut stdlib_imports = BTreeSet::new();
         let mut intrinsic_use = BTreeSet::new();
         if !context.manifest.is_workspace_only() {
-            let entry = canonicalize_package_path(
-                &entry_path(&root, &context.manifest),
-                &root,
-                "manifest",
-                "build.entry resolves outside the package",
-            )?;
-            let modules = load_modules(&graph, &root, &entry)?;
-            for module in &modules {
+            let analyzed = analyze_package(&graph, &root)?;
+            for module in &analyzed.modules {
                 collect_stdlib_imports(&module.program, &mut stdlib_imports);
-                collect_program_intrinsic_use(&module.path, &module.program, &mut intrinsic_use);
             }
+            collect_hir_intrinsic_use(&analyzed.hir, &mut intrinsic_use);
         }
         let unsafe_grants = graph_package
             .capabilities
@@ -1037,6 +1031,7 @@ impl PackageGraph {
 struct AnalyzedProject {
     manifest: Manifest,
     entry_path: PathBuf,
+    hir: hir::Program,
     mir: mir::Program,
     modules: Vec<LoadedModule>,
 }
@@ -1140,6 +1135,7 @@ fn analyze_entry(
     Ok(AnalyzedProject {
         manifest,
         entry_path: entry,
+        hir,
         mir,
         modules,
     })
@@ -2704,156 +2700,147 @@ fn collect_stdlib_imports(program: &syntax::Program, imports: &mut BTreeSet<Stri
         }
     }
 }
-fn collect_program_intrinsic_use(
-    module_path: &Path,
-    program: &syntax::Program,
+
+fn collect_hir_intrinsic_use(
+    program: &hir::Program,
     uses: &mut BTreeSet<CapabilitySbomIntrinsicUse>,
 ) {
-    for f in &program.functions {
-        for stmt in &f.body {
-            collect_stmt_intrinsic_use(module_path, stmt, uses);
+    for static_def in &program.statics {
+        collect_hir_expr_intrinsic_use(&program.path, &static_def.expr, 1, 1, uses);
+    }
+    for function in &program.functions {
+        for stmt in &function.body {
+            collect_hir_stmt_intrinsic_use(&function.path, stmt, uses);
         }
     }
     for stmt in &program.stmts {
-        collect_stmt_intrinsic_use(module_path, stmt, uses);
+        collect_hir_stmt_intrinsic_use(&program.path, stmt, uses);
     }
 }
-fn collect_stmt_intrinsic_use(
-    module_path: &Path,
-    stmt: &syntax::Stmt,
+
+fn collect_hir_stmt_intrinsic_use(
+    module_path: &str,
+    stmt: &hir::Stmt,
     uses: &mut BTreeSet<CapabilitySbomIntrinsicUse>,
 ) {
     match stmt {
-        syntax::Stmt::Let { expr, .. }
-        | syntax::Stmt::Print { expr, .. }
-        | syntax::Stmt::Panic { expr, .. }
-        | syntax::Stmt::Defer { expr, .. }
-        | syntax::Stmt::Return { expr, .. } => collect_expr_intrinsic_use(module_path, expr, uses),
-        syntax::Stmt::If {
+        hir::Stmt::Let { expr, span, .. }
+        | hir::Stmt::Print { expr, span }
+        | hir::Stmt::Defer { expr, span }
+        | hir::Stmt::Return { expr, span } => {
+            collect_hir_expr_intrinsic_use(module_path, expr, span.line, span.column, uses)
+        }
+        hir::Stmt::Panic { message, span } => {
+            collect_hir_expr_intrinsic_use(module_path, message, span.line, span.column, uses)
+        }
+        hir::Stmt::If {
             cond,
             then_block,
             else_block,
-            ..
+            span,
         } => {
-            collect_expr_intrinsic_use(module_path, cond, uses);
-            for s in then_block {
-                collect_stmt_intrinsic_use(module_path, s, uses);
+            collect_hir_expr_intrinsic_use(module_path, cond, span.line, span.column, uses);
+            for stmt in then_block {
+                collect_hir_stmt_intrinsic_use(module_path, stmt, uses);
             }
-            if let Some(b) = else_block {
-                for s in b {
-                    collect_stmt_intrinsic_use(module_path, s, uses);
+            if let Some(block) = else_block {
+                for stmt in block {
+                    collect_hir_stmt_intrinsic_use(module_path, stmt, uses);
                 }
             }
         }
-        syntax::Stmt::IfLet {
-            expr,
-            then_block,
-            else_block,
-            ..
-        } => {
-            collect_expr_intrinsic_use(module_path, expr, uses);
-            for s in then_block {
-                collect_stmt_intrinsic_use(module_path, s, uses);
-            }
-            if let Some(b) = else_block {
-                for s in b {
-                    collect_stmt_intrinsic_use(module_path, s, uses);
-                }
+        hir::Stmt::While { cond, body, span } => {
+            collect_hir_expr_intrinsic_use(module_path, cond, span.line, span.column, uses);
+            for stmt in body {
+                collect_hir_stmt_intrinsic_use(module_path, stmt, uses);
             }
         }
-        syntax::Stmt::While { cond, body, .. } => {
-            collect_expr_intrinsic_use(module_path, cond, uses);
-            for s in body {
-                collect_stmt_intrinsic_use(module_path, s, uses);
-            }
-        }
-        syntax::Stmt::Match { expr, arms, .. } => {
-            collect_expr_intrinsic_use(module_path, expr, uses);
+        hir::Stmt::Match { expr, arms, span } => {
+            collect_hir_expr_intrinsic_use(module_path, expr, span.line, span.column, uses);
             for arm in arms {
-                for s in &arm.body {
-                    collect_stmt_intrinsic_use(module_path, s, uses);
+                for stmt in &arm.body {
+                    collect_hir_stmt_intrinsic_use(module_path, stmt, uses);
                 }
             }
         }
     }
 }
-fn collect_expr_intrinsic_use(
-    module_path: &Path,
-    expr: &syntax::Expr,
+
+fn collect_hir_expr_intrinsic_use(
+    module_path: &str,
+    expr: &hir::Expr,
+    line: usize,
+    column: usize,
     uses: &mut BTreeSet<CapabilitySbomIntrinsicUse>,
 ) {
     match expr {
-        syntax::Expr::Literal(_) | syntax::Expr::VarRef { .. } => {}
-        syntax::Expr::Call {
-            name,
-            args,
-            line,
-            column,
-            ..
-        } => {
+        hir::Expr::Call { name, args, .. } => {
             if let Some(kind) = intrinsic_capability(name) {
                 uses.insert(CapabilitySbomIntrinsicUse {
                     intrinsic: name.clone(),
                     capability: kind.name().to_string(),
-                    module: module_path.display().to_string(),
-                    line: *line,
-                    column: *column,
+                    module: module_path.to_string(),
+                    line,
+                    column,
                 });
             }
-            for a in args {
-                collect_expr_intrinsic_use(module_path, a, uses);
+            for arg in args {
+                collect_hir_expr_intrinsic_use(module_path, arg, line, column, uses);
             }
         }
-        syntax::Expr::MethodCall { base, args, .. } => {
-            collect_expr_intrinsic_use(module_path, base, uses);
-            for a in args {
-                collect_expr_intrinsic_use(module_path, a, uses);
+        hir::Expr::BinaryAdd { lhs, rhs, .. } | hir::Expr::BinaryCompare { lhs, rhs, .. } => {
+            collect_hir_expr_intrinsic_use(module_path, lhs, line, column, uses);
+            collect_hir_expr_intrinsic_use(module_path, rhs, line, column, uses);
+        }
+        hir::Expr::Cast { expr, .. }
+        | hir::Expr::Try { expr, .. }
+        | hir::Expr::Await { expr, .. }
+        | hir::Expr::StringBorrow { expr, .. } => {
+            collect_hir_expr_intrinsic_use(module_path, expr, line, column, uses)
+        }
+        hir::Expr::StructLiteral { fields, .. } => {
+            for field in fields {
+                collect_hir_expr_intrinsic_use(module_path, &field.expr, line, column, uses);
             }
         }
-        syntax::Expr::BinaryAdd { lhs, rhs, .. } | syntax::Expr::BinaryCompare { lhs, rhs, .. } => {
-            collect_expr_intrinsic_use(module_path, lhs, uses);
-            collect_expr_intrinsic_use(module_path, rhs, uses);
+        hir::Expr::FieldAccess { base, .. } | hir::Expr::TupleIndex { base, .. } => {
+            collect_hir_expr_intrinsic_use(module_path, base, line, column, uses)
         }
-        syntax::Expr::Cast { expr, .. }
-        | syntax::Expr::Try { expr, .. }
-        | syntax::Expr::Await { expr, .. }
-        | syntax::Expr::FieldAccess { base: expr, .. }
-        | syntax::Expr::TupleIndex { base: expr, .. }
-        | syntax::Expr::Closure { body: expr, .. } => {
-            collect_expr_intrinsic_use(module_path, expr, uses)
-        }
-        syntax::Expr::StructLiteral { fields, .. } => {
-            for f in fields {
-                collect_expr_intrinsic_use(module_path, &f.expr, uses);
+        hir::Expr::TupleLiteral { elements, .. } | hir::Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                collect_hir_expr_intrinsic_use(module_path, element, line, column, uses);
             }
         }
-        syntax::Expr::TupleLiteral { elements, .. }
-        | syntax::Expr::ArrayLiteral { elements, .. } => {
-            for e in elements {
-                collect_expr_intrinsic_use(module_path, e, uses);
+        hir::Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                collect_hir_expr_intrinsic_use(module_path, &entry.key, line, column, uses);
+                collect_hir_expr_intrinsic_use(module_path, &entry.value, line, column, uses);
             }
         }
-        syntax::Expr::MapLiteral { entries, .. } => {
-            for e in entries {
-                collect_expr_intrinsic_use(module_path, &e.key, uses);
-                collect_expr_intrinsic_use(module_path, &e.value, uses);
-            }
+        hir::Expr::Index { base, index, .. } => {
+            collect_hir_expr_intrinsic_use(module_path, base, line, column, uses);
+            collect_hir_expr_intrinsic_use(module_path, index, line, column, uses);
         }
-        syntax::Expr::Slice {
+        hir::Expr::Slice {
             base, start, end, ..
         } => {
-            collect_expr_intrinsic_use(module_path, base, uses);
-            if let Some(s) = start {
-                collect_expr_intrinsic_use(module_path, s, uses);
+            collect_hir_expr_intrinsic_use(module_path, base, line, column, uses);
+            if let Some(start) = start {
+                collect_hir_expr_intrinsic_use(module_path, start, line, column, uses);
             }
-            if let Some(e) = end {
-                collect_expr_intrinsic_use(module_path, e, uses);
+            if let Some(end) = end {
+                collect_hir_expr_intrinsic_use(module_path, end, line, column, uses);
             }
         }
-        syntax::Expr::Index { base, index, .. } => {
-            collect_expr_intrinsic_use(module_path, base, uses);
-            collect_expr_intrinsic_use(module_path, index, uses);
+        hir::Expr::EnumVariant { payloads, .. } => {
+            for payload in payloads {
+                collect_hir_expr_intrinsic_use(module_path, payload, line, column, uses);
+            }
         }
+        hir::Expr::Closure { body, .. } => {
+            collect_hir_expr_intrinsic_use(module_path, body, line, column, uses);
+        }
+        hir::Expr::Literal { .. } | hir::Expr::VarRef { .. } => {}
     }
 }
 

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -857,7 +857,7 @@ pub fn capability_sbom(project_root: &Path) -> Result<CapabilitySbomOutput, Diag
         let mut stdlib_imports = BTreeSet::new();
         let mut intrinsic_use = BTreeSet::new();
         if !context.manifest.is_workspace_only() {
-            let analyzed = analyze_package(&graph, &root)?;
+            let analyzed = analyze_package_for_capability_sbom(&graph, &root)?;
             for module in &analyzed.modules {
                 collect_stdlib_imports(&module.program, &mut stdlib_imports);
             }
@@ -1090,6 +1090,65 @@ impl SymbolNamespace {
             SymbolNamespace::Enum => "enum",
         }
     }
+}
+
+fn audit_capabilities_for_sbom(manifest_capabilities: &CapabilityConfig) -> CapabilityConfig {
+    let mut capabilities = manifest_capabilities.clone();
+    capabilities.fs = true;
+    capabilities.fs_write = true;
+    capabilities.net = true;
+    capabilities.net_hosts.clear();
+    capabilities.net_ports.clear();
+    capabilities.process = true;
+    capabilities.process_commands.clear();
+    capabilities.env = true;
+    capabilities.env_vars.clear();
+    capabilities.env_unrestricted = true;
+    capabilities.clock = true;
+    capabilities.crypto = true;
+    capabilities.ffi = true;
+    capabilities.async_runtime = true;
+    capabilities
+}
+
+fn analyze_package_for_capability_sbom(
+    graph: &PackageGraph,
+    package_root: &Path,
+) -> Result<AnalyzedProject, Diagnostic> {
+    let package_root = normalize_path(package_root);
+    let package_root = canonicalize_existing_path(&package_root, "package root")?;
+    let mut manifest = graph.context(&package_root)?.manifest.clone();
+    if manifest.is_workspace_only() {
+        return Err(Diagnostic::new(
+            "manifest",
+            format!(
+                "workspace-only manifest at {} is not directly buildable",
+                manifest_path(&package_root).display()
+            ),
+        )
+        .with_path(manifest_path(&package_root).display().to_string()));
+    }
+    validate_lockfile(&package_root, &manifest)?;
+    let entry = entry_path(&package_root, &manifest);
+    let entry = canonicalize_package_path(
+        &entry,
+        &package_root,
+        "manifest",
+        "build.entry resolves outside the package",
+    )?;
+    let modules = load_modules(graph, &package_root, &entry)?;
+    let flattened = flatten_modules(graph, &modules)?;
+    manifest.capabilities = audit_capabilities_for_sbom(&manifest.capabilities);
+    let hir = hir::lower_with_capabilities(&flattened, &manifest.capabilities)
+        .map_err(|error| diagnostic_with_default_path(error, &entry))?;
+    let mir = mir::lower(&hir);
+    Ok(AnalyzedProject {
+        manifest,
+        entry_path: entry,
+        hir,
+        mir,
+        modules,
+    })
 }
 
 fn analyze_package(


### PR DESCRIPTION
## Summary

Reports capability requirements from the lowered HIR path before MIR/codegen. The capability SBOM now lowers the flattened module graph with an audit-only capability context, then walks HIR intrinsic calls with preserved call-site spans so agents can inspect required capability surfaces without native build execution.

## Changes

- Add HIR call-site span preservation for intrinsic calls.
- Add an audit-only HIR capability attribution pass for `axiomc caps --manifest-json` / SBOM output.
- Keep capability-denial behavior separate from attribution so missing grants do not hide required capability usage.

## Testing

- `git diff --check`
- `cd stage1 && cargo fmt --all --check`
- `cd stage1 && cargo test -p axiomc capability_sbom --lib`

## Merge Automation

Auto-merge is enabled with squash; current merge state is blocked pending required checks/review gates.

Fixes OMT-Global/axiom#353
