### PR TITLE
Require unsafe_rationale for unrestricted process grants (#389)

### DIFF
--- a/scripts/ci/test-validate-capability-manifests.sh
+++ b/scripts/ci/test-validate-capability-manifests.sh
@@ -25,6 +25,7 @@ clock = false
 crypto = false
 ffi = false
 async = false
+unsafe_rationale = "test fixture documents unrestricted grants"
 TOML
 
 python3 "$repo_root/scripts/ci/validate-capability-manifests.py" --root "$tmpdir"

--- a/scripts/ci/validate-capability-manifests.py
+++ b/scripts/ci/validate-capability-manifests.py
@@ -24,7 +24,7 @@ BOOL_KEYS = {
     "ffi",
     "async",
 }
-KNOWN_KEYS = BOOL_KEYS | {"fs_root", "env"}
+KNOWN_KEYS = BOOL_KEYS | {"fs_root", "env", "unsafe_rationale"}
 
 
 def iter_manifests(root: Path) -> list[Path]:
@@ -57,6 +57,8 @@ def validate_manifest(path: Path) -> list[str]:
             validate_fs_root(path, value, errors)
         elif key == "env":
             validate_env(path, value, errors)
+        elif key == "unsafe_rationale" and (not isinstance(value, str) or not value.strip()):
+            errors.append(f"{path}: [capabilities].unsafe_rationale must be a non-empty string")
     return errors
 
 

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -56,8 +56,10 @@ mod tests {
         let mut manifest = format!(
             "[package]\nname = {name:?}\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = {fs}\n\"fs:write\" = {fs}\nnet = {net}\nprocess = {process}\nenv = {env}\nclock = {clock}\ncrypto = {crypto}\nasync = false\n"
         );
-        if env {
-            manifest.push_str("unsafe_rationale = \"test fixture uses legacy unrestricted env\"\n");
+        if env || process {
+            manifest.push_str(
+                "unsafe_rationale = \"test fixture uses legacy unrestricted env/process\"\n",
+            );
         }
         manifest
     }
@@ -3652,6 +3654,80 @@ clock = false
         assert_eq!(
             env.unsafe_rationale.as_deref(),
             Some("migration reads audited CI variables")
+        );
+    }
+
+    #[test]
+    fn unrestricted_process_requires_unsafe_rationale() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("caps-process-unrestricted");
+        create_project(&project, Some("caps-process-unrestricted-app")).expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            "[package]\nname = \"caps-process-unrestricted-app\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nprocess = true\n",
+        )
+        .expect("write manifest");
+
+        let error = load_manifest(&project)
+            .expect_err("unrestricted process should require unsafe rationale");
+        assert_eq!(error.kind, "manifest");
+        assert!(
+            error
+                .message
+                .contains("capabilities.unsafe_rationale is required"),
+            "got {:?}",
+            error.message
+        );
+        assert!(
+            error.message.contains("unrestricted process execution"),
+            "diagnostic should name the offending grant, got {:?}",
+            error.message
+        );
+    }
+
+    #[test]
+    fn process_allowlist_does_not_require_unsafe_rationale() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("caps-process-allowlist");
+        create_project(&project, Some("caps-process-allowlist-app")).expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            "[package]\nname = \"caps-process-allowlist-app\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nprocess = [\"/bin/echo\"]\n",
+        )
+        .expect("write manifest");
+
+        let manifest = load_manifest(&project).expect("allowlisted process should load");
+        assert!(manifest.capabilities.process);
+        assert!(manifest.capabilities.unsafe_rationale.is_none());
+        assert!(
+            !manifest.capabilities.warnings().iter().any(|warning| {
+                warning.contains("unrestricted process execution")
+            })
+        );
+    }
+
+    #[test]
+    fn unrestricted_process_emits_warning_alongside_rationale() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("caps-process-warning");
+        create_project(&project, Some("caps-process-warning-app")).expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            "[package]\nname = \"caps-process-warning-app\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nprocess = true\nunsafe_rationale = \"smoke test spawns a single audited helper\"\n",
+        )
+        .expect("write manifest");
+
+        let manifest = load_manifest(&project).expect("load manifest with rationale");
+        let warnings = manifest.capabilities.warnings();
+        assert!(
+            warnings
+                .iter()
+                .any(|warning| warning.contains("unrestricted process execution")),
+            "warnings should flag unrestricted process: {warnings:?}"
+        );
+        assert_eq!(
+            manifest.capabilities.unsafe_rationale.as_deref(),
+            Some("smoke test spawns a single audited helper")
         );
     }
 

--- a/stage1/crates/axiomc/src/manifest.rs
+++ b/stage1/crates/axiomc/src/manifest.rs
@@ -409,17 +409,22 @@ impl CapabilityConfig {
     }
 
     pub fn warnings(&self) -> Vec<String> {
+        let mut warnings = Vec::new();
         if self.env_legacy_unrestricted {
-            vec![String::from(
+            warnings.push(String::from(
                 "warning: [capabilities].env = true is deprecated and grants unrestricted environment access; prefer env = [\"NAME\"] or use env_unrestricted = true only during migration",
-            )]
+            ));
         } else if self.env_unrestricted {
-            vec![String::from(
+            warnings.push(String::from(
                 "warning: [capabilities].env_unrestricted = true grants unrestricted environment access and bypasses the env allowlist",
-            )]
-        } else {
-            Vec::new()
+            ));
         }
+        if self.process && self.process_commands.is_empty() {
+            warnings.push(String::from(
+                "warning: [capabilities].process = true grants unrestricted process execution; prefer process = [\"COMMAND\"] to declare an allowlist",
+            ));
+        }
+        warnings
     }
 }
 
@@ -493,6 +498,7 @@ fn normalize_manifest(raw: RawManifest, path: &Path) -> Result<Manifest, Diagnos
         normalize_optional_relative_path(path, "capabilities.fs_root", capabilities.fs_root)?;
     let (net, net_hosts, net_ports) = normalize_net_capability(path, capabilities.net)?;
     let (process, process_commands) = normalize_process_capability(path, capabilities.process)?;
+    let process_unrestricted = process && process_commands.is_empty();
     let explicit_env_unrestricted = capabilities.env_unrestricted.unwrap_or(false);
     let (env, env_vars, env_unrestricted, env_legacy_unrestricted) =
         normalize_env_capability(path, capabilities.env, explicit_env_unrestricted)?;
@@ -500,6 +506,7 @@ fn normalize_manifest(raw: RawManifest, path: &Path) -> Result<Manifest, Diagnos
         path,
         capabilities.unsafe_rationale,
         explicit_env_unrestricted,
+        process_unrestricted,
     )?;
     let unsafe_opt_ins = normalize_capability_name_list(
         path,
@@ -865,19 +872,29 @@ fn normalize_unsafe_rationale(
     path: &Path,
     rationale: Option<String>,
     env_unrestricted: bool,
+    process_unrestricted: bool,
 ) -> Result<Option<String>, Diagnostic> {
     let rationale = rationale.map(|value| value.trim().to_string());
+    let mut triggers: Vec<&str> = Vec::new();
     if env_unrestricted {
-        match rationale {
-            Some(value) if !value.is_empty() => Ok(Some(value)),
-            _ => Err(Diagnostic::new(
-                "manifest",
-                "capabilities.unsafe_rationale is required when unrestricted environment access is enabled",
-            )
-            .with_path(path.display().to_string())),
-        }
-    } else {
-        Ok(rationale.filter(|value| !value.is_empty()))
+        triggers.push("unrestricted environment access");
+    }
+    if process_unrestricted {
+        triggers.push("unrestricted process execution");
+    }
+    if triggers.is_empty() {
+        return Ok(rationale.filter(|value| !value.is_empty()));
+    }
+    match rationale {
+        Some(value) if !value.is_empty() => Ok(Some(value)),
+        _ => Err(Diagnostic::new(
+            "manifest",
+            format!(
+                "capabilities.unsafe_rationale is required when {} is enabled",
+                triggers.join(" and "),
+            ),
+        )
+        .with_path(path.display().to_string())),
     }
 }
 

--- a/stage1/examples/stdlib_process/axiom.toml
+++ b/stage1/examples/stdlib_process/axiom.toml
@@ -13,3 +13,4 @@ process = true
 env = false
 clock = false
 crypto = false
+unsafe_rationale = "stdlib_process example exercises unrestricted process execution intentionally"


### PR DESCRIPTION
## Summary

Closes the unrestricted-process gap in the capability rationale rule (#389).

### Background
`unsafe_rationale` was already required for `env_unrestricted = true`. The acceptance criterion for #389 named `env_unrestricted` **and** `process` access as needing rationale strings plus JSON warnings. Process grants were the asymmetric hole: `[capabilities].process = true` granted unrestricted process exec with no allowlist and no rationale demand, while `process = ["cmd"]` was a safe allowlist.

### Changes
1. **`normalize_unsafe_rationale`** now accepts both `env_unrestricted` and `process_unrestricted` as rationale triggers. When either is set, `unsafe_rationale` is required. The diagnostic message names every triggering grant so operators don't have to guess.
2. **`CapabilityConfig::warnings()`** emits a new warning when `process = true` with no allowlist, mirroring the existing `env_unrestricted` warning. These warnings flow through `check --json` / `caps --json` output via the existing schema.
3. **Fixture update**: `stage1/examples/stdlib_process/axiom.toml` and the inline `render_manifest_with_capabilities` test helper now supply rationale when granting unrestricted process exec (these were the only fixtures affected).
4. **Regression tests**:
   - `unrestricted_process_requires_unsafe_rationale` — missing rationale rejected with helpful diagnostic
   - `process_allowlist_does_not_require_unsafe_rationale` — allowlist form stays rationale-free and warning-free
   - `unrestricted_process_emits_warning_alongside_rationale` — rationale satisfies the requirement and the warning still surfaces

### Test plan
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib process_` — 12/12 pass including the three new tests.
- [x] Full lib pass: 470 pass; 10 pre-existing environment-dependent failures (linker / proof workloads) unchanged from main.

Closes #389.


---
_Generated by [Claude Code](https://claude.ai/code/session_015ZVS3EVZcFnCrjmDBfnQYQ)_