### PR TITLE
Validate generic aggregate constructor type args

### DIFF
--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -1365,11 +1365,13 @@ fn infer_generic_calls_in_expr(
         },
         syntax::Expr::StructLiteral {
             name,
+            type_args,
             fields,
             line,
             column,
         } => syntax::Expr::StructLiteral {
             name: name.clone(),
+            type_args: type_args.clone(),
             fields: fields
                 .iter()
                 .map(|field| {
@@ -3218,30 +3220,69 @@ fn rewrite_expr_aggregate_types(
         },
         syntax::Expr::StructLiteral {
             name,
+            type_args,
             fields,
             line,
             column,
-        } => syntax::Expr::StructLiteral {
-            name: name.clone(),
-            fields: fields
+        } => {
+            let rewritten_type_args = type_args
                 .iter()
-                .map(|field| {
-                    Ok(syntax::StructFieldValue {
-                        name: field.name.clone(),
-                        expr: rewrite_expr_aggregate_types(
-                            &field.expr,
-                            generic_structs,
-                            generic_enums,
-                            queue,
-                            queued,
-                        )?,
-                        line: field.line,
-                        column: field.column,
-                    })
+                .map(|type_arg| {
+                    rewrite_aggregate_type_name(
+                        type_arg,
+                        generic_structs,
+                        generic_enums,
+                        queue,
+                        queued,
+                        *line,
+                        *column,
+                    )
                 })
-                .collect::<Result<Vec<_>, Diagnostic>>()?,
-            line: *line,
-            column: *column,
+                .collect::<Result<Vec<_>, _>>()?;
+            let rewritten_name = if !rewritten_type_args.is_empty() {
+                let type_params = generic_structs
+                    .get(name)
+                    .map(|decl| decl.type_params.as_slice())
+                    .or_else(|| generic_enums.get(name).map(|decl| decl.type_params.as_slice()))
+                    .ok_or_else(|| {
+                        Diagnostic::new("type", format!("type {name:?} is not generic"))
+                            .with_span(*line, *column)
+                    })?;
+                generic_decl_type_bindings(name, type_params, &rewritten_type_args, *line, *column)?;
+                let instantiation = GenericInstantiation {
+                    name: name.clone(),
+                    type_args: rewritten_type_args.clone(),
+                };
+                if queued.insert(instantiation.clone()) {
+                    queue.push_back(instantiation);
+                }
+                monomorphized_type_name(name, &rewritten_type_args)
+            } else {
+                name.clone()
+            };
+            syntax::Expr::StructLiteral {
+                name: rewritten_name,
+                type_args: Vec::new(),
+                fields: fields
+                    .iter()
+                    .map(|field| {
+                        Ok(syntax::StructFieldValue {
+                            name: field.name.clone(),
+                            expr: rewrite_expr_aggregate_types(
+                                &field.expr,
+                                generic_structs,
+                                generic_enums,
+                                queue,
+                                queued,
+                            )?,
+                            line: field.line,
+                            column: field.column,
+                        })
+                    })
+                    .collect::<Result<Vec<_>, Diagnostic>>()?,
+                line: *line,
+                column: *column,
+            }
         },
         syntax::Expr::FieldAccess {
             base,
@@ -3909,11 +3950,13 @@ fn rewrite_expr_generic_calls(
         },
         syntax::Expr::StructLiteral {
             name,
+            type_args,
             fields,
             line,
             column,
         } => syntax::Expr::StructLiteral {
             name: name.clone(),
+            type_args: type_args.clone(),
             fields: fields
                 .iter()
                 .map(|field| {
@@ -8721,10 +8764,18 @@ fn lower_expr_with_expected_inner(
         }
         syntax::Expr::StructLiteral {
             name,
+            type_args,
             fields,
             line,
             column,
         } => {
+            if !type_args.is_empty() {
+                return Err(Diagnostic::new(
+                    "type",
+                    format!("generic constructor {name:?} was not monomorphized"),
+                )
+                .with_span(*line, *column));
+            }
             if let Some(variant) = resolve_variant(name, expected, ctx, *line, *column)?
                 && !variant.payload_names.is_empty()
             {

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -5023,6 +5023,7 @@ fn rewrite_expr(
         },
         syntax::Expr::StructLiteral {
             name,
+            type_args,
             fields,
             line,
             column,
@@ -5040,6 +5041,7 @@ fn rewrite_expr(
                     .get(name)
                     .cloned()
                     .unwrap_or_else(|| name.clone()),
+                type_args: type_args.clone(),
                 fields: fields
                     .iter()
                     .map(|field| {

--- a/stage1/crates/axiomc/src/syntax.rs
+++ b/stage1/crates/axiomc/src/syntax.rs
@@ -364,6 +364,7 @@ pub enum Expr {
     },
     StructLiteral {
         name: String,
+        type_args: Vec<TypeName>,
         fields: Vec<StructFieldValue>,
         line: usize,
         column: usize,
@@ -2962,8 +2963,9 @@ fn parse_term(raw: &str, path: &Path, line_no: usize, column: usize) -> Result<E
         && let Some(open_brace) = find_top_level_char(raw, '{')
         && matches!(find_matching_brace(raw, open_brace), Some(close) if close == raw.len() - 1)
     {
-        let name = raw[..open_brace].trim();
-        if !name.is_empty() {
+        let target = raw[..open_brace].trim();
+        if !target.is_empty() {
+            let (name, type_args) = parse_call_name(target, path, line_no, column)?;
             validate_ident(name, path, line_no, column)?;
             let fields = parse_struct_literal_fields(
                 &raw[open_brace + 1..raw.len() - 1],
@@ -2973,6 +2975,7 @@ fn parse_term(raw: &str, path: &Path, line_no: usize, column: usize) -> Result<E
             )?;
             return Ok(Expr::StructLiteral {
                 name: name.to_string(),
+                type_args,
                 fields,
                 line: line_no,
                 column,


### PR DESCRIPTION
## Summary
- parse explicit type arguments on aggregate-style struct/named-payload constructor syntax
- monomorphize explicit generic aggregate constructor type arguments before HIR lowering
- preserve explicit constructor type args through import rewriting and reject any unmonomorphized constructor args before codegen

Closes #339

## Checks
- `cargo check --manifest-path stage1/Cargo.toml`

## Merge Automation
Auto-merge requested with squash after PR creation.