### PR TITLE
Add enum payload borrow region facts

### DIFF
--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -146,6 +146,8 @@ pub struct MatchArm {
     pub bindings: Vec<String>,
     pub is_named: bool,
     pub ignore_payloads: bool,
+    #[serde(skip)]
+    pub borrow_region_facts: Vec<BorrowRegionFact>,
     pub body: Vec<Stmt>,
 }
 
@@ -289,6 +291,7 @@ pub struct BorrowRegionFact {
     pub binding: String,
     pub origin: BorrowRegionOrigin,
     pub scope: BorrowRegionScope,
+    pub source: BorrowRegionSource,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -306,6 +309,16 @@ pub enum BorrowRegionProjection {
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub enum BorrowRegionScope {
     Binding(String),
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub enum BorrowRegionSource {
+    Direct,
+    EnumPayload {
+        enum_origin: BorrowRegionOrigin,
+        variant: String,
+        payload_index: usize,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Eq)]
@@ -6139,9 +6152,19 @@ fn lower_match_stmt(
                 variant_def.payload_tys.clone()
             }
         };
+        let mut arm_borrow_region_facts = Vec::new();
         for (binding_index, (binding, payload_ty)) in
             arm.bindings.iter().zip(binding_tys.iter()).enumerate()
         {
+            let payload_index = if arm.is_named {
+                variant_def
+                    .payload_names
+                    .iter()
+                    .position(|name| name == binding)
+                    .expect("named match binding already validated")
+            } else {
+                binding_index
+            };
             if ctx.functions.contains_key(binding) {
                 return Err(Diagnostic::new(
                     "type",
@@ -6158,6 +6181,23 @@ fn lower_match_stmt(
                 )
                 .with_span(arm.line, arm.column));
             }
+            let borrowed_owners = match_binding_borrowed_owners(
+                &lowered_expr,
+                &arm.variant,
+                binding,
+                binding_index,
+                payload_ty,
+                &before,
+                ctx,
+            );
+            arm_borrow_region_facts.extend(borrow_region_facts_for_enum_payload_binding(
+                binding,
+                payload_ty,
+                &borrowed_owners,
+                &lowered_expr,
+                &arm.variant,
+                payload_index,
+            ));
             arm_env.insert(
                 binding.clone(),
                 Binding {
@@ -6174,15 +6214,7 @@ fn lower_match_stmt(
                         &before,
                         ctx,
                     ),
-                    borrowed_owners: match_binding_borrowed_owners(
-                        &lowered_expr,
-                        &arm.variant,
-                        binding,
-                        binding_index,
-                        payload_ty,
-                        &before,
-                        ctx,
-                    ),
+                    borrowed_owners,
                     active_borrow_count: 0,
                     active_mut_borrow_count: 0,
                     active_borrows: HashMap::new(),
@@ -6207,6 +6239,7 @@ fn lower_match_stmt(
             bindings: arm.bindings.clone(),
             is_named: arm.is_named,
             ignore_payloads: arm.ignore_payloads,
+            borrow_region_facts: arm_borrow_region_facts,
             body,
         });
         arm_states.push((after, returns));
@@ -6291,6 +6324,7 @@ fn lower_const_match_stmt(
             bindings: Vec::new(),
             is_named: false,
             ignore_payloads: false,
+            borrow_region_facts: Vec::new(),
             body,
         });
         arm_states.push((after, returns));
@@ -11571,8 +11605,33 @@ fn borrow_region_facts_for_binding(
             binding: binding.to_string(),
             origin: BorrowRegionOrigin::from(owner),
             scope: BorrowRegionScope::Binding(binding.to_string()),
+            source: BorrowRegionSource::Direct,
         })
         .collect()
+}
+
+fn borrow_region_facts_for_enum_payload_binding(
+    binding: &str,
+    payload_ty: &Type,
+    borrowed_owners: &HashSet<BorrowedOwner>,
+    matched_expr: &Expr,
+    variant: &str,
+    payload_index: usize,
+) -> Vec<BorrowRegionFact> {
+    let Some(enum_origin) =
+        owned_borrow_owner(matched_expr).map(|owner| BorrowRegionOrigin::from(&owner))
+    else {
+        return Vec::new();
+    };
+    let mut facts = borrow_region_facts_for_binding(binding, payload_ty, borrowed_owners);
+    for fact in &mut facts {
+        fact.source = BorrowRegionSource::EnumPayload {
+            enum_origin: enum_origin.clone(),
+            variant: variant.to_string(),
+            payload_index,
+        };
+    }
+    facts
 }
 
 impl From<&BorrowedOwner> for BorrowRegionOrigin {
@@ -12602,6 +12661,7 @@ mod boundary_tests {
                 Stmt::While { body, .. } => facts.extend(collect_borrow_region_facts(body)),
                 Stmt::Match { arms, .. } => {
                     for arm in arms {
+                        facts.extend(arm.borrow_region_facts.iter().cloned());
                         facts.extend(collect_borrow_region_facts(&arm.body));
                     }
                 }
@@ -12636,6 +12696,52 @@ let s: &[int] = arr[:]
                     projection: Vec::new(),
                 },
                 scope: BorrowRegionScope::Binding("s".to_string()),
+                source: BorrowRegionSource::Direct,
+            }]
+        );
+    }
+
+    #[test]
+    fn hir_records_borrow_region_fact_for_enum_payload_binding() {
+        let parsed = parse(
+            r#"
+let values: [int] = [1, 2, 3]
+let opt: Option<&[int]> = Some(values[:])
+match opt {
+Some(view) {
+print len(view)
+}
+None {
+print 0
+}
+}
+"#,
+        );
+
+        let lowered = lower(&parsed).expect("HIR lowering should accept borrowed enum payload");
+        let facts = collect_borrow_region_facts(&lowered.stmts);
+        let enum_payload_facts = facts
+            .into_iter()
+            .filter(|fact| fact.binding == "view")
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            enum_payload_facts,
+            vec![BorrowRegionFact {
+                binding: "view".to_string(),
+                origin: BorrowRegionOrigin {
+                    name: "values".to_string(),
+                    projection: Vec::new(),
+                },
+                scope: BorrowRegionScope::Binding("view".to_string()),
+                source: BorrowRegionSource::EnumPayload {
+                    enum_origin: BorrowRegionOrigin {
+                        name: "opt".to_string(),
+                        projection: Vec::new(),
+                    },
+                    variant: "Some".to_string(),
+                    payload_index: 0,
+                },
             }]
         );
     }


### PR DESCRIPTION
## Summary

- Extends borrow-region facts with a source descriptor so direct slice bindings and enum payload bindings can be distinguished.
- Records match payload borrow facts with enum value origin, variant tag, and payload index.
- Adds a HIR boundary test proving `Some(view)` from `opt: Option<&[int]>` records the payload as `opt` / `Some` / index `0` while retaining the underlying borrowed owner.

## Governing Issue

Closes #613

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Commands run:

- `cargo test --manifest-path stage1/Cargo.toml -p axiomc hir_records_borrow_region_fact_for_enum_payload_binding -- --nocapture` - passed
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc hir_records_borrow_region_fact_for_borrowed_slice_binding -- --nocapture` - passed
- `cargo check --manifest-path stage1/Cargo.toml -p axiomc` - passed with existing warnings in `axiom-lsp` and existing unused helper warnings
- `git diff --check` - passed
- `cargo fmt --manifest-path stage1/Cargo.toml -p axiomc --check` - failed only on pre-existing `stage1/crates/axiomc/tests/schema_metadata.rs` formatting drift; branch leaves that file unchanged
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib` - failed on four failures reproduced on `origin/main`: `async_timeout_returns_without_joining_slow_host_task`, `parser_does_not_substitute_macro_parameters_inside_template_strings`, `parser_expands_nested_declarative_macro_invocations_before_lowering`, and `stage1_project_imports_synthetic_stdlib_crypto_umbrella_module`

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Semantic details:

- Node types changed: HIR `MatchArm` now carries skipped borrow-region facts for enum payload bindings; `BorrowRegionFact` includes `BorrowRegionSource`.
- Schemas changed: none; borrow-region metadata is skipped for serde output.
- Evidence changed: HIR boundary test coverage for enum payload borrow-region facts.
- Rust capture risk: none expected; metadata is consumed only by HIR/test inspection and not by MIR/codegen.
- Agent-facing inspection impact: future inspection can distinguish direct slice borrows from enum payload borrows and trace payload facts back to enum value origin, variant tag, and payload index.

## Flow Contract

- Owner lane: semantic IR / evidence-verification
- Repair owner: Codex
- Autonomy class: issue-scoped stacked implementation
- Risk class: low, internal skipped HIR metadata

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is appropriate when gates pass

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- This PR is stacked on #811 / `codex/issue-612-borrow-region-slices`.
- Auto-merge should wait for #811, required checks, and non-author approval.
- Full `axiomc --lib` currently has inherited main-branch failures listed above; targeted #613 evidence is green.
