### PR TITLE
[codex] Add doc JSON output schema

### DIFF
--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -77,7 +77,9 @@ cargo run --manifest-path stage1/Cargo.toml -p axiomc -- lsp
 `axiomc doc --json` emits the same API extraction pass as a versioned machine
 contract, including generated Markdown/HTML paths, documented symbols, comments,
 signatures, simple example notes, declaration kind/visibility, and package
-capability descriptors when the input path is a package root.
+capability descriptors when the input path is a package root. The output
+validates against `stage1/schemas/axiom-doc-v0.schema.json` as well as the
+shared `axiom.stage1.v1` envelope.
 
 `axiomc new` defaults to the `cli` starter and also accepts `--template worker`
 and `--template service`. Each starter writes `axiom.toml`, `axiom.lock`,

--- a/stage1/compiler-contracts/snapshots/debug-map.json
+++ b/stage1/compiler-contracts/snapshots/debug-map.json
@@ -3,19 +3,19 @@
   "generated_rust": "<project>/dist/debug-map-contract.generated.rs",
   "mappings": [
     {
-      "generated_line": 3248,
+      "generated_line": 3547,
       "source": "<project>/src/helper.ax",
       "line": 2,
       "column": 1
     },
     {
-      "generated_line": 3255,
+      "generated_line": 3554,
       "source": "<project>/src/main.ax",
       "line": 2,
       "column": 1
     },
     {
-      "generated_line": 3257,
+      "generated_line": 3556,
       "source": "<project>/src/main.ax",
       "line": 3,
       "column": 1

--- a/stage1/crates/axiomc/tests/json_contract_snapshots.rs
+++ b/stage1/crates/axiomc/tests/json_contract_snapshots.rs
@@ -110,13 +110,19 @@ fn cli_json_outputs_validate_against_public_v1_schema() {
     )
     .expect("write mutation input");
     let mutation_input_str = mutation_input.to_str().expect("mutation input path");
-    let invocations: [(&str, Vec<&str>); 8] = [
+    let doc_out = temp.path().join("docs/api");
+    let doc_out_str = doc_out.to_str().expect("doc output path");
+    let invocations: [(&str, Vec<&str>); 9] = [
         ("check", vec!["check", project_str, "--json"]),
         ("build", vec!["build", project_str, "--json"]),
         ("test", vec!["test", project_str, "--json"]),
         ("caps", vec!["caps", project_str, "--json"]),
         ("parse", vec!["parse", project_str, "--json"]),
         ("fmt", vec!["fmt", project_str, "--check", "--json"]),
+        (
+            "doc",
+            vec!["doc", project_str, "--out-dir", doc_out_str, "--json"],
+        ),
         ("run", vec!["run", project_str, "--json"]),
         (
             "mutation-report",
@@ -143,6 +149,51 @@ fn cli_json_outputs_validate_against_public_v1_schema() {
             "{label} payload command field drifted"
         );
     }
+}
+
+#[test]
+fn doc_json_output_validates_against_doc_schema() {
+    let public_schema = read_json(&public_v1_schema_path());
+    let public_validator =
+        jsonschema::validator_for(&public_schema).expect("compile public v1 schema");
+    let doc_schema = read_json(&doc_schema_path());
+    let doc_validator = jsonschema::validator_for(&doc_schema).expect("compile doc schema");
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("doc-json");
+    fs::create_dir_all(project.join("src")).expect("mkdir");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"doc-json\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nenv = true\nenv_vars = [\"AXIOM_ENV\"]\n",
+    )
+    .expect("write manifest");
+    fs::write(project.join("axiom.lock"), "version = 1\n").expect("write lock");
+    fs::write(
+        project.join("src/main.ax"),
+        "/// Handles a request.\n/// Example: route(\"/health\")\npub fn route(path: string): string {\nreturn \"ok\"\n}\n\n/// Response envelope.\npub struct Response {\nstatus: int\n}\n",
+    )
+    .expect("write source");
+
+    let out_dir = temp.path().join("docs/api");
+    let output = run_axiomc_json(&[
+        "doc",
+        project.to_str().expect("project path"),
+        "--out-dir",
+        out_dir.to_str().expect("out dir"),
+        "--json",
+    ]);
+
+    assert_payload_matches_schema(&public_validator, "doc", &output);
+    assert_payload_matches_schema(&doc_validator, "doc", &output);
+    assert_eq!(output["command"], "doc");
+    assert_eq!(output["items"][0]["kind"], "function");
+    assert_eq!(output["items"][0]["examples"][0], "route(\"/health\")");
+    assert!(
+        output["capabilities"]
+            .as_array()
+            .expect("capabilities array")
+            .iter()
+            .any(|capability| capability["name"] == "env")
+    );
 }
 
 #[test]
@@ -199,6 +250,13 @@ fn public_v1_schema_path() -> PathBuf {
         .join("../../schemas/axiom.stage1.v1.schema.json")
         .canonicalize()
         .expect("public v1 schema path")
+}
+
+fn doc_schema_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../schemas/axiom-doc-v0.schema.json")
+        .canonicalize()
+        .expect("doc schema path")
 }
 
 fn semantic_graph_schema_path() -> PathBuf {

--- a/stage1/crates/axiomc/tests/schema_metadata.rs
+++ b/stage1/crates/axiomc/tests/schema_metadata.rs
@@ -32,6 +32,11 @@ fn editor_metadata_schemas_are_parseable_and_current() {
             .expect("read inspect JSON schema"),
     )
     .expect("inspect schema is valid JSON");
+    let doc_schema: Value = serde_json::from_str(
+        &fs::read_to_string(schema_dir().join("axiom-doc-v0.schema.json"))
+            .expect("read doc JSON schema"),
+    )
+    .expect("doc schema is valid JSON");
 
     assert_eq!(
         compiler_schema["properties"]["schema_version"]["const"],
@@ -56,6 +61,15 @@ fn editor_metadata_schemas_are_parseable_and_current() {
     assert_eq!(
         inspect_schema["$id"],
         "https://axiom.omt.global/schemas/axiom-inspect-v0.schema.json"
+    );
+    assert_eq!(
+        doc_schema["$id"],
+        "https://axiom.omt.global/schemas/axiom-doc-v0.schema.json"
+    );
+    assert_eq!(doc_schema["properties"]["command"]["const"], "doc");
+    assert_eq!(
+        doc_schema["properties"]["schema_version"]["const"],
+        json_contract::JSON_SCHEMA_VERSION
     );
     assert_eq!(
         inspect_schema["properties"]["schema_version"]["const"],

--- a/stage1/schemas/axiom-doc-v0.schema.json
+++ b/stage1/schemas/axiom-doc-v0.schema.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axiom.omt.global/schemas/axiom-doc-v0.schema.json",
+  "title": "Axiom documentation JSON output v0",
+  "description": "Structured output emitted by axiomc doc --json.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "command",
+    "ok",
+    "markdown",
+    "html",
+    "items",
+    "capabilities"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "axiom.stage1.v1"
+    },
+    "command": {
+      "const": "doc"
+    },
+    "ok": {
+      "const": true
+    },
+    "markdown": {
+      "$ref": "#/$defs/path"
+    },
+    "html": {
+      "$ref": "#/$defs/path"
+    },
+    "items": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/docItem"
+      }
+    },
+    "capabilities": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/capability"
+      }
+    }
+  },
+  "$defs": {
+    "path": {
+      "type": "string",
+      "minLength": 1
+    },
+    "docItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "file",
+        "kind",
+        "public",
+        "signature",
+        "docs",
+        "examples"
+      ],
+      "properties": {
+        "file": {
+          "$ref": "#/$defs/path"
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "function",
+            "struct",
+            "enum",
+            "const",
+            "declaration"
+          ]
+        },
+        "public": {
+          "type": "boolean"
+        },
+        "signature": {
+          "type": "string",
+          "minLength": 1
+        },
+        "docs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "examples": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "capability": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "name",
+        "description",
+        "enabled"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "enum": [
+            "fs",
+            "fs:write",
+            "net",
+            "process",
+            "env",
+            "clock",
+            "crypto",
+            "ffi",
+            "async"
+          ]
+        },
+        "description": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/stage1/schemas/axiom.stage1.v1.schema.json
+++ b/stage1/schemas/axiom.stage1.v1.schema.json
@@ -51,6 +51,15 @@
         "$ref": "#/$defs/capability"
       }
     },
+    "markdown": {
+      "$ref": "#/$defs/path"
+    },
+    "html": {
+      "$ref": "#/$defs/path"
+    },
+    "items": {
+      "type": "array"
+    },
     "binary": {
       "type": [
         "string",
@@ -595,6 +604,52 @@
       },
       "additionalProperties": false
     },
+    "docItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "file",
+        "kind",
+        "public",
+        "signature",
+        "docs",
+        "examples"
+      ],
+      "properties": {
+        "file": {
+          "$ref": "#/$defs/path"
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "function",
+            "struct",
+            "enum",
+            "const",
+            "declaration"
+          ]
+        },
+        "public": {
+          "type": "boolean"
+        },
+        "signature": {
+          "type": "string",
+          "minLength": 1
+        },
+        "docs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "examples": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "path": {
       "type": "string",
       "minLength": 1
@@ -832,6 +887,58 @@
                   }
                 }
               }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "command": {
+            "const": "doc"
+          }
+        },
+        "required": [
+          "command"
+        ]
+      },
+      "then": {
+        "required": [
+          "schema_version",
+          "ok",
+          "command",
+          "markdown",
+          "html",
+          "items",
+          "capabilities"
+        ],
+        "properties": {
+          "schema_version": {
+            "$ref": "#/$defs/schemaVersion"
+          },
+          "ok": {
+            "const": true
+          },
+          "command": {
+            "const": "doc"
+          },
+          "markdown": {
+            "$ref": "#/$defs/path"
+          },
+          "html": {
+            "$ref": "#/$defs/path"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/$defs/docItem"
+            }
+          },
+          "capabilities": {
+            "type": "array",
+            "items": {
+              "$ref": "#/$defs/capability"
             }
           }
         }


### PR DESCRIPTION
## Summary

- Add `stage1/schemas/axiom-doc-v0.schema.json` for the current `axiomc doc --json` success payload, including markdown, html, item, and capability fields.
- Extend the public `axiom.stage1.v1` JSON envelope so `command: "doc"` output is validated by the shared schema harness.
- Add doc-specific and shared-envelope JSON contract tests, schema metadata coverage, and refresh the stale debug-map snapshot exposed by the expanded contract run.
- Document the doc JSON schema location in the stage1 user docs.

## Governing Issue

Refs #725.

This PR is a non-resolving scaffold for issue 725 because the live issue requires the Phase-K.1 AxiOM-native doc generator shape (`functions` and `types`) and explicitly depends on `std/doc.ax`. This branch fills the schema and validation harness gap for the current `axiomc doc --json` output so the Phase-K work has a concrete contract target without claiming broader self-hosting completion.

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Commands run:

- `jq empty stage1/schemas/axiom-doc-v0.schema.json`
- `jq empty stage1/schemas/axiom.stage1.v1.schema.json`
- `cargo fmt --manifest-path stage1/Cargo.toml --all`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test json_contract_snapshots doc_json_output_validates_against_doc_schema`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test json_contract_snapshots cli_json_outputs_validate_against_public_v1_schema`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test schema_metadata editor_metadata_schemas_are_parseable_and_current`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test json_contract_snapshots`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test schema_metadata`

The first full `json_contract_snapshots` run exposed stale debug-map fixture line numbers; the snapshot was refreshed and the full test passed after that update. Compiler warnings observed during the test runs were pre-existing dead-code and unused-import warnings outside this change.

No checks were intentionally skipped.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

No contributor, PR guidance, bootstrap onboarding, secret, auth, or machine-local environment changes are included.

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Semantic node types added/changed: none.

Schemas added/changed:

- `stage1/schemas/axiom-doc-v0.schema.json`
- `stage1/schemas/axiom.stage1.v1.schema.json`

Evidence added/changed:

- `stage1/crates/axiomc/tests/json_contract_snapshots.rs`
- `stage1/crates/axiomc/tests/schema_metadata.rs`
- `stage1/compiler-contracts/snapshots/debug-map.json`

Rust capture check: the schema describes the current CLI JSON payload contract and does not define semantic behavior in terms of Rust implementation internals. The PR also records that issue 725's AxiOM-native Phase-K generator work remains open.

Agent-facing inspection impact: none; this does not change the inspect API.

## Flow Contract

- Owner lane: hermes
- Repair owner: codex
- Autonomy class: agent-authored with human review required
- Risk class: low

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

Next actor: pheidon review for non-author approval.

## Merge Automation

- [x] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

Auto-merge will be enabled after PR creation.

## Notes

- This is a contract and validation scaffold toward #725, not the Phase-K.1 `std/doc.ax` implementation.
- Broader AxiOM-native doc generator and self-hosting work remains tracked by #723, #725, #727, and #563.
