### PR TITLE
Recover parser at top-level declarations

### DIFF
--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -957,6 +957,43 @@ print fail()
     }
 
     #[test]
+    fn parser_recovery_reports_multiple_top_level_declaration_errors() {
+        let source = "struct Broken {
+field int
+fn missing_return() {
+return 0
+struct BadHeader
+enum AlsoBroken {
+Variant(
+";
+        let diagnostics = parse_program_with_recovery(source, Path::new("main.ax"))
+            .expect_err("recovering parser should report independent declaration parse errors");
+
+        assert!(
+            diagnostics.len() >= 3,
+            "expected at least three diagnostics, got {diagnostics:?}"
+        );
+        assert_eq!(
+            diagnostics
+                .iter()
+                .take(4)
+                .map(|diagnostic| diagnostic.line)
+                .collect::<Vec<_>>(),
+            vec![Some(2), Some(3), Some(5), Some(7)]
+        );
+        assert_eq!(diagnostics[0].message, "struct field is missing ':'");
+        assert_eq!(
+            diagnostics[1].message,
+            "function declaration must include a return type"
+        );
+        assert_eq!(
+            diagnostics[2].message,
+            "struct declaration must use `struct Name {` syntax"
+        );
+        assert_eq!(diagnostics[3].message, "invalid identifier \"Variant(\"");
+    }
+
+    #[test]
     fn parser_recovery_reports_multiple_errors_inside_function_blocks() {
         let source = "fn main(): int {\nlet a: int = \nprint .broken\nreturn 0\n}\n";
         let diagnostics = parse_program_with_recovery(source, Path::new("main.ax"))

--- a/stage1/crates/axiomc/src/syntax.rs
+++ b/stage1/crates/axiomc/src/syntax.rs
@@ -1161,9 +1161,50 @@ fn synchronize_top_level(lines: &[&str], index: &mut usize) {
     let mut depth = brace_delta(lines[*index]);
     *index += 1;
     while *index < lines.len() && depth > 0 {
+        if depth == 1 && is_top_level_recovery_anchor(lines[*index]) {
+            return;
+        }
         depth += brace_delta(lines[*index]);
         *index += 1;
     }
+}
+
+fn is_top_level_recovery_anchor(line: &str) -> bool {
+    if line.trim_start() != line {
+        return false;
+    }
+    let trimmed = line.trim();
+    trimmed.starts_with("import ")
+        || trimmed.starts_with("pub import ")
+        || trimmed.starts_with("pub(pkg) import ")
+        || trimmed.starts_with("pub use ")
+        || trimmed.starts_with("pub(pkg) use ")
+        || trimmed.starts_with("export ")
+        || trimmed.starts_with("fn ")
+        || trimmed.starts_with("async fn ")
+        || trimmed.starts_with("extern fn ")
+        || trimmed.starts_with("pub fn ")
+        || trimmed.starts_with("pub async fn ")
+        || trimmed.starts_with("pub extern fn ")
+        || trimmed.starts_with("pub(pkg) fn ")
+        || trimmed.starts_with("pub(pkg) async fn ")
+        || trimmed.starts_with("pub(pkg) extern fn ")
+        || trimmed.starts_with("const ")
+        || trimmed.starts_with("pub const ")
+        || trimmed.starts_with("pub(pkg) const ")
+        || trimmed.starts_with("static ")
+        || trimmed.starts_with("pub static ")
+        || trimmed.starts_with("pub(pkg) static ")
+        || trimmed.starts_with("type ")
+        || trimmed.starts_with("pub type ")
+        || trimmed.starts_with("pub(pkg) type ")
+        || trimmed.starts_with("struct ")
+        || trimmed.starts_with("pub struct ")
+        || trimmed.starts_with("pub(pkg) struct ")
+        || trimmed.starts_with("enum ")
+        || trimmed.starts_with("pub enum ")
+        || trimmed.starts_with("pub(pkg) enum ")
+        || trimmed.starts_with("impl ")
 }
 
 fn brace_delta(line: &str) -> i32 {


### PR DESCRIPTION
## Summary
- improve top-level parser recovery so an unterminated/malformed declaration can resynchronize at the next column-1 declaration instead of swallowing the rest of the file
- preserve nested/block recovery by only anchoring at top-level-looking declaration lines
- add regression coverage requiring multiple independent malformed top-level declaration diagnostics

Closes #349.

## Checks
- `cargo fmt --all`
- `cargo test -p axiomc parser_recovery --manifest-path stage1/Cargo.toml` (passed before rebase)
- `cargo test -p axiomc parser_recovery_reports_multiple_top_level_declaration_errors --manifest-path stage1/Cargo.toml` (passed after rebase)

## Merge Automation
Auto-merge is enabled with squash on PR #591.
