### PR TITLE
Refine project vision document

### DIFF
--- a/VISION.md
+++ b/VISION.md
@@ -1,34 +1,41 @@
 # Axiom Vision
 
-Version: 0.1
+Version: 0.2
 
-Axiom is the semantic and operational backbone for agent-native software delivery in the OMT-Global portfolio.
+Axiom is an agent-native typed intent layer and semantic construction system. It should let humans and agents describe software in terms of intent, capabilities, effects, invariants, required evidence, and generated artifacts instead of only editing files and hoping the reason for the system survives.
 
-Its purpose is to turn scattered repository state, diagnostics, backend contracts, and workflow expectations into stable interfaces that agents and humans can rely on.
+The current product is the Rust-hosted `stage1` compiler and `axiomc` workflow. Rust is the bootstrap implementation and generated-Rust backend, not the identity of the language. The long-term identity is the semantic graph and Intent IR that agents can inspect, verify, and project into code, tests, docs, policies, schemas, runbooks, and service contracts.
 
 ## Who It Serves
 
-- Agents that need durable project context instead of brittle prompt memory.
-- Maintainers who need trustworthy diagnostics, schemas, and repair loops.
-- The OMT-Global portfolio, where each repo benefits from shared delivery patterns without becoming coupled to a central app.
+- Agent operators who need stable semantic context before changing code.
+- Language contributors building the first practical `axiomc` compiler and conformance corpus.
+- Future backend authors who need a target contract that prevents Rust, native code, OpenAPI, SQL, policy bundles, or docs from becoming ad hoc projections.
+
+## Current Product Boundary
+
+- Supported path: `stage1/` and the `axiomc` commands for `new`, `check`, `build`, `run`, `test`, `caps`, package manifests, conformance fixtures, generated Rust, and capability inspection.
+- Semantic path: schema-first, fixture-backed increments such as target contracts, evidence reports, artifact plans, effect models, and semantic declarations.
+- Deprecated path: Python `stage0` and bytecode VM execution are documentation and migration references only.
 
 ## Product Principles
 
-- Prefer stable contracts over clever inference.
-- Diagnostics should be structured, testable, and documented.
-- Backend schema changes must be treated as product-facing behavior.
-- CI repair is not complete until live checks and review state are rechecked.
-- Agent-native does not mean agent-only; humans should be able to inspect every decision surface.
+- Semantics define the contract; backend implementation details only explain how a target realizes that contract.
+- Every new semantic primitive needs a schema or schema delta, fixture coverage, and an inspection path before runtime behavior depends on it.
+- Diagnostics and evidence must be structured enough for agents to attach them to PRs without scraping terminal logs.
+- Capability and effect boundaries are part of the language, not optional policy afterthoughts.
+- The compiler should become agent-grade before it becomes ambitious: complete package workflows and clear JSON diagnostics matter more than direct-native parity.
 
 ## Near-Term Direction
 
-- Harden backend target schemas and diagnostic codes.
-- Make queue-wide PR remediation repeatable.
-- Improve issue-to-PR traceability.
-- Keep CI and review state visible as first-class delivery signals.
+- Finish the agent-grade compiler floor: ownership/borrowing, package workflows, capability-gated stdlib/runtime APIs, and three proof workloads.
+- Make `axiomc` inspection commands useful for agent repair: evidence, artifacts, semantic nodes, unsupported target features, and safe edit surfaces.
+- Keep backend target contracts explicit as generated Rust, direct native, and non-code artifact targets evolve.
+- Preserve the conformance corpus and fast gates as the minimum trust surface for every language slice.
 
 ## Non-Goals
 
-- Do not turn Axiom into a generic task manager.
-- Do not hide product behavior behind opaque agent heuristics.
-- Do not accept schema drift without explicit migration and test coverage.
+- Axiom is not a generic task manager, YAML workflow engine, natural-language executor, or Rust replacement.
+- Do not introduce semantic-layer behavior as undocumented compiler magic.
+- Do not let generated Rust or any future target define Axiom's vocabulary.
+- Do not revive Python VM execution as a supported product path.


### PR DESCRIPTION
## Summary

- Refine `VISION.md` for axiom after reviewing the current README, repo docs, manifest, and product surfaces.
- Replace generic first-pass language with repo-specific product boundaries, principles, near-term direction, and non-goals.

## Governing Issue

- No issue is linked because this PR was created directly from the operator request to take another pass after reviewing each repository.
- This is documentation-only planning work and does not close a tracked implementation issue.

## Validation

- Not run; documentation-only change.
- Verified each refinement branch changes only `VISION.md`.
- Verified updated `VISION.md` files are ASCII-only.

## Bootstrap Governance

- No bootstrap-managed files changed.
- No GitHub policy, runner, release, or repository settings changed.

## Merge Automation

- Not enabled. Please review and merge manually after the refined draft matches the product direction.

## Notes

- Follow-up to the first-pass VISION.md seed PRs that have already merged.
