### PR TITLE
Parser: recover multiple statement block errors

### DIFF
--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -957,6 +957,47 @@ print fail()
     }
 
     #[test]
+    fn parser_recovery_reports_multiple_errors_inside_function_blocks() {
+        let source = "fn main(): int {\nlet a: int = \nprint .broken\nreturn 0\n}\n";
+        let diagnostics = parse_program_with_recovery(source, Path::new("main.ax"))
+            .expect_err("recovering parser should report multiple block parse errors");
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.line)
+                .collect::<Vec<_>>(),
+            vec![Some(2), Some(3)]
+        );
+        assert_eq!(diagnostics[0].message, "expression is empty");
+        assert_eq!(diagnostics[1].message, "field access is incomplete");
+    }
+
+    #[test]
+    fn parser_recovery_continues_after_bad_nested_statement_blocks() {
+        let source =
+            "fn main(): int {\nfor value in [1] {\nprint value\n}\nlet a: int = \nreturn 0\n}\n";
+        let diagnostics = parse_program_with_recovery(source, Path::new("main.ax"))
+            .expect_err("recovering parser should skip bad nested blocks and continue");
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.line)
+                .collect::<Vec<_>>(),
+            vec![Some(2), Some(5)]
+        );
+        assert!(
+            diagnostics[0]
+                .message
+                .contains("does not support `for` loops yet")
+        );
+        assert_eq!(diagnostics[1].message, "expression is empty");
+    }
+
+    #[test]
     fn parser_recovery_resynchronizes_top_level_statements_from_their_start() {
         let source =
             "if true {\nfor value in [1] {\nprint value\n}\n}\nlet answer int = 42\nprint answer\n";

--- a/stage1/crates/axiomc/src/syntax.rs
+++ b/stage1/crates/axiomc/src/syntax.rs
@@ -520,7 +520,7 @@ pub fn parse_program_with_recovery(source: &str, path: &Path) -> Result<Program,
             match parse_function(&lines, &mut index, path) {
                 Ok(function) => functions.push(function),
                 Err(error) => {
-                    diagnostics.push(error);
+                    push_diagnostic_with_related(&mut diagnostics, error);
                     index = start_index;
                     synchronize_top_level(&lines, &mut index);
                 }
@@ -560,7 +560,7 @@ pub fn parse_program_with_recovery(source: &str, path: &Path) -> Result<Program,
             match parse_struct(&lines, &mut index, path) {
                 Ok(struct_decl) => structs.push(struct_decl),
                 Err(error) => {
-                    diagnostics.push(error);
+                    push_diagnostic_with_related(&mut diagnostics, error);
                     index = start_index;
                     synchronize_top_level(&lines, &mut index);
                 }
@@ -575,7 +575,7 @@ pub fn parse_program_with_recovery(source: &str, path: &Path) -> Result<Program,
             match parse_enum(&lines, &mut index, path) {
                 Ok(enum_decl) => enums.push(enum_decl),
                 Err(error) => {
-                    diagnostics.push(error);
+                    push_diagnostic_with_related(&mut diagnostics, error);
                     index = start_index;
                     synchronize_top_level(&lines, &mut index);
                 }
@@ -587,7 +587,7 @@ pub fn parse_program_with_recovery(source: &str, path: &Path) -> Result<Program,
             match parse_impl(&lines, &mut index, path) {
                 Ok(methods) => functions.extend(methods),
                 Err(error) => {
-                    diagnostics.push(error);
+                    push_diagnostic_with_related(&mut diagnostics, error);
                     index = start_index;
                     synchronize_top_level(&lines, &mut index);
                 }
@@ -598,7 +598,7 @@ pub fn parse_program_with_recovery(source: &str, path: &Path) -> Result<Program,
         match parse_stmt(&lines, &mut index, path, false) {
             Ok(stmt) => stmts.push(stmt),
             Err(error) => {
-                diagnostics.push(error);
+                push_diagnostic_with_related(&mut diagnostics, error);
                 index = start_index;
                 synchronize_top_level(&lines, &mut index);
             }
@@ -1180,11 +1180,87 @@ fn parse_stmt_list(
             .with_path(path.display().to_string())
             .with_span(line_no, 1));
         }
-        stmts.push(parse_stmt(lines, index, path, true)?);
+        match parse_stmt(lines, index, path, true) {
+            Ok(stmt) => stmts.push(stmt),
+            Err(error) => {
+                let mut diagnostics = vec![error];
+                let failed_index = *index;
+                synchronize_statement(lines, index);
+                while *index < lines.len() {
+                    let trimmed = lines[*index].trim();
+                    if trimmed.is_empty() {
+                        *index += 1;
+                        continue;
+                    }
+                    if trimmed == "}" || trimmed == "} else {" {
+                        break;
+                    }
+                    match parse_stmt(lines, index, path, true) {
+                        Ok(stmt) => stmts.push(stmt),
+                        Err(error) => {
+                            diagnostics.push(error);
+                            let before = *index;
+                            synchronize_statement(lines, index);
+                            if *index == before {
+                                *index += 1;
+                            }
+                        }
+                    }
+                }
+                let mut first = diagnostics.remove(0);
+                first.related = diagnostics;
+                if *index == failed_index {
+                    *index += 1;
+                }
+                return Err(first);
+            }
+        }
     }
     Err(Diagnostic::new("parse", "missing closing brace for block")
         .with_path(path.display().to_string())
         .with_span(lines.len().max(1), 1))
+}
+
+fn push_diagnostic_with_related(diagnostics: &mut Vec<Diagnostic>, mut diagnostic: Diagnostic) {
+    diagnostics.push(Diagnostic {
+        related: Vec::new(),
+        ..diagnostic.clone()
+    });
+    diagnostics.append(&mut diagnostic.related);
+}
+
+fn synchronize_statement(lines: &[&str], index: &mut usize) {
+    if *index >= lines.len() {
+        return;
+    }
+    let trimmed = lines[*index].trim();
+    if trimmed.ends_with('{') {
+        synchronize_nested_block(lines, index);
+    } else {
+        *index += 1;
+    }
+}
+
+fn synchronize_nested_block(lines: &[&str], index: &mut usize) {
+    let mut depth = 0usize;
+    while *index < lines.len() {
+        let trimmed = lines[*index].trim();
+        if trimmed.ends_with('{') {
+            depth += 1;
+        }
+        if trimmed == "}" || trimmed == "} else {" {
+            if depth == 0 {
+                return;
+            }
+            depth -= 1;
+            *index += 1;
+            if depth == 0 {
+                return;
+            }
+            continue;
+        }
+        *index += 1;
+    }
 }
 
 fn parse_stmt(


### PR DESCRIPTION
## Summary
- Flatten related parser diagnostics during recovery so nested statement-block failures surface as ordered diagnostics.
- Recover inside statement lists after bad expressions/statements and continue parsing later statements in the same block.
- Add parser recovery coverage for multiple expression errors and recovery after bad nested statement blocks.

Closes #350

## Checks
- `cargo fmt --manifest-path stage1/Cargo.toml --all`
- `cargo test --manifest-path stage1/Cargo.toml parser_recovery --no-run`
- `cargo test --manifest-path stage1/Cargo.toml parser_recovery -- --nocapture`

## Merge Automation
Auto-merge requested with `gh pr merge --auto --squash`.
