### PR TITLE
Document stage1 debug map workflow

### DIFF
--- a/docs/stage1-debug-map.md
+++ b/docs/stage1-debug-map.md
@@ -1,0 +1,84 @@
+# Stage1 Debug Map
+
+`axiomc build --debug` currently emits Rust debuginfo for the generated Rust
+shim and writes Axiom source-position sidecars next to the generated artifact:
+
+- `<artifact>.debug-map.json` maps generated Rust statement lines back to
+  `.ax` source file, line, and column positions.
+- `<artifact>.debug-manifest.json` binds the native binary, generated Rust,
+  debug map, rustc debug settings, source hashes, and mapping counts.
+
+This is an interim generated-Rust bridge. Native DWARF line tables still point
+at generated Rust, so debugger integrations should translate generated Rust
+frames through the debug map instead of assuming the binary contains native
+`.ax` line records.
+
+## Build
+
+```sh
+axiomc build --debug --json
+```
+
+The JSON payload includes `binary`, `generated_rust`, `debug_map`, and
+`debug_manifest`. Use those paths as the source of truth; do not derive sidecar
+paths by hand in tooling.
+
+## LLDB
+
+The simplest LLDB workflow is to stop in the generated Rust frame, read the
+current generated Rust location, and translate that line through the debug map:
+
+```sh
+lldb <binary>
+(lldb) breakpoint set --name main
+(lldb) run
+(lldb) frame info
+```
+
+Use the `line_entry.line` from `frame info` as `generated_line`. A helper script
+can then load the debug map and print the matching Axiom span:
+
+```python
+import json
+
+def axiom_span(debug_map_path, generated_line):
+    with open(debug_map_path, "r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    for mapping in payload["mappings"]:
+        if mapping["generated_line"] == generated_line:
+            return f'{mapping["source"]}:{mapping["line"]}:{mapping["column"]}'
+    return None
+```
+
+LLDB command scripts should keep this translation explicit. Until the direct
+native backend emits Axiom line tables, remapping generated Rust paths to Axiom
+paths would overstate the debug format.
+
+## GDB
+
+GDB follows the same generated-line translation model:
+
+```sh
+gdb <binary>
+(gdb) break main
+(gdb) run
+(gdb) frame
+```
+
+Use the generated Rust line shown by `frame` as `generated_line`, then resolve
+it through `debug_map` with the same JSON lookup shown above. A GDB Python
+command can call `gdb.selected_frame().find_sal().line`, load the debug map,
+and print the mapped `.ax` span.
+
+## Tooling Contract
+
+Consumers should treat `debug_manifest` as the integrity envelope:
+
+- `binary_hash` and `generated_rust_hash` identify the exact artifacts.
+- `source_files[*].source_hash` identifies the `.ax` inputs.
+- `rustc.axiom_dwarf` is `false` for the generated-Rust backend.
+- `source_files[*].mapping_count` lets tools detect missing or unexpectedly
+  sparse source mappings.
+
+If `rustc.axiom_dwarf` is `false`, tools must report that stepping is mediated
+through the sidecar map and not through native Axiom DWARF.

--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -131,9 +131,11 @@ aggregate source hash inspection. Debug builds report `debug_map`, a JSON
 sidecar that maps generated Rust statement lines back to Axiom file/line/column
 positions, plus `debug_manifest`, a JSON sidecar that binds the native binary
 hash, generated Rust hash, rustc debug-mode settings, source file hashes, and
-mapping counts for debugger/tooling consumers. `axiomc build --timings` prints
-total build time, cache hit/miss counts, and per-package compile timing/cache
-status for the incremental generated-Rust cache.
+mapping counts for debugger/tooling consumers. See
+`docs/stage1-debug-map.md` for the LLDB/GDB sidecar translation workflow.
+`axiomc build --timings` prints total build time, cache hit/miss counts, and
+per-package compile timing/cache status for the incremental generated-Rust
+cache.
 Parser diagnostics now preserve additional recovered top-level parse errors in
 the error payload's `related` array when possible, so editor tooling can show
 more than the first syntax error without waiting for full checker recovery.
@@ -226,11 +228,12 @@ still far from the stated 1.0 target for service and agent workloads.
   shim, disables optimization, emits generated Rust source markers, and writes a
   JSON source-map sidecar for Axiom file/line/column positions. It also writes
   a debug manifest sidecar that ties the native binary to the generated Rust,
-  the source map, and the hashed `.ax` source files. The manifest is an
-  explicit generated-Rust bridge: current DWARF still points at generated Rust,
-  and rustc path remapping cannot represent Axiom span rows or multiple
-  imported source files, so full Axiom-native debugger stepping remains a
-  direct-backend follow-on.
+  the source map, and the hashed `.ax` source files. `docs/stage1-debug-map.md`
+  documents how LLDB/GDB helpers translate generated Rust frame lines through
+  the sidecar map. The manifest is an explicit generated-Rust bridge: current
+  DWARF still points at generated Rust, and rustc path remapping cannot
+  represent Axiom span rows or multiple imported source files, so full
+  Axiom-native debugger stepping remains a direct-backend follow-on.
 - `axiomc fmt`, `axiomc bench`, `axiomc doc`, the stage1 scratch `repl`, and a
   bounded `axiomc lsp` analyzer now exist as bootstrap-grade toolchain
   commands. The LSP endpoint currently serves compiler-backed diagnostics over


### PR DESCRIPTION
## Summary

- Add `docs/stage1-debug-map.md` with the generated-Rust debug-map contract.
- Document LLDB and GDB workflows for translating generated Rust frame lines through the debug-map sidecar.
- Link the new operator doc from `docs/stage1.md`.

## Governing Issue

Closes #668

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Local checks:

- `git diff --check`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc build_project_debug_mode_emits_source_markers_and_uses_separate_cache_key --features run-native-tests`

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Flow Contract

- Owner lane: `lane:daedalus`
- Repair owner: Codex
- Autonomy class: issue-scoped documentation/contract closure
- Risk class: low; docs only, backed by existing debug-map regression test

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is appropriate when gates pass

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- Auto-merge is not enabled yet; this should wait for live PR checks and required review state.
