### PR TITLE
[codex] Add Cranelift hello backend spike

### DIFF
--- a/docs/performance-benchmarks.md
+++ b/docs/performance-benchmarks.md
@@ -85,3 +85,10 @@ make stage1-bench-update-baseline
 The parser timing is backed by `axiomc parse`, a parse-only command that validates
 the primary package entrypoint and emits the same machine-readable stage1 JSON
 contract shape as the other compiler commands.
+
+## Cranelift spike fixture
+
+The first direct-object backend slice records an advisory hello-world baseline at
+`stage1/benchmarks/cranelift-hello-baseline.json`. It is intentionally separate
+from the generated-Rust regression baselines because `--backend cranelift` only
+supports `stage1/examples/hello` in #691 and is not yet a broad native backend.

--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -286,8 +286,16 @@ still far from the stated 1.0 target for service and agent workloads.
 
 ### Backend and tooling gaps
 
-- Native builds still work by generating Rust and invoking `rustc`; there is no Cranelift backend yet.
-- The backend-selection surface is only preparatory backend plumbing for later native-backend expansion; today `generated-rust` is the only implemented backend, so this branch is part of #105 rather than closure for it.
+- Native builds still default to generating Rust and invoking `rustc`.
+  `axiomc build stage1/examples/hello --backend cranelift` is an opt-in
+  direct-object spike for #691: it folds the supported hello-world MIR subset
+  into print lines, emits a Cranelift object, links it with the host linker, and
+  leaves generated Rust as the production backend.
+- The backend-selection surface remains preparatory backend plumbing for later
+  native-backend expansion. `generated-rust` is still the default and only broad
+  backend; `cranelift` is intentionally limited to the #691 hello-world spike,
+  so this is not closure for #105 or the later full-surface native backend
+  slices.
 - Generated-Rust builds now use a persistent per-artifact cache keyed by
   compiler version, target, debug mode, manifest/lockfile hash, rendered Rust,
   module source hashes, and dependency imports. Cache hits skip `rustc`, cache

--- a/stage1/Cargo.lock
+++ b/stage1/Cargo.lock
@@ -26,6 +26,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,6 +88,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,6 +118,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axiom-lsp",
+ "axiomc-backend-cranelift",
  "clap",
  "jsonschema",
  "serde",
@@ -113,6 +126,18 @@ dependencies = [
  "tempfile",
  "toml",
  "which",
+]
+
+[[package]]
+name = "axiomc-backend-cranelift"
+version = "0.1.0"
+dependencies = [
+ "cranelift-codegen",
+ "cranelift-frontend",
+ "cranelift-module",
+ "cranelift-native",
+ "cranelift-object",
+ "tempfile",
 ]
 
 [[package]]
@@ -153,6 +178,9 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "bytecount"
@@ -219,6 +247,177 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "cranelift-assembler-x64"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c80cf55a351448317210f26c434be761bcb25e7b36116ec92f89540b73e2833"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07937ca8617b340162fe3a4716be885b5847e9b56d6c7a89abbe4d42340fdc91"
+dependencies = [
+ "cranelift-srcgen",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88217b08180882436d54c0133274885c590698ae854e352bede1cda041230800"
+dependencies = [
+ "cranelift-entity",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5c3cf7ba29fa56e56040848e34835d4e45988b2760ef212413409af95ffd8c1"
+dependencies = [
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe1aac2efd4cba2047845fce38a68519935a30e20c8a6294ba7e2f448fe722d"
+dependencies = [
+ "bumpalo",
+ "cranelift-assembler-x64",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli",
+ "hashbrown 0.17.1",
+ "libm",
+ "log",
+ "regalloc2",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0909eaf9d6f18f5bf802d50608cb4368ac340fbd03cc44f2888d1cfcc3faa64e"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+ "cranelift-codegen-shared",
+ "cranelift-srcgen",
+ "heck",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c95a8da8be283f49cda7d0ef228c94f10d791e517b27b0c7e282dadd2e79ce45"
+
+[[package]]
+name = "cranelift-control"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5b19c81145146da1f7afda2e7f52111842fe6793512e740ad5cf3f5639e6212"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a55309b47e6633ab05821304206cb1e92952e845b1224985562bb7ac1e92323"
+dependencies = [
+ "cranelift-bitset",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "064d2d3533d9608f1cf44c8899cf2f7f33feb70300b0fb83e687b0d9e7b91147"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac4e0bc095b2dab2212d1e99d7a74b62afc1485db023f1c0cb34a68758f7bd1"
+
+[[package]]
+name = "cranelift-module"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28f05d9efce7a4e8c2ceec49c76d26e53f1ee8cb13de822b6ca5118d48f50976"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "cranelift-control",
+]
+
+[[package]]
+name = "cranelift-native"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a40053f5cb925451dd1d57393d14ad3145c8e0786701c27b5415ebb9a3ba4f"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-object"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f7a263727954f7b310796e1b5543e6dfd6afed7e15c62f2454b51b6f38a39e1"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-module",
+ "log",
+ "object",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ceab9a53f7d362c89841fbaa8e63e44d47c40e91dc96ee6f777fca5d6b323b"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,10 +482,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -382,12 +593,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
+dependencies = [
+ "fnv",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -395,6 +618,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -595,12 +827,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -676,9 +908,15 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
@@ -801,6 +1039,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "object"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "memchr",
 ]
 
 [[package]]
@@ -949,6 +1199,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "regalloc2"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de2c52737737f8609e94f975dee22854a2d5c125772d4b1cf292120f4d45c186"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.17.1",
+ "log",
+ "rustc-hash",
+ "smallvec",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1010,6 +1274,12 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
@@ -1176,6 +1446,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
@@ -1511,6 +1787,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "wasmtime-internal-core"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bdae4b55b15a23d774b15f6e7cd90ae0d0aa17c47c12b4db098b3dd11ba9d58"
+dependencies = [
+ "hashbrown 0.17.1",
+ "libm",
 ]
 
 [[package]]

--- a/stage1/Cargo.toml
+++ b/stage1/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/axiom-lsp", "crates/axiomc"]
+members = ["crates/axiom-lsp", "crates/axiomc", "crates/axiomc-backend-cranelift"]
 resolver = "2"
 
 [workspace.package]
@@ -10,8 +10,14 @@ license = "MIT"
 [workspace.dependencies]
 anyhow = "1.0.100"
 clap = { version = "4.5.53", features = ["derive"] }
+cranelift-codegen = "0.132.0"
+cranelift-frontend = "0.132.0"
+cranelift-module = "0.132.0"
+cranelift-native = "0.132.0"
+cranelift-object = "0.132.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
+target-lexicon = "0.13.5"
 tempfile = "3.23.0"
 toml = "0.9.8"
 which = "8.0.2"

--- a/stage1/benchmarks/cranelift-hello-baseline.json
+++ b/stage1/benchmarks/cranelift-hello-baseline.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": "axiom.stage1.cranelift-spike-baseline.v1",
+  "issue": 691,
+  "updated": "2026-05-31",
+  "workload": "stage1/examples/hello",
+  "command": "cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build stage1/examples/hello --backend cranelift --json",
+  "policy": "advisory",
+  "metrics": {
+    "compile_ms": 28,
+    "duration_ms": 33
+  },
+  "notes": "Initial local measurement for the opt-in Cranelift hello-world spike. This is not a regression threshold; it records the first working object/link path for #691."
+}

--- a/stage1/crates/axiomc-backend-cranelift/Cargo.toml
+++ b/stage1/crates/axiomc-backend-cranelift/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "axiomc-backend-cranelift"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+cranelift-codegen.workspace = true
+cranelift-frontend.workspace = true
+cranelift-module.workspace = true
+cranelift-native.workspace = true
+cranelift-object.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/stage1/crates/axiomc-backend-cranelift/src/lib.rs
+++ b/stage1/crates/axiomc-backend-cranelift/src/lib.rs
@@ -1,0 +1,205 @@
+use cranelift_codegen::ir::{AbiParam, InstBuilder, types};
+use cranelift_codegen::isa;
+use cranelift_codegen::settings::{self, Configurable};
+use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
+use cranelift_module::{DataDescription, Linkage, Module, default_libcall_names};
+use cranelift_object::{ObjectBuilder, ObjectModule};
+use std::error::Error;
+use std::fmt;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+#[derive(Debug)]
+pub struct CraneliftBackendError {
+    message: String,
+}
+
+impl CraneliftBackendError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for CraneliftBackendError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl Error for CraneliftBackendError {}
+
+pub fn compile_print_lines(
+    lines: &[String],
+    object_path: &Path,
+    binary_path: &Path,
+) -> Result<(), CraneliftBackendError> {
+    emit_cranelift_object(lines, object_path)?;
+    link_object(object_path, binary_path)
+}
+
+fn emit_cranelift_object(
+    lines: &[String],
+    object_path: &Path,
+) -> Result<(), CraneliftBackendError> {
+    let isa_builder = host_isa_builder()?;
+    let mut flag_builder = settings::builder();
+    flag_builder.set("is_pic", "true").map_err(|message| {
+        CraneliftBackendError::new(format!("cranelift flag setup: {message}"))
+    })?;
+    let flags = settings::Flags::new(flag_builder);
+    let isa = isa_builder
+        .finish(flags)
+        .map_err(|message| CraneliftBackendError::new(format!("cranelift ISA setup: {message}")))?;
+    let builder = ObjectBuilder::new(isa, "axiom_cranelift_hello", default_libcall_names())
+        .map_err(|message| {
+            CraneliftBackendError::new(format!("cranelift object setup: {message}"))
+        })?;
+    let mut module = ObjectModule::new(builder);
+    let pointer_type = module.target_config().pointer_type();
+
+    let mut puts_sig = module.make_signature();
+    puts_sig.params.push(AbiParam::new(pointer_type));
+    puts_sig.returns.push(AbiParam::new(types::I32));
+    let puts_id = module
+        .declare_function("puts", Linkage::Import, &puts_sig)
+        .map_err(|message| CraneliftBackendError::new(format!("declare puts import: {message}")))?;
+
+    let mut data_ids = Vec::new();
+    for (index, line) in lines.iter().enumerate() {
+        let data_id = module
+            .declare_data(
+                &format!("__axiom_line_{index}"),
+                Linkage::Local,
+                false,
+                false,
+            )
+            .map_err(|message| CraneliftBackendError::new(format!("declare data: {message}")))?;
+        let mut description = DataDescription::new();
+        let mut bytes = line.as_bytes().to_vec();
+        bytes.push(0);
+        description.define(bytes.into_boxed_slice());
+        module
+            .define_data(data_id, &description)
+            .map_err(|message| CraneliftBackendError::new(format!("define data: {message}")))?;
+        data_ids.push(data_id);
+    }
+
+    let mut context = module.make_context();
+    context
+        .func
+        .signature
+        .returns
+        .push(AbiParam::new(types::I32));
+    let main_id = module
+        .declare_function("main", Linkage::Export, &context.func.signature)
+        .map_err(|message| CraneliftBackendError::new(format!("declare main: {message}")))?;
+    let mut builder_context = FunctionBuilderContext::new();
+    {
+        let mut builder = FunctionBuilder::new(&mut context.func, &mut builder_context);
+        let block = builder.create_block();
+        builder.switch_to_block(block);
+        builder.seal_block(block);
+        let puts_ref = module.declare_func_in_func(puts_id, builder.func);
+        for data_id in data_ids {
+            let data_ref = module.declare_data_in_func(data_id, builder.func);
+            let pointer = builder.ins().global_value(pointer_type, data_ref);
+            builder.ins().call(puts_ref, &[pointer]);
+        }
+        let ok = builder.ins().iconst(types::I32, 0);
+        builder.ins().return_(&[ok]);
+        builder.finalize();
+    }
+    module
+        .define_function(main_id, &mut context)
+        .map_err(|message| CraneliftBackendError::new(format!("define main: {message}")))?;
+    module.clear_context(&mut context);
+    let product = module.finish();
+    let bytes = product.emit().map_err(|message| {
+        CraneliftBackendError::new(format!("emit cranelift object: {message}"))
+    })?;
+    fs::write(object_path, bytes).map_err(|err| {
+        CraneliftBackendError::new(format!("failed to write {}: {err}", object_path.display()))
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn host_isa_builder() -> Result<isa::Builder, CraneliftBackendError> {
+    let architecture = match std::env::consts::ARCH {
+        "aarch64" => "aarch64",
+        "x86_64" => "x86_64",
+        other => {
+            return Err(CraneliftBackendError::new(format!(
+                "unsupported macOS architecture {other:?}"
+            )));
+        }
+    };
+    let triple = format!("{architecture}-apple-macosx")
+        .parse()
+        .map_err(|message| CraneliftBackendError::new(format!("macOS target triple: {message}")))?;
+    isa::lookup(triple)
+        .map_err(|message| CraneliftBackendError::new(format!("cranelift ISA: {message}")))
+}
+
+#[cfg(not(target_os = "macos"))]
+fn host_isa_builder() -> Result<isa::Builder, CraneliftBackendError> {
+    cranelift_native::builder()
+        .map_err(|message| CraneliftBackendError::new(format!("cranelift host ISA: {message}")))
+}
+
+fn link_object(object_path: &Path, binary_path: &Path) -> Result<(), CraneliftBackendError> {
+    let mut command = Command::new("cc");
+    let output = command
+        .arg(object_path)
+        .arg("-o")
+        .arg(binary_path)
+        .output()
+        .map_err(|err| {
+            CraneliftBackendError::new(format!("failed to invoke system linker `cc`: {err}"))
+        })?;
+    if output.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    Err(CraneliftBackendError::new(format!(
+        "system linker `cc` failed for cranelift object: {}",
+        stderr.trim()
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn links_hello_print_lines() {
+        if std::env::var_os("AXIOM_SKIP_CRANELIFT_LINK_TEST").is_some() {
+            return;
+        }
+        if Command::new("cc").arg("--version").output().is_err() {
+            eprintln!("skipping cranelift link test because cc is unavailable");
+            return;
+        }
+        let temp = tempfile::tempdir().expect("tempdir");
+        let object = temp.path().join("hello.o");
+        let binary = temp.path().join("hello");
+        compile_print_lines(
+            &[
+                String::from("hello from stage1"),
+                String::from("42"),
+                String::from("true"),
+            ],
+            &object,
+            &binary,
+        )
+        .expect("compile print lines");
+        let output = Command::new(&binary).output().expect("run binary");
+        assert!(output.status.success(), "binary exits successfully");
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout),
+            "hello from stage1\n42\ntrue\n"
+        );
+    }
+}

--- a/stage1/crates/axiomc/Cargo.toml
+++ b/stage1/crates/axiomc/Cargo.toml
@@ -10,6 +10,7 @@ run-native-tests = []
 
 [dependencies]
 axiom-lsp = { path = "../axiom-lsp" }
+axiomc-backend-cranelift = { path = "../axiomc-backend-cranelift" }
 anyhow.workspace = true
 clap.workspace = true
 serde.workspace = true

--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -29,12 +29,14 @@ thread_local! {
 pub enum NativeBackendKind {
     #[default]
     GeneratedRust,
+    Cranelift,
 }
 
 impl NativeBackendKind {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::GeneratedRust => "generated-rust",
+            Self::Cranelift => "cranelift",
         }
     }
 }
@@ -51,8 +53,9 @@ impl FromStr for NativeBackendKind {
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         match value {
             "generated-rust" => Ok(Self::GeneratedRust),
+            "cranelift" => Ok(Self::Cranelift),
             other => Err(format!(
-                "unsupported backend {other:?}; only generated-rust is implemented in this preparatory backend plumbing"
+                "unsupported backend {other:?}; supported backends: generated-rust, cranelift"
             )),
         }
     }
@@ -79,14 +82,18 @@ mod tests {
     }
 
     #[test]
+    fn parses_cranelift_backend() {
+        assert_eq!(
+            NativeBackendKind::from_str("cranelift").expect("parse cranelift"),
+            NativeBackendKind::Cranelift
+        );
+    }
+
+    #[test]
     fn rejects_unsupported_backend_value() {
         let error = NativeBackendKind::from_str("direct-native")
             .expect_err("unsupported backend values should be rejected");
-        assert!(
-            error.contains(
-                "only generated-rust is implemented in this preparatory backend plumbing"
-            )
-        );
+        assert!(error.contains("supported backends: generated-rust, cranelift"));
     }
 
     #[test]
@@ -7435,6 +7442,11 @@ pub fn compile_native(
         NativeBackendKind::GeneratedRust => {
             compile_generated_rust(generated_rust, binary_path, target, debug)
         }
+        NativeBackendKind::Cranelift => Err(Diagnostic::new(
+            "build",
+            "internal error: cranelift backend requires MIR input from the project build pipeline",
+        )
+        .with_path(generated_rust.display().to_string())),
     }
 }
 

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -1,0 +1,400 @@
+use crate::diagnostics::Diagnostic;
+use crate::mir::{ArithmeticOp, CompareOp, Expr, Function, LiteralValue, Program, Stmt, Type};
+use std::collections::HashMap;
+use std::path::Path;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SpikeValue {
+    Int(i64),
+    Bool(bool),
+    Text(String),
+}
+
+type SpikeEnv = HashMap<String, SpikeValue>;
+
+pub fn compile_cranelift_hello_spike(
+    program: &Program,
+    object_path: &Path,
+    binary_path: &Path,
+    target: Option<&str>,
+    debug: bool,
+) -> Result<(), Diagnostic> {
+    if target.is_some() {
+        return Err(unsupported(
+            "the cranelift backend spike currently supports only the host target",
+        ));
+    }
+    if debug {
+        return Err(unsupported(
+            "the cranelift backend spike does not emit debug sidecars yet",
+        ));
+    }
+    let lines = collect_print_lines(program)?;
+    axiomc_backend_cranelift::compile_print_lines(&lines, object_path, binary_path).map_err(|err| {
+        Diagnostic::new("build", err.to_string()).with_path(object_path.display().to_string())
+    })
+}
+
+fn collect_print_lines(program: &Program) -> Result<Vec<String>, Diagnostic> {
+    if !program.structs.is_empty() || !program.enums.is_empty() || !program.statics.is_empty() {
+        return Err(unsupported(
+            "structs, enums, and statics are not part of the cranelift hello spike",
+        ));
+    }
+    let functions = program
+        .functions
+        .iter()
+        .map(|function| (function.name.as_str(), function))
+        .collect::<HashMap<_, _>>();
+    let mut env = SpikeEnv::new();
+    let mut lines = Vec::new();
+    eval_block(&program.stmts, &functions, &mut env, &mut lines)?;
+    Ok(lines)
+}
+
+fn eval_block(
+    stmts: &[Stmt],
+    functions: &HashMap<&str, &Function>,
+    env: &mut SpikeEnv,
+    lines: &mut Vec<String>,
+) -> Result<Option<SpikeValue>, Diagnostic> {
+    for stmt in stmts {
+        if let Some(value) = eval_stmt(stmt, functions, env, lines)? {
+            return Ok(Some(value));
+        }
+    }
+    Ok(None)
+}
+
+fn eval_stmt(
+    stmt: &Stmt,
+    functions: &HashMap<&str, &Function>,
+    env: &mut SpikeEnv,
+    lines: &mut Vec<String>,
+) -> Result<Option<SpikeValue>, Diagnostic> {
+    match stmt {
+        Stmt::Let { name, expr, .. } => {
+            let value = eval_expr(expr, functions, env)?;
+            env.insert(name.clone(), value);
+            Ok(None)
+        }
+        Stmt::Print { expr, .. } => {
+            lines.push(render_value(&eval_expr(expr, functions, env)?));
+            Ok(None)
+        }
+        Stmt::If {
+            cond,
+            then_block,
+            else_block,
+            ..
+        } => {
+            let branch = match eval_expr(cond, functions, env)? {
+                SpikeValue::Bool(true) => Some(then_block.as_slice()),
+                SpikeValue::Bool(false) => else_block.as_deref(),
+                _ => return Err(unsupported("if conditions must be boolean")),
+            };
+            if let Some(branch) = branch {
+                eval_block(branch, functions, env, lines)
+            } else {
+                Ok(None)
+            }
+        }
+        Stmt::While { cond, .. } => match eval_expr(cond, functions, env)? {
+            SpikeValue::Bool(false) => Ok(None),
+            SpikeValue::Bool(true) => Err(unsupported(
+                "runtime loops are not part of the cranelift hello spike",
+            )),
+            _ => Err(unsupported("while conditions must be boolean")),
+        },
+        Stmt::Return { expr, .. } => Ok(Some(eval_expr(expr, functions, env)?)),
+        Stmt::Assign { .. } | Stmt::Panic { .. } | Stmt::Defer { .. } | Stmt::Match { .. } => {
+            Err(unsupported(
+                "only let, print, if, while false, and return statements are supported by the cranelift hello spike",
+            ))
+        }
+    }
+}
+
+fn eval_expr(
+    expr: &Expr,
+    functions: &HashMap<&str, &Function>,
+    env: &SpikeEnv,
+) -> Result<SpikeValue, Diagnostic> {
+    match expr {
+        Expr::Literal(LiteralValue::Int(value)) => Ok(SpikeValue::Int(*value)),
+        Expr::Literal(LiteralValue::Numeric { raw, .. }) => raw
+            .parse::<i64>()
+            .map(SpikeValue::Int)
+            .map_err(|_| unsupported("only integer numeric literals are supported")),
+        Expr::Literal(LiteralValue::Bool(value)) => Ok(SpikeValue::Bool(*value)),
+        Expr::Literal(LiteralValue::String(value)) | Expr::Literal(LiteralValue::Str(value)) => {
+            Ok(SpikeValue::Text(value.clone()))
+        }
+        Expr::VarRef { name, .. } => env
+            .get(name)
+            .cloned()
+            .ok_or_else(|| unsupported(&format!("unknown cranelift spike variable {name:?}"))),
+        Expr::Call { name, args, .. } => eval_call(name, args, functions, env),
+        Expr::BinaryAdd { op, lhs, rhs, ty } => eval_add(*op, lhs, rhs, ty, functions, env),
+        Expr::BinaryCompare {
+            op,
+            lhs,
+            rhs,
+            ty: _,
+        } => eval_compare(*op, lhs, rhs, functions, env),
+        Expr::BinaryLogic { op, lhs, rhs, .. } => {
+            let left = expect_bool(eval_expr(lhs, functions, env)?)?;
+            match op {
+                crate::mir::LogicOp::And if !left => Ok(SpikeValue::Bool(false)),
+                crate::mir::LogicOp::Or if left => Ok(SpikeValue::Bool(true)),
+                crate::mir::LogicOp::And | crate::mir::LogicOp::Or => Ok(SpikeValue::Bool(
+                    expect_bool(eval_expr(rhs, functions, env)?)?,
+                )),
+            }
+        }
+        Expr::Cast { expr, .. } => eval_expr(expr, functions, env),
+        _ => Err(unsupported(
+            "this expression is outside the cranelift hello spike subset",
+        )),
+    }
+}
+
+fn eval_call(
+    name: &str,
+    args: &[Expr],
+    functions: &HashMap<&str, &Function>,
+    env: &SpikeEnv,
+) -> Result<SpikeValue, Diagnostic> {
+    let function = functions
+        .get(name)
+        .ok_or_else(|| unsupported(&format!("unsupported cranelift spike call {name:?}")))?;
+    if function.params.len() != args.len() {
+        return Err(unsupported("function argument count mismatch"));
+    }
+    let mut local_env = SpikeEnv::new();
+    for (param, arg) in function.params.iter().zip(args) {
+        local_env.insert(param.name.clone(), eval_expr(arg, functions, env)?);
+    }
+    let mut lines = Vec::new();
+    let returned = eval_block(&function.body, functions, &mut local_env, &mut lines)?;
+    if !lines.is_empty() {
+        return Err(unsupported(
+            "functions with print side effects are not part of the cranelift hello spike",
+        ));
+    }
+    returned.ok_or_else(|| unsupported("cranelift spike functions must return a scalar value"))
+}
+
+fn eval_add(
+    op: ArithmeticOp,
+    lhs: &Expr,
+    rhs: &Expr,
+    ty: &Type,
+    functions: &HashMap<&str, &Function>,
+    env: &SpikeEnv,
+) -> Result<SpikeValue, Diagnostic> {
+    if op != ArithmeticOp::Add {
+        return Err(unsupported(
+            "only addition is supported by the cranelift hello spike",
+        ));
+    }
+    let left = eval_expr(lhs, functions, env)?;
+    let right = eval_expr(rhs, functions, env)?;
+    match (ty, left, right) {
+        (Type::Int, SpikeValue::Int(left), SpikeValue::Int(right)) => {
+            Ok(SpikeValue::Int(left + right))
+        }
+        (Type::String | Type::Str, left, right) => Ok(SpikeValue::Text(format!(
+            "{}{}",
+            render_value(&left),
+            render_value(&right)
+        ))),
+        _ => Err(unsupported("unsupported cranelift spike addition operands")),
+    }
+}
+
+fn eval_compare(
+    op: CompareOp,
+    lhs: &Expr,
+    rhs: &Expr,
+    functions: &HashMap<&str, &Function>,
+    env: &SpikeEnv,
+) -> Result<SpikeValue, Diagnostic> {
+    let left = eval_expr(lhs, functions, env)?;
+    let right = eval_expr(rhs, functions, env)?;
+    let result = match (left, right) {
+        (SpikeValue::Int(left), SpikeValue::Int(right)) => compare_ord(op, left, right),
+        (SpikeValue::Bool(left), SpikeValue::Bool(right)) => compare_eq(op, left, right)?,
+        (SpikeValue::Text(left), SpikeValue::Text(right)) => compare_eq(op, left, right)?,
+        _ => return Err(unsupported("mismatched comparison operands")),
+    };
+    Ok(SpikeValue::Bool(result))
+}
+
+fn compare_ord<T: Ord>(op: CompareOp, left: T, right: T) -> bool {
+    match op {
+        CompareOp::Eq => left == right,
+        CompareOp::Ne => left != right,
+        CompareOp::Lt => left < right,
+        CompareOp::Le => left <= right,
+        CompareOp::Gt => left > right,
+        CompareOp::Ge => left >= right,
+    }
+}
+
+fn compare_eq<T: Eq>(op: CompareOp, left: T, right: T) -> Result<bool, Diagnostic> {
+    match op {
+        CompareOp::Eq => Ok(left == right),
+        CompareOp::Ne => Ok(left != right),
+        _ => Err(unsupported("only equality comparisons are supported here")),
+    }
+}
+
+fn expect_bool(value: SpikeValue) -> Result<bool, Diagnostic> {
+    match value {
+        SpikeValue::Bool(value) => Ok(value),
+        _ => Err(unsupported("expected boolean expression")),
+    }
+}
+
+fn render_value(value: &SpikeValue) -> String {
+    match value {
+        SpikeValue::Int(value) => value.to_string(),
+        SpikeValue::Bool(true) => String::from("true"),
+        SpikeValue::Bool(false) => String::from("false"),
+        SpikeValue::Text(value) => value.clone(),
+    }
+}
+
+fn unsupported(message: &str) -> Diagnostic {
+    Diagnostic::new(
+        "build",
+        format!("unsupported by --backend cranelift spike: {message}"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hello_program() -> Program {
+        Program {
+            path: String::from("hello"),
+            structs: vec![],
+            enums: vec![],
+            statics: vec![],
+            functions: vec![
+                Function {
+                    name: String::from("banner"),
+                    source_name: String::from("banner"),
+                    path: String::from("hello"),
+                    params: vec![crate::mir::Param {
+                        name: String::from("name"),
+                        ty: Type::String,
+                    }],
+                    return_ty: Type::String,
+                    body: vec![Stmt::Return {
+                        expr: Expr::BinaryAdd {
+                            op: ArithmeticOp::Add,
+                            lhs: Box::new(Expr::Literal(LiteralValue::String(String::from(
+                                "hello ",
+                            )))),
+                            rhs: Box::new(Expr::VarRef {
+                                name: String::from("name"),
+                                ty: Type::String,
+                            }),
+                            ty: Type::String,
+                        },
+                        span: crate::mir::SourceSpan { line: 1, column: 1 },
+                    }],
+                    is_property: false,
+                    is_async: false,
+                    is_extern: false,
+                    extern_abi: None,
+                    extern_library: None,
+                    line: 1,
+                    column: 1,
+                },
+                Function {
+                    name: String::from("lucky"),
+                    source_name: String::from("lucky"),
+                    path: String::from("hello"),
+                    params: vec![crate::mir::Param {
+                        name: String::from("base"),
+                        ty: Type::Int,
+                    }],
+                    return_ty: Type::Int,
+                    body: vec![Stmt::Return {
+                        expr: Expr::BinaryAdd {
+                            op: ArithmeticOp::Add,
+                            lhs: Box::new(Expr::VarRef {
+                                name: String::from("base"),
+                                ty: Type::Int,
+                            }),
+                            rhs: Box::new(Expr::Literal(LiteralValue::Int(2))),
+                            ty: Type::Int,
+                        },
+                        span: crate::mir::SourceSpan { line: 1, column: 1 },
+                    }],
+                    is_property: false,
+                    is_async: false,
+                    is_extern: false,
+                    extern_abi: None,
+                    extern_library: None,
+                    line: 1,
+                    column: 1,
+                },
+            ],
+            stmts: vec![
+                Stmt::Let {
+                    name: String::from("answer"),
+                    ty: Type::Int,
+                    expr: Expr::Call {
+                        name: String::from("lucky"),
+                        args: vec![Expr::Literal(LiteralValue::Int(40))],
+                        ty: Type::Int,
+                    },
+                    span: crate::mir::SourceSpan { line: 1, column: 1 },
+                },
+                Stmt::If {
+                    cond: Expr::BinaryCompare {
+                        op: CompareOp::Eq,
+                        lhs: Box::new(Expr::VarRef {
+                            name: String::from("answer"),
+                            ty: Type::Int,
+                        }),
+                        rhs: Box::new(Expr::Literal(LiteralValue::Int(42))),
+                        ty: Type::Bool,
+                    },
+                    then_block: vec![Stmt::Print {
+                        expr: Expr::Call {
+                            name: String::from("banner"),
+                            args: vec![Expr::Literal(LiteralValue::String(String::from(
+                                "from stage1",
+                            )))],
+                            ty: Type::String,
+                        },
+                        span: crate::mir::SourceSpan { line: 1, column: 1 },
+                    }],
+                    else_block: None,
+                    span: crate::mir::SourceSpan { line: 1, column: 1 },
+                },
+                Stmt::Print {
+                    expr: Expr::VarRef {
+                        name: String::from("answer"),
+                        ty: Type::Int,
+                    },
+                    span: crate::mir::SourceSpan { line: 1, column: 1 },
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn folds_hello_subset_into_print_lines() {
+        assert_eq!(
+            collect_print_lines(&hello_program()).expect("fold hello"),
+            vec![String::from("hello from stage1"), String::from("42")]
+        );
+    }
+}

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -1,5 +1,6 @@
 pub(crate) mod borrowck;
 pub mod codegen;
+pub(crate) mod cranelift_backend;
 pub mod dap;
 pub mod diagnostic_catalog;
 pub mod diagnostics;

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -1,6 +1,7 @@
 use crate::codegen::{
     GeneratedRustBackendInput, NativeBackendKind, compile_native, try_render_generated_rust,
 };
+use crate::cranelift_backend::compile_cranelift_hello_spike;
 use crate::diagnostics::Diagnostic;
 use crate::hir;
 use crate::json_contract;
@@ -1991,13 +1992,30 @@ fn build_artifacts(
         )
     })?;
     let started = Instant::now();
-    compile_native(
-        options.backend,
-        generated_rust,
-        binary,
-        resolved_target,
-        options.debug,
-    )?;
+    match options.backend {
+        NativeBackendKind::GeneratedRust => compile_native(
+            options.backend,
+            generated_rust,
+            binary,
+            resolved_target,
+            options.debug,
+        )?,
+        NativeBackendKind::Cranelift => {
+            let object_path = generated_rust.with_extension("cranelift.o");
+            ensure_output_path_stays_inside_package(
+                package_root,
+                &object_path,
+                "Cranelift object output",
+            )?;
+            compile_cranelift_hello_spike(
+                &analyzed.mir,
+                &object_path,
+                binary,
+                resolved_target,
+                options.debug,
+            )?;
+        }
+    }
     let compile_ms = started.elapsed().as_millis() as u64;
     if options.debug {
         write_debug_artifacts(generated_rust, binary, analyzed)?;

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -1,0 +1,76 @@
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+#[cfg(not(windows))]
+#[test]
+fn cranelift_backend_builds_hello_binary() {
+    if which::which("cc").is_err() {
+        eprintln!("skipping cranelift backend smoke test because cc is unavailable");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("hello");
+    fs::create_dir_all(project.join("src")).expect("create project src");
+    copy_fixture("axiom.toml", &project.join("axiom.toml"));
+    copy_fixture("axiom.lock", &project.join("axiom.lock"));
+    copy_fixture("src/main.ax", &project.join("src/main.ax"));
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+    assert!(
+        output.status.success(),
+        "cranelift build failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
+    assert_eq!(payload["backend"], "cranelift");
+    assert_eq!(payload["packages"][0]["backend"], "cranelift");
+    let binary = payload["binary"].as_str().expect("binary path");
+    let generated_rust = payload["generated_rust"]
+        .as_str()
+        .expect("generated Rust path");
+    assert!(Path::new(binary).exists(), "cranelift binary exists");
+    assert!(
+        Path::new(generated_rust)
+            .with_extension("cranelift.o")
+            .exists(),
+        "cranelift object exists"
+    );
+
+    let run = Command::new(binary).output().expect("run cranelift binary");
+    assert!(
+        run.status.success(),
+        "cranelift binary failed: stderr={}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "hello from stage1\n42\ntrue\n"
+    );
+}
+
+fn copy_fixture(relative: &str, destination: &Path) {
+    let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../examples/hello")
+        .join(relative);
+    fs::copy(&fixture, destination).unwrap_or_else(|err| {
+        panic!(
+            "copy fixture {} to {}: {err}",
+            fixture.display(),
+            destination.display()
+        )
+    });
+}

--- a/stage1/supply-chain/config.toml
+++ b/stage1/supply-chain/config.toml
@@ -30,6 +30,10 @@ criteria = "safe-to-run"
 version = "1.1.4"
 criteria = "safe-to-run"
 
+[[exemptions.allocator-api2]]
+version = "0.2.21"
+criteria = "safe-to-deploy"
+
 [[exemptions.anstream]]
 version = "0.6.21"
 criteria = "safe-to-deploy"
@@ -52,6 +56,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.anyhow]]
 version = "1.0.102"
+criteria = "safe-to-deploy"
+
+[[exemptions.arbitrary]]
+version = "1.4.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.atomic-waker]]
@@ -84,7 +92,7 @@ criteria = "safe-to-run"
 
 [[exemptions.bumpalo]]
 version = "3.20.2"
-criteria = "safe-to-run"
+criteria = "safe-to-deploy"
 
 [[exemptions.bytecount]]
 version = "0.6.9"
@@ -114,6 +122,70 @@ criteria = "safe-to-deploy"
 version = "1.0.4"
 criteria = "safe-to-deploy"
 
+[[exemptions.cranelift-assembler-x64]]
+version = "0.132.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.cranelift-assembler-x64-meta]]
+version = "0.132.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.cranelift-bforest]]
+version = "0.132.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.cranelift-bitset]]
+version = "0.132.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.cranelift-codegen]]
+version = "0.132.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.cranelift-codegen-meta]]
+version = "0.132.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.cranelift-codegen-shared]]
+version = "0.132.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.cranelift-control]]
+version = "0.132.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.cranelift-entity]]
+version = "0.132.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.cranelift-frontend]]
+version = "0.132.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.cranelift-isle]]
+version = "0.132.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.cranelift-module]]
+version = "0.132.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.cranelift-native]]
+version = "0.132.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.cranelift-object]]
+version = "0.132.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.cranelift-srcgen]]
+version = "0.132.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.crc32fast]]
+version = "1.5.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.displaydoc]]
 version = "0.2.5"
 criteria = "safe-to-run"
@@ -129,6 +201,14 @@ criteria = "safe-to-run"
 [[exemptions.fluent-uri]]
 version = "0.3.2"
 criteria = "safe-to-run"
+
+[[exemptions.fnv]]
+version = "1.0.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.foldhash]]
+version = "0.2.0"
+criteria = "safe-to-deploy"
 
 [[exemptions.form_urlencoded]]
 version = "1.2.2"
@@ -162,12 +242,20 @@ criteria = "safe-to-run"
 version = "0.3.32"
 criteria = "safe-to-run"
 
+[[exemptions.gimli]]
+version = "0.33.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.hashbrown]]
 version = "0.15.5"
 criteria = "safe-to-run"
 
 [[exemptions.hashbrown]]
 version = "0.16.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.hashbrown]]
+version = "0.17.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.http]]
@@ -235,7 +323,7 @@ version = "1.2.2"
 criteria = "safe-to-run"
 
 [[exemptions.indexmap]]
-version = "2.13.0"
+version = "2.14.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.ipnet]]
@@ -263,8 +351,12 @@ version = "1.5.0"
 criteria = "safe-to-run"
 
 [[exemptions.libc]]
-version = "0.2.183"
-criteria = "safe-to-run"
+version = "0.2.186"
+criteria = "safe-to-deploy"
+
+[[exemptions.libm]]
+version = "0.2.16"
+criteria = "safe-to-deploy"
 
 [[exemptions.linux-raw-sys]]
 version = "0.12.1"
@@ -317,6 +409,10 @@ criteria = "safe-to-run"
 [[exemptions.num-traits]]
 version = "0.2.19"
 criteria = "safe-to-run"
+
+[[exemptions.object]]
+version = "0.39.1"
+criteria = "safe-to-deploy"
 
 [[exemptions.once_cell_polyfill]]
 version = "1.70.2"
@@ -382,6 +478,10 @@ criteria = "safe-to-run"
 version = "0.33.0"
 criteria = "safe-to-run"
 
+[[exemptions.regalloc2]]
+version = "0.15.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.regex]]
 version = "1.12.3"
 criteria = "safe-to-run"
@@ -397,6 +497,10 @@ criteria = "safe-to-run"
 [[exemptions.reqwest]]
 version = "0.12.28"
 criteria = "safe-to-run"
+
+[[exemptions.rustc-hash]]
+version = "2.1.2"
+criteria = "safe-to-deploy"
 
 [[exemptions.rustix]]
 version = "1.1.4"
@@ -432,7 +536,7 @@ criteria = "safe-to-run"
 
 [[exemptions.smallvec]]
 version = "1.15.1"
-criteria = "safe-to-run"
+criteria = "safe-to-deploy"
 
 [[exemptions.socket2]]
 version = "0.6.3"
@@ -440,7 +544,7 @@ criteria = "safe-to-run"
 
 [[exemptions.stable_deref_trait]]
 version = "1.2.1"
-criteria = "safe-to-run"
+criteria = "safe-to-deploy"
 
 [[exemptions.syn]]
 version = "2.0.117"
@@ -453,6 +557,10 @@ criteria = "safe-to-run"
 [[exemptions.synstructure]]
 version = "0.13.2"
 criteria = "safe-to-run"
+
+[[exemptions.target-lexicon]]
+version = "0.13.5"
+criteria = "safe-to-deploy"
 
 [[exemptions.tempfile]]
 version = "3.26.0"
@@ -557,6 +665,10 @@ criteria = "safe-to-run"
 [[exemptions.wasm-bindgen-shared]]
 version = "0.2.121"
 criteria = "safe-to-run"
+
+[[exemptions.wasmtime-internal-core]]
+version = "45.0.0"
+criteria = "safe-to-deploy"
 
 [[exemptions.web-sys]]
 version = "0.3.98"


### PR DESCRIPTION
## Summary

- Adds a new `axiomc-backend-cranelift` workspace crate and wires `axiomc build --backend cranelift` through a narrow hello-world backend spike.
- Lowers the supported `stage1/examples/hello` MIR subset into print lines, emits a Cranelift object, links it with the host linker, and verifies the resulting binary output.
- Keeps `generated-rust` as the default and only broad production backend, and records an advisory hello-world baseline at `stage1/benchmarks/cranelift-hello-baseline.json`.

## Governing Issue

Closes #691

## Validation

- [x] Relevant local checks passed
  - `cargo fmt --manifest-path stage1/Cargo.toml --all`
  - `jq empty stage1/benchmarks/cranelift-hello-baseline.json`
  - `cargo test --manifest-path stage1/Cargo.toml -p axiomc-backend-cranelift`
  - `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend`
  - `cargo test --manifest-path stage1/Cargo.toml -p axiomc cranelift_backend`
  - `cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build stage1/examples/hello --backend cranelift --json`
  - `stage1/examples/hello/dist/hello-stage1`
  - `cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build stage1/examples/hello --json`
  - `git diff --check`
  - `cargo vet --manifest-path stage1/Cargo.toml --locked --frozen`
  - `PATH="/Users/johnteneyckjr./.cargo/bin:$PATH" bash scripts/ci/run-toolchain-supply-chain.sh`
  - `AXIOM_PYTHON_EXIT_ISSUE_STATES_JSON='{"266":"closed","267":"closed","268":"closed","269":"closed","270":"closed","271":"closed"}' bash scripts/ci/run-fast-checks.sh`
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
  - Semantic node types: none.
- [x] Schemas added/changed are listed, or this PR does not touch schemas
  - Schemas: none.
- [x] Evidence added/changed is listed, or this PR does not touch evidence
  - Evidence: `stage1/crates/axiomc-backend-cranelift/src/lib.rs` unit coverage, `stage1/crates/axiomc/tests/cranelift_backend.rs`, and `stage1/benchmarks/cranelift-hello-baseline.json`.
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
  - Rust capture: the Cranelift spike consumes typed MIR through an `axiomc` evaluator and does not define Axiom semantics by Rust output. Generated Rust remains the default backend.
- [x] Agent-facing inspection impact is described, or there is no inspection impact
  - Agent-facing inspection impact: build JSON can report `backend: "cranelift"` for the opt-in hello spike; no inspect API changes.

## Flow Contract

- Owner lane: daedalus
- Repair owner: codex
- Autonomy class: agent-authored, human review required
- Risk class: high

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

## Merge Automation

- [x] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- This PR is scoped only to issue 691's Cranelift integration spike.
- Issues #105, #692, #693, and #694 remain out of scope; this does not provide full MIR lowering, replace the generated-Rust backend, or remove the generated-Rust path.
- The new Cranelift dependency graph required cargo-vet safe-to-deploy exemptions in `stage1/supply-chain/config.toml`; the full supply-chain script now passes locally.
- The first unauthenticated `bash scripts/ci/run-fast-checks.sh` attempt could not verify GitHub issue state because local Python certificate verification failed. I verified #266-#271 as closed through `gh api`, then supplied those states via the script's documented `AXIOM_PYTHON_EXIT_ISSUE_STATES_JSON` override.
- A sandboxed fast-check run reached `proof_http_service` and failed with `Operation not permitted`; rerunning the same command elevated passed.
