### PR TITLE
Add HTTP proof workload fixture

### DIFF
--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -7792,8 +7792,16 @@ print serve_once("127.0.0.1:18080", "hello")
         fs::write(
             project.join("axiom.toml"),
             format!(
-                "{}\n[[tests]]\nname = \"service-smoke\"\nentry = \"src/service_test.ax\"\nstdout = \"true\\n\"\ncapabilities = [\"net\", \"env\"]\nhttp = {{ path = \"/health\", expected_body = \"ok\" }}\n",
-                render_manifest("service-runner-app")
+                "{}\n[[tests]]\nname = \"service-smoke\"\nentry = \"src/service_test.ax\"\nstdout = \"true\\n\"\nhttp = {{ path = \"/health\", expected_body = \"ok\" }}\n",
+                render_manifest_with_capabilities(
+                    "service-runner-app",
+                    false,
+                    true,
+                    false,
+                    true,
+                    false,
+                    false,
+                )
             ),
         )
         .expect("write manifest");

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -8403,6 +8403,7 @@ print serve_health("127.0.0.1:18080", 1, started)
                         .expect("test checked-in proof workload example");
                     let expected_passed = match example {
                         "proof_cli" => 2,
+                        "proof_http_service" => 2,
                         _ => 1,
                     };
                     assert_eq!(tests.passed, expected_passed, "example {example}");

--- a/stage1/examples/proof_http_service/axiom.toml
+++ b/stage1/examples/proof_http_service/axiom.toml
@@ -10,6 +10,12 @@ out_dir = "dist"
 fs = false
 net = true
 process = false
-env = ["REQUEST_METHOD", "REQUEST_PATH"]
+env = ["REQUEST_METHOD", "REQUEST_PATH", "AXIOM_TEST_BIND"]
 clock = true
 crypto = false
+
+[[tests]]
+name = "http-service-health"
+entry = "src/server_test.ax"
+stdout = "true\n"
+http = { path = "/health", expected_body = "{\"path\":\"/health\",\"ok\":true}" }

--- a/stage1/examples/proof_http_service/src/server.ax
+++ b/stage1/examples/proof_http_service/src/server.ax
@@ -1,12 +1,9 @@
 import "std/http.ax"
-import "std/encoding.ax"
 import "response.ax"
 
 pub fn health_route(started: bool): HttpRoute {
-let path: string = path_join_segment("", "health")
-let req: HttpRequest = request("GET", "/" + path, "")
-let selected_response: HttpResponse = json_response(req, started)
-return route_response(req.path, selected_response)
+let selected_response: HttpResponse = response(200, body("/health", started), [header("content-type", "application/json")])
+return route_response("/health", selected_response)
 }
 
 pub fn serve_health(bind: string, max_requests: int, started: bool): bool {

--- a/stage1/examples/proof_http_service/src/server_test.ax
+++ b/stage1/examples/proof_http_service/src/server_test.ax
@@ -1,0 +1,14 @@
+import "std/env.ax"
+import "std/time.ax"
+import "server.ax"
+
+let started: bool = now_ms() > 0
+
+match get_env("AXIOM_TEST_BIND") {
+Some(bind) {
+print serve_health(bind, 1, started)
+}
+None {
+print false
+}
+}


### PR DESCRIPTION
## Summary

- Add a manifest-backed `[[tests]].http` fixture for `stage1/examples/proof_http_service`.
- Add `src/server_test.ax`, which binds through `AXIOM_TEST_BIND`, serves `/health`, and lets the test runner validate the JSON response body end to end.
- Fix the proof service route helper so it does not read request state after moving the request into response construction.
- Update the checked-in proof workload regression to expect the HTTP proof example's second test case.

Closes #622

## Validation

- `cargo run --manifest-path stage1/Cargo.toml -p axiomc -- check stage1/examples/proof_http_service --json` - pass
- `cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/examples/proof_http_service --json` - pass outside sandbox; 2 passed, 0 failed
- `make stage1-proof-test` - pass outside sandbox
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc checked_in_proof_workload_examples_build_run_and_test --features run-native-tests` - pass outside sandbox
- `cargo check --manifest-path stage1/Cargo.toml -p axiomc` - pass with pre-existing warnings
- `cargo run --manifest-path stage1/Cargo.toml -p axiomc -- fmt stage1/examples/proof_http_service` - pass
- `git diff --check` - pass

## Notes

- `cargo fmt --manifest-path stage1/Cargo.toml -p axiomc -- --check` currently reports a pre-existing formatting diff in `stage1/crates/axiomc/tests/schema_metadata.rs`; this PR does not touch that file.

## Risk

- Low. This is a checked-in proof workload fixture plus a narrow route-helper ownership fix in the example.

## Semantic Layer Checklist

- Semantic node types added or changed: none.
- Schemas added or changed: none.
- Evidence added or changed: manifest-backed HTTP proof workload fixture.
- Rust capture risk: none; this is example/test evidence over the existing stage1 HTTP server surface.
- Agent-facing inspection impact: none.
