### PR TITLE
Add project vision document

### DIFF
--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,34 @@
+# Axiom Vision
+
+Version: 0.1
+
+Axiom is the semantic and operational backbone for agent-native software delivery in the OMT-Global portfolio.
+
+Its purpose is to turn scattered repository state, diagnostics, backend contracts, and workflow expectations into stable interfaces that agents and humans can rely on.
+
+## Who It Serves
+
+- Agents that need durable project context instead of brittle prompt memory.
+- Maintainers who need trustworthy diagnostics, schemas, and repair loops.
+- The OMT-Global portfolio, where each repo benefits from shared delivery patterns without becoming coupled to a central app.
+
+## Product Principles
+
+- Prefer stable contracts over clever inference.
+- Diagnostics should be structured, testable, and documented.
+- Backend schema changes must be treated as product-facing behavior.
+- CI repair is not complete until live checks and review state are rechecked.
+- Agent-native does not mean agent-only; humans should be able to inspect every decision surface.
+
+## Near-Term Direction
+
+- Harden backend target schemas and diagnostic codes.
+- Make queue-wide PR remediation repeatable.
+- Improve issue-to-PR traceability.
+- Keep CI and review state visible as first-class delivery signals.
+
+## Non-Goals
+
+- Do not turn Axiom into a generic task manager.
+- Do not hide product behavior behind opaque agent heuristics.
+- Do not accept schema drift without explicit migration and test coverage.


### PR DESCRIPTION
## Summary

- Add an initial `VISION.md` for axiom.
- Capture the project audience, product principles, near-term direction, and non-goals.

## Governing Issue

- No issue is linked: this is a documentation-only seed for review, not an implementation slice closing a tracked issue.

## Validation

- Not run; documentation-only change. PR description validator also passes locally with this body.

## Bootstrap Governance

- No bootstrap-managed files changed.
- No GitHub policy, runner, or repository settings changed.

## Merge Automation

- Auto-merge enabled by Daedalus using squash merge; waiting on required review.

## Notes

- Draft v0.1 for review and iteration in this PR.