### PR TITLE
[codex] Record stdlib property summary evidence

### DIFF
--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -126,7 +126,8 @@ suite across the deterministic stdlib surfaces and is exercised by
 `scripts/ci/run-stdlib-property-checks.sh`; that script also runs the checked-in
 `stage1/examples/stdlib_*` AxiOM tests so CI covers stdlib behavior through
 `axiomc test`. `make stage1-test` also runs `make stage1-stdlib-test`, so local
-stage1 verification records the same property summary before proof workloads.
+stage1 verification records `properties passed: N/N` in stdout and in the
+GitHub step summary when that environment is available before proof workloads.
 The default CLI summary prints `passed` / `failed` / `skipped` counts.
 `axiomc test --list` exposes the same discovery pass without building or running
 the tests; text output emits package, test name, and entry path columns, while
@@ -386,10 +387,10 @@ Current proof points:
   support.
 - `make stage1-test`, `make stage1-conformance`, and `make stage1-smoke` now
   cover the checked-in stage1 language gate. `make stage1-test` also carries
-  the AG5 proof-workload tests for `stage1/examples/proof_cli` and
-  `stage1/examples/proof_worker`, while `make stage1-smoke` carries their
-  blocking build/run acceptance path. The small HTTP service proof remains
-  blocked on server-side HTTP support.
+  the stdlib `axiomc test --properties` gate and the AG5 proof-workload tests
+  for `stage1/examples/proof_cli`, `stage1/examples/proof_worker`, and
+  `stage1/examples/proof_http_service`, while `make stage1-smoke` carries their
+  blocking build/run acceptance path.
 - Local `cargo test --manifest-path stage1/Cargo.toml -p axiomc` keeps native
   runtime tests listed but ignored by default so sandboxed contributor hosts
   without linker tooling still get a clean compiler test signal. Use

--- a/scripts/ci/run-stdlib-property-checks.sh
+++ b/scripts/ci/run-stdlib-property-checks.sh
@@ -4,7 +4,23 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$repo_root"
 
-cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/examples/stdlib_testing --properties
+property_log="$(mktemp)"
+trap 'rm -f "$property_log"' EXIT
+
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/examples/stdlib_testing --properties 2>&1 | tee "$property_log"
+property_ratio="$(sed -nE 's/^([0-9]+\/[0-9]+) properties passed$/\1/p' "$property_log" | tail -n 1)"
+if [[ -z "$property_ratio" ]]; then
+  echo "error: missing stdlib property summary from axiomc test --properties" >&2
+  exit 1
+fi
+echo "properties passed: $property_ratio"
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  {
+    echo "### Stdlib property checks"
+    echo
+    echo "- properties passed: $property_ratio"
+  } >>"$GITHUB_STEP_SUMMARY"
+fi
 
 stdlib_projects=(
   stage1/examples/stdlib_async


### PR DESCRIPTION
## Summary

- Teach `scripts/ci/run-stdlib-property-checks.sh` to parse the property result line, echo `properties passed: N/N`, and write the same evidence to `GITHUB_STEP_SUMMARY` when available.
- Update Stage 1 docs so operators can see that `make stage1-test` runs the stdlib property gate before proof workloads and records the same property summary.
- Keep #719 scoped to the stdlib `axiomc test` evidence path now that current `main` already routes `stage1-test` through `stage1-stdlib-test`.

## Governing Issue

Closes #719.

## Validation

- [x] `bash -n scripts/ci/run-stdlib-property-checks.sh`
- [x] `make -n stage1-test`
- [x] `GITHUB_STEP_SUMMARY=/private/tmp/axiom-stdlib-test-stage1-gate-summary-rebased.md make stage1-test`
- [x] Summary file contained `- properties passed: 12/12`
- [x] `SSL_CERT_FILE=/Users/johnteneyckjr./Library/Python/3.10/lib/python/site-packages/certifi/cacert.pem bash scripts/ci/run-fast-checks.sh`

## Bootstrap Governance

- [x] Changes are scoped to the linked issue.
- [x] Contributor or PR guidance changes are not applicable.
- [ ] Auto-merge is not enabled by this author; non-author review is required first.
- [x] No real secrets, runtime auth, or machine-local env files are committed.

## Semantic Layer Checklist

- [x] Semantic node types added/changed: none.
- [x] Schemas added/changed: none.
- [x] Evidence added/changed: stdlib property evidence is now echoed as `properties passed: N/N` and mirrored into the GitHub step summary.
- [x] Rust capture check: no compiler capture semantics changed; this is a verification-target and wrapper change.
- [x] Agent-facing inspection impact: no inspection API changes.

## Flow Contract

- Owner lane: pheidon
- Repair owner: codex
- Autonomy class: agent-authored implementation
- Risk class: high, because #719 is labeled `risk:high` and changes the Stage 1 test gate

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action.
- [x] No active blocking requested changes remain.
- [ ] Non-author approval is still required.
- [ ] Auto-merge is appropriate only after required checks are green and review is satisfied.

## Merge Automation

- [ ] Auto-merge is not enabled by this author; apply the fallback merge-readiness policy after review and green checks.

## Notes

- The local Python trust store does not validate GitHub TLS for the issue-state probe, so the fast check was run with the installed certifi bundle via `SSL_CERT_FILE`.
- The untracked proof worker scratch output generated by validation was intentionally left out of this PR.
