### PR TITLE
[codex] Add LSP protocol stdlib surface

### DIFF
--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -83,6 +83,10 @@ shared `axiom.stage1.v1` envelope.
 `std/doc.ax` now defines the AxiOM-side doc item contract and Markdown renderer;
 source extraction and `axiomc doc` driver integration remain bootstrap-hosted
 until Phase-K.1 can follow Phase-J.3.
+`std/lsp.ax` defines the AxiOM-side JSON-RPC/LSP message contract for
+initialize, document-change, diagnostic, completion, shutdown, and exit flows;
+the Stage1 Rust stdio loop still owns process I/O until the Phase-L self-hosting
+dependencies are satisfied.
 
 `axiomc new` defaults to the `cli` starter and also accepts `--template worker`
 and `--template service`. Each starter writes `axiom.toml`, `axiom.lock`,

--- a/scripts/ci/run-stdlib-property-checks.sh
+++ b/scripts/ci/run-stdlib-property-checks.sh
@@ -37,6 +37,7 @@ stdlib_projects=(
   stage1/examples/stdlib_io
   stage1/examples/stdlib_json
   stage1/examples/stdlib_json_value
+  stage1/examples/stdlib_lsp
   stage1/examples/stdlib_log
   stage1/examples/stdlib_net
   stage1/examples/stdlib_outcome

--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -472,6 +472,7 @@ fn render_rust_for_package_with_backend_context(
     .any(|name| program_uses_call(program, name));
     let uses_json_serdes = [
         "json_serdes_parse",
+        "json_serdes_parse_str",
         "json_serdes_value_to_json",
         "json_serdes_to_json",
     ]
@@ -5256,7 +5257,12 @@ impl<'a> AxiomJsonSerdesParser<'a> {
 
 #[allow(dead_code)]
 fn axiom_json_serdes_parse(text: String) -> Result<std_serdes_Value, std_serdes_ParseError> {
-    let mut parser = AxiomJsonSerdesParser::new(text.as_str());
+    axiom_json_serdes_parse_str(text.as_str())
+}
+
+#[allow(dead_code)]
+fn axiom_json_serdes_parse_str(text: &str) -> Result<std_serdes_Value, std_serdes_ParseError> {
+    let mut parser = AxiomJsonSerdesParser::new(text);
     match parser.parse_value() {
         Ok(value) => {
             parser.skip_ws();
@@ -6442,6 +6448,9 @@ fn render_expr(expr: &Expr) -> String {
         }
         Expr::Call { name, args, .. } if name == "json_serdes_parse" => {
             format!("axiom_json_serdes_parse({})", render_expr(&args[0]))
+        }
+        Expr::Call { name, args, .. } if name == "json_serdes_parse_str" => {
+            format!("axiom_json_serdes_parse_str({})", render_expr(&args[0]))
         }
         Expr::Call { name, args, .. } if name == "json_serdes_value_to_json" => {
             format!("axiom_json_serdes_value_to_json({})", render_expr(&args[0]))

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -9812,6 +9812,47 @@ fn lower_expr_with_expected_inner(
                     ty: Type::Result(Box::new(value_ty), Box::new(error_ty)),
                 });
             }
+            if name == "json_serdes_parse_str" {
+                if args.len() != 1 {
+                    return Err(Diagnostic::new(
+                        "type",
+                        format!(
+                            "json_serdes_parse_str expects 1 argument, got {}",
+                            args.len()
+                        ),
+                    )
+                    .with_span(*line, *column));
+                }
+                let lowered = lower_expr_with_expected(&args[0], Some(&Type::Str), env, ctx)?;
+                if lowered.ty() != &Type::Str {
+                    return Err(Diagnostic::new(
+                        "type",
+                        format!(
+                            "json_serdes_parse_str expects an &str argument, got {}",
+                            lowered.ty()
+                        ),
+                    )
+                    .with_span(args[0].line(), args[0].column()));
+                }
+                let value_ty = Type::Enum(String::from("std_serdes_Value"));
+                let error_ty = Type::Struct(String::from("std_serdes_ParseError"));
+                if !ctx.enums.contains_key("std_serdes_Value")
+                    || !ctx.structs.contains_key("std_serdes_ParseError")
+                {
+                    return Err(Diagnostic::new(
+                        "type",
+                        "json_serdes_parse_str requires std/serdes.ax Value and ParseError types",
+                    )
+                    .with_span(*line, *column));
+                }
+                move_lowered_value(&lowered, env)?;
+                return Ok(Expr::Call {
+                    span: SourceSpan::point(*line, *column),
+                    name: name.clone(),
+                    args: vec![lowered],
+                    ty: Type::Result(Box::new(value_ty), Box::new(error_ty)),
+                });
+            }
             if name == "json_serdes_value_to_json" {
                 if args.len() != 1 {
                     return Err(Diagnostic::new(

--- a/stage1/crates/axiomc/src/stdlib.rs
+++ b/stage1/crates/axiomc/src/stdlib.rs
@@ -8,7 +8,7 @@
 //! enforcement continues to run against the importing package's manifest via
 //! `hir::lower_with_capabilities`.
 //!
-//! Today this provides thirty stdlib modules. The capability-gated
+//! Today this provides thirty-one stdlib modules. The capability-gated
 //! wrappers include the six manifest capability classes:
 //!
 //! * `std/time.ax` — `Duration`, `Instant`, `now_ms()`, `now()`,
@@ -89,6 +89,8 @@
 //!   layered over the bootstrap test intrinsics.
 //! * `std/doc.ax` — the AxiOM-side doc item contract and Markdown renderer
 //!   used to retire bootstrap Rust rendering in Phase-K.
+//! * `std/lsp.ax` — the AxiOM-side JSON-RPC/LSP protocol message contract used
+//!   to retire bootstrap Rust protocol handling in Phase-L.
 //! * `std/outcome.ax` — generic `Option<T>` / `Result<T, E>` predicates and
 //!   fallback unwrap helpers implemented in Axiom.
 //! * `std/encoding.ax` — URL query and path percent-encoding helpers.
@@ -399,6 +401,7 @@ pub async fn udp_send_recv(host: string, port: int, message: string, timeout_ms:
     ),
     ("testing.ax", include_str!("../../../stdlib/std/testing.ax")),
     ("doc.ax", include_str!("../../../stdlib/std/doc.ax")),
+    ("lsp.ax", include_str!("../../../stdlib/std/lsp.ax")),
     (
         "http.ax",
         "pub type Server = int

--- a/stage1/examples/stdlib_lsp/axiom.lock
+++ b/stage1/examples/stdlib_lsp/axiom.lock
@@ -1,0 +1,6 @@
+version = 1
+
+[[package]]
+name = "stdlib-lsp"
+version = "0.1.0"
+source = "path"

--- a/stage1/examples/stdlib_lsp/axiom.toml
+++ b/stage1/examples/stdlib_lsp/axiom.toml
@@ -1,0 +1,20 @@
+[package]
+name = "stdlib-lsp"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false
+
+[[tests]]
+name = "stdlib-lsp-protocol"
+entry = "src/main_test.ax"
+stdout = "0\n0\n0\n0\n0\n0\n0\n0\n"

--- a/stage1/examples/stdlib_lsp/src/main.ax
+++ b/stage1/examples/stdlib_lsp/src/main.ax
@@ -1,0 +1,3 @@
+import "std/lsp.ax"
+
+print supports_method(method_initialize())

--- a/stage1/examples/stdlib_lsp/src/main_test.ax
+++ b/stage1/examples/stdlib_lsp/src/main_test.ax
@@ -1,0 +1,112 @@
+import "std/lsp.ax"
+import "std/serdes.ax"
+import "std/testing.ax"
+
+fn parses_request(): int {
+let expected_params: {string: Value} = {"rootUri": Text("file:///tmp/axiom")}
+let request_params: {string: Value} = {"rootUri": Text("file:///tmp/axiom")}
+let expected: Value = Object({"id": Int(7), "jsonrpc": Text("2.0"), "method": Text("initialize"), "params": Object(expected_params)})
+let payload: string = request(7, method_initialize(), request_params)
+match parse_message(payload) {
+Ok(value) {
+return property("lsp request parse", value == expected)
+}
+Err(_error) {
+return property("lsp request parse", false)
+}
+}
+}
+
+fn publishes_diagnostic(): int {
+let diagnostic_payload: Diagnostic = diagnostic(range(position(0, 0), position(0, 1)), 1, "axiomc", "parse", "unexpected closing brace")
+let expected_diagnostic: Value = Object({"code": Text("parse"), "message": Text("unexpected closing brace"), "range": Object({"end": Object({"character": Int(1), "line": Int(0)}), "start": Object({"character": Int(0), "line": Int(0)})}), "severity": Int(1), "source": Text("axiomc")})
+let expected_params: {string: Value} = {"diagnostics": Array([expected_diagnostic]), "uri": Text("file:///tmp/bad.ax")}
+let expected: Value = Object({"jsonrpc": Text("2.0"), "method": Text("textDocument/publishDiagnostics"), "params": Object(expected_params)})
+let payload: string = publish_diagnostic("file:///tmp/bad.ax", diagnostic_payload)
+match parse_message(payload) {
+Ok(value) {
+return property("lsp diagnostic notification", value == expected)
+}
+Err(_error) {
+return property("lsp diagnostic notification", false)
+}
+}
+}
+
+fn completion_has_items(): int {
+let item: {string: Value} = {"kind": Int(3), "label": Text("fn")}
+let result: {string: Value} = {"isIncomplete": Bool(false), "items": Array([Object(item)])}
+let expected: Value = Object({"id": Int(9), "jsonrpc": Text("2.0"), "result": Object(result)})
+let payload: string = completion_response(9)
+match parse_message(payload) {
+Ok(value) {
+return property("lsp completion response", value == expected)
+}
+Err(_error) {
+return property("lsp completion response", false)
+}
+}
+}
+
+fn supports_required_methods(): int {
+return property("lsp required methods", supports_method(method_initialize()) && supports_method(method_did_open()) && supports_method(method_did_change()) && supports_method(method_completion()) && supports_method(method_shutdown()) && supports_method(method_exit()) && supports_method("workspace/symbol") == false)
+}
+
+fn no_text(value: Option<string>): bool {
+match value {
+Some(_text) {
+return false
+}
+None {
+return true
+}
+}
+}
+
+fn no_request_id(value: Option<RequestId>): bool {
+match value {
+Some(_id) {
+return false
+}
+None {
+return true
+}
+}
+}
+
+fn dispatches_request_responses(): int {
+let params: {string: Value} = {"rootUri": Text("file:///tmp/axiom")}
+let initialize_payload: string = request(7, method_initialize(), params)
+let completion_params: {string: Value} = {"uri": Text("file:///tmp/axiom/main.ax")}
+let completion_payload: string = request(9, method_completion(), completion_params)
+let shutdown_payload: string = request(10, method_shutdown(), {"reason": Text("done")})
+return property("lsp request dispatch", message_method(initialize_payload) == Some(method_initialize()) && message_number_id(initialize_payload) == Some(7) && message_supported(initialize_payload) && response_for_request(initialize_payload) == Some(initialize_response(7)) && response_for_request(completion_payload) == Some(completion_response(9)) && response_for_request(shutdown_payload) == Some(shutdown_response(10)))
+}
+
+fn dispatches_string_request_ids(): int {
+let params: {string: Value} = {"rootUri": Text("file:///tmp/axiom")}
+let initialize_payload: string = request_with_text_id("abc", method_initialize(), params)
+let completion_payload: string = request_with_text_id("completion-1", method_completion(), {"uri": Text("file:///tmp/axiom/main.ax")})
+return property("lsp string request id dispatch", message_text_id(initialize_payload) == Some("abc") && response_for_request(initialize_payload) == Some(initialize_response_id(TextId("abc"))) && response_for_request(completion_payload) == Some(completion_response_id(TextId("completion-1"))))
+}
+
+fn extracts_text_document_notifications(): int {
+let open_payload: string = did_open("file:///tmp/axiom/main.ax", "axiom", 3, "print 1")
+let change_payload: string = did_change("file:///tmp/axiom/main.ax", 4, "print 2")
+return property("lsp text document extraction", message_method(open_payload) == Some(method_did_open()) && message_method(change_payload) == Some(method_did_change()) && did_open_uri(open_payload) == Some("file:///tmp/axiom/main.ax") && did_open_language_id(open_payload) == Some("axiom") && did_open_version(open_payload) == Some(3) && did_open_text(open_payload) == Some("print 1") && did_change_uri(change_payload) == Some("file:///tmp/axiom/main.ax") && did_change_version(change_payload) == Some(4) && did_change_text(change_payload) == Some("print 2"))
+}
+
+fn rejects_invalid_messages(): int {
+let initialized_payload: string = notification(method_initialized(), {"ready": Bool(true)})
+let invalid_payload: string = "{"
+return property("lsp invalid message rejected", no_text(message_method(invalid_payload)) && no_request_id(message_id(invalid_payload)) && message_supported(invalid_payload) == false && no_text(response_for_request(initialized_payload)))
+}
+
+print parses_request()
+print publishes_diagnostic()
+print completion_has_items()
+print supports_required_methods()
+print dispatches_request_responses()
+print dispatches_string_request_ids()
+print extracts_text_document_notifications()
+print rejects_invalid_messages()

--- a/stage1/stdlib/std/lsp.ax
+++ b/stage1/stdlib/std/lsp.ax
@@ -1,0 +1,384 @@
+import "std/serdes.ax"
+
+pub type Position = (int, int)
+pub type Range = (Position, Position)
+pub type Diagnostic = (Range, int, string, string, string)
+
+pub enum RequestId {
+NumberId(int)
+TextId(string)
+}
+
+pub fn method_initialize(): string {
+return "initialize"
+}
+
+pub fn method_initialized(): string {
+return "initialized"
+}
+
+pub fn method_shutdown(): string {
+return "shutdown"
+}
+
+pub fn method_exit(): string {
+return "exit"
+}
+
+pub fn method_did_open(): string {
+return "textDocument/didOpen"
+}
+
+pub fn method_did_change(): string {
+return "textDocument/didChange"
+}
+
+pub fn method_publish_diagnostics(): string {
+return "textDocument/publishDiagnostics"
+}
+
+pub fn method_completion(): string {
+return "textDocument/completion"
+}
+
+pub fn supports_method(method: string): bool {
+return method == method_initialize() || method == method_initialized() || method == method_shutdown() || method == method_exit() || method == method_did_open() || method == method_did_change() || method == method_completion()
+}
+
+pub fn position(line: int, character: int): Position {
+return (line, character)
+}
+
+pub fn range(start: Position, end: Position): Range {
+return (start, end)
+}
+
+pub fn diagnostic(range: Range, severity: int, source: string, code: string, message: string): Diagnostic {
+return (range, severity, source, code, message)
+}
+
+pub fn request_id_value(id: RequestId): Value {
+match id {
+NumberId(number) {
+return Int(number)
+}
+TextId(text) {
+return Text(text)
+}
+}
+}
+
+pub fn request_with_id(id: RequestId, method: string, params: {string: Value}): string {
+return stringify(Object({"jsonrpc": Text("2.0"), "id": request_id_value(id), "method": Text(method), "params": Object(params)}))
+}
+
+pub fn request(id: int, method: string, params: {string: Value}): string {
+return request_with_id(NumberId(id), method, params)
+}
+
+pub fn request_with_text_id(id: string, method: string, params: {string: Value}): string {
+return request_with_id(TextId(id), method, params)
+}
+
+pub fn notification(method: string, params: {string: Value}): string {
+return stringify(Object({"jsonrpc": Text("2.0"), "method": Text(method), "params": Object(params)}))
+}
+
+pub fn initialize_response(id: int): string {
+return initialize_response_id(NumberId(id))
+}
+
+pub fn initialize_response_id(id: RequestId): string {
+let text_sync: {string: Value} = {"openClose": Bool(true), "change": Int(1)}
+let completion: {string: Value} = {"triggerCharacters": Array([Text(".")])}
+let capabilities: {string: Value} = {"completionProvider": Object(completion), "textDocumentSync": Object(text_sync)}
+let server_info: {string: Value} = {"name": Text("axiom-analyzer")}
+let result: {string: Value} = {"capabilities": Object(capabilities), "serverInfo": Object(server_info)}
+return stringify(Object({"jsonrpc": Text("2.0"), "id": request_id_value(id), "result": Object(result)}))
+}
+
+pub fn shutdown_response(id: int): string {
+return shutdown_response_id(NumberId(id))
+}
+
+pub fn shutdown_response_id(id: RequestId): string {
+return stringify(Object({"jsonrpc": Text("2.0"), "id": request_id_value(id), "result": Null}))
+}
+
+pub fn completion_response(id: int): string {
+return completion_response_id(NumberId(id))
+}
+
+pub fn completion_response_id(id: RequestId): string {
+let item: {string: Value} = {"kind": Int(3), "label": Text("fn")}
+let result: {string: Value} = {"isIncomplete": Bool(false), "items": Array([Object(item)])}
+return stringify(Object({"jsonrpc": Text("2.0"), "id": request_id_value(id), "result": Object(result)}))
+}
+
+pub fn did_open(uri: string, language_id: string, version: int, text: string): string {
+let text_document: {string: Value} = {"languageId": Text(language_id), "text": Text(text), "uri": Text(uri), "version": Int(version)}
+return notification(method_did_open(), {"textDocument": Object(text_document)})
+}
+
+pub fn did_change(uri: string, version: int, text: string): string {
+let text_document: {string: Value} = {"uri": Text(uri), "version": Int(version)}
+let change: {string: Value} = {"text": Text(text)}
+return notification(method_did_change(), {"contentChanges": Array([Object(change)]), "textDocument": Object(text_document)})
+}
+
+pub fn publish_diagnostic(uri: string, diagnostic: Diagnostic): string {
+let params: {string: Value} = {"diagnostics": Array([diagnostic_value(diagnostic)]), "uri": Text(uri)}
+return notification(method_publish_diagnostics(), params)
+}
+
+pub fn parse_message(payload: &str): Result<Value, ParseError> {
+return from_json_str(payload)
+}
+
+pub fn message_method(payload: &str): Option<string> {
+match parse_message(payload) {
+Ok(value) {
+return text_field(value, "method")
+}
+Err(_error) {
+return None
+}
+}
+}
+
+pub fn message_id(payload: &str): Option<RequestId> {
+match parse_message(payload) {
+Ok(value) {
+return request_id_field(value)
+}
+Err(_error) {
+return None
+}
+}
+}
+
+pub fn message_number_id(payload: &str): Option<int> {
+match message_id(payload) {
+Some(id) {
+match id {
+NumberId(number) {
+return Some(number)
+}
+TextId(_text) {
+return None
+}
+}
+}
+None {
+return None
+}
+}
+}
+
+pub fn message_text_id(payload: &str): Option<string> {
+match message_id(payload) {
+Some(id) {
+match id {
+NumberId(_number) {
+return None
+}
+TextId(text) {
+return Some(text)
+}
+}
+}
+None {
+return None
+}
+}
+}
+
+pub fn message_supported(payload: &str): bool {
+match message_method(payload) {
+Some(method) {
+return supports_method(method)
+}
+None {
+return false
+}
+}
+}
+
+pub fn response_for_request(payload: &str): Option<string> {
+match message_method(payload) {
+Some(method) {
+match message_id(payload) {
+Some(id) {
+if method == method_initialize() {
+return Some(initialize_response_id(id))
+}
+if method == method_shutdown() {
+return Some(shutdown_response_id(id))
+}
+if method == method_completion() {
+return Some(completion_response_id(id))
+}
+return None
+}
+None {
+return None
+}
+}
+}
+None {
+return None
+}
+}
+}
+
+pub fn did_open_uri(payload: &str): Option<string> {
+match text_document_value(payload) {
+Some(text_document) {
+return text_field(text_document, "uri")
+}
+None {
+return None
+}
+}
+}
+
+pub fn did_open_language_id(payload: &str): Option<string> {
+match text_document_value(payload) {
+Some(text_document) {
+return text_field(text_document, "languageId")
+}
+None {
+return None
+}
+}
+}
+
+pub fn did_open_version(payload: &str): Option<int> {
+match text_document_value(payload) {
+Some(text_document) {
+return int_field(text_document, "version")
+}
+None {
+return None
+}
+}
+}
+
+pub fn did_open_text(payload: &str): Option<string> {
+match text_document_value(payload) {
+Some(text_document) {
+return text_field(text_document, "text")
+}
+None {
+return None
+}
+}
+}
+
+pub fn did_change_uri(payload: &str): Option<string> {
+return did_open_uri(payload)
+}
+
+pub fn did_change_version(payload: &str): Option<int> {
+return did_open_version(payload)
+}
+
+pub fn did_change_text(payload: &str): Option<string> {
+match first_content_change_value(payload) {
+Some(change) {
+return text_field(change, "text")
+}
+None {
+return None
+}
+}
+}
+
+fn request_id_field(value: Value): Option<RequestId> {
+match field(value, "id") {
+Some(id) {
+return request_id_from_value(id)
+}
+None {
+return None
+}
+}
+}
+
+fn request_id_from_value(value: Value): Option<RequestId> {
+match value {
+Int(number) {
+return Some(NumberId(number))
+}
+Text(text) {
+return Some(TextId(text))
+}
+Null {
+return None
+}
+Bool(_value) {
+return None
+}
+Float(_value) {
+return None
+}
+Array(_items) {
+return None
+}
+Object(_fields) {
+return None
+}
+}
+}
+
+fn message_params_value(payload: &str): Option<Value> {
+match parse_message(payload) {
+Ok(value) {
+return field(value, "params")
+}
+Err(_error) {
+return None
+}
+}
+}
+
+fn text_document_value(payload: &str): Option<Value> {
+match message_params_value(payload) {
+Some(params) {
+return field(params, "textDocument")
+}
+None {
+return None
+}
+}
+}
+
+fn first_content_change_value(payload: &str): Option<Value> {
+match message_params_value(payload) {
+Some(params) {
+match field(params, "contentChanges") {
+Some(changes) {
+return value_item(changes, 0)
+}
+None {
+return None
+}
+}
+}
+None {
+return None
+}
+}
+}
+
+fn position_value(position: Position): Value {
+return Object({"character": Int(position.1), "line": Int(position.0)})
+}
+
+fn range_value(range: Range): Value {
+return Object({"end": position_value(range.1), "start": position_value(range.0)})
+}
+
+fn diagnostic_value(diagnostic: Diagnostic): Value {
+return Object({"code": Text(diagnostic.3), "message": Text(diagnostic.4), "range": range_value(diagnostic.0), "severity": Int(diagnostic.1), "source": Text(diagnostic.2)})
+}

--- a/stage1/stdlib/std/serdes.ax
+++ b/stage1/stdlib/std/serdes.ax
@@ -1,3 +1,5 @@
+import "std/collections.ax"
+
 pub struct ParseError {
 message: string
 }
@@ -24,6 +26,131 @@ pub fn from_json(text: string): Result<Value, ParseError> {
 return json_serdes_parse(text)
 }
 
+pub fn from_json_str(text: &str): Result<Value, ParseError> {
+return json_serdes_parse_str(text)
+}
+
 pub fn parse_error_message(error: ParseError): string {
 return error.message
+}
+
+pub fn field(value: Value, key: string): Option<Value> {
+match value {
+Object(fields) {
+return get<string, Value>(fields, key)
+}
+Null {
+return None
+}
+Bool(_value) {
+return None
+}
+Int(_value) {
+return None
+}
+Float(_value) {
+return None
+}
+Text(_value) {
+return None
+}
+Array(_items) {
+return None
+}
+}
+}
+
+pub fn text_field(value: Value, key: string): Option<string> {
+match field(value, key) {
+Some(item) {
+match item {
+Text(text) {
+return Some(text)
+}
+Null {
+return None
+}
+Bool(_value) {
+return None
+}
+Int(_value) {
+return None
+}
+Float(_value) {
+return None
+}
+Array(_items) {
+return None
+}
+Object(_fields) {
+return None
+}
+}
+}
+None {
+return None
+}
+}
+}
+
+pub fn int_field(value: Value, key: string): Option<int> {
+match field(value, key) {
+Some(item) {
+match item {
+Int(number) {
+return Some(number)
+}
+Null {
+return None
+}
+Bool(_value) {
+return None
+}
+Float(_value) {
+return None
+}
+Text(_value) {
+return None
+}
+Array(_items) {
+return None
+}
+Object(_fields) {
+return None
+}
+}
+}
+None {
+return None
+}
+}
+}
+
+pub fn value_item(value: Value, index: int): Option<Value> {
+match value {
+Array(items) {
+if index < 0 || index >= len(items) {
+return None
+}
+return Some(items[index])
+}
+Null {
+return None
+}
+Bool(_value) {
+return None
+}
+Int(_value) {
+return None
+}
+Float(_value) {
+return None
+}
+Text(_value) {
+return None
+}
+Object(_fields) {
+return None
+}
+}
 }


### PR DESCRIPTION
## Summary

- Adds an AxiOM stdlib LSP protocol surface for JSON-RPC request parsing, method/id inspection, supported-method dispatch, and text-document notification extraction.
- Extends `std/serdes.ax` with borrowed JSON parsing plus object/array field helpers so protocol modules can inspect parsed JSON values without hand-coded shape logic.
- Adds compiler support for the borrowed `json_serdes_parse_str` intrinsic and expands the `stdlib_lsp` property fixture to cover initialize/shutdown/completion responses, string and numeric request ids, and didOpen/didChange extraction.
- Removes the unsafe caller-supplied `Content-Length` framing helper until the stdlib has a byte-length primitive that can derive the header from the payload.

## Governing Issue

Part of #728.

This PR intentionally does not close #728. The remaining acceptance work still requires the Phase-J.3 AxiOM LSP server/driver path, including AxiOM-owned process I/O and diagnostics sourced from `axiomc check`.

## Validation

- [x] `cargo fmt --manifest-path stage1/Cargo.toml --all`
- [x] `cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/examples/stdlib_lsp --json`
- [x] `bash scripts/ci/run-stdlib-property-checks.sh`
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc stage1_project_imports_synthetic_stdlib_serdes_module --features run-native-tests -- --nocapture`
- [x] `git diff --check origin/main...HEAD`
- [x] `SSL_CERT_FILE=/Users/johnteneyckjr./Library/Python/3.10/lib/python/site-packages/certifi/cacert.pem bash scripts/ci/run-fast-checks.sh`
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Semantic notes:

- Owner lane: stdlib/capability
- Semantic node types: none
- Schemas: none
- Evidence: `stage1/examples/stdlib_lsp` property fixture expected output now covers dispatch, string/numeric request IDs, and text-document extraction
- Rust capture risk: existing stage1 Rust codegen gains a borrowed JSON parse intrinsic helper; this is still bootstrap support and does not move the LSP server process loop out of Rust
- Agent-facing inspection impact: agents can inspect LSP JSON-RPC methods, request ids, supported responses, and text-document notification fields through AxiOM stdlib helpers

## Flow Contract

- Owner lane: stdlib/capability
- Repair owner: Codex
- Autonomy class: supervised
- Risk class: medium

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

## Merge Automation

- [x] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- Remaining #728 blockers are intentionally left open for a later server/driver slice: AxiOM-owned stdio I/O, full LSP client acceptance, and diagnostics routed from `axiomc check`.
- Review feedback addressed in this update: JSON-RPC/LSP string request IDs now dispatch and response IDs preserve string-or-number shape; unsafe caller-supplied LSP content-length framing was removed rather than retained with an arbitrary length.
