### PR TITLE
Verify registry archive integrity

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ cargo run --manifest-path stage1/Cargo.toml -p axiomc -- caps stage1/examples/he
 # Publish to a local static registry tree and build/validate its index
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- publish stage1/examples/hello --registry-dir ./registry/packages --signing-key dev-key
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- registry-index ./registry/packages --base-url https://packages.example.test --out ./registry/index.json
-cargo run --manifest-path stage1/Cargo.toml -p axiomc -- registry-validate ./registry/index.json
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- registry-validate ./registry/index.json --packages-dir ./registry/packages --signing-key dev-key
 
 # Format source, generate docs, and run benchmark entrypoints
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- fmt stage1/examples/hello --check

--- a/docs/package.md
+++ b/docs/package.md
@@ -14,7 +14,7 @@ cargo run --manifest-path stage1/Cargo.toml -p axiomc -- caps stage1/examples/he
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- publish stage1/examples/hello --registry-dir ./registry/packages --signing-key dev-key
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- pkg graph stage1/examples/workspace_only --json
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- registry-index ./registry/packages --base-url https://packages.example.test --out ./registry/index.json
-cargo run --manifest-path stage1/Cargo.toml -p axiomc -- registry-validate ./registry/index.json
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- registry-validate ./registry/index.json --packages-dir ./registry/packages --signing-key dev-key
 ```
 
 ## Manifest Shape
@@ -80,7 +80,7 @@ analysis.
 - `axiom-registry.toml` with `yanked = true` and optional `yank_reason`
 
 The generated index records per-release capability manifests, archive/signature URLs,
-and yanked status so a simple static host can serve lockfile-friendly package metadata. This is publish and registry-index groundwork for a future hosted registry service, not the hosted service itself.
+and yanked status so a simple static host can serve lockfile-friendly package metadata. `axiomc registry-validate` checks the index contract by default; when passed `--packages-dir` and `--signing-key`, it also reads every indexed local archive plus sidecar and rejects tampered archives or mismatched integrity keys. This is publish and registry-index groundwork for a future hosted registry service, not the hosted service itself.
 
 ## Registry And Publish Contract
 

--- a/stage1/crates/axiomc/src/main.rs
+++ b/stage1/crates/axiomc/src/main.rs
@@ -20,6 +20,7 @@ use axiomc::project::{
 };
 use axiomc::registry::{
     PublishOptions, load_registry_index, publish_package, render_registry_index,
+    verify_registry_index_integrity,
 };
 use axiomc::syntax::parse_program;
 use clap::{Parser, Subcommand, ValueEnum};
@@ -227,7 +228,16 @@ enum Command {
         out: Option<PathBuf>,
     },
     /// Validate a static package-registry index JSON file.
-    RegistryValidate { index: PathBuf },
+    ///
+    /// Pass --packages-dir with --signing-key to also verify local archive
+    /// integrity sidecars for every indexed release with an archive.
+    RegistryValidate {
+        index: PathBuf,
+        #[arg(long = "packages-dir")]
+        packages_dir: Option<PathBuf>,
+        #[arg(long = "signing-key")]
+        signing_key: Option<String>,
+    },
     /// Start the bounded axiom-analyzer Language Server Protocol endpoint.
     Lsp,
     /// Start the bounded axiom-debug Debug Adapter Protocol endpoint.
@@ -872,8 +882,29 @@ fn main() {
             }
             Err(error) => print_error("registry-index", error, false),
         },
-        Command::RegistryValidate { index } => match load_registry_index(&index) {
-            Ok(_) => {
+        Command::RegistryValidate {
+            index,
+            packages_dir,
+            signing_key,
+        } => match load_registry_index(&index).and_then(|registry_index| {
+            if packages_dir.is_some() || signing_key.is_some() {
+                let packages_dir = packages_dir.as_deref().ok_or_else(|| {
+                    Diagnostic::new(
+                        "registry",
+                        "registry-validate integrity checks require --packages-dir and --signing-key",
+                    )
+                })?;
+                let signing_key = signing_key.as_deref().ok_or_else(|| {
+                    Diagnostic::new(
+                        "registry",
+                        "registry-validate integrity checks require --packages-dir and --signing-key",
+                    )
+                })?;
+                verify_registry_index_integrity(&registry_index, packages_dir, signing_key)?;
+            }
+            Ok(())
+        }) {
+            Ok(()) => {
                 eprintln!("OK");
                 0
             }
@@ -3932,6 +3963,31 @@ mod tests {
         assert!(help.contains("Pack and publish a stage1 package into a local registry tree"));
         assert!(help.contains("Build a static package-registry index"));
         assert!(help.contains("Validate a static package-registry index JSON file"));
+    }
+
+    #[test]
+    fn registry_validate_cli_parses_integrity_options() {
+        let cli = Cli::parse_from([
+            "axiomc",
+            "registry-validate",
+            "registry/index.json",
+            "--packages-dir",
+            "registry/packages",
+            "--signing-key",
+            "dev-key",
+        ]);
+        match cli.command {
+            Command::RegistryValidate {
+                index,
+                packages_dir,
+                signing_key,
+            } => {
+                assert_eq!(index, PathBuf::from("registry/index.json"));
+                assert_eq!(packages_dir, Some(PathBuf::from("registry/packages")));
+                assert_eq!(signing_key.as_deref(), Some("dev-key"));
+            }
+            other => panic!("expected registry validate command, got {other:?}"),
+        }
     }
 
     #[test]

--- a/stage1/crates/axiomc/src/registry.rs
+++ b/stage1/crates/axiomc/src/registry.rs
@@ -485,6 +485,84 @@ pub fn validate_registry_index(
     Ok(())
 }
 
+/// Verify local release archives listed by a registry index against their
+/// `axiom-integrity-v1` sidecars using the supplied stage1 integrity key.
+pub fn verify_registry_index_integrity(
+    index: &RegistryIndex,
+    packages_root: &Path,
+    signing_key: &str,
+) -> Result<(), Diagnostic> {
+    if signing_key.trim().is_empty() {
+        return Err(Diagnostic::new(
+            "registry",
+            "--signing-key must not be empty when verifying registry integrity",
+        ));
+    }
+    validate_registry_index(index, None)?;
+
+    for (package, releases) in &index.packages {
+        let package_segment = safe_registry_lookup_segment("package name", package)?;
+        for release in releases {
+            let Some(archive_location) = release.archive.as_deref() else {
+                continue;
+            };
+            let signature_location = release.signature.as_deref().ok_or_else(|| {
+                Diagnostic::new(
+                    "registry",
+                    format!(
+                        "package {package:?} version {:?} declares an archive without a signature",
+                        release.version
+                    ),
+                )
+            })?;
+            let version_segment =
+                safe_registry_lookup_segment("package version", &release.version)?;
+            let archive_file = registry_artifact_file_name("archive file name", archive_location)?;
+            let signature_file =
+                registry_artifact_file_name("signature file name", signature_location)?;
+            let release_dir = packages_root.join(&package_segment).join(version_segment);
+            let archive_path = release_dir.join(archive_file);
+            let signature_path = release_dir.join(signature_file);
+            let archive_bytes = fs::read(&archive_path).map_err(|err| {
+                registry_error(
+                    Some(&archive_path),
+                    format!(
+                        "failed to read registry archive for {package}@{}: {err}",
+                        release.version
+                    ),
+                )
+            })?;
+            let signature_payload = fs::read_to_string(&signature_path).map_err(|err| {
+                registry_error(
+                    Some(&signature_path),
+                    format!(
+                        "failed to read registry signature for {package}@{}: {err}",
+                        release.version
+                    ),
+                )
+            })?;
+            verify_archive_integrity(
+                package,
+                &release.version,
+                &archive_bytes,
+                &signature_payload,
+                signing_key,
+            )
+            .map_err(|error| {
+                registry_error(
+                    Some(&signature_path),
+                    format!(
+                        "registry release {package}@{} failed integrity verification: {}",
+                        release.version, error.message
+                    ),
+                )
+            })?;
+        }
+    }
+
+    Ok(())
+}
+
 fn load_release(
     package_name: &str,
     version_dir: &Path,
@@ -639,7 +717,44 @@ fn normalize_base_url(base_url: &str, packages_root: &Path) -> Result<String, Di
 
 fn safe_registry_path_segment(kind: &str, value: &str) -> Result<String, Diagnostic> {
     let trimmed = value.trim();
-    let invalid = trimmed.is_empty()
+    if is_unsafe_registry_path_segment(value) {
+        return Err(Diagnostic::new(
+            "publish",
+            format!("registry {kind} must be a safe path segment: {value:?}"),
+        ));
+    }
+    Ok(trimmed.to_string())
+}
+
+fn safe_registry_lookup_segment(kind: &str, value: &str) -> Result<String, Diagnostic> {
+    let trimmed = value.trim();
+    if is_unsafe_registry_path_segment(value) {
+        return Err(Diagnostic::new(
+            "registry",
+            format!("registry {kind} must be a safe path segment: {value:?}"),
+        ));
+    }
+    Ok(trimmed.to_string())
+}
+
+fn registry_artifact_file_name(kind: &str, location: &str) -> Result<String, Diagnostic> {
+    let file_name = location.rsplit('/').next().unwrap_or_default();
+    if file_name.is_empty()
+        || file_name
+            .chars()
+            .any(|ch| matches!(ch, '?' | '#' | ':' | '\0'))
+    {
+        return Err(Diagnostic::new(
+            "registry",
+            format!("registry {kind} must be a safe file name: {location:?}"),
+        ));
+    }
+    safe_registry_lookup_segment(kind, file_name)
+}
+
+fn is_unsafe_registry_path_segment(value: &str) -> bool {
+    let trimmed = value.trim();
+    trimmed.is_empty()
         || trimmed != value
         || trimmed == "."
         || trimmed == ".."
@@ -647,14 +762,7 @@ fn safe_registry_path_segment(kind: &str, value: &str) -> Result<String, Diagnos
         || trimmed.contains('\\')
         || Path::new(trimmed)
             .components()
-            .any(|component| !matches!(component, Component::Normal(_)));
-    if invalid {
-        return Err(Diagnostic::new(
-            "publish",
-            format!("registry {kind} must be a safe path segment: {value:?}"),
-        ));
-    }
-    Ok(trimmed.to_string())
+            .any(|component| !matches!(component, Component::Normal(_)))
 }
 
 fn registry_error(path: Option<&Path>, message: impl Into<String>) -> Diagnostic {
@@ -805,6 +913,96 @@ mod tests {
                 .message
                 .contains("does not match supplied signing key")
         );
+    }
+
+    #[test]
+    fn verifies_registry_index_integrity_for_local_release_artifacts() {
+        let dir = tempdir().expect("tempdir");
+        let project = write_publishable_project(dir.path(), "core", "1.0.0");
+        let registry = dir.path().join("registry");
+        publish_package(
+            &project,
+            &registry,
+            &PublishOptions {
+                signing_key: Some(String::from("test-key")),
+                allow_overwrite: false,
+            },
+        )
+        .expect("publish package");
+        let index = build_registry_index(&registry, "https://packages.example.test")
+            .expect("build registry index");
+
+        verify_registry_index_integrity(&index, &registry, "test-key")
+            .expect("registry release artifacts verify");
+    }
+
+    #[test]
+    fn registry_index_integrity_rejects_tampered_local_archive() {
+        let dir = tempdir().expect("tempdir");
+        let project = write_publishable_project(dir.path(), "core", "1.0.0");
+        let registry = dir.path().join("registry");
+        publish_package(
+            &project,
+            &registry,
+            &PublishOptions {
+                signing_key: Some(String::from("test-key")),
+                allow_overwrite: false,
+            },
+        )
+        .expect("publish package");
+        let index = build_registry_index(&registry, "https://packages.example.test")
+            .expect("build registry index");
+        fs::write(
+            registry.join("core").join("1.0.0").join("package.axp"),
+            b"AXIOM_PACKAGE_ARCHIVE_V1\n--- file tampered.ax 9 ---\ntampered\n",
+        )
+        .expect("tamper archive");
+
+        let error = verify_registry_index_integrity(&index, &registry, "test-key")
+            .expect_err("tampered archive should fail registry integrity validation");
+
+        assert_eq!(error.kind, "registry");
+        assert!(
+            error
+                .message
+                .contains("failed integrity verification: archive hash mismatch")
+        );
+        assert!(
+            error
+                .path
+                .as_deref()
+                .is_some_and(|path| path.ends_with("package.axp.sig"))
+        );
+    }
+
+    #[test]
+    fn registry_index_integrity_rejects_unsafe_artifact_locations() {
+        let index = RegistryIndex {
+            version: 1,
+            packages: BTreeMap::from([(
+                String::from("core"),
+                vec![RegistryRelease {
+                    version: String::from("1.0.0"),
+                    source: String::from("registry+https://packages.example.test/core/1.0.0"),
+                    manifest: String::from("https://packages.example.test/core/1.0.0/axiom.toml"),
+                    archive: Some(String::from(
+                        "https://packages.example.test/core/1.0.0/package.axp?download=1",
+                    )),
+                    signature: Some(String::from(
+                        "https://packages.example.test/core/1.0.0/package.axp.sig",
+                    )),
+                    yanked: false,
+                    yank_reason: None,
+                    capabilities: Vec::new(),
+                }],
+            )]),
+        };
+
+        let error = verify_registry_index_integrity(&index, Path::new("."), "test-key")
+            .expect_err("unsafe artifact location should fail before filesystem access");
+
+        assert_eq!(error.kind, "registry");
+        assert!(error.message.contains("archive file name"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add optional `axiomc registry-validate --packages-dir --signing-key` integrity verification for local registry release artifacts.
- Verify every indexed archive with its `axiom-integrity-v1` sidecar and supplied integrity key, rejecting tampered archives, mismatched keys, and unsafe artifact file names.
- Update README and package docs so the local static-registry workflow exercises integrity validation.

## Governing Issue

Closes #538

## Validation

- [x] Relevant local checks passed
  - `cargo fmt -p axiomc --manifest-path stage1/Cargo.toml -- --check`
  - `cargo test -p axiomc registry::tests:: --manifest-path stage1/Cargo.toml`
  - `cargo test -p axiomc tests::registry_validate_cli_parses_integrity_options --manifest-path stage1/Cargo.toml`
  - `cargo test -p axiomc tests::help_describes_supported_stage1_workflows --manifest-path stage1/Cargo.toml`
  - `cargo run --quiet --manifest-path stage1/Cargo.toml -p axiomc -- publish stage1/examples/hello --registry-dir "$scratch/packages" --signing-key dev-key` plus `registry-index` and `registry-validate --packages-dir "$scratch/packages" --signing-key dev-key`
  - `AXIOM_PYTHON_EXIT_ISSUE_STATES_JSON='{"266":"closed","267":"closed","268":"closed","269":"closed","270":"closed","271":"closed"}' bash scripts/ci/run-fast-checks.sh`
  - `git diff --check`
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Note: the unscoped `cargo fmt --manifest-path stage1/Cargo.toml` command still exits with the existing workspace-level `Failed to find targets` cargo-fmt behavior. The package-scoped `axiomc` format check above passed.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

No semantic node types, schemas, semantic evidence models, Rust capture semantics, or agent-facing inspection APIs are changed. This is a registry CLI/library validation change.

## Flow Contract

- Owner lane: Ares / security registry validation
- Repair owner: Codex
- Autonomy class: issue-scoped security fix
- Risk class: security-sensitive registry integrity check, low runtime blast radius

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

Current next actors: GitHub Actions/self-hosted runner for required checks, then a non-author maintainer/reviewer for approval.

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

Auto-merge is not enabled by this author. It should be enabled after required checks pass and non-author approval is present.

## Notes

- This closes the remaining #538 gap called out in the issue body: `registry validate` now verifies local package archive sidecars when the operator supplies local packages and a key.
- The sidecar remains documented as a stage1 integrity tag, not cryptographic authenticity proof.
