### PR TITLE
Gate HTTP server binds by network allowlists

### DIFF
--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -2487,12 +2487,11 @@ fn axiom_http_response(body: &str) -> Vec<u8> {
 
 #[allow(dead_code)]
 fn axiom_http_loopback_bind_addr(bind: &str) -> Option<std::net::SocketAddr> {
-    use std::net::ToSocketAddrs;
-    let addrs: Vec<std::net::SocketAddr> = bind.to_socket_addrs().ok()?.collect();
-    if addrs.is_empty() || addrs.iter().any(|addr| !addr.ip().is_loopback()) {
+    let parsed = axiom_parse_tcp_bind(bind)?;
+    if !axiom_net_socket_addr_allowed(&parsed) {
         return None;
     }
-    addrs.into_iter().next()
+    Some(parsed.addr)
 }
 
 #[allow(dead_code)]

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -8815,6 +8815,7 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[1].line(), args[1].column()));
                 }
+                validate_net_socket_allowlist_hir(ctx.capabilities, name, &bind, *line, *column)?;
                 move_lowered_value(&bind, env)?;
                 move_lowered_value(&body, env)?;
                 return Ok(Expr::Call {
@@ -8882,6 +8883,7 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[3].line(), args[3].column()));
                 }
+                validate_net_socket_allowlist_hir(ctx.capabilities, name, &bind, *line, *column)?;
                 move_lowered_value(&bind, env)?;
                 move_lowered_value(&route_path, env)?;
                 move_lowered_value(&body, env)?;

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -4790,6 +4790,72 @@ net = { hosts = ["example.com"], ports = [443] }
     }
 
     #[test]
+    fn http_server_bind_accepts_network_allowlist() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("http-server-bind-allowlisted");
+        create_project(&project, Some("http-server-bind-allowlisted-app")).expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            r#"[package]
+name = "http-server-bind-allowlisted-app"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+net = { hosts = ["127.0.0.1"], ports = [8080] }
+"#,
+        )
+        .expect("write manifest");
+        fs::write(
+            project.join("src/main.ax"),
+            "print http_serve_once(\"127.0.0.1:8080\", \"ok\")\n",
+        )
+        .expect("write source");
+
+        check_project(&project).expect("allowlisted HTTP server bind should check");
+    }
+
+    #[test]
+    fn http_server_bind_rejects_network_port_missing_from_allowlist() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("http-server-bind-port-not-allowlisted");
+        create_project(&project, Some("http-server-bind-port-not-allowlisted-app"))
+            .expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            r#"[package]
+name = "http-server-bind-port-not-allowlisted-app"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+net = { hosts = ["127.0.0.1"], ports = [8080] }
+"#,
+        )
+        .expect("write manifest");
+        fs::write(
+            project.join("src/main.ax"),
+            "print http_serve_once(\"127.0.0.1:9090\", \"ok\")\n",
+        )
+        .expect("write source");
+
+        let error = check_project(&project).expect_err("unlisted HTTP bind port should fail");
+        assert_eq!(error.kind, "capability");
+        assert!(
+            error
+                .message
+                .contains("requires [capabilities].net.ports to include 9090"),
+            "unexpected diagnostic: {error:?}",
+        );
+    }
+
+    #[test]
     fn check_project_rejects_crypto_intrinsic_without_capability() {
         let dir = tempdir().expect("tempdir");
         let project = dir.path().join("crypto-denied");


### PR DESCRIPTION
## Summary

- Apply `[capabilities].net.hosts` and `[capabilities].net.ports` allowlists to `http_serve_once` and `http_serve_route` bind arguments during checking.
- Reuse the generated socket bind parser and allowlist guard so dynamic HTTP server binds fail closed at runtime too.
- Add focused `http_server_` coverage for an allowlisted bind and a rejected port.

Closes #611

## Validation

- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib http_server_` - pass
- `cargo fmt --manifest-path stage1/Cargo.toml -p axiomc -- --check` - pass
- `git diff --check` - pass
- `cargo check --manifest-path stage1/Cargo.toml -p axiomc` - pass with pre-existing warnings

## Risk

- This stacks on #828 because it reuses the shared socket allowlist parsing and generated runtime guard.
- HTTP server bind resolution now only accepts literal loopback host:port forms supported by the raw socket parser (`127.0.0.1`, `localhost`, bracketed IPv6) instead of arbitrary `ToSocketAddrs`; this is aligned with Stage 1's loopback-only deterministic server policy.

## Semantic-layer impact

- Semantic node types added or changed: none.
- Schemas added or changed: none.
- Evidence added or changed: focused checker/runtime tests for HTTP server bind allowlists.
- Rust capture risk: HTTP server generated runtime bind path now shares socket bind policy enforcement.
- Agent-facing inspection impact: none.
