### PR TITLE
Enforce manifest [[tests]].expected_error and reject silent per-test capabilities (#536)

### DIFF
--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -6845,6 +6845,121 @@ print serve_once("127.0.0.1:18080", "hello")
     }
 
     #[test]
+    fn manifest_rejects_per_test_capabilities_until_enforced() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("per-test-caps");
+        create_project(&project, Some("per-test-caps-app")).expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            format!(
+                "{}\n[[tests]]\nname = \"smoke\"\nentry = \"src/main_test.ax\"\ncapabilities = [\"net\"]\n",
+                render_manifest("per-test-caps-app")
+            ),
+        )
+        .expect("write manifest");
+
+        let err = load_manifest(&project).expect_err("per-test capabilities should be rejected");
+        assert_eq!(err.kind, "manifest");
+        assert!(
+            err.message.contains("tests[0].capabilities"),
+            "diagnostic should name the offending field, got {:?}",
+            err.message
+        );
+        assert!(
+            err.message.contains("not yet enforced"),
+            "diagnostic should explain why, got {:?}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn manifest_test_expected_error_passes_on_diagnostic_match() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("manifest-expected-error-pass");
+        create_project(&project, Some("manifest-expected-error-pass-app"))
+            .expect("create project");
+        fs::write(
+            project.join("src/broken_test.ax"),
+            "let x: int = \"not an int\"\n",
+        )
+        .expect("write broken test source");
+        fs::write(
+            project.join("axiom.toml"),
+            format!(
+                "{}\n[[tests]]\nname = \"compile-fail-smoke\"\nentry = \"src/broken_test.ax\"\n[tests.expected_error]\nkind = \"type\"\nmessage = \"let binding \\\"x\\\" expects int, got string\"\npath = \"src/broken_test.ax\"\nline = 1\ncolumn = 1\n",
+                render_manifest("manifest-expected-error-pass-app")
+            ),
+        )
+        .expect("write manifest");
+        let manifest = load_manifest(&project).expect("load manifest");
+        fs::write(
+            project.join("axiom.lock"),
+            render_lockfile_for_project(&project, &manifest).expect("lockfile"),
+        )
+        .expect("write lockfile");
+
+        let tests = run_project_tests(&project).expect("run tests");
+        let smoke = tests
+            .cases
+            .iter()
+            .find(|case| case.name == "compile-fail-smoke")
+            .expect("compile-fail-smoke case");
+        assert!(
+            smoke.ok,
+            "matching manifest expected_error should pass: {smoke:?}"
+        );
+        assert!(smoke.expected_error.is_some());
+    }
+
+    #[test]
+    fn manifest_test_expected_error_fails_on_diagnostic_mismatch() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("manifest-expected-error-mismatch");
+        create_project(&project, Some("manifest-expected-error-mismatch-app"))
+            .expect("create project");
+        fs::write(
+            project.join("src/broken_test.ax"),
+            "let x: int = \"not an int\"\n",
+        )
+        .expect("write broken test source");
+        fs::write(
+            project.join("axiom.toml"),
+            format!(
+                "{}\n[[tests]]\nname = \"compile-fail-smoke\"\nentry = \"src/broken_test.ax\"\n[tests.expected_error]\nkind = \"type\"\ncode = \"AX-TYPE-999\"\nmessage = \"wrong message\"\npath = \"src/broken_test.ax\"\nline = 1\ncolumn = 14\n",
+                render_manifest("manifest-expected-error-mismatch-app")
+            ),
+        )
+        .expect("write manifest");
+        let manifest = load_manifest(&project).expect("load manifest");
+        fs::write(
+            project.join("axiom.lock"),
+            render_lockfile_for_project(&project, &manifest).expect("lockfile"),
+        )
+        .expect("write lockfile");
+
+        let tests = run_project_tests(&project).expect("run tests");
+        let smoke = tests
+            .cases
+            .iter()
+            .find(|case| case.name == "compile-fail-smoke")
+            .expect("compile-fail-smoke case");
+        assert!(
+            !smoke.ok,
+            "mismatched manifest expected_error should fail: {smoke:?}"
+        );
+        let error_message = smoke
+            .error
+            .as_ref()
+            .map(|err| err.message.clone())
+            .unwrap_or_default();
+        assert!(
+            error_message.contains("compile-fail diagnostic mismatch"),
+            "diagnostic should explain the mismatch, got {:?}",
+            error_message
+        );
+    }
+
+    #[test]
     fn manifest_parses_richer_test_kinds() {
         let dir = tempdir().expect("tempdir");
         let project = dir.path().join("typed-tests");

--- a/stage1/crates/axiomc/src/manifest.rs
+++ b/stage1/crates/axiomc/src/manifest.rs
@@ -1111,6 +1111,19 @@ fn normalize_tests(
         validate_relative_path(path, &format!("{field_prefix}.entry"), &entry)?;
         let package =
             normalize_optional_name(path, &format!("{field_prefix}.package"), raw_test.package)?;
+        if raw_test
+            .capabilities
+            .as_ref()
+            .is_some_and(|capabilities| !capabilities.is_empty())
+        {
+            return Err(Diagnostic::new(
+                "manifest",
+                format!(
+                    "{field_prefix}.capabilities is not yet enforced per test; declare capabilities at the package [capabilities] level instead",
+                ),
+            )
+            .with_path(path.display().to_string()));
+        }
         let capabilities = normalize_test_capabilities(
             path,
             &format!("{field_prefix}.capabilities"),

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -2053,6 +2053,9 @@ fn run_test_case(
     manifest: &Manifest,
     test: &crate::manifest::TestTarget,
 ) -> TestCaseResult {
+    if test.expected_error.is_some() {
+        return run_manifest_compile_fail_case(project_root, graph, manifest, test);
+    }
     let started = Instant::now();
     let entry_path = project_root.join(&test.entry);
     let generated_rust = match test_generated_rust_path(project_root, manifest, &test.name) {
@@ -2284,6 +2287,78 @@ fn run_http_fixture_case(
     }
 
     child.wait_with_output()
+}
+
+fn run_manifest_compile_fail_case(
+    project_root: &Path,
+    graph: &PackageGraph,
+    manifest: &Manifest,
+    test: &crate::manifest::TestTarget,
+) -> TestCaseResult {
+    let started = Instant::now();
+    let manifest_expected = test
+        .expected_error
+        .as_ref()
+        .expect("caller checked expected_error.is_some()");
+    let expected = ExpectedDiagnostic {
+        kind: manifest_expected.kind.clone(),
+        code: manifest_expected.code.clone(),
+        message: manifest_expected.message.clone(),
+        path: manifest_expected.path.clone(),
+        line: manifest_expected.line,
+        column: manifest_expected.column,
+    };
+    let entry_path = project_root.join(&test.entry);
+    let actual = match analyze_entry(graph, project_root, manifest.clone(), entry_path.clone()) {
+        Ok(_) => {
+            return TestCaseResult {
+                package_root: project_root.display().to_string(),
+                name: test.name.clone(),
+                kind: test.kind,
+                entry: test.entry.clone(),
+                ok: false,
+                binary: None,
+                generated_rust: None,
+                exit_code: None,
+                stdout: String::new(),
+                stderr: String::new(),
+                expected_stdout: None,
+                expected_stderr: None,
+                expected_error: Some(expected),
+                duration_ms: started.elapsed().as_millis() as u64,
+                error: Some(
+                    Diagnostic::new(
+                        "test",
+                        format!(
+                            "manifest compile-fail test {:?} unexpectedly checked successfully",
+                            test.name
+                        ),
+                    )
+                    .with_path(entry_path.display().to_string()),
+                ),
+            };
+        }
+        Err(error) => diagnostic_with_default_path(error, &entry_path),
+    };
+    let mismatch = expected_error_mismatch(project_root, &expected, &actual);
+    TestCaseResult {
+        package_root: project_root.display().to_string(),
+        name: test.name.clone(),
+        kind: test.kind,
+        entry: test.entry.clone(),
+        ok: mismatch.is_none(),
+        binary: None,
+        generated_rust: None,
+        exit_code: None,
+        stdout: String::new(),
+        stderr: String::new(),
+        expected_stdout: None,
+        expected_stderr: None,
+        expected_error: Some(expected),
+        duration_ms: started.elapsed().as_millis() as u64,
+        error: mismatch
+            .map(|message| Diagnostic::new("test", message).with_path(entry_path.display().to_string())),
+    }
 }
 
 fn run_compile_fail_case(


### PR DESCRIPTION
## Summary

Closes the manifest test-contract enforcement gap flagged by #536. (Branch name is incidental — the planned #541 fix turned out to be stale; only the #536 changes are here.)

### Findings
- `[[tests]].expected_error` was parsed into `TestTarget.expected_error` but `run_test_case` always built the test as a normal executable. Inline compile-fail expectations were silently unenforced.
- `[[tests]].capabilities` was parsed but never read at runtime — manifest-level capabilities still governed.
- `[[tests]].package` is at least surfaced in test list output, so it stays as-is.

### Changes
1. **`run_test_case` routes through diagnostic comparison when `expected_error.is_some()`.** New `run_manifest_compile_fail_case` analyzes the test's own entry, fails if it checks successfully, and otherwise compares the actual diagnostic against the declared `expected_error` using the same `expected_error_mismatch` logic that covers project-root `expected-error.json` fixtures.
2. **`normalize_tests` rejects `[[tests]].capabilities`** at parse time with a clear diagnostic pointing operators at the package `[capabilities]` section. Better than silently dropping the field. Per-test capability isolation can be opened as scoped follow-up.
3. **Regression tests added** in `lib.rs`:
   - `manifest_rejects_per_test_capabilities_until_enforced`
   - `manifest_test_expected_error_passes_on_diagnostic_match`
   - `manifest_test_expected_error_fails_on_diagnostic_mismatch`

### Note on #541
While auditing this work I confirmed #541 is stale on current main — PR #573 already fixed the timeout bug. Commented on the issue with the details and recommended closing.

### Test plan
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib manifest_` — all manifest tests pass including the three new ones.
- [x] Full `axiomc --lib` pass — 470 pass; 10 pre-existing environment-dependent failures (linker / proof workloads) unchanged from main.

Closes #536.


---
_Generated by [Claude Code](https://claude.ai/code/session_015ZVS3EVZcFnCrjmDBfnQYQ)_