### PR TITLE
[codex] Close numeric tower issue drift

### DIFF
--- a/docs/stage1-language-issue-disposition.md
+++ b/docs/stage1-language-issue-disposition.md
@@ -16,9 +16,11 @@ not sufficient closure evidence by itself.
 
 - Stage1 already supports explicit generic functions, generic structs and
   enums, borrowed slices, aggregate borrowed returns, owned `string`, scalar
-  `int` / `bool`, top-level scalar `const`, statement-level `match`,
-  `Option<T>` / `Result<T, E>`, package-local imports, local dependency graphs,
-  capability-gated stdlib modules, and generated-Rust native builds.
+  `int` / `bool`, first-class signed, unsigned, and floating numeric widths,
+  explicit numeric casts, suffixed numeric literals, top-level scalar `const`,
+  statement-level `match`, `Option<T>` / `Result<T, E>`, package-local imports,
+  local dependency graphs, capability-gated stdlib modules, and generated-Rust
+  native builds.
 - Stage1 still has no trait system, no generic type inference at call sites, no
   exposed lifetime parameter syntax, no `String` / `&str` split, no declarative
   macro expander, and no operator overloading protocol.
@@ -39,7 +41,7 @@ not sufficient closure evidence by itself.
 | [#217](https://github.com/OMT-Global/axiom/issues/217) Generic type inference | Keep open until scoped | The current AG2 contract deliberately uses explicit type arguments and monomorphized generics. Inference depends on a constraint model and eventual trait bounds, so implementation should wait for a focused inference RFC after the trait decision. |
 | [#218](https://github.com/OMT-Global/axiom/issues/218) Mutable references | Keep open as active AG1 follow-up | This maps to AG1.2. The current compiler has borrowed slices and some mutable-slice plumbing, but not the full exposed `&mut T` aliasing and lifetime contract requested by the issue. |
 | [#219](https://github.com/OMT-Global/axiom/issues/219) Explicit lifetimes | Partial implementation landed | Stage1 now accepts explicit lifetime annotations on borrowed slice and mutable borrowed slice function signatures, preserving them through project rewriting and using the return lifetime to restrict which borrowed parameters may feed a borrowed return. Broader lifetime parameters on aggregate declarations, traits, and the final syntax-versus-elision policy still need RFC follow-up. |
-| [#220](https://github.com/OMT-Global/axiom/issues/220) Full numeric tower | Keep open or split | The current language still only exposes scalar `int` and `bool` as first-class numerics. This is real product work, but the issue should be split before implementation into integer widths, float support, casts, overflow policy, and literal suffixes. |
+| [#220](https://github.com/OMT-Global/axiom/issues/220) Full numeric tower | Implementation slices landed | The numeric tower has been split into independently testable issue slices covering signed widths, unsigned widths, floats, explicit cross-width casts, and literal suffixes. `docs/stage1.md` records overflow and floating-point behavior, while focused unit tests and conformance fixtures cover the shipped surface. Keep future numeric work as separate follow-up issues instead of reopening the broad umbrella. |
 | [#221](https://github.com/OMT-Global/axiom/issues/221) Owned `String` and borrowed `&str` | Keep open or split after lifetime policy | Stage1 has owned `string` and borrowed slices, but not a user-facing string view model. This depends on the lifetime and reference decisions, so it should remain deferred rather than be treated as complete. |
 | [#222](https://github.com/OMT-Global/axiom/issues/222) Const / static evaluation | Keep open as partially landed | Top-level scalar `const` evaluation has landed, including local and imported public constants plus const-sized array lengths. Module-scope `static` now covers scalar values, strings, and small tuples. Match-pattern constants and `const fn` remain outside the current bootstrap contract, so the current evidence is partial only. |
 | [#223](https://github.com/OMT-Global/axiom/issues/223) Declarative macros | Keep open pending RFC | Macros are explicitly beyond the agent-grade compiler bar. They need an RFC covering hygiene and expansion boundaries before implementation issues are useful. |

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -1485,7 +1485,7 @@ Variant(
         assert!(rendered.contains("fn widen(value: u8) -> u32 {"));
         assert!(rendered.contains("return (value) as u32;"));
         assert!(rendered.contains("let byte: u8 = 255u8;"));
-        assert!(rendered.contains("let word: u32 = widen(byte) + 1u32;"));
+        assert!(rendered.contains("let word: u32 = (widen(byte)).wrapping_add(1u32);"));
         assert!(rendered.contains("let signed: i16 = -1i16;"));
         assert!(rendered.contains("let same: i16 = signed;"));
         assert!(!rendered.contains("let same: i16 = (signed) as i16;"));


### PR DESCRIPTION
## Summary

- Updates the numeric tower unit expectation to match the current unsigned `wrapping_add` codegen behavior.
- Updates the stage1 language disposition guide so it no longer says stage1 only exposes `int`/`bool`; it now records the landed signed, unsigned, float, cast, suffix, and overflow coverage.
- Groups the completed numeric tower slices under the tracking issue so the issue queue can close from current evidence.

## Governing Issue

Closes #716
Closes #718
Closes #685
Closes #686
Closes #690
Closes #842

## Validation

- [x] Relevant local checks passed
- [ ] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Validation run locally:

- `cargo test -p axiomc numeric --manifest-path stage1/Cargo.toml`
- `cargo run --quiet --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/conformance/pass/numeric_literal_suffixes --json`
- `cargo run --quiet --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/conformance/pass/numeric_cross_width_casts --json`
- `cargo run --quiet --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/conformance/pass/numeric_float_mean --json`
- `cargo run --quiet --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/conformance/pass/numeric_overflow_policy --json`
- `cargo run --quiet --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/conformance/fail/numeric_float_mixed_width_add --json`
- `cargo run --quiet --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/conformance/fail/numeric_literal_suffix_mismatch --json`
- `cargo fmt -p axiomc --manifest-path stage1/Cargo.toml -- --check`
- `git diff --check`
- `AXIOM_PYTHON_EXIT_ISSUE_STATES_JSON='{"266":"closed","267":"closed","268":"closed","269":"closed","270":"closed","271":"closed"}' bash scripts/ci/run-fast-checks.sh`

Skipped checks: none locally. GitHub CI still needs runner execution.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

Auto-merge note: not enabled by this author. Merge readiness depends on CI, required non-author approval, and repository policy.

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Semantic notes:

- Semantic node types: none.
- Schemas: none.
- Evidence: numeric unit and conformance evidence listed above.
- Rust capture risk: no generated runtime behavior changes beyond the assertion reflecting existing unsigned wrapping-add codegen.
- Agent-facing inspection impact: the disposition guide now reflects current numeric capability for planning and issue triage.

## Flow Contract

- Owner lane: language/type-system
- Repair owner: Codex
- Autonomy class: issue-closure evidence and test/doc drift fix
- Risk class: low

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is appropriate when gates pass

Current blockers:

- GitHub CI must complete.
- A non-author maintainer approval may be required by branch protection.

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

Auto-merge is not enabled by this author because review and required checks are still pending.

## Notes

- Clean `origin/main` had the numeric implementation and conformance fixtures, but `cargo test -p axiomc numeric` was red due to the old unsigned-add render expectation. This PR makes the closure evidence executable again.
