### PR TITLE
Harden registry archive path normalization

### DIFF
--- a/stage1/crates/axiomc/src/registry.rs
+++ b/stage1/crates/axiomc/src/registry.rs
@@ -278,8 +278,27 @@ fn normalize_archive_path(path: &Path) -> Result<String, Diagnostic> {
     let mut out = Vec::new();
     for component in path.components() {
         match component {
-            Component::Normal(value) => out.push(value.to_string_lossy().to_string()),
-            Component::CurDir => {}
+            Component::Normal(value) => {
+                let value = value.to_str().ok_or_else(|| {
+                    Diagnostic::new(
+                        "publish",
+                        format!(
+                            "archive path component is not valid UTF-8 in {}",
+                            path.display()
+                        ),
+                    )
+                })?;
+                if !is_safe_archive_component(value) {
+                    return Err(Diagnostic::new(
+                        "publish",
+                        format!(
+                            "unsafe archive path component {value:?} in {}",
+                            path.display()
+                        ),
+                    ));
+                }
+                out.push(value.to_string());
+            }
             _ => {
                 return Err(Diagnostic::new(
                     "publish",
@@ -288,7 +307,31 @@ fn normalize_archive_path(path: &Path) -> Result<String, Diagnostic> {
             }
         }
     }
+    if out.is_empty() {
+        return Err(Diagnostic::new(
+            "publish",
+            format!(
+                "archive path must name a descendant file: {}",
+                path.display()
+            ),
+        ));
+    }
     Ok(out.join("/"))
+}
+
+fn is_safe_archive_component(value: &str) -> bool {
+    !value.is_empty()
+        && value != "."
+        && value != ".."
+        && !value.contains('\0')
+        && !value.contains('/')
+        && !value.contains('\\')
+        && !looks_like_windows_drive_component(value)
+}
+
+fn looks_like_windows_drive_component(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
 }
 
 fn render_archive_signature(
@@ -833,6 +876,42 @@ mod tests {
 
         assert_eq!(error.kind, "publish");
         assert!(error.message.contains("symlinked"));
+    }
+
+    #[test]
+    fn archive_path_normalization_accepts_safe_descendant_paths() {
+        assert_eq!(
+            normalize_archive_path(Path::new("src/main.ax")).expect("safe archive path"),
+            "src/main.ax"
+        );
+        assert_eq!(
+            normalize_archive_path(Path::new("axiom.lock")).expect("safe archive path"),
+            "axiom.lock"
+        );
+    }
+
+    #[test]
+    fn archive_path_normalization_rejects_unsafe_components() {
+        for path in [
+            "dir/../etc/passwd",
+            "./foo",
+            "/abs/path",
+            "C:\\bad",
+            "C:bad",
+            "link/../escape",
+            "bad\0name.ax",
+            ".",
+        ] {
+            let error = normalize_archive_path(Path::new(path))
+                .expect_err("unsafe archive path should fail");
+            assert_eq!(error.kind, "publish");
+            assert!(
+                error.message.contains("archive path")
+                    || error.message.contains("archive path component"),
+                "unexpected error for {path:?}: {}",
+                error.message
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Harden `normalize_archive_path` so archive entry names reject traversal, current-directory, absolute/rooted, Windows-style, NUL-containing, empty, and invalid-UTF-8 components before normalization.
- Preserve safe descendant archive paths such as `src/main.ax` and `axiom.lock`.
- Add regression tests for `dir/../etc/passwd`, `./foo`, `/abs/path`, `C:\bad`, `C:bad`, `link/../escape`, NUL-containing names, and the empty/current path case.

## Governing Issue

Closes #833

## Validation

- [x] Relevant local checks passed
- [ ] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Passed locally:

- `cargo fmt --manifest-path stage1/Cargo.toml --all`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc archive_path_normalization`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc publish_rejects_symlinked_source_file`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc publishes_package_archive_signature_and_registry_index_release`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc registry::tests`
- `git diff --check`

Security proof:

- Original source: archive-entry paths passed to `normalize_archive_path` before writing `package.axp` file headers.
- Broken control: `Component::CurDir` was silently dropped, and path safety was not checked for Windows-style separators/drive strings or NULs inside normal components.
- Fixed invariant: every archive component must be a UTF-8, non-empty normal descendant segment that is not `.`, `..`, NUL-containing, slash/backslash-containing, or Windows drive-like; absolute/root/prefix paths are rejected by component matching.
- Regression coverage now rejects the exploit shapes listed in #833 and keeps positive coverage for legitimate descendant paths.

Skipped checks:

- Full crate test suite was not rerun for this PR because focused registry coverage and formatting cover the touched security boundary. A broader full-suite run on the sibling tooling branch found unrelated existing async/parser/stdlib crypto-sign failures.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

No contributor or PR guidance changed. Auto-merge is not enabled while live CI, security review, and non-author review are still pending.

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

This PR does not touch semantic-layer behavior, schemas, evidence models, Rust capture boundaries, or agent-facing inspection APIs.

## Flow Contract

- Owner lane: tooling / security
- Repair owner: Codex
- Autonomy class: agent-executed security fix
- Risk class: medium

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is appropriate when gates pass

Next actor: CI and security/non-author reviewer.

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

Auto-merge is not enabled because live CI and security review are still pending.

## Notes

- Cross-reference: #263, #538, and #248 remain broader registry/authenticity follow-ups; this PR only enforces the archive path safety invariant for published package entries.
