### PR TITLE
Review cleanup: stage1-test dedup + publish symlink/integrity hardening

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,6 @@ python-exit-readiness-github:
 
 stage1-test:
 	RUST_MIN_STACK=8388608 cargo test --manifest-path stage1/Cargo.toml
-	cargo test --manifest-path stage1/Cargo.toml
 	$(MAKE) stage1-proof-test
 
 stage1-proof-test:


### PR DESCRIPTION
## Summary

Three review findings, bundled because the designated branch (`claude/review-group-issues-Y43xD`) is fixed by repo policy.

### #540 — Drop duplicate `cargo test` in `stage1-test`
The second invocation re-ran the Stage 1 Rust suite without `RUST_MIN_STACK=8388608`, doubling cost and risking stack-sensitive flakes. Removed the duplicate line in `Makefile`.

### #537 — Reject symlinks during `axiomc publish`
`collect_publishable_files` now uses `symlink_metadata`, refuses to package symlinked files or directories, and canonicalizes each included file to verify it resolves under the canonical project root. Added a unit test that creates a symlink pointing outside the project and asserts publish rejects it.

### #538 — Honest integrity tag in publish sidecar
- `publish` now requires `--signing-key`; removed the hardcoded `"axiom-stage1-dev-key"` fallback.
- Sidecar header is `axiom-integrity-v1` with an `integrity=` field, since the underlying 64-bit FNV-style tag is tamper detection, not authenticity proof.
- Added `verify_archive_integrity()` and regression tests for both tampered archives and mismatched keys.
- `docs/package.md` and `docs/roadmap-status.md` updated.
- File extension `.sig` and the registry index `signature` JSON field are unchanged to keep blast radius small; the in-file format + CLI help spell out the weaker semantics.

### #542 — stale
The blocking Stage 1 benchmark gate cited in `.github/workflows/pr-fast-ci.yml` no longer exists in either that workflow or `scripts/ci/run-fast-checks.sh`. `scripts/ci/check-stage1-benchmarks.py` still exists but isn't referenced from any CI workflow. Recommend closing #542 without code changes.

## Test plan
- [ ] `RUST_MIN_STACK=8388608 cargo test --manifest-path stage1/Cargo.toml -p axiomc registry::` — 11 passed locally including the new `publish_rejects_symlinked_source_file`, `publish_requires_explicit_signing_key`, `verify_archive_integrity_rejects_tampered_archive`.
- [ ] `make stage1-test` runs the Rust suite once with `RUST_MIN_STACK`, then `stage1-proof-test`.
- [ ] Manual: `axiomc publish` without `--signing-key` errors with a message that explains integrity vs. authenticity.

Closes #540, #537, #538.
