### PR TITLE
Add dedicated TCP stdlib wrapper

### DIFF
--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -5675,6 +5675,83 @@ print "missing"
     }
 
     #[test]
+    #[cfg_attr(not(feature = "run-native-tests"), ignore)]
+    fn stage1_project_imports_synthetic_stdlib_net_tcp_module() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("stdlib-net-tcp-app");
+        create_project(&project, Some("stdlib-net-tcp-app")).expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            render_manifest_with_capabilities(
+                "stdlib-net-tcp-app",
+                false,
+                true,
+                false,
+                false,
+                false,
+                false,
+            ),
+        )
+        .expect("write manifest");
+        let manifest = load_manifest(&project).expect("load manifest");
+        fs::write(
+            project.join("axiom.lock"),
+            render_lockfile_for_project(&project, &manifest).expect("lockfile"),
+        )
+        .expect("write lockfile");
+        let source = "import \"std/net_tcp.ax\"\nmatch listen_loopback_once(\"tcp pong\", 1000) {\nSome(port) {\nmatch dial(\"127.0.0.1\", port, \"tcp ping\", 1000) {\nSome(reply) {\nprint reply\n}\nNone {\nprint \"tcp none\"\n}\n}\n}\nNone {\nprint \"tcp listen none\"\n}\n}\n";
+        fs::write(project.join("src/main.ax"), source).expect("write source");
+
+        let built = build_project(&project).expect("build project");
+        let output = compiled_binary_command(&built.binary)
+            .output()
+            .expect("run compiled binary");
+        let expected = if loopback_socket_bind_available() {
+            "tcp pong\n"
+        } else {
+            "tcp listen none\n"
+        };
+        assert_eq!(String::from_utf8_lossy(&output.stdout), expected);
+    }
+
+    #[test]
+    fn stage1_project_rejects_stdlib_net_tcp_without_net_capability() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("stdlib-net-tcp-denied");
+        create_project(&project, Some("stdlib-net-tcp-denied")).expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            render_manifest_with_capabilities(
+                "stdlib-net-tcp-denied",
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+            ),
+        )
+        .expect("write manifest");
+        let manifest = load_manifest(&project).expect("load manifest");
+        fs::write(
+            project.join("axiom.lock"),
+            render_lockfile_for_project(&project, &manifest).expect("lockfile"),
+        )
+        .expect("write lockfile");
+        fs::write(
+            project.join("src/main.ax"),
+            "import \"std/net_tcp.ax\"\nmatch listen_loopback_once(\"pong\", 1000) {\nSome(_port) {\nprint true\n}\nNone {\nprint false\n}\n}\n",
+        )
+        .expect("write source");
+
+        let err = check_project(&project).expect_err("expected capability denial");
+        assert!(
+            err.message.contains("requires [capabilities].net = true"),
+            "unexpected diagnostic: {err:?}",
+        );
+    }
+
+    #[test]
     fn stage1_project_imports_synthetic_stdlib_io_module() {
         // `std/io.ax` is the first stdlib module not tied to a capability
         // flag: `io_eprintln` is ungated, matching the ambient status of the

--- a/stage1/crates/axiomc/src/stdlib.rs
+++ b/stage1/crates/axiomc/src/stdlib.rs
@@ -8,8 +8,8 @@
 //! enforcement continues to run against the importing package's manifest via
 //! `hir::lower_with_capabilities`.
 //!
-//! Today this provides twenty-two stdlib modules. Six are thin wrappers over
-//! single-intrinsic capability-gated surfaces, one per capability class:
+//! Today this provides twenty-three stdlib modules. The capability-gated
+//! wrappers include the six manifest capability classes:
 //!
 //! * `std/time.ax` — `Duration`, `Instant`, `now_ms()`, `now()`,
 //!   `elapsed_ms(start)`, and `sleep(duration)` on top of `clock_now_ms`,
@@ -19,6 +19,8 @@
 //! * `std/net.ax` — `resolve(host)` on top of `net_resolve`, plus a bounded
 //!   loopback-only TCP/UDP socket floor on top of `net_tcp_*` and `net_udp_*`
 //!   intrinsics (net).
+//! * `std/net_tcp.ax` — dedicated TCP wrappers over the current bounded
+//!   loopback-only `net_tcp_*` intrinsics (net).
 //! * `std/process.ax` — `run_status(command)` on top of `process_status`
 //!   (process).
 //! * `std/crypto_hash.ax` — `sha256(input)` on top of `crypto_sha256` (crypto).
@@ -33,9 +35,9 @@
 //! * `std/crypto.ax` — umbrella re-export module for the stage1 crypto hash
 //!   and MAC helpers.
 //!
-//! The seventh module shares an existing capability class with a peer
-//! wrapper, demonstrating that the `std.*` surface is not limited to one
-//! wrapper per capability:
+//! Additional modules share existing capability classes with peer wrappers,
+//! demonstrating that the `std.*` surface is not limited to one wrapper per
+//! capability:
 //!
 //! * `std/http.ax` — `get(url)`, `serve_once(bind, body)`, and the route-shaped
 //!   `serve(bind, route(path, body), max_requests)` helper on top of the new
@@ -155,6 +157,11 @@ pub fn tcp_listen_loopback_once(response: string, timeout_ms: int): Option<int> 
 pub fn tcp_dial(host: string, port: int, message: string, timeout_ms: int): Option<string> {\nreturn net_tcp_dial(host, port, message, timeout_ms)\n}\n\
 pub fn udp_bind_loopback_once(response: string, timeout_ms: int): Option<int> {\nreturn net_udp_bind_loopback_once(response, timeout_ms)\n}\n\
 pub fn udp_send_recv(host: string, port: int, message: string, timeout_ms: int): Option<string> {\nreturn net_udp_send_recv(host, port, message, timeout_ms)\n}\n",
+    ),
+    (
+        "net_tcp.ax",
+        "pub fn listen_loopback_once(response: string, timeout_ms: int): Option<int> {\nreturn net_tcp_listen_loopback_once(response, timeout_ms)\n}\n\
+pub fn dial(host: string, port: int, message: string, timeout_ms: int): Option<string> {\nreturn net_tcp_dial(host, port, message, timeout_ms)\n}\n",
     ),
     (
         "process.ax",


### PR DESCRIPTION
## Summary
- Added `std/net_tcp.ax` as a dedicated TCP wrapper module over the current bounded loopback TCP intrinsics.
- Added stage1 build/run coverage for the wrapper and a deterministic missing-`net` capability denial test.
- Updated stage1 docs to describe the dedicated TCP module and keep raw TCP listener/stream handles as remaining #735 scope.

## Governing Issue
Refs #735.

## Validation
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc net_tcp --features run-native-tests` passed: 2 passed, 0 failed.
- [x] `git diff --check` passed.
- [x] `PR_BODY="$(cat pr-body.md)" scripts/ci/validate-pr-description.sh` passed.

## Bootstrap Governance
This is a narrow stage1 stdlib/compiler test slice. It does not change bootstrap policy, runner labels, repository environments, or portable home-profile assets.

## Flow Contract
The slice exposes the existing bounded loopback TCP floor through a dedicated `std/net_tcp.ax` module. It intentionally does not claim full #735 closure: raw `TcpListener` / `TcpStream` host handles, read/write buffers, and explicit close primitives remain future work.

## Flow Merge Readiness
Ready for review after required PR checks pass. The branch is based on `main` and does not depend on the open UDP wrapper branch.

## Merge Automation
Enable auto-merge after required checks and review requirements are satisfied. If repository policy blocks auto-merge, a maintainer can merge manually once fallback merge-readiness is met.

## Notes
The root checkout remains untouched; this work was prepared in `/private/tmp/axiom-issue735`.
