### PR TITLE
[codex] Add property check gate

### DIFF
--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -111,7 +111,10 @@ fixtures once so benchmark code participates in functional gates. The command
 also accepts `--filter <pattern>` to run a subset of discovered tests by test
 name or entry path. `axiomc test --properties` narrows discovery to property
 fixtures and prints an explicit `N/N properties passed` summary for Phase-H
-property gates. The `std/testing.ax` helper surface is backed by
+property gates. `axiomc check --properties` first performs the normal type,
+ownership, capability, and manifest checks, then runs the same property-only
+fixture gate so property failures block a check command before build artifacts
+are accepted. The `std/testing.ax` helper surface is backed by
 `stage1/stdlib/std/testing.ax` and embedded into the virtual stdlib at compiler
 build time. The default CLI summary prints `passed` / `failed` / `skipped`
 counts. `axiomc test --list` exposes the same discovery pass without building or

--- a/stage1/compiler-contracts/schemas/axiom.stage1.command.schema.json
+++ b/stage1/compiler-contracts/schemas/axiom.stage1.command.schema.json
@@ -391,7 +391,7 @@
           "$ref": "#/$defs/path"
         },
         "ok": {
-          "const": true
+          "type": "boolean"
         },
         "command": {
           "const": "check"
@@ -433,6 +433,29 @@
           "type": "array",
           "items": {
             "$ref": "#/$defs/macroExpansion"
+          }
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "passed",
+            "failed",
+            "total"
+          ],
+          "properties": {
+            "passed": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "failed": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "total": {
+              "type": "integer",
+              "minimum": 0
+            }
           }
         }
       }

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -15878,6 +15878,25 @@ return input == input && true && true
     }
 
     #[test]
+    fn hir_lowers_property_clause_with_borrowed_input() {
+        let parsed = parse(
+            r#"
+property fn borrowed_input_len(input: [int]): bool {
+let view: &[int] = input[:]
+return len(view) == len(input)
+}
+"#,
+        );
+
+        let lowered =
+            lower(&parsed).expect("property clauses should typecheck borrowed input reads");
+        let property = &lowered.functions[0];
+
+        assert!(property.is_property);
+        assert_eq!(property.return_ty, Type::Bool);
+    }
+
+    #[test]
     fn hir_lowers_assert_true_as_property_verdict() {
         let parsed = parse(
             r#"

--- a/stage1/crates/axiomc/src/json_contract.rs
+++ b/stage1/crates/axiomc/src/json_contract.rs
@@ -33,6 +33,29 @@ pub fn check_success(project: &Path, output: &CheckOutput) -> Value {
     payload
 }
 
+pub fn test_property_summary(output: &TestOutput) -> Value {
+    let property_total = output
+        .cases
+        .iter()
+        .filter(|case| case.kind == TestKind::Property)
+        .count();
+    let property_passed = output
+        .cases
+        .iter()
+        .filter(|case| case.kind == TestKind::Property && case.ok)
+        .count();
+    let property_failed = output
+        .cases
+        .iter()
+        .filter(|case| case.kind == TestKind::Property && !case.ok)
+        .count();
+    json!({
+        "passed": property_passed,
+        "failed": property_failed,
+        "total": property_total,
+    })
+}
+
 pub fn build_success(project: &Path, output: &BuildOutput) -> Value {
     let payload = json!({
         "schema_version": JSON_SCHEMA_VERSION,
@@ -107,21 +130,6 @@ pub fn test_success(
     properties_only: bool,
     output: &TestOutput,
 ) -> Value {
-    let property_total = output
-        .cases
-        .iter()
-        .filter(|case| case.kind == TestKind::Property)
-        .count();
-    let property_passed = output
-        .cases
-        .iter()
-        .filter(|case| case.kind == TestKind::Property && case.ok)
-        .count();
-    let property_failed = output
-        .cases
-        .iter()
-        .filter(|case| case.kind == TestKind::Property && !case.ok)
-        .count();
     json!({
         "schema_version": JSON_SCHEMA_VERSION,
         "ok": output.failed == 0,
@@ -135,11 +143,7 @@ pub fn test_success(
         "failed": output.failed,
         "skipped": output.skipped,
         "kinds": output.kinds,
-        "properties": {
-            "passed": property_passed,
-            "failed": property_failed,
-            "total": property_total,
-        },
+        "properties": test_property_summary(output),
         "duration_ms": output.duration_ms,
         "cases": output.cases,
     })

--- a/stage1/crates/axiomc/src/main.rs
+++ b/stage1/crates/axiomc/src/main.rs
@@ -13,10 +13,11 @@ use axiomc::manifest::{
 use axiomc::new_project::create_project;
 use axiomc::new_project::{WorkloadTemplate, create_project_with_template};
 use axiomc::project::{
-    BuildOptions, BuildOutput, CheckOptions, RunOptions, TestOptions, build_project_with_options,
-    capability_sbom, check_project_with_options, list_project_tests_with_options,
-    package_graph_metadata, project_capabilities, run_project_report_with_options,
-    run_project_tests_with_options, run_project_with_options, trace_provenance,
+    BuildOptions, BuildOutput, CheckOptions, RunOptions, TestOptions, TestOutput,
+    build_project_with_options, capability_sbom, check_project_with_options,
+    list_project_tests_with_options, package_graph_metadata, project_capabilities,
+    run_project_report_with_options, run_project_tests_with_options, run_project_with_options,
+    trace_provenance,
 };
 use axiomc::registry::{
     PublishOptions, load_registry_index, publish_package, render_registry_index,
@@ -60,6 +61,9 @@ enum Command {
         path: PathBuf,
         #[arg(long)]
         json: bool,
+        /// After type and ownership checks pass, run discovered property fixtures.
+        #[arg(long)]
+        properties: bool,
         #[arg(long)]
         exports: bool,
         #[arg(long = "debug-symbols")]
@@ -409,32 +413,61 @@ fn main() {
         Command::Check {
             path,
             json,
+            properties,
             exports,
             debug_symbols,
             macro_recursion_limit,
             package,
-        } => match check_project_with_options(
-            &path,
-            &CheckOptions {
-                package: package.clone(),
-                include_exports: exports,
-                include_debug_symbols: debug_symbols,
-                macro_recursion_limit,
-            },
-        ) {
-            Ok(output) => {
-                if json {
-                    println!("{}", json_contract::check_success(&path, &output));
-                } else {
-                    for warning in &output.warnings {
-                        eprintln!("{warning}");
+        } => {
+            match check_project_with_options(
+                &path,
+                &CheckOptions {
+                    package: package.clone(),
+                    include_exports: exports,
+                    include_debug_symbols: debug_symbols,
+                    macro_recursion_limit,
+                },
+            ) {
+                Ok(output) => {
+                    let property_output = if properties {
+                        match run_property_check_tests(&path, package.clone()) {
+                            Ok(output) => Some(output),
+                            Err(error) => std::process::exit(print_error("check", error, json)),
+                        }
+                    } else {
+                        None
+                    };
+
+                    if json {
+                        let mut payload = json_contract::check_success(&path, &output);
+                        if let Some(property_output) = &property_output {
+                            payload["ok"] = serde_json::json!(property_output.failed == 0);
+                            payload["properties"] =
+                                json_contract::test_property_summary(property_output);
+                        }
+                        println!("{payload}");
+                    } else {
+                        for warning in &output.warnings {
+                            eprintln!("{warning}");
+                        }
+                        eprintln!("OK");
+                        if let Some(property_output) = &property_output {
+                            print_property_summary(property_output);
+                        }
                     }
-                    eprintln!("OK");
+                    if property_output
+                        .as_ref()
+                        .map(|output| output.failed == 0)
+                        .unwrap_or(true)
+                    {
+                        0
+                    } else {
+                        1
+                    }
                 }
-                0
+                Err(error) => print_error("check", error, json),
             }
-            Err(error) => print_error("check", error, json),
-        },
+        }
         Command::Build {
             path,
             json,
@@ -1226,6 +1259,36 @@ fn parse_project_entry(path: &Path) -> Result<ParseOutput, Diagnostic> {
         entry: entry.display().to_string(),
         statement_count: program.stmts.len(),
     })
+}
+
+fn run_property_check_tests(
+    path: &Path,
+    package: Option<String>,
+) -> Result<TestOutput, Diagnostic> {
+    run_project_tests_with_options(
+        path,
+        &TestOptions {
+            filter: None,
+            package,
+            include_benchmarks: false,
+            properties_only: true,
+        },
+    )
+}
+
+fn print_property_summary(output: &TestOutput) {
+    for case in &output.cases {
+        let status = if case.ok { "PASS" } else { "FAIL" };
+        eprintln!("{status} {:?} {} ({})", case.kind, case.name, case.entry);
+        if let Some(error) = &case.error {
+            eprintln!("  {error}");
+        }
+        eprintln!("  duration: {} ms", case.duration_ms);
+    }
+    let properties = json_contract::test_property_summary(output);
+    let passed = properties["passed"].as_u64().unwrap_or(0);
+    let total = properties["total"].as_u64().unwrap_or(0);
+    eprintln!("{passed}/{total} properties passed");
 }
 
 fn build_summary_lines(output: &BuildOutput, timings: bool) -> Vec<String> {
@@ -7383,6 +7446,17 @@ mod tests {
     }
 
     #[test]
+    fn check_help_lists_properties_flag() {
+        let mut command = Cli::command();
+        let check_help = command
+            .find_subcommand_mut("check")
+            .expect("check subcommand")
+            .render_long_help()
+            .to_string();
+        assert!(check_help.contains("--properties"));
+    }
+
+    #[test]
     fn registry_validate_cli_parses_integrity_options() {
         let cli = Cli::parse_from([
             "axiomc",
@@ -7540,6 +7614,42 @@ mod tests {
             }
             other => panic!("expected test command, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn check_accepts_properties_flag() {
+        let cli = Cli::parse_from(["axiomc", "check", ".", "--properties", "--json"]);
+        match cli.command {
+            Command::Check {
+                properties, json, ..
+            } => {
+                assert!(properties);
+                assert!(json);
+            }
+            other => panic!("expected check command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn check_properties_runs_property_only_tests() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let project = dir.path().join("check-properties");
+        create_project(&project, Some("check-properties-app")).expect("create project");
+        fs::write(project.join("src/main_test.ax"), "print \"unit\"\n").expect("write unit test");
+        fs::write(project.join("src/main_test.stdout"), "unit\n").expect("write unit golden");
+        fs::write(
+            project.join("src/addition_property.ax"),
+            "import \"std/testing.ax\"\nlet ok: int = property(\"addition identity\", 40 + 2 == 42)\nprint ok\n",
+        )
+        .expect("write property test");
+        fs::write(project.join("src/addition_property.stdout"), "0\n")
+            .expect("write property golden");
+
+        let output = run_property_check_tests(&project, None).expect("run property checks");
+
+        assert_eq!(output.failed, 0);
+        assert_eq!(output.cases.len(), 1);
+        assert_eq!(output.cases[0].kind, TestKind::Property);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `axiomc check --properties` as a public Phase-I property gate: normal check analysis runs first, then discovered property fixtures run through the existing property-only test runner.
- Adds a reusable JSON property summary and allows the check contract to report property pass/fail totals when `--properties` is requested.
- Documents the new check gate and adds focused CLI/HIR coverage, including a property function that borrows from its input under the ownership checker.

## Governing Issue

Closes #715

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Commands run:

- `cargo fmt --all`
- `cargo test -p axiomc check_`
- `cargo test -p axiomc hir_lowers_property_clause_with_borrowed_input`
- `cargo test -p axiomc cli_json_outputs_match_checked_in_contract_snapshots`
- `cargo run --manifest-path stage1/Cargo.toml -p axiomc -- check stage1/examples/property_smoke --properties --json`
- `cargo run --manifest-path stage1/Cargo.toml -p axiomc -- check stage1/conformance/fail/property_clause_failure --properties --json` exited 1 as expected with `property_failed`.

Skipped checks:

- No local checks were intentionally skipped.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Semantic details:

- Semantic node types added/changed: no new node types; this wires the existing property-function and property-fixture behavior into `axiomc check --properties`.
- Schemas added/changed: `stage1/compiler-contracts/schemas/axiom.stage1.command.schema.json` now allows check JSON envelopes to report property summary totals and `ok: false` for property-gate failures.
- Evidence added/changed: CLI tests for `check --properties`, property-only check helper coverage, contract snapshot validation, and HIR coverage for borrowed property input.
- Rust capture risk: low; the gate reuses existing `run_project_tests_with_options(... properties_only: true)` after normal `check_project_with_options`, with no generated-Rust backend change.
- Agent-facing inspection impact: agents can now use `axiomc check --properties --json` to get property pass/fail totals as part of check validation.

## Flow Contract

- Owner lane: ares
- Repair owner: codex
- Autonomy class: issue-scoped implementation
- Risk class: medium

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

## Merge Automation

- [x] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- This closes the first-class property check gate in #715. The broader Phase-I tracker (#561) and stdlib/conformance migration issues (#712 and #714) remain open for their separate migration work.
