### PR TITLE
Authenticate Python exit issue checks

### DIFF
--- a/.github/workflows/pr-fast-ci.yml
+++ b/.github/workflows/pr-fast-ci.yml
@@ -129,6 +129,8 @@ jobs:
           exit 1
 
       - name: Run fast checks
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: bash scripts/ci/run-fast-checks.sh
 
   validate-pr-description:

--- a/.github/workflows/pr-fast-ci.yml
+++ b/.github/workflows/pr-fast-ci.yml
@@ -10,6 +10,7 @@ concurrency:
 
 permissions:
   contents: read
+  issues: read
 
 env:
   NODE_VERSION: '20'

--- a/scripts/ci/check-python-exit-docs.sh
+++ b/scripts/ci/check-python-exit-docs.sh
@@ -143,8 +143,15 @@ if states_json:
 else:
     states = {}
     try:
+        token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "axiom-python-exit-readiness-check",
+        }
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
         for issue in required_issues:
-            req = urllib.request.Request(f"https://api.github.com/repos/OMT-Global/axiom/issues/{issue}", headers={"Accept":"application/vnd.github+json","User-Agent":"axiom-python-exit-readiness-check"})
+            req = urllib.request.Request(f"https://api.github.com/repos/OMT-Global/axiom/issues/{issue}", headers=headers)
             with urllib.request.urlopen(req, timeout=20) as response:
                 item = json.load(response)
             states[issue] = str(item.get("state", "")).lower()


### PR DESCRIPTION
## Summary
- authenticate the Python deletion readiness issue-state check with `GITHUB_TOKEN`/`GH_TOKEN` when available
- grant the PR Fast CI workflow read-only issue permission so common fleet runners do not burn anonymous GitHub API quota

## Governing Issue
No linked issue; this is an operational CI unblocker for the Axiom PR merge train.

## Validation
- [x] `AXIOM_PYTHON_EXIT_ISSUE_STATES_JSON='{"266":"closed","267":"closed","268":"closed","269":"closed","270":"closed","271":"closed"}' bash scripts/ci/check-python-exit-docs.sh`
- [x] `GITHUB_TOKEN="$(gh auth token)" bash scripts/ci/check-python-exit-docs.sh`
- [x] `bash scripts/ci/test-pr-fast-ci-workflow.sh`

## Bootstrap Governance
- Keeps the required Python-exit blocker check, but makes it deterministic on shared self-hosted runners.

## Notes
- This does not bypass the blocker-state requirement; it only avoids unauthenticated API rate-limit failures.
