### PR TITLE
Pin GitHub Actions workflow dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     ignore:
       - dependency-name: "*"
         update-types:

--- a/.github/workflows/extended-validation.yml
+++ b/.github/workflows/extended-validation.yml
@@ -31,7 +31,7 @@ jobs:
       ci: ${{ steps.preset.outputs.ci || steps.filter.outputs.ci || 'false' }}
       extended: ${{ steps.preset.outputs.extended || steps.filter.outputs.extended || 'false' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 pinned 2026-05-30
         if: github.event_name == 'push'
         with:
           fetch-depth: 0
@@ -46,7 +46,7 @@ jobs:
           extended=true
           EOF
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3 pinned 2026-05-30
         id: filter
         if: github.event_name == 'push'
         with:
@@ -84,7 +84,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.app == 'true' || needs.changes.outputs.ci == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 pinned 2026-05-30
 
       - name: Run fast checks
         run: bash scripts/ci/run-fast-checks.sh
@@ -96,7 +96,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.extended == 'true' || needs.changes.outputs.app == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 pinned 2026-05-30
 
       - name: Run extended validation
         run: bash scripts/ci/run-extended-validation.sh
@@ -106,7 +106,7 @@ jobs:
     runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 pinned 2026-05-30
       - name: Scan repository for secret patterns
         run: bash scripts/check-detect-secrets.sh --all-files
 

--- a/.github/workflows/pr-fast-ci.yml
+++ b/.github/workflows/pr-fast-ci.yml
@@ -27,7 +27,7 @@ jobs:
       app: ${{ steps.filter.outputs.app }}
       ci: ${{ steps.filter.outputs.ci }}
     steps:
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3 pinned 2026-05-30
         id: filter
         with:
           filters: |
@@ -65,7 +65,7 @@ jobs:
       github.event.pull_request.draft == false &&
       (needs.changes.outputs.app == 'true' || needs.changes.outputs.ci == 'true')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 pinned 2026-05-30
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -139,7 +139,7 @@ jobs:
       PR_BODY: ${{ github.event.pull_request.body }}
       PR_AUTHOR: ${{ github.event.pull_request.user.login }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 pinned 2026-05-30
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Require generated PR template content
@@ -152,7 +152,7 @@ jobs:
     timeout-minutes: 10
     if: github.event.pull_request.draft == false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 pinned 2026-05-30
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Scan repository for secret patterns

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,13 @@ Treat the repo as a staged bootstrap:
 - Language behavior should be proven with Rust crate tests, `stage1/conformance`,
   and `axiomc test` package fixtures.
 
+## Workflow supply chain
+
+All GitHub Actions `uses:` entries in `.github/workflows/` must be pinned to a
+full commit SHA, including first-party `actions/*` actions. Keep a trailing
+comment with the readable upstream version, such as `# v4 pinned YYYY-MM-DD`,
+so Dependabot SHA-bump PRs are reviewable without returning to mutable tags.
+
 ### Ownership and borrowing changes
 
 If you touch ownership, borrowing, projection rules, or diagnostics:


### PR DESCRIPTION
## Summary

- Pin mutable `actions/checkout@v4` and `dorny/paths-filter@v3` workflow references to full commit SHAs with readable version comments.
- Document the workflow pinning policy in `CONTRIBUTING.md` so future workflow edits keep immutable action refs.
- Group weekly Dependabot GitHub Actions updates so SHA bumps arrive as reviewable PRs.

## Governing Issue

Closes #834

## Validation

- [x] Relevant local checks passed
- [ ] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Passed locally:

- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/pr-fast-ci.yml .github/workflows/extended-validation.yml .github/dependabot.yml`
- `ruby -e 'bad=[]; Dir[".github/workflows/*.{yml,yaml}"].sort.each do |f| File.readlines(f).each_with_index do |line,i| next unless line =~ /uses:\\s*([^\\s#]+)\\s*(#.*)?$/; ref=$1.split("@",2)[1]; comment=$2.to_s; bad << "#{f}:#{i+1}: #{line.strip}" unless ref =~ /\\A[0-9a-f]{40}\\z/ && comment =~ /pinned \\d{4}-\\d{2}-\\d{2}/; end end; abort(bad.join("\\n")) unless bad.empty?; puts "all workflow uses entries are SHA pinned with readable comments"'`
- `rg -n 'uses:\s+[^#\s]+@(v[0-9]+|latest|main|master|stable)(\s|$)' .github/workflows || true` returned no mutable action refs.
- `git diff --check`

Skipped checks:

- No compiler/runtime tests were run because this PR only changes workflow metadata, Dependabot grouping, and contribution policy text.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

Contributor guidance changed only in `CONTRIBUTING.md`, where the new workflow pinning policy is documented. Auto-merge is not enabled while live CI and non-author review are still pending.

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

This PR does not touch semantic-layer behavior, schemas, evidence models, Rust capture boundaries, or agent-facing inspection APIs.

## Flow Contract

- Owner lane: tooling / security
- Repair owner: Codex
- Autonomy class: agent-executed issue bundle
- Risk class: low

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is appropriate when gates pass

Next actor: CI and non-author reviewer.

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

Auto-merge is not enabled because live CI and non-author review are still pending.

## Notes

- Commit SHAs were resolved from the live upstream tags on 2026-05-30: `actions/checkout@v4` -> `34e114876b0b11c390a56381ad16ebd13914f8d5`; `dorny/paths-filter@v3` -> `d1c1ffe0248fe513906c8e24db8ea791d46f8590`.
