### PR TITLE
Add HIR never type groundwork

### DIFF
--- a/stage1/crates/axiomc/src/borrowck.rs
+++ b/stage1/crates/axiomc/src/borrowck.rs
@@ -333,6 +333,7 @@ fn contains_borrowed_slice_type_inner(
             contains
         }
         Type::Error
+        | Type::Never
         | Type::Int
         | Type::Numeric(_)
         | Type::Bool
@@ -353,6 +354,7 @@ fn contains_mut_borrowed_slice_type_inner(
         Type::MutSlice(_) | Type::MutRef(_) => true,
         Type::Slice(_)
         | Type::Error
+        | Type::Never
         | Type::Int
         | Type::Numeric(_)
         | Type::Bool

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -285,6 +285,7 @@ pub enum Expr {
 #[derive(Debug, Clone, Serialize, Eq)]
 pub enum Type {
     Error,
+    Never,
     Int,
     Numeric(syntax::NumericType),
     Bool,
@@ -313,6 +314,7 @@ impl PartialEq for Type {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (Type::Error, Type::Error)
+            | (Type::Never, Type::Never)
             | (Type::Int, Type::Int)
             | (Type::Bool, Type::Bool)
             | (Type::String, Type::String)
@@ -350,6 +352,7 @@ impl PartialEq for Type {
 fn type_assignable_to(actual: &Type, expected: &Type) -> bool {
     match (actual, expected) {
         (_, Type::Error) | (Type::Error, _) => true,
+        (Type::Never, _) => true,
         (Type::Array(actual_inner, actual_len), Type::Array(expected_inner, expected_len)) => {
             type_assignable_to(actual_inner, expected_inner)
                 && match expected_len {
@@ -389,7 +392,17 @@ fn type_assignable_to(actual: &Type, expected: &Type) -> bool {
                     .all(|(actual, expected)| type_assignable_to(actual, expected))
                 && type_assignable_to(actual_return, expected_return)
         }
-        _ => actual == expected,
+        _ => unify_types(actual, expected).is_some_and(|ty| ty == *expected),
+    }
+}
+
+pub(crate) fn unify_types(left: &Type, right: &Type) -> Option<Type> {
+    match (left, right) {
+        (Type::Never, Type::Never) => Some(Type::Never),
+        (Type::Never, other) | (other, Type::Never) => Some(other.clone()),
+        (Type::Error, other) | (other, Type::Error) => Some(other.clone()),
+        _ if left == right => Some(left.clone()),
+        _ => None,
     }
 }
 
@@ -954,6 +967,7 @@ fn type_has_unboxed_recursive_path(
 ) -> bool {
     match ty {
         Type::Error
+        | Type::Never
         | Type::Int
         | Type::Numeric(_)
         | Type::Bool
@@ -4639,6 +4653,7 @@ impl Type {
     pub fn is_copy(&self) -> bool {
         match self {
             Type::Error
+            | Type::Never
             | Type::Int
             | Type::Numeric(_)
             | Type::Bool
@@ -4668,6 +4683,7 @@ impl Type {
             Type::Int | Type::Numeric(_) | Type::Bool | Type::String | Type::Str => true,
             Type::Tuple(elements) => elements.iter().all(Type::supports_map_key),
             Type::Error
+            | Type::Never
             | Type::Struct(_)
             | Type::Enum(_)
             | Type::Ptr(_)
@@ -11887,6 +11903,7 @@ fn contains_borrowed_slice_type_inner(
             contains
         }
         Type::Error
+        | Type::Never
         | Type::Int
         | Type::Numeric(_)
         | Type::Bool
@@ -11906,6 +11923,7 @@ fn contains_mut_borrowed_slice_type_inner(
     match ty {
         Type::MutSlice(_) | Type::MutRef(_) => true,
         Type::Error
+        | Type::Never
         | Type::Slice(_)
         | Type::Int
         | Type::Numeric(_)
@@ -12625,6 +12643,24 @@ fn format(value: Display): string
     }
 
     #[test]
+    fn never_type_is_assignable_to_concrete_types() {
+        assert!(type_assignable_to(&Type::Never, &Type::Int));
+        assert!(type_assignable_to(
+            &Type::Never,
+            &Type::Option(Box::new(Type::String))
+        ));
+        assert!(!type_assignable_to(&Type::Int, &Type::Never));
+    }
+
+    #[test]
+    fn never_type_unifies_to_the_other_side() {
+        assert_eq!(unify_types(&Type::Never, &Type::Int), Some(Type::Int));
+        assert_eq!(unify_types(&Type::Bool, &Type::Never), Some(Type::Bool));
+        assert_eq!(unify_types(&Type::Never, &Type::Never), Some(Type::Never));
+        assert_eq!(unify_types(&Type::Int, &Type::Bool), None);
+    }
+
+    #[test]
     fn hir_lowering_owns_ownership_validation() {
         let parsed = parse(
             r#"
@@ -12806,6 +12842,7 @@ impl std::fmt::Display for Type {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Type::Error => write!(f, "<type-error>"),
+            Type::Never => write!(f, "!"),
             Type::Int => write!(f, "int"),
             Type::Numeric(numeric) => write!(f, "{}", numeric.as_str()),
             Type::Bool => write!(f, "bool"),

--- a/stage1/crates/axiomc/src/mir.rs
+++ b/stage1/crates/axiomc/src/mir.rs
@@ -685,6 +685,7 @@ fn lower_expr(expr: &hir::Expr) -> Expr {
 fn lower_type(ty: &hir::Type) -> Type {
     match ty {
         hir::Type::Error => unreachable!("type-error sentinel must not reach MIR lowering"),
+        hir::Type::Never => unreachable!("never type must not reach MIR lowering"),
         hir::Type::Int => Type::Int,
         hir::Type::Numeric(numeric) => Type::Numeric(*numeric),
         hir::Type::Bool => Type::Bool,


### PR DESCRIPTION
## Summary

- Add internal `Type::Never` HIR groundwork for bottom-type typing.
- Make `Never` assignable to every expected type while keeping concrete types unassignable to `Never`.
- Add a small HIR unification helper where `Never` unifies to the other side, and cover exhaustive borrow/MIR type matches.

## Governing Issue

Closes #603

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Commands:

- `cargo check --manifest-path stage1/Cargo.toml -p axiomc` - passed with existing warnings
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib never_type -- --nocapture` - passed
- `git diff --check` - passed

Attempted wider gate:

- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib` - failed on pre-existing/non-slice failures unrelated to `Type::Never`: `async_timeout_returns_without_joining_slow_host_task`, two parser macro expansion tests, and `stage1_project_imports_synthetic_stdlib_crypto_umbrella_module`.
- Confirmed at least `parser_expands_nested_declarative_macro_invocations_before_lowering` fails the same way on `origin/main` in `/private/tmp/axiom-main-check-603`.

Skipped / known local blockers:

- `cargo fmt --manifest-path stage1/Cargo.toml -p axiomc --check` still fails only on pre-existing formatting drift in untouched `stage1/crates/axiomc/tests/schema_metadata.rs`.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- Semantic node types added or changed: none
- Schemas added or changed: none
- Evidence added or changed: HIR unit tests for `Never` assignability and unification
- Rust capture risk: none; this is internal HIR type groundwork and does not lower to generated Rust
- Agent-facing inspection impact: none

## Flow Contract

- Owner lane: daedalus
- Repair owner: codex
- Autonomy class: issue-scoped implementation
- Risk class: low, internal type-system groundwork

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is appropriate when gates pass

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

Auto-merge note: keep manual until maintainer review confirms the inherited lib-test failures are acceptable for this narrow slice.
