### PR TITLE
Add policy bundle target generator

### DIFF
--- a/docs/artifact-plan-v0.md
+++ b/docs/artifact-plan-v0.md
@@ -35,12 +35,15 @@ For a buildable package, the artifact plan includes:
 - the native binary at the manifest build output directory,
 - generated Rust beside the binary,
 - the OpenAPI target artifact at `<out_dir>/openapi.json`,
+- the policy bundle target artifact at `<out_dir>/policy-bundle.json`,
 - docs at `docs/axiom/index.md`,
 - one test report for each manifest test target,
 - one benchmark report for each manifest benchmark target.
 
 `openapi_spec` records move from `planned` to `generated` after
 `axiomc generate openapi <path> --out <out_dir>/openapi.json` writes the
-document. The inspect command does not generate files and does not replace
+document. `policy_bundle` records move from `planned` to `generated` after
+`axiomc generate policy <path> --out <out_dir>/policy-bundle.json` writes the
+allowlist. The inspect command does not generate files and does not replace
 `axiomc build`, `axiomc test`, `axiomc doc`, `axiomc bench`, or target
 generators.

--- a/docs/backend-target-interface-v0.md
+++ b/docs/backend-target-interface-v0.md
@@ -15,6 +15,8 @@ their contracts using the same shape before they ship.
 The first implemented non-source artifact target is
 [OpenAPI Target v0](openapi-target-v0.md), which emits an `openapi_spec`
 artifact from HTTP-serving semantic routes.
+[Policy Bundle Target v0](policy-bundle-target-v0.md) emits a
+`policy_bundle` artifact from manifest capabilities and effect records.
 
 ## Where It Fits
 
@@ -238,8 +240,10 @@ expressive enough for non-source targets:
   data); artifacts are forward and rollback SQL files.
 - `terraform_module`: input node kinds include `Capability` and
   `RuntimeSurface`; artifacts are HCL modules.
-- `policy_bundle`: input node kinds include `Capability` and `Effect`;
-  artifacts are policy files consumed by allowlist gates.
+- `policy_bundle`: implemented for stage1 as
+  [Policy Bundle Target v0](policy-bundle-target-v0.md). Input node kinds
+  include `Package`, `Capability`, and `Effect`; artifacts are deterministic
+  JSON policy files consumed by allowlist gates.
 
 These sketches share the same contract shape. Adding them does not require
 inventing a new schema.

--- a/docs/policy-bundle-target-v0.md
+++ b/docs/policy-bundle-target-v0.md
@@ -1,0 +1,95 @@
+# Policy Bundle Target v0
+
+Policy Bundle Target v0 projects the package capability surface and effect
+graph into a deterministic JSON allowlist. The bundle is an artifact for
+downstream gates such as CI policy checks, runtime allowlists, or OPA adapters;
+it does not enforce policy by itself and does not change compile-time
+capability checks.
+
+## Target Contract
+
+```json
+{
+  "id": "axiom://target/stage1-policy-bundle-v0",
+  "class": "policy_bundle",
+  "description": "Stage 1 policy bundle generator for manifest capabilities and effect allowlists.",
+  "status": "experimental",
+  "input_node_kinds": ["Package", "Capability", "Effect"],
+  "supported_effect_kinds": [
+    "clock.now",
+    "clock.sleep",
+    "crypto.hash",
+    "crypto.mac",
+    "env.read",
+    "fs.read",
+    "fs.write",
+    "network.dns.resolve",
+    "network.http.get",
+    "network.tcp.bind",
+    "network.tcp.connect",
+    "network.udp.send",
+    "process.status"
+  ],
+  "supported_type_features": [],
+  "artifact_outputs": [
+    {
+      "id": "axiom://package/<package>/artifact/policy-bundle",
+      "kind": "policy_bundle",
+      "path": "dist/policy-bundle.json",
+      "generated_from": ["axiom://package/<package>"],
+      "status": "planned"
+    }
+  ],
+  "evidence_requirements": ["unit_test", "fixture"],
+  "unsupported_feature_diagnostics": []
+}
+```
+
+## Command
+
+```bash
+axiomc generate policy <path> --out dist/policy-bundle.json --json
+```
+
+Relative `--out` paths are resolved inside the package path. The command emits
+a JSON report with the target contract, generated artifact record,
+`allowed_effect_kinds`, and observed effect records.
+
+## Projection Rules
+
+The allowlist is derived from manifest capabilities:
+
+- `clock` permits `clock.now` and `clock.sleep`.
+- `env` permits `env.read`.
+- `fs` permits `fs.read`.
+- `fs:write` permits `fs.write`.
+- `net` permits `network.dns.resolve`, `network.http.get`,
+  `network.tcp.bind`, `network.tcp.connect`, and `network.udp.send`.
+- `process` permits `process.status`.
+- `crypto` permits `crypto.hash` and `crypto.mac`.
+
+Capabilities with no effect kind in the current effect model, such as `ffi` and
+`async`, remain represented in the `capabilities` section but do not add
+effect allowlist entries.
+
+Observed effects come from `axiomc inspect effects`. They let downstream policy
+checks compare what a package uses against what the manifest permits without
+changing `axiomc caps` or compiler enforcement.
+
+## Drift Detection
+
+The bundle is byte-deterministic. Removing a capability from `axiom.toml`
+removes its effect kinds from `allowed_effect_kinds` when the bundle is
+regenerated, so policy drift is visible in a normal artifact diff.
+
+## Artifact Plan
+
+`axiomc inspect artifacts <path> --json` reports
+`<out_dir>/policy-bundle.json` as a `policy_bundle` target artifact. Its status
+is `planned` before generation and `generated` once the file exists.
+
+## Boundaries
+
+Policy Bundle Target v0 emits a neutral JSON allowlist only. It does not add an
+OPA/Rego renderer, runtime policy enforcement, new capability flags, or
+signed/attested bundles.

--- a/stage1/crates/axiomc/src/main.rs
+++ b/stage1/crates/axiomc/src/main.rs
@@ -288,6 +288,14 @@ enum GenerateCommand {
         #[arg(long)]
         json: bool,
     },
+    /// Generate a deterministic policy allowlist bundle from manifest capabilities and effects.
+    Policy {
+        path: PathBuf,
+        #[arg(long)]
+        out: PathBuf,
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -744,6 +752,21 @@ fn main() {
                     0
                 }
                 Err(error) => print_error("generate openapi", error, json),
+            },
+            GenerateCommand::Policy { path, out, json } => match generate_policy(&path, &out) {
+                Ok(report) => {
+                    if json {
+                        println!(
+                            "{}",
+                            json_contract::to_pretty_string(&report)
+                                .unwrap_or_else(|_| String::from("{}"))
+                        );
+                    } else {
+                        eprintln!("wrote {}", report.artifact.path);
+                    }
+                    0
+                }
+                Err(error) => print_error("generate policy", error, json),
             },
         },
         Command::Pkg { command } => match command {
@@ -1874,6 +1897,7 @@ fn inspect_effects(path: &Path) -> Result<InspectEffectsReport, Diagnostic> {
         for decl in &program.consts {
             collect_effects_in_expr(&decl.expr, &file, &mut effects);
         }
+        collect_effects_in_stmts(&program.stmts, &file, &mut effects);
         for function in &program.functions {
             collect_effects_in_stmts(&function.body, &file, &mut effects);
         }
@@ -2051,12 +2075,17 @@ fn collect_effects_in_expr(
 
 fn effect_for_call(name: &str) -> Option<(&'static str, &'static str, &'static str)> {
     match name {
-        "clock_now_ms" | "clock_elapsed_ms" => Some(("clock.now", "read", "clock")),
-        "clock_sleep_ms" => Some(("clock.sleep", "sleep", "clock")),
-        "env_get" => Some(("env.read", "read", "env")),
-        "fs_read" => Some(("fs.read", "read", "fs")),
+        "clock_now_ms" | "clock_elapsed_ms" | "now_ms" | "now" | "elapsed_ms" => {
+            Some(("clock.now", "read", "clock"))
+        }
+        "clock_sleep_ms" | "sleep" => Some(("clock.sleep", "sleep", "clock")),
+        "env_get" | "get_env" => Some(("env.read", "read", "env")),
+        "fs_read" | "read_file" => Some(("fs.read", "read", "fs")),
         "fs_write" | "fs_create" | "fs_append" | "fs_mkdir" | "fs_mkdir_all" | "fs_remove_file"
-        | "fs_remove_dir" | "fs_replace" => Some(("fs.write", "write", "fs:write")),
+        | "fs_remove_dir" | "fs_replace" | "write_file" | "create_file" | "append_file"
+        | "mkdir" | "mkdir_all" | "remove_file" | "remove_dir" | "replace_file" => {
+            Some(("fs.write", "write", "fs:write"))
+        }
         "net_resolve" => Some(("network.dns.resolve", "resolve", "net")),
         "http_get" => Some(("network.http.get", "get", "net")),
         "http_serve_once"
@@ -2838,6 +2867,256 @@ fn openapi_operation_id(path: &str) -> String {
     out
 }
 
+const POLICY_TARGET_ID: &str = "axiom://target/stage1-policy-bundle-v0";
+const POLICY_ARTIFACT_KIND: &str = "policy_bundle";
+const POLICY_SCHEMA_VERSION: &str = "axiom.policy_bundle.v0";
+const GENERATE_POLICY_SCHEMA_VERSION: &str = "axiom.generate.policy.v0";
+
+#[derive(Debug, Clone, Serialize)]
+struct GeneratePolicyReport {
+    schema_version: &'static str,
+    ok: bool,
+    command: &'static str,
+    project: String,
+    target_contract: TargetContract,
+    artifact: GeneratedArtifact,
+    allowed_effect_kinds: Vec<String>,
+    observed_effects: Vec<PolicyObservedEffect>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct PolicyBundle {
+    schema_version: &'static str,
+    package: String,
+    target_id: &'static str,
+    generated_from: Vec<String>,
+    capabilities: Vec<PolicyCapability>,
+    allowed_effect_kinds: Vec<String>,
+    allowed_effects: Vec<PolicyEffectAllowance>,
+    observed_effects: Vec<PolicyObservedEffect>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct PolicyCapability {
+    name: String,
+    enabled: bool,
+    description: &'static str,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    allowed: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    configured_root: Option<String>,
+    #[serde(skip_serializing_if = "is_false_bool")]
+    deny_by_default: bool,
+    #[serde(skip_serializing_if = "is_false_bool")]
+    unsafe_unrestricted: bool,
+    #[serde(skip_serializing_if = "is_false_bool")]
+    unsafe_opt_in: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    unsafe_rationale: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    owner: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rationale: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct PolicyEffectAllowance {
+    kind: String,
+    capability_gate: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct PolicyObservedEffect {
+    kind: String,
+    resource: String,
+    operation: &'static str,
+    capability_gate: &'static str,
+    source_span: SymbolSpan,
+}
+
+fn generate_policy(project: &Path, out: &Path) -> Result<GeneratePolicyReport, Diagnostic> {
+    let manifest = load_manifest(project)?;
+    let _package = manifest.package.as_ref().ok_or_else(|| {
+        Diagnostic::new(
+            "policy",
+            "policy bundle generation requires a package manifest with [package].",
+        )
+    })?;
+    let output_path = if out.is_absolute() {
+        out.to_path_buf()
+    } else {
+        project.join(out)
+    };
+    let capabilities = project_capabilities(project)?;
+    let allowed_effects = policy_allowed_effects(&capabilities);
+    let allowed_effect_kinds = allowed_effects
+        .iter()
+        .map(|effect| effect.kind.clone())
+        .collect::<Vec<_>>();
+    let observed_effects = inspect_effects(project)?
+        .effects
+        .iter()
+        .map(policy_observed_effect)
+        .collect::<Vec<_>>();
+    let package_id = package_node_for_path(project);
+    let bundle = PolicyBundle {
+        schema_version: POLICY_SCHEMA_VERSION,
+        package: package_id.clone(),
+        target_id: POLICY_TARGET_ID,
+        generated_from: vec![package_id.clone()],
+        capabilities: policy_capabilities(&capabilities),
+        allowed_effect_kinds: allowed_effect_kinds.clone(),
+        allowed_effects: allowed_effects.clone(),
+        observed_effects: observed_effects.clone(),
+    };
+    if let Some(parent) = output_path.parent() {
+        fs::create_dir_all(parent).map_err(|err| {
+            Diagnostic::new(
+                "policy",
+                format!("failed to create {}: {err}", parent.display()),
+            )
+        })?;
+    }
+    let body = serde_json::to_string_pretty(&bundle)
+        .map_err(|err| Diagnostic::new("json", format!("failed to serialize policy: {err}")))?;
+    fs::write(&output_path, format!("{body}\n")).map_err(|err| {
+        Diagnostic::new(
+            "policy",
+            format!("failed to write {}: {err}", output_path.display()),
+        )
+    })?;
+    let artifact = policy_artifact(project, &output_path, &package_id, "generated");
+    Ok(GeneratePolicyReport {
+        schema_version: GENERATE_POLICY_SCHEMA_VERSION,
+        ok: true,
+        command: "generate policy",
+        project: project.display().to_string(),
+        target_contract: policy_target_contract(artifact.clone()),
+        artifact,
+        allowed_effect_kinds,
+        observed_effects,
+    })
+}
+
+fn policy_target_contract(artifact: GeneratedArtifact) -> TargetContract {
+    TargetContract {
+        id: POLICY_TARGET_ID,
+        target_class: POLICY_ARTIFACT_KIND,
+        description: "Stage 1 policy bundle generator for manifest capabilities and effect allowlists.",
+        status: "experimental",
+        input_node_kinds: vec!["Package", "Capability", "Effect"],
+        supported_effect_kinds: policy_known_effect_kinds(),
+        supported_type_features: Vec::new(),
+        artifact_outputs: vec![artifact],
+        evidence_requirements: vec!["unit_test", "fixture"],
+        unsupported_feature_diagnostics: Vec::new(),
+    }
+}
+
+fn policy_artifact(
+    project: &Path,
+    output_path: &Path,
+    package_id: &str,
+    status: &'static str,
+) -> GeneratedArtifact {
+    GeneratedArtifact {
+        id: format!("{package_id}/artifact/policy-bundle"),
+        kind: POLICY_ARTIFACT_KIND,
+        path: project_relative_path(project, output_path),
+        generated_from: vec![package_id.to_string()],
+        status,
+    }
+}
+
+fn policy_allowed_effects(capabilities: &[CapabilityDescriptor]) -> Vec<PolicyEffectAllowance> {
+    let enabled = capabilities
+        .iter()
+        .filter(|capability| capability.enabled)
+        .map(|capability| capability.name.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut effects = Vec::new();
+    for (capability, kinds) in policy_effects_by_capability() {
+        if enabled.contains(capability) {
+            for kind in kinds {
+                effects.push(PolicyEffectAllowance {
+                    kind: (*kind).to_string(),
+                    capability_gate: capability.to_string(),
+                });
+            }
+        }
+    }
+    effects.sort_by(|left, right| {
+        left.kind
+            .cmp(&right.kind)
+            .then_with(|| left.capability_gate.cmp(&right.capability_gate))
+    });
+    effects
+}
+
+fn policy_capabilities(capabilities: &[CapabilityDescriptor]) -> Vec<PolicyCapability> {
+    capabilities
+        .iter()
+        .map(|capability| PolicyCapability {
+            name: capability.name.clone(),
+            enabled: capability.enabled,
+            description: capability.description,
+            allowed: capability.allowed.clone(),
+            configured_root: capability.configured_root.clone(),
+            deny_by_default: capability.deny_by_default,
+            unsafe_unrestricted: capability.unsafe_unrestricted,
+            unsafe_opt_in: capability.unsafe_opt_in,
+            unsafe_rationale: capability.unsafe_rationale.clone(),
+            owner: capability.owner.clone(),
+            rationale: capability.rationale.clone(),
+        })
+        .collect()
+}
+
+fn is_false_bool(value: &bool) -> bool {
+    !*value
+}
+
+fn policy_known_effect_kinds() -> Vec<&'static str> {
+    let mut kinds = policy_effects_by_capability()
+        .iter()
+        .flat_map(|(_, kinds)| kinds.iter().copied())
+        .collect::<Vec<_>>();
+    kinds.sort_unstable();
+    kinds.dedup();
+    kinds
+}
+
+fn policy_effects_by_capability() -> Vec<(&'static str, Vec<&'static str>)> {
+    vec![
+        ("clock", vec!["clock.now", "clock.sleep"]),
+        ("env", vec!["env.read"]),
+        ("fs", vec!["fs.read"]),
+        ("fs:write", vec!["fs.write"]),
+        (
+            "net",
+            vec![
+                "network.dns.resolve",
+                "network.http.get",
+                "network.tcp.bind",
+                "network.tcp.connect",
+                "network.udp.send",
+            ],
+        ),
+        ("process", vec!["process.status"]),
+        ("crypto", vec!["crypto.hash", "crypto.mac"]),
+    ]
+}
+
+fn policy_observed_effect(effect: &EffectNode) -> PolicyObservedEffect {
+    PolicyObservedEffect {
+        kind: effect.kind.to_string(),
+        resource: effect.resource.clone(),
+        operation: effect.operation,
+        capability_gate: effect.capability_gate,
+        source_span: effect.source_span.clone(),
+    }
+}
+
 fn symbol_span(path: &Path, line: usize, column: usize) -> SymbolSpan {
     SymbolSpan {
         path: path.display().to_string(),
@@ -3061,11 +3340,13 @@ fn collect_expr_capabilities(expr: &axiomc::syntax::Expr, capabilities: &mut Vec
 
 fn capability_for_call(name: &str) -> Option<&'static str> {
     match name {
-        "clock_now_ms" | "clock_elapsed_ms" | "clock_sleep_ms" => Some("clock"),
-        "env_get" => Some("env"),
-        "fs_read" => Some("fs"),
+        "clock_now_ms" | "clock_elapsed_ms" | "clock_sleep_ms" | "now_ms" | "now"
+        | "elapsed_ms" | "sleep" => Some("clock"),
+        "env_get" | "get_env" => Some("env"),
+        "fs_read" | "read_file" => Some("fs"),
         "fs_write" | "fs_create" | "fs_append" | "fs_mkdir" | "fs_mkdir_all" | "fs_remove_file"
-        | "fs_remove_dir" | "fs_replace" => Some("fs:write"),
+        | "fs_remove_dir" | "fs_replace" | "write_file" | "create_file" | "append_file"
+        | "mkdir" | "mkdir_all" | "remove_file" | "remove_dir" | "replace_file" => Some("fs:write"),
         "net_resolve"
         | "http_get"
         | "http_serve_once"
@@ -4359,6 +4640,13 @@ fn inspect_artifacts(project: &Path) -> Result<InspectArtifactsReport, Diagnosti
         out_dir_path(project, &manifest).join("openapi.json"),
         "target_contract",
     );
+    push_artifact(
+        &mut artifacts,
+        &package_id,
+        POLICY_ARTIFACT_KIND,
+        out_dir_path(project, &manifest).join("policy-bundle.json"),
+        "target_contract",
+    );
     if manifest.package.is_some() {
         push_artifact(
             &mut artifacts,
@@ -4508,7 +4796,9 @@ fn inspect_existing_output_artifacts(
         let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
             continue;
         };
-        let kind = if name == "openapi.json" || name.ends_with(".openapi.json") {
+        let kind = if name == "policy-bundle.json" || name.ends_with(".policy-bundle.json") {
+            POLICY_ARTIFACT_KIND
+        } else if name == "openapi.json" || name.ends_with(".openapi.json") {
             OPENAPI_ARTIFACT_KIND
         } else if name.ends_with(".generated.rs") {
             "generated_rust"
@@ -4777,6 +5067,29 @@ mod tests {
                 assert!(json);
             }
             other => panic!("expected generate openapi command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn generate_policy_cli_parses_output_path_and_json_flag() {
+        let cli = Cli::parse_from([
+            "axiomc",
+            "generate",
+            "policy",
+            ".",
+            "--out",
+            "dist/policy-bundle.json",
+            "--json",
+        ]);
+        match cli.command {
+            Command::Generate {
+                command: GenerateCommand::Policy { path, out, json },
+            } => {
+                assert_eq!(path, PathBuf::from("."));
+                assert_eq!(out, PathBuf::from("dist/policy-bundle.json"));
+                assert!(json);
+            }
+            other => panic!("expected generate policy command, got {other:?}"),
         }
     }
 
@@ -5612,6 +5925,11 @@ mod tests {
                 && artifact.source == "target_contract"
                 && artifact.status == "planned"
         }));
+        assert!(artifacts.artifacts.iter().any(|artifact| {
+            artifact.kind == POLICY_ARTIFACT_KIND
+                && artifact.source == "target_contract"
+                && artifact.status == "planned"
+        }));
     }
 
     #[test]
@@ -5698,6 +6016,93 @@ mod tests {
         .expect("spec json");
         assert_eq!(spec["openapi"], OPENAPI_SPEC_VERSION);
         assert!(spec["paths"].as_object().expect("paths object").is_empty());
+    }
+
+    #[test]
+    fn generate_policy_writes_manifest_effect_allowlist() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let project = dir.path().join("policy-service");
+        create_project(&project, Some("policy-service")).expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            "[package]\nname = \"policy-service\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = true\n\"fs:write\" = false\nnet = false\nprocess = false\nenv = [\"POLICY_MODE\"]\nclock = true\ncrypto = false\nffi = false\nasync = false\n",
+        )
+        .expect("write manifest");
+        fs::write(
+            project.join("src/main.ax"),
+            "import \"std/env.ax\"\nimport \"std/fs.ax\"\nimport \"std/time.ax\"\n\nlet now: int = now_ms()\nlet mode: Option<string> = get_env(\"POLICY_MODE\")\nlet contents: Option<string> = read_file(\"policy-input.txt\")\nprint now > 0\n",
+        )
+        .expect("write source");
+
+        let report =
+            generate_policy(&project, Path::new("dist/policy-bundle.json")).expect("policy");
+
+        assert_eq!(report.schema_version, GENERATE_POLICY_SCHEMA_VERSION);
+        assert_eq!(report.target_contract.id, POLICY_TARGET_ID);
+        assert_eq!(report.target_contract.target_class, POLICY_ARTIFACT_KIND);
+        let target_payload =
+            serde_json::to_value(&report.target_contract).expect("serialize target contract");
+        let target_schema_path =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("../../schemas/axiom-target-v0.schema.json");
+        let target_schema: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(target_schema_path).expect("read schema"))
+                .expect("target schema json");
+        jsonschema::validator_for(&target_schema)
+            .expect("compile target schema")
+            .validate(&target_payload)
+            .expect("policy target contract matches target schema");
+        assert_eq!(report.artifact.status, "generated");
+        assert_eq!(
+            report.allowed_effect_kinds,
+            vec!["clock.now", "clock.sleep", "env.read", "fs.read"]
+        );
+        let observed = report
+            .observed_effects
+            .iter()
+            .map(|effect| effect.kind.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(observed, vec!["clock.now", "env.read", "fs.read"]);
+
+        let bundle: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(project.join("dist/policy-bundle.json")).expect("read bundle"),
+        )
+        .expect("bundle json");
+        assert_eq!(bundle["schema_version"], POLICY_SCHEMA_VERSION);
+        assert_eq!(bundle["target_id"], POLICY_TARGET_ID);
+        assert_eq!(
+            bundle["allowed_effect_kinds"],
+            serde_json::json!(["clock.now", "clock.sleep", "env.read", "fs.read"])
+        );
+    }
+
+    #[test]
+    fn generate_policy_reflects_removed_manifest_capability() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let project = dir.path().join("policy-drift");
+        create_project(&project, Some("policy-drift")).expect("create project");
+        let manifest = |clock: bool| {
+            format!(
+                "[package]\nname = \"policy-drift\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = {clock}\ncrypto = false\n"
+            )
+        };
+        fs::write(project.join("axiom.toml"), manifest(true)).expect("write manifest");
+        fs::write(
+            project.join("src/main.ax"),
+            "let now: int = clock_now_ms()\nprint now > 0\n",
+        )
+        .expect("write source");
+
+        let with_clock =
+            generate_policy(&project, Path::new("dist/policy-bundle.json")).expect("policy");
+        fs::write(project.join("axiom.toml"), manifest(false)).expect("rewrite manifest");
+        let without_clock =
+            generate_policy(&project, Path::new("dist/policy-bundle.json")).expect("policy");
+
+        assert_eq!(
+            with_clock.allowed_effect_kinds,
+            vec!["clock.now", "clock.sleep"]
+        );
+        assert!(without_clock.allowed_effect_kinds.is_empty());
     }
 
     #[test]

--- a/stage1/crates/axiomc/tests/schema_metadata.rs
+++ b/stage1/crates/axiomc/tests/schema_metadata.rs
@@ -320,3 +320,34 @@ fn openapi_service_fixture_is_deterministic() {
         "axiom://target/stage1-openapi-v0"
     );
 }
+
+#[test]
+fn policy_bundle_service_fixture_is_deterministic() {
+    let fixture_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("examples")
+        .join("policy_bundle_service")
+        .join("dist")
+        .join("policy-bundle.json");
+    let fixture: Value =
+        serde_json::from_str(&fs::read_to_string(&fixture_path).expect("read policy fixture"))
+            .expect("policy fixture is valid JSON");
+
+    assert_eq!(fixture["schema_version"], "axiom.policy_bundle.v0");
+    assert_eq!(
+        fixture["target_id"],
+        "axiom://target/stage1-policy-bundle-v0"
+    );
+    assert_eq!(
+        fixture["allowed_effect_kinds"],
+        serde_json::json!(["clock.now", "clock.sleep", "env.read", "fs.read"])
+    );
+    assert_eq!(
+        fixture["observed_effects"]
+            .as_array()
+            .expect("effects")
+            .len(),
+        3
+    );
+}

--- a/stage1/examples/policy_bundle_service/axiom.lock
+++ b/stage1/examples/policy_bundle_service/axiom.lock
@@ -1,0 +1,6 @@
+version = 1
+
+[[package]]
+name = "policy-bundle-service"
+version = "0.1.0"
+source = "path"

--- a/stage1/examples/policy_bundle_service/axiom.toml
+++ b/stage1/examples/policy_bundle_service/axiom.toml
@@ -1,0 +1,18 @@
+[package]
+name = "policy-bundle-service"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = true
+"fs:write" = false
+net = false
+process = false
+env = ["POLICY_MODE"]
+clock = true
+crypto = false
+ffi = false
+async = false

--- a/stage1/examples/policy_bundle_service/dist/policy-bundle.json
+++ b/stage1/examples/policy_bundle_service/dist/policy-bundle.json
@@ -1,0 +1,118 @@
+{
+  "schema_version": "axiom.policy_bundle.v0",
+  "package": "axiom://package/policy-bundle-service",
+  "target_id": "axiom://target/stage1-policy-bundle-v0",
+  "generated_from": [
+    "axiom://package/policy-bundle-service"
+  ],
+  "capabilities": [
+    {
+      "name": "fs",
+      "enabled": true,
+      "description": "filesystem read access",
+      "configured_root": "."
+    },
+    {
+      "name": "fs:write",
+      "enabled": false,
+      "description": "filesystem write access"
+    },
+    {
+      "name": "net",
+      "enabled": false,
+      "description": "network access"
+    },
+    {
+      "name": "process",
+      "enabled": false,
+      "description": "child process execution"
+    },
+    {
+      "name": "env",
+      "enabled": true,
+      "description": "environment variable access",
+      "allowed": [
+        "POLICY_MODE"
+      ]
+    },
+    {
+      "name": "clock",
+      "enabled": true,
+      "description": "wall-clock time access"
+    },
+    {
+      "name": "crypto",
+      "enabled": false,
+      "description": "hashing and cryptography primitives"
+    },
+    {
+      "name": "ffi",
+      "enabled": false,
+      "description": "foreign function interface access"
+    },
+    {
+      "name": "async",
+      "enabled": false,
+      "description": "host async runtime access"
+    }
+  ],
+  "allowed_effect_kinds": [
+    "clock.now",
+    "clock.sleep",
+    "env.read",
+    "fs.read"
+  ],
+  "allowed_effects": [
+    {
+      "kind": "clock.now",
+      "capability_gate": "clock"
+    },
+    {
+      "kind": "clock.sleep",
+      "capability_gate": "clock"
+    },
+    {
+      "kind": "env.read",
+      "capability_gate": "env"
+    },
+    {
+      "kind": "fs.read",
+      "capability_gate": "fs"
+    }
+  ],
+  "observed_effects": [
+    {
+      "kind": "clock.now",
+      "resource": "*",
+      "operation": "read",
+      "capability_gate": "clock",
+      "source_span": {
+        "path": "stage1/examples/policy_bundle_service/src/main.ax",
+        "line": 5,
+        "column": 15
+      }
+    },
+    {
+      "kind": "env.read",
+      "resource": "POLICY_MODE",
+      "operation": "read",
+      "capability_gate": "env",
+      "source_span": {
+        "path": "stage1/examples/policy_bundle_service/src/main.ax",
+        "line": 6,
+        "column": 24
+      }
+    },
+    {
+      "kind": "fs.read",
+      "resource": "policy-input.txt",
+      "operation": "read",
+      "capability_gate": "fs",
+      "source_span": {
+        "path": "stage1/examples/policy_bundle_service/src/main.ax",
+        "line": 7,
+        "column": 28
+      }
+    }
+  ]
+}

--- a/stage1/examples/policy_bundle_service/src/main.ax
+++ b/stage1/examples/policy_bundle_service/src/main.ax
@@ -1,0 +1,9 @@
+import "std/env.ax"
+import "std/fs.ax"
+import "std/time.ax"
+
+let started: int = now_ms()
+let _mode: Option<string> = get_env("POLICY_MODE")
+let _contents: Option<string> = read_file("policy-input.txt")
+
+print started > 0

--- a/stage1/schemas/axiom-artifacts-v0.schema.json
+++ b/stage1/schemas/axiom-artifacts-v0.schema.json
@@ -44,6 +44,7 @@
             "native_binary",
             "generated_rust",
             "openapi_spec",
+            "policy_bundle",
             "test_report",
             "benchmark_report",
             "docs"


### PR DESCRIPTION
## Summary

- Adds `axiomc generate policy <path> --out <file>` for the `policy_bundle` target.
- Emits a deterministic JSON allowlist from manifest capabilities plus observed effect records.
- Adds `docs/policy-bundle-target-v0.md`, artifact-plan visibility for `policy_bundle`, and `stage1/examples/policy_bundle_service/dist/policy-bundle.json` as the checked-in fixture.

## Governing Issue

Closes #848 when this stack reaches `main`.

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Commands run:

- `cargo test -p axiomc policy --manifest-path stage1/Cargo.toml`
- `cargo test -p axiomc --test schema_metadata --manifest-path stage1/Cargo.toml`
- `cargo test -p axiomc inspect_effects_reports_known_runtime_surfaces --manifest-path stage1/Cargo.toml`
- `cargo fmt -p axiomc --manifest-path stage1/Cargo.toml -- --check`
- `cargo run --quiet --manifest-path stage1/Cargo.toml -p axiomc -- check stage1/examples/policy_bundle_service --json`
- `cargo run --quiet --manifest-path stage1/Cargo.toml -p axiomc -- generate policy stage1/examples/policy_bundle_service --out dist/policy-bundle.json --json`
- `git diff --check`
- `AXIOM_PYTHON_EXIT_ISSUE_STATES_JSON='{"266":"closed","267":"closed","268":"closed","269":"closed","270":"closed","271":"closed"}' bash scripts/ci/run-fast-checks.sh`

Skipped checks: none intentionally skipped. Existing Rust warnings about unused code/imports remain non-fatal.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

Auto-merge note: this is stacked on #871 and should merge after #871 plus required review/checks.

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Semantic node types: consumes `Package`, `Capability`, and `Effect`; no new Intent IR node kind is introduced.

Schemas changed: `stage1/schemas/axiom-artifacts-v0.schema.json` now allows `policy_bundle`.

Evidence changed: adds generator unit coverage, manifest-drift coverage, and a checked-in policy fixture integration test.

Rust capture risk: the target is documented as a neutral Axiom policy artifact; Rust is only the stage1 implementation host.

Agent-facing inspection impact: `axiomc inspect artifacts <path> --json` reports `<out_dir>/policy-bundle.json` as `policy_bundle`, moving from `planned` to `generated`.

## Flow Contract

- Owner lane: lane:daedalus
- Repair owner: Codex
- Autonomy class: issue-scoped stacked implementation
- Risk class: medium; policy artifact/reporting changes, no compile-time enforcement change

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is appropriate when gates pass

Next actor: reviewer/maintainer after #871 is accepted, then this PR can be reviewed/merged.

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

Auto-merge not enabled by this agent because the PR is stacked on #871 and review/check state is pending.

## Notes

- Base branch is `codex/issue-847-openapi-target` so this PR shows only the #848 policy-bundle delta. It should be retargeted to `main` after #871 lands if GitHub does not do so automatically.
- The generated policy fixture is force-added under the ignored example `dist/` path so the artifact itself is reviewable.
