### PR TITLE
test: enforce AST-to-HIR ownership boundary

### DIFF
--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -11445,6 +11445,87 @@ fn literal_value(expr: &Expr) -> Option<&LiteralValue> {
     }
 }
 
+#[cfg(test)]
+mod boundary_tests {
+    use super::*;
+    use std::path::Path;
+
+    fn parse(source: &str) -> syntax::Program {
+        syntax::parse_program(source, Path::new("main.ax")).expect("parse fixture")
+    }
+
+    #[test]
+    fn hir_lowering_drops_parser_import_syntax() {
+        let parsed = parse(
+            r#"
+import "./other.ax"
+fn main(): int {
+return 1
+}
+let value: int = main()
+"#,
+        );
+
+        assert_eq!(parsed.imports.len(), 1, "parser owns import syntax");
+        let lowered = lower(&parsed).expect("HIR lowering should ignore unresolved unused imports");
+
+        assert_eq!(lowered.path, "main.ax");
+        assert_eq!(lowered.functions.len(), 1);
+        assert_eq!(lowered.stmts.len(), 1);
+    }
+
+    #[test]
+    fn hir_lowering_owns_duplicate_symbol_validation() {
+        let parsed = parse(
+            r#"
+fn value(): int {
+return 1
+}
+fn value(): int {
+return 2
+}
+"#,
+        );
+
+        let error = lower(&parsed).expect_err("HIR lowering should reject duplicate symbols");
+        assert_eq!(error.kind, "type");
+        assert!(error.message.contains("duplicate function"));
+    }
+
+    #[test]
+    fn hir_lowering_owns_type_name_resolution() {
+        let parsed = parse(
+            r#"
+fn main(): MissingType {
+return 1
+}
+"#,
+        );
+
+        let error = lower(&parsed).expect_err("HIR lowering should reject unknown type names");
+        assert_eq!(error.kind, "type");
+        assert!(error.message.contains("unknown type \"MissingType\""));
+    }
+
+    #[test]
+    fn hir_lowering_owns_ownership_validation() {
+        let parsed = parse(
+            r#"
+fn consume(value: string): int {
+return 1
+}
+let value: string = "owned"
+let first: int = consume(value)
+let second: int = consume(value)
+"#,
+        );
+
+        let error = lower(&parsed).expect_err("HIR lowering should reject use after move");
+        assert_eq!(error.kind, "ownership");
+        assert!(error.message.contains("use of moved value") || error.message.contains("moved"));
+    }
+}
+
 impl Expr {
     pub fn ty(&self) -> &Type {
         match self {

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -255,6 +255,84 @@ mod tests {
     }
 
     #[test]
+    fn hir_lowering_keeps_imports_as_parser_metadata() {
+        let source =
+            "import \"core/math.ax\"\n\nfn answer(): int {\nreturn 42\n}\n\nprint answer()\n";
+        let parsed = parse_program(source, Path::new("main.ax")).expect("parse");
+        assert_eq!(parsed.imports.len(), 1);
+        assert_eq!(parsed.imports[0].path, "core/math.ax");
+
+        let lowered = hir::lower(&parsed).expect("lower");
+        assert_eq!(lowered.functions.len(), 1);
+        assert_eq!(lowered.functions[0].name, "answer");
+        assert_eq!(lowered.path, "main.ax");
+    }
+
+    #[test]
+    fn hir_lowering_owns_symbol_resolution_for_impl_methods() {
+        let source = "struct Widget {\nlabel: string\n}\n\nimpl Widget {\nfn label(self): string {\nreturn self.label\n}\n}\n\nlet widget: Widget = Widget { label: \"ok\" }\nprint widget.label()\n";
+        let parsed = parse_program(source, Path::new("main.ax")).expect("parse");
+        let parsed_method = parsed
+            .functions
+            .iter()
+            .find(|function| function.source_name == "label")
+            .expect("parsed method");
+        assert_eq!(parsed_method.name, "label");
+        assert_eq!(parsed_method.impl_target.as_deref(), Some("Widget"));
+
+        let lowered = hir::lower(&parsed).expect("lower");
+        let lowered_method = lowered
+            .functions
+            .iter()
+            .find(|function| function.source_name == "label")
+            .expect("lowered method");
+        assert_eq!(lowered_method.name, "Widget__label");
+        assert_eq!(lowered_method.params[0].name, "self_");
+        assert_eq!(
+            lowered_method.params[0].ty,
+            hir::Type::Struct("Widget".to_string())
+        );
+    }
+
+    #[test]
+    fn hir_lowering_owns_type_name_classification() {
+        let source = "struct Widget {\nlabel: string\n}\n\nenum Status {\nReady\n}\n\nfn mark(widget: Widget, status: Status): Widget {\nmatch status {\nReady {\nreturn widget\n}\n}\n}\n\nprint 0\n";
+        let parsed = parse_program(source, Path::new("main.ax")).expect("parse");
+        let parsed_function = parsed
+            .functions
+            .iter()
+            .find(|function| function.name == "mark")
+            .expect("parsed function");
+        assert_eq!(
+            parsed_function.params[0].ty,
+            TypeName::Named("Widget".to_string(), Vec::new())
+        );
+        assert_eq!(
+            parsed_function.params[1].ty,
+            TypeName::Named("Status".to_string(), Vec::new())
+        );
+
+        let lowered = hir::lower(&parsed).expect("lower");
+        let lowered_function = lowered
+            .functions
+            .iter()
+            .find(|function| function.name == "mark")
+            .expect("lowered function");
+        assert_eq!(
+            lowered_function.params[0].ty,
+            hir::Type::Struct("Widget".to_string())
+        );
+        assert_eq!(
+            lowered_function.params[1].ty,
+            hir::Type::Enum("Status".to_string())
+        );
+        assert_eq!(
+            lowered_function.return_ty,
+            hir::Type::Struct("Widget".to_string())
+        );
+    }
+
+    #[test]
     fn render_rust_orders_generated_definitions_deterministically() {
         let source_a = r#"fn zed(): int {
 return 2

--- a/stage1/crates/axiomc/src/syntax.rs
+++ b/stage1/crates/axiomc/src/syntax.rs
@@ -3,6 +3,13 @@ use serde::Serialize;
 use std::path::Path;
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+/// Parser-owned AST for a single stage1 source file.
+///
+/// This layer records syntax only: imports are raw module references, names are
+/// raw source spellings, and type annotations are `TypeName` syntax trees.
+/// Visibility, duplicate-symbol checks, imported symbol availability, concrete
+/// type resolution, and ownership/borrow validation are intentionally deferred
+/// to project flattening and HIR lowering.
 pub struct Program {
     pub path: String,
     pub imports: Vec<Import>,


### PR DESCRIPTION
## Summary
- Document the parser/AST boundary: imports, source spellings, and type annotations remain syntax-only.
- Add focused HIR boundary tests covering parser-owned imports, duplicate symbol validation, type-name resolution, and ownership validation.
- Add integration-level regression coverage showing HIR owns import handling, impl symbol rewriting, and struct/enum type classification.

Closes #351

## Checks
- PASS: `cargo fmt --all --check` from `stage1/`
- PASS: `cargo test -p axiomc hir_lowering_ --lib -- --nocapture` from `stage1/` — 7 passed

## Merge Automation
Auto-merge enabled with `gh pr merge 589 --auto --squash`; merge is waiting on required GitHub checks.
