### PR TITLE
[codex] Add hosted registry serve command

### DIFF
--- a/docs/package.md
+++ b/docs/package.md
@@ -15,6 +15,7 @@ cargo run --manifest-path stage1/Cargo.toml -p axiomc -- publish stage1/examples
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- pkg graph stage1/examples/workspace_only --json
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- registry-index ./registry/packages --base-url https://packages.example.test --out ./registry/index.json
 cargo run --manifest-path stage1/Cargo.toml -p axiomc -- registry-validate ./registry/index.json --packages-dir ./registry/packages --signing-key dev-key
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- registry-serve ./registry/packages --addr 127.0.0.1:8080 --base-url http://127.0.0.1:8080
 ```
 
 ## Manifest Shape
@@ -80,7 +81,17 @@ analysis.
 - `axiom-registry.toml` with `yanked = true` and optional `yank_reason`
 
 The generated index records per-release capability manifests, archive/signature URLs,
-and yanked status so a simple static host can serve lockfile-friendly package metadata. `axiomc registry-validate` checks the index contract by default; when passed `--packages-dir` and `--signing-key`, it also reads every indexed local archive plus sidecar and rejects tampered archives or mismatched integrity keys. This is publish and registry-index groundwork for a future hosted registry service, not the hosted service itself.
+and yanked status so a simple static host can serve lockfile-friendly package metadata. `axiomc registry-validate` checks the index contract by default; when passed `--packages-dir` and `--signing-key`, it also reads every indexed local archive plus sidecar and rejects tampered archives or mismatched integrity keys.
+
+`axiomc registry-serve <packages-dir>` starts a small read-only HTTP registry for that same release tree. It serves:
+
+- `/index.json` and `/` as a freshly rendered registry index
+- `/<package>/<version>/axiom.toml`
+- `/<package>/<version>/axiom.lock`
+- `/<package>/<version>/package.axp`
+- `/<package>/<version>/package.axp.sig`
+
+The server rebuilds and validates the index before serving package files, so malformed manifests, mismatched archive sidecars, unsafe path segments, or invalid yank metadata fail before artifacts are exposed. Pass `--base-url` when the registry is behind a proxy or a stable hostname; otherwise the server derives a local `http://host:port` base URL from the bound address. The hosted stage1 registry remains read-only: package uploads still happen through `axiomc publish`, and the `.sig` sidecar is still an integrity tag rather than cryptographic authenticity proof.
 
 ## Registry And Publish Contract
 

--- a/stage1/crates/axiomc/src/main.rs
+++ b/stage1/crates/axiomc/src/main.rs
@@ -20,8 +20,8 @@ use axiomc::project::{
     trace_provenance,
 };
 use axiomc::registry::{
-    PublishOptions, load_registry_index, publish_package, render_registry_index,
-    verify_registry_index_integrity,
+    PublishOptions, RegistryServeOptions, load_registry_index, publish_package,
+    render_registry_index, serve_registry, verify_registry_index_integrity,
 };
 use axiomc::syntax::parse_program;
 use clap::{Parser, Subcommand, ValueEnum};
@@ -269,6 +269,16 @@ enum Command {
         packages_dir: Option<PathBuf>,
         #[arg(long = "signing-key")]
         signing_key: Option<String>,
+    },
+    /// Serve a hosted package-registry index and release artifacts over HTTP.
+    RegistryServe {
+        packages_dir: PathBuf,
+        #[arg(long, default_value = "127.0.0.1:8080")]
+        addr: String,
+        #[arg(long = "base-url")]
+        base_url: Option<String>,
+        #[arg(long)]
+        once: bool,
     },
     /// Start the bounded axiom-analyzer Language Server Protocol endpoint.
     Lsp,
@@ -1224,6 +1234,28 @@ fn main() {
                 0
             }
             Err(error) => print_error("registry-validate", error, false),
+        },
+        Command::RegistryServe {
+            packages_dir,
+            addr,
+            base_url,
+            once,
+        } => match serve_registry(
+            &packages_dir,
+            &RegistryServeOptions {
+                addr,
+                base_url,
+                once,
+            },
+        ) {
+            Ok(output) => {
+                eprintln!(
+                    "served {} registry request(s) from {}",
+                    output.requests, output.base_url
+                );
+                0
+            }
+            Err(error) => print_error("registry-serve", error, false),
         },
         Command::Lsp => match lsp::run_stdio(io::stdin().lock(), io::stdout()) {
             Ok(()) => 0,
@@ -7441,6 +7473,7 @@ mod tests {
         assert!(help.contains("Pack and publish a stage1 package into a local registry tree"));
         assert!(help.contains("Build a static package-registry index"));
         assert!(help.contains("Validate a static package-registry index JSON file"));
+        assert!(help.contains("Serve a hosted package-registry index"));
         assert!(help.contains("Verify declared axioms and target evidence requirements"));
         assert!(help.contains("Diff two Intent IR snapshots"));
     }
@@ -7478,6 +7511,34 @@ mod tests {
                 assert_eq!(signing_key.as_deref(), Some("dev-key"));
             }
             other => panic!("expected registry validate command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn registry_serve_cli_parses_host_options() {
+        let cli = Cli::parse_from([
+            "axiomc",
+            "registry-serve",
+            "registry/packages",
+            "--addr",
+            "127.0.0.1:0",
+            "--base-url",
+            "http://127.0.0.1:0",
+            "--once",
+        ]);
+        match cli.command {
+            Command::RegistryServe {
+                packages_dir,
+                addr,
+                base_url,
+                once,
+            } => {
+                assert_eq!(packages_dir, PathBuf::from("registry/packages"));
+                assert_eq!(addr, "127.0.0.1:0");
+                assert_eq!(base_url.as_deref(), Some("http://127.0.0.1:0"));
+                assert!(once);
+            }
+            other => panic!("expected registry serve command, got {other:?}"),
         }
     }
 

--- a/stage1/crates/axiomc/src/registry.rs
+++ b/stage1/crates/axiomc/src/registry.rs
@@ -6,6 +6,8 @@ use crate::manifest::{
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fs;
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
 use std::path::{Component, Path, PathBuf};
 
 const REGISTRY_METADATA_FILENAME: &str = "axiom-registry.toml";
@@ -58,6 +60,27 @@ pub struct PublishOutput {
 pub struct PublishOptions {
     pub signing_key: Option<String>,
     pub allow_overwrite: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegistryServeOptions {
+    pub addr: String,
+    pub base_url: Option<String>,
+    pub once: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RegistryServeOutput {
+    pub addr: String,
+    pub base_url: String,
+    pub requests: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RegistryHttpResponse {
+    status: &'static str,
+    content_type: &'static str,
+    body: Vec<u8>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -581,6 +604,241 @@ pub fn load_registry_index(path: &Path) -> Result<RegistryIndex, Diagnostic> {
     })?;
     validate_registry_index(&index, Some(path))?;
     Ok(index)
+}
+
+pub fn serve_registry(
+    packages_root: &Path,
+    options: &RegistryServeOptions,
+) -> Result<RegistryServeOutput, Diagnostic> {
+    let listener = TcpListener::bind(&options.addr).map_err(|err| {
+        Diagnostic::new(
+            "registry",
+            format!("failed to bind registry server {}: {err}", options.addr),
+        )
+    })?;
+    let local_addr = listener.local_addr().map_err(|err| {
+        Diagnostic::new(
+            "registry",
+            format!("failed to inspect registry bind addr: {err}"),
+        )
+    })?;
+    let addr = local_addr.to_string();
+    let base_url = options
+        .base_url
+        .clone()
+        .unwrap_or_else(|| format!("http://{addr}"));
+    build_registry_index(packages_root, &base_url)?;
+
+    eprintln!(
+        "serving registry {} at {}",
+        packages_root.display(),
+        base_url
+    );
+
+    let mut requests = 0usize;
+    for stream in listener.incoming() {
+        let mut stream = stream.map_err(|err| {
+            Diagnostic::new(
+                "registry",
+                format!("failed to accept registry request: {err}"),
+            )
+        })?;
+        serve_registry_stream(packages_root, &base_url, &mut stream)?;
+        requests += 1;
+        if options.once {
+            break;
+        }
+    }
+
+    Ok(RegistryServeOutput {
+        addr,
+        base_url,
+        requests,
+    })
+}
+
+fn serve_registry_stream(
+    packages_root: &Path,
+    base_url: &str,
+    stream: &mut TcpStream,
+) -> Result<(), Diagnostic> {
+    let mut buffer = [0u8; 16 * 1024];
+    let len = stream.read(&mut buffer).map_err(|err| {
+        Diagnostic::new(
+            "registry",
+            format!("failed to read registry request: {err}"),
+        )
+    })?;
+    let request = String::from_utf8_lossy(&buffer[..len]);
+    let response = registry_http_response(packages_root, base_url, &request)?;
+    write_registry_http_response(stream, &response)
+}
+
+fn registry_http_response(
+    packages_root: &Path,
+    base_url: &str,
+    request: &str,
+) -> Result<RegistryHttpResponse, Diagnostic> {
+    let Some(request_line) = request.lines().next() else {
+        return Ok(registry_http_error("400 Bad Request", "empty request"));
+    };
+    let mut parts = request_line.split_whitespace();
+    let Some(method) = parts.next() else {
+        return Ok(registry_http_error("400 Bad Request", "missing method"));
+    };
+    let Some(target) = parts.next() else {
+        return Ok(registry_http_error("400 Bad Request", "missing target"));
+    };
+    let Some(version) = parts.next() else {
+        return Ok(registry_http_error("400 Bad Request", "missing version"));
+    };
+    if !version.starts_with("HTTP/") {
+        return Ok(registry_http_error("400 Bad Request", "invalid version"));
+    }
+    if method != "GET" && method != "HEAD" {
+        return Ok(RegistryHttpResponse {
+            status: "405 Method Not Allowed",
+            content_type: "text/plain; charset=utf-8",
+            body: b"method not allowed\n".to_vec(),
+        });
+    }
+
+    let target = target.split('?').next().unwrap_or(target);
+    let mut response = if target == "/" || target == "/index.json" {
+        let index = render_registry_index(packages_root, base_url)?;
+        RegistryHttpResponse {
+            status: "200 OK",
+            content_type: "application/json",
+            body: index.into_bytes(),
+        }
+    } else {
+        registry_release_file_response(packages_root, base_url, target)?
+    };
+    if method == "HEAD" {
+        response.body.clear();
+    }
+    Ok(response)
+}
+
+fn registry_release_file_response(
+    packages_root: &Path,
+    base_url: &str,
+    target: &str,
+) -> Result<RegistryHttpResponse, Diagnostic> {
+    let Some(relative) = target.strip_prefix('/') else {
+        return Ok(registry_http_error(
+            "400 Bad Request",
+            "target must be absolute",
+        ));
+    };
+    let segments = relative.split('/').collect::<Vec<_>>();
+    if segments.len() != 3 {
+        return Ok(registry_http_error("404 Not Found", "not found"));
+    }
+    let package = match safe_registry_lookup_segment("package name", segments[0]) {
+        Ok(value) => value,
+        Err(_) => {
+            return Ok(registry_http_error(
+                "400 Bad Request",
+                "unsafe package path segment",
+            ));
+        }
+    };
+    let version = match safe_registry_lookup_segment("package version", segments[1]) {
+        Ok(value) => value,
+        Err(_) => {
+            return Ok(registry_http_error(
+                "400 Bad Request",
+                "unsafe version path segment",
+            ));
+        }
+    };
+    let file = match safe_registry_lookup_segment("artifact file name", segments[2]) {
+        Ok(value) => value,
+        Err(_) => {
+            return Ok(registry_http_error(
+                "400 Bad Request",
+                "unsafe artifact path segment",
+            ));
+        }
+    };
+    let index = build_registry_index(packages_root, base_url)?;
+    let Some(release) = index
+        .packages
+        .get(&package)
+        .and_then(|releases| releases.iter().find(|release| release.version == version))
+    else {
+        return Ok(registry_http_error("404 Not Found", "not found"));
+    };
+
+    if !registry_release_allows_file(release, &file)? {
+        return Ok(registry_http_error("404 Not Found", "not found"));
+    }
+
+    let path = packages_root.join(&package).join(&version).join(&file);
+    let body = fs::read(&path).map_err(|err| {
+        Diagnostic::new(
+            "registry",
+            format!("failed to read registry artifact {}: {err}", path.display()),
+        )
+        .with_path(path.display().to_string())
+    })?;
+    Ok(RegistryHttpResponse {
+        status: "200 OK",
+        content_type: registry_content_type(&file),
+        body,
+    })
+}
+
+fn registry_release_allows_file(release: &RegistryRelease, file: &str) -> Result<bool, Diagnostic> {
+    if file == MANIFEST_FILENAME || file == LOCK_FILENAME {
+        return Ok(true);
+    }
+    if let Some(archive) = release.archive.as_deref() {
+        if registry_artifact_file_name("archive file name", archive)? == file {
+            return Ok(true);
+        }
+    }
+    if let Some(signature) = release.signature.as_deref() {
+        if registry_artifact_file_name("signature file name", signature)? == file {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn registry_content_type(file: &str) -> &'static str {
+    match file {
+        MANIFEST_FILENAME | LOCK_FILENAME => "application/toml; charset=utf-8",
+        "package.axp.sig" => "text/plain; charset=utf-8",
+        _ if file.ends_with(".json") => "application/json",
+        _ => "application/octet-stream",
+    }
+}
+
+fn registry_http_error(status: &'static str, message: &str) -> RegistryHttpResponse {
+    RegistryHttpResponse {
+        status,
+        content_type: "text/plain; charset=utf-8",
+        body: format!("{message}\n").into_bytes(),
+    }
+}
+
+fn write_registry_http_response(
+    stream: &mut TcpStream,
+    response: &RegistryHttpResponse,
+) -> Result<(), Diagnostic> {
+    write!(
+        stream,
+        "HTTP/1.1 {}\r\ncontent-type: {}\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+        response.status,
+        response.content_type,
+        response.body.len()
+    )
+    .map_err(|err| Diagnostic::new("registry", format!("failed to write response: {err}")))?;
+    stream
+        .write_all(&response.body)
+        .map_err(|err| Diagnostic::new("registry", format!("failed to write response: {err}")))
 }
 
 pub fn validate_registry_index(
@@ -1475,5 +1733,86 @@ integrity=ignored
         )
         .expect("write index");
         load_registry_index(&path).expect("valid index");
+    }
+
+    #[test]
+    fn hosted_registry_serves_index_and_signed_artifacts() {
+        let dir = tempdir().expect("tempdir");
+        let project = write_publishable_project(dir.path(), "core", "1.0.0");
+        let registry = dir.path().join("registry");
+        publish_package(
+            &project,
+            &registry,
+            &PublishOptions {
+                signing_key: Some(String::from("dev-key")),
+                allow_overwrite: false,
+            },
+        )
+        .expect("publish package");
+        fs::write(
+            registry
+                .join("core")
+                .join("1.0.0")
+                .join("axiom-registry.toml"),
+            "yanked = true\nyank_reason = \"superseded\"\n",
+        )
+        .expect("write registry metadata");
+
+        let index = registry_http_response(
+            &registry,
+            "http://registry.test",
+            "GET /index.json HTTP/1.1\r\nHost: registry.test\r\n\r\n",
+        )
+        .expect("index response");
+        assert_eq!(index.status, "200 OK");
+        assert_eq!(index.content_type, "application/json");
+        let index_text = String::from_utf8(index.body).expect("utf8 index");
+        assert!(index_text.contains("\"core\""));
+        assert!(index_text.contains("\"yanked\": true"));
+        assert!(index_text.contains("\"yank_reason\": \"superseded\""));
+        assert!(index_text.contains("http://registry.test/core/1.0.0/package.axp"));
+
+        let archive = registry_http_response(
+            &registry,
+            "http://registry.test",
+            "GET /core/1.0.0/package.axp HTTP/1.1\r\nHost: registry.test\r\n\r\n",
+        )
+        .expect("archive response");
+        assert_eq!(archive.status, "200 OK");
+        assert_eq!(archive.content_type, "application/octet-stream");
+        assert!(archive.body.starts_with(b"AXIOM_PACKAGE_ARCHIVE_V1\n"));
+    }
+
+    #[test]
+    fn hosted_registry_rejects_traversal_and_unknown_files() {
+        let dir = tempdir().expect("tempdir");
+        let project = write_publishable_project(dir.path(), "core", "1.0.0");
+        let registry = dir.path().join("registry");
+        publish_package(
+            &project,
+            &registry,
+            &PublishOptions {
+                signing_key: Some(String::from("dev-key")),
+                allow_overwrite: false,
+            },
+        )
+        .expect("publish package");
+
+        let traversal = registry_http_response(
+            &registry,
+            "http://registry.test",
+            "GET /core/../package.axp HTTP/1.1\r\nHost: registry.test\r\n\r\n",
+        )
+        .expect("traversal response");
+        assert_eq!(traversal.status, "400 Bad Request");
+        assert!(String::from_utf8_lossy(&traversal.body).contains("unsafe version"));
+
+        let metadata = registry_http_response(
+            &registry,
+            "http://registry.test",
+            "GET /core/1.0.0/axiom-registry.toml HTTP/1.1\r\nHost: registry.test\r\n\r\n",
+        )
+        .expect("metadata response");
+        assert_eq!(metadata.status, "404 Not Found");
     }
 }


### PR DESCRIPTION
## Summary

- Add `axiomc registry-serve` as a read-only hosted registry surface over the existing signed static registry tree.
- Serve `/index.json`, release manifests, lockfiles, package archives, and integrity sidecars over HTTP.
- Rebuild and validate the registry index before serving artifacts, preserve yanked/capability metadata, and reject unsafe request paths before filesystem access.
- Document the hosted registry workflow in `docs/package.md`.

## Governing Issue

Closes #263.

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Commands run:

- `cargo fmt --manifest-path stage1/Cargo.toml --all`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc registry --features run-native-tests`
- `cargo run --manifest-path stage1/Cargo.toml -p axiomc -- publish stage1/examples/hello --registry-dir /private/tmp/axiom-registry-serve-smoke/packages --signing-key dev-key --allow-overwrite`
- `cargo run --manifest-path stage1/Cargo.toml -p axiomc -- registry-serve /private/tmp/axiom-registry-serve-smoke/packages --addr 127.0.0.1:18163 --base-url http://127.0.0.1:18163 --once`
- `curl -fsS http://127.0.0.1:18163/index.json`
- `AXIOM_PYTHON_EXIT_ISSUE_STATES_JSON='{"266":"closed","267":"closed","268":"closed","269":"closed","270":"closed","271":"closed"}' bash scripts/ci/run-fast-checks.sh`
- `git diff --check`

No checks were intentionally skipped. The Python-exit issue-state override is the repo-supported local substitute for the GitHub issue-state probe.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

No contributor, PR guidance, bootstrap onboarding, secret, auth, or machine-local environment changes are included.

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Semantic node types added/changed: none.

Schemas added/changed: none.

Evidence added/changed:

- Registry unit coverage for hosted index/artifact serving.
- Registry unit coverage for unsafe request path rejection.
- CLI parse coverage for `registry-serve`.
- Local one-shot HTTP smoke against `registry-serve --once`.

Rust capture check: the hosted registry serves existing package artifacts and metadata; it does not define semantic contracts in terms of Rust implementation details.

Agent-facing inspection impact: none; this does not change inspect APIs.

## Flow Contract

- Owner lane: hephaestus
- Repair owner: codex
- Autonomy class: agent-authored with human review required
- Risk class: low

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

Next actor: pheidon review for non-author approval.

## Merge Automation

- [x] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

Auto-merge will be enabled after PR creation.

## Notes

- The hosted registry is intentionally read-only. Uploads still use `axiomc publish`.
- The `.sig` sidecar remains an integrity tag, not a cryptographic authenticity proof.
- `stage1/examples/proof_worker/scratch/` was generated by local proof workload validation and intentionally left unstaged.
