### PR TITLE
[codex] Add doc source extraction stdlib

### DIFF
--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -1724,6 +1724,44 @@ fn axiom_regex_replace_all(pattern: String, text: String, replacement: String) -
     out
 }
 
+#[allow(dead_code)]
+fn axiom_string_line_at(text: &str, index: i64) -> Option<String> {
+    if index < 0 {
+        return None;
+    }
+    text.lines().nth(index as usize).map(|line| line.to_string())
+}
+
+#[allow(dead_code)]
+fn axiom_string_clone(text: &str) -> String {
+    text.to_string()
+}
+
+#[allow(dead_code)]
+fn axiom_string_starts_with(text: &str, prefix: &str) -> bool {
+    text.starts_with(prefix)
+}
+
+#[allow(dead_code)]
+fn axiom_string_strip_prefix(text: &str, prefix: &str) -> Option<String> {
+    text.strip_prefix(prefix).map(|rest| rest.to_string())
+}
+
+#[allow(dead_code)]
+fn axiom_string_strip_suffix(text: &str, suffix: &str) -> Option<String> {
+    text.strip_suffix(suffix).map(|rest| rest.to_string())
+}
+
+#[allow(dead_code)]
+fn axiom_string_trim(text: &str) -> String {
+    text.trim().to_string()
+}
+
+#[allow(dead_code)]
+fn axiom_string_trim_start(text: &str) -> String {
+    text.trim_start().to_string()
+}
+
 "#);
     out.push_str(
         r#"#[allow(dead_code)]
@@ -6515,6 +6553,43 @@ fn render_expr(expr: &Expr) -> String {
                 render_expr(&args[1]),
                 render_expr(&args[2])
             )
+        }
+        Expr::Call { name, args, .. } if name == "string_line_at" => {
+            format!(
+                "axiom_string_line_at({}, {})",
+                render_expr(&args[0]),
+                render_expr(&args[1])
+            )
+        }
+        Expr::Call { name, args, .. } if name == "string_clone" => {
+            format!("axiom_string_clone({})", render_expr(&args[0]))
+        }
+        Expr::Call { name, args, .. } if name == "string_starts_with" => {
+            format!(
+                "axiom_string_starts_with({}, {})",
+                render_expr(&args[0]),
+                render_expr(&args[1])
+            )
+        }
+        Expr::Call { name, args, .. } if name == "string_strip_prefix" => {
+            format!(
+                "axiom_string_strip_prefix({}, {})",
+                render_expr(&args[0]),
+                render_expr(&args[1])
+            )
+        }
+        Expr::Call { name, args, .. } if name == "string_strip_suffix" => {
+            format!(
+                "axiom_string_strip_suffix({}, {})",
+                render_expr(&args[0]),
+                render_expr(&args[1])
+            )
+        }
+        Expr::Call { name, args, .. } if name == "string_trim" => {
+            format!("axiom_string_trim({})", render_expr(&args[0]))
+        }
+        Expr::Call { name, args, .. } if name == "string_trim_start" => {
+            format!("axiom_string_trim_start({})", render_expr(&args[0]))
         }
         Expr::Call { name, args, .. } if name == "encoding_url_component_encode" => {
             format!("axiom_percent_encode({})", render_expr(&args[0]))

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -9965,6 +9965,85 @@ fn lower_expr_with_expected_inner(
             }
             if matches!(
                 name.as_str(),
+                "string_line_at"
+                    | "string_clone"
+                    | "string_starts_with"
+                    | "string_strip_prefix"
+                    | "string_strip_suffix"
+                    | "string_trim"
+                    | "string_trim_start"
+            ) {
+                let expected_len = if name == "string_clone"
+                    || name == "string_trim"
+                    || name == "string_trim_start"
+                {
+                    1
+                } else {
+                    2
+                };
+                if args.len() != expected_len {
+                    return Err(Diagnostic::new(
+                        "type",
+                        format!(
+                            "{name} expects {expected_len} arguments, got {}",
+                            args.len()
+                        ),
+                    )
+                    .with_span(*line, *column));
+                }
+                let mut lowered_args = Vec::new();
+                let string_arg_count = if name == "string_line_at" {
+                    1
+                } else {
+                    args.len()
+                };
+                for (idx, arg) in args.iter().take(string_arg_count).enumerate() {
+                    let lowered = lower_expr_with_expected(arg, Some(&Type::Str), env, ctx)?;
+                    if lowered.ty() != &Type::Str {
+                        return Err(Diagnostic::new(
+                            "type",
+                            format!(
+                                "{name} expects argument {} type &str, got {}",
+                                idx + 1,
+                                lowered.ty()
+                            ),
+                        )
+                        .with_span(arg.line(), arg.column()));
+                    }
+                    lowered_args.push(lowered);
+                }
+                if name == "string_line_at" {
+                    let lowered = lower_expr_with_expected(&args[1], Some(&Type::Int), env, ctx)?;
+                    if lowered.ty() != &Type::Int {
+                        return Err(Diagnostic::new(
+                            "type",
+                            format!(
+                                "string_line_at expects argument 2 type int, got {}",
+                                lowered.ty()
+                            ),
+                        )
+                        .with_span(args[1].line(), args[1].column()));
+                    }
+                    lowered_args.push(lowered);
+                }
+                let ty = match name.as_str() {
+                    "string_line_at" => Type::Option(Box::new(Type::String)),
+                    "string_clone" => Type::String,
+                    "string_starts_with" => Type::Bool,
+                    "string_strip_prefix" => Type::Option(Box::new(Type::String)),
+                    "string_strip_suffix" => Type::Option(Box::new(Type::String)),
+                    "string_trim" | "string_trim_start" => Type::String,
+                    _ => unreachable!("string intrinsic checked above"),
+                };
+                return Ok(Expr::Call {
+                    span: SourceSpan::point(*line, *column),
+                    name: name.clone(),
+                    args: lowered_args,
+                    ty,
+                });
+            }
+            if matches!(
+                name.as_str(),
                 "encoding_url_component_encode"
                     | "encoding_url_component_decode"
                     | "encoding_path_segment_encode"

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -8910,11 +8910,18 @@ print false
         assert_eq!(virtual_source, include_str!("../../../stdlib/std/doc.ax"));
         assert!(virtual_source.contains("pub type DocItem"));
         assert!(virtual_source.contains("pub fn render_markdown(items: [DocItem]): string"));
+        assert!(
+            virtual_source
+                .contains("pub fn render_source_markdown(file: &str, source: &str): string")
+        );
+        assert!(
+            virtual_source.contains("pub fn render_source_html(file: &str, source: &str): string")
+        );
         assert!(virtual_source.contains("pub fn doc_signature(item: DocItem): &str"));
     }
 
     #[test]
-    fn checked_in_stdlib_doc_example_renders_markdown() {
+    fn checked_in_stdlib_doc_example_renders_docs() {
         let project = checked_in_example_fixture("stdlib_doc");
         let output = run_project_tests(&project).expect("run stdlib doc example");
 

--- a/stage1/crates/axiomc/src/stdlib.rs
+++ b/stage1/crates/axiomc/src/stdlib.rs
@@ -88,8 +88,8 @@
 //!   `find`, `replace_all`) over a stage1-safe NFA engine.
 //! * `std/testing.ax` — table-case, property, and snapshot assertion helpers
 //!   layered over the bootstrap test intrinsics.
-//! * `std/doc.ax` — the AxiOM-side doc item contract and Markdown renderer
-//!   used to retire bootstrap Rust rendering in Phase-K.
+//! * `std/doc.ax` — the AxiOM-side doc item contract, source extractor, and
+//!   Markdown/HTML renderers used to retire bootstrap Rust rendering in Phase-K.
 //! * `std/lsp.ax` — the AxiOM-side JSON-RPC/LSP protocol message contract used
 //!   to retire bootstrap Rust protocol handling in Phase-L.
 //! * `std/outcome.ax` — generic `Option<T>` / `Result<T, E>` predicates and

--- a/stage1/examples/stdlib_doc/axiom.toml
+++ b/stage1/examples/stdlib_doc/axiom.toml
@@ -17,4 +17,4 @@ crypto = false
 [[tests]]
 name = "stdlib-doc-renderer"
 entry = "src/main_test.ax"
-stdout = "# Axiom API\n\n## `pub fn hello(): int`\n\nSource: `src/main.ax`\n\nSays hello from the fixture.\nReturns a stable integer.\n\n## `pub struct Greeting`\n\nSource: `src/model.ax`\n\nCarries the greeting text.\n"
+stdout = "src/main_test.stdout"

--- a/stage1/examples/stdlib_doc/src/main.ax
+++ b/stage1/examples/stdlib_doc/src/main.ax
@@ -3,3 +3,5 @@ import "std/doc.ax"
 let first: DocItem = ("src/main.ax", "function", true, "pub fn hello(): int", "Says hello from the fixture.\nReturns a stable integer.", "")
 let second: DocItem = ("src/model.ax", "struct", true, "pub struct Greeting", "Carries the greeting text.", "")
 print render_markdown([first, second])
+let source: string = "/// Says hello from source.\n/// Returns a stable integer.\npub fn hello(): int {\nreturn 1\n}\n\n/// Runs async work.\nasync fn compute(): int {\nreturn 2\n}\n\n  /// Carries the greeting text.\n  pub struct Greeting {\ntext: string\n}\n"
+print render_source_markdown("src/main.ax", source)

--- a/stage1/examples/stdlib_doc/src/main_test.ax
+++ b/stage1/examples/stdlib_doc/src/main_test.ax
@@ -2,4 +2,10 @@ import "std/doc.ax"
 
 let first: DocItem = ("src/main.ax", "function", true, "pub fn hello(): int", "Says hello from the fixture.\nReturns a stable integer.", "")
 let second: DocItem = ("src/model.ax", "struct", true, "pub struct Greeting", "Carries the greeting text.", "")
+let escaped_kind: DocItem = ("src/quoted.ax", "function\" data-risk=\"x", true, "pub fn quoted(): int", "Exercises attribute quotes.", "")
 print render_markdown([first, second])
+print render_html([first, second, escaped_kind])
+
+let source: string = "/// Says hello from source.\n/// Returns a stable integer.\npub fn hello(): int {\nreturn 1\n}\n\nfn hidden(): int {\nreturn 0\n}\n\n/// Runs async work.\nasync fn compute(): int {\nreturn 2\n}\n\n  /// Carries the greeting text.\n  pub struct Greeting {\ntext: string\n}\n"
+print render_source_markdown("src/main.ax", source)
+print render_source_html("src/main.ax", source)

--- a/stage1/examples/stdlib_doc/src/main_test.stdout
+++ b/stage1/examples/stdlib_doc/src/main_test.stdout
@@ -12,3 +12,63 @@ Returns a stable integer.
 Source: `src/model.ax`
 
 Carries the greeting text.
+<section class="axiom-docs">
+<h1>Axiom API</h1>
+<article data-kind="function">
+<h2><code>pub fn hello(): int</code></h2>
+<p>Source: <code>src/main.ax</code></p>
+<pre>Says hello from the fixture.
+Returns a stable integer.</pre>
+</article>
+<article data-kind="struct">
+<h2><code>pub struct Greeting</code></h2>
+<p>Source: <code>src/model.ax</code></p>
+<pre>Carries the greeting text.</pre>
+</article>
+<article data-kind="function&quot; data-risk=&quot;x">
+<h2><code>pub fn quoted(): int</code></h2>
+<p>Source: <code>src/quoted.ax</code></p>
+<pre>Exercises attribute quotes.</pre>
+</article>
+</section>
+# Axiom API
+
+## `pub fn hello(): int`
+
+Source: `src/main.ax`
+
+Says hello from source.
+Returns a stable integer.
+
+## `async fn compute(): int`
+
+Source: `src/main.ax`
+
+Runs async work.
+
+## `pub struct Greeting`
+
+Source: `src/main.ax`
+
+Carries the greeting text.
+<section class="axiom-docs">
+<h1>Axiom API</h1>
+<article data-kind="function">
+<h2><code>pub fn hello(): int</code></h2>
+<p>Source: <code>src/main.ax</code></p>
+<pre>Says hello from source.
+Returns a stable integer.</pre>
+</article>
+
+<article data-kind="function">
+<h2><code>async fn compute(): int</code></h2>
+<p>Source: <code>src/main.ax</code></p>
+<pre>Runs async work.</pre>
+</article>
+
+<article data-kind="struct">
+<h2><code>pub struct Greeting</code></h2>
+<p>Source: <code>src/main.ax</code></p>
+<pre>Carries the greeting text.</pre>
+</article>
+</section>

--- a/stage1/stdlib/std/doc.ax
+++ b/stage1/stdlib/std/doc.ax
@@ -36,6 +36,34 @@ return output + "No public or documented declarations found."
 return render_items(output, items, 0)
 }
 
+pub fn render_html(items: [DocItem]): string {
+return render_html_view(items[:])
+}
+
+pub fn render_html_view(items: &[DocItem]): string {
+let output: string = "<section class=\"axiom-docs\">\n<h1>Axiom API</h1>\n"
+if len(items) == 0 {
+return output + "<p>No public or documented declarations found.</p>\n</section>"
+}
+return render_html_items(output, items, 0) + "\n</section>"
+}
+
+pub fn render_source_markdown(file: &str, source: &str): string {
+let output: string = render_source_markdown_lines("", file, source, 0, "")
+if output == "" {
+return "# Axiom API\n\nNo public or documented declarations found."
+}
+return "# Axiom API\n\n" + output
+}
+
+pub fn render_source_html(file: &str, source: &str): string {
+let output: string = render_source_html_lines("", file, source, 0, "")
+if output == "" {
+return "<section class=\"axiom-docs\">\n<h1>Axiom API</h1>\n<p>No public or documented declarations found.</p>\n</section>"
+}
+return "<section class=\"axiom-docs\">\n<h1>Axiom API</h1>\n" + output + "\n</section>"
+}
+
 fn render_items(output: string, items: &[DocItem], index: int): string {
 if index >= len(items) {
 return output
@@ -50,4 +78,257 @@ return render_items(rendered + "\n\n", items, index + 1)
 
 fn render_item(output: string, item: DocItem): string {
 return output + "## `" + doc_signature(item) + "`\n\nSource: `" + doc_file(item) + "`\n\n" + doc_text(item)
+}
+
+fn render_html_items(output: string, items: &[DocItem], index: int): string {
+if index >= len(items) {
+return output
+}
+let item: DocItem = items[index]
+let rendered: string = render_html_item(output, item)
+if index + 1 >= len(items) {
+return rendered
+}
+return render_html_items(rendered + "\n", items, index + 1)
+}
+
+fn render_html_item(output: string, item: DocItem): string {
+return output + "<article data-kind=\"" + escape_html_attr(doc_kind(item)) + "\">\n<h2><code>" + escape_html(doc_signature(item)) + "</code></h2>\n<p>Source: <code>" + escape_html(doc_file(item)) + "</code></p>\n<pre>" + escape_html(doc_text(item)) + "</pre>\n</article>"
+}
+
+fn render_source_markdown_lines(output: string, file: &str, source: &str, index: int, pending: string): string {
+match string_line_at(source, index) {
+Some(line) {
+if is_doc_comment(line) {
+return render_source_markdown_after_doc(output, file, source, index + 1, append_doc_line(pending, doc_comment_text(line)))
+}
+return render_source_markdown_lines(output, file, source, index + 1, "")
+}
+None {
+return output
+}
+}
+}
+
+fn render_source_markdown_after_doc(output: string, file: &str, source: &str, index: int, pending: string): string {
+match string_line_at(source, index) {
+Some(line) {
+if is_doc_comment(line) {
+return render_source_markdown_after_doc(output, file, source, index + 1, append_doc_line(pending, doc_comment_text(line)))
+}
+if is_blank(line) {
+return render_source_markdown_after_doc(output, file, source, index + 1, pending)
+}
+if is_documented_declaration(line) {
+let item: string = markdown_source_item(file, line, pending)
+let joined: string = append_rendered(output, item)
+return render_source_markdown_lines(joined, file, source, index + 1, "")
+}
+return render_source_markdown_lines(output, file, source, index + 1, "")
+}
+None {
+return output
+}
+}
+}
+
+fn render_source_html_lines(output: string, file: &str, source: &str, index: int, pending: string): string {
+match string_line_at(source, index) {
+Some(line) {
+if is_doc_comment(line) {
+return render_source_html_after_doc(output, file, source, index + 1, append_doc_line(pending, doc_comment_text(line)))
+}
+return render_source_html_lines(output, file, source, index + 1, "")
+}
+None {
+return output
+}
+}
+}
+
+fn render_source_html_after_doc(output: string, file: &str, source: &str, index: int, pending: string): string {
+match string_line_at(source, index) {
+Some(line) {
+if is_doc_comment(line) {
+return render_source_html_after_doc(output, file, source, index + 1, append_doc_line(pending, doc_comment_text(line)))
+}
+if is_blank(line) {
+return render_source_html_after_doc(output, file, source, index + 1, pending)
+}
+if is_documented_declaration(line) {
+let item: string = html_source_item(file, line, pending)
+let joined: string = append_rendered(output, item)
+return render_source_html_lines(joined, file, source, index + 1, "")
+}
+return render_source_html_lines(output, file, source, index + 1, "")
+}
+None {
+return output
+}
+}
+}
+
+fn append_rendered(output: string, item: string): string {
+if output == "" {
+return item
+}
+return output + "\n\n" + item
+}
+
+fn markdown_source_item(file: &str, line: &str, text: string): string {
+let signature: string = normalized_signature(line)
+return "## `" + signature + "`\n\nSource: `" + file + "`\n\n" + text
+}
+
+fn html_source_item(file: &str, line: &str, text: string): string {
+let signature: string = normalized_signature(line)
+return "<article data-kind=\"" + escape_html_attr(doc_kind_from_signature(line)) + "\">\n<h2><code>" + escape_html(signature) + "</code></h2>\n<p>Source: <code>" + escape_html(file) + "</code></p>\n<pre>" + escape_html(text) + "</pre>\n</article>"
+}
+
+fn normalized_signature(line: &str): string {
+let trimmed: string = string_trim(line)
+match string_strip_suffix(trimmed, " {") {
+Some(signature) {
+return signature
+}
+None {
+match string_strip_suffix(trimmed, "{") {
+Some(signature) {
+return string_trim(signature)
+}
+None {
+return trimmed
+}
+}
+}
+}
+}
+
+fn append_doc_line(existing: string, line: string): string {
+if existing == "" {
+return line
+}
+return existing + "\n" + line
+}
+
+fn is_doc_comment(line: &str): bool {
+let trimmed: string = string_trim_start(line)
+return string_starts_with(trimmed, "///")
+}
+
+fn doc_comment_text(line: &str): string {
+let trimmed: string = string_trim_start(line)
+match string_strip_prefix(trimmed, "///") {
+Some(text) {
+return trim_doc_prefix(text)
+}
+None {
+return ""
+}
+}
+}
+
+fn trim_doc_prefix(text: &str): string {
+match string_strip_prefix(text, " ") {
+Some(rest) {
+return rest
+}
+None {
+return string_trim_start(text)
+}
+}
+}
+
+fn is_blank(line: &str): bool {
+return string_trim(line) == ""
+}
+
+fn is_documented_declaration(line: &str): bool {
+let trimmed: string = string_trim_start(line)
+if is_function_declaration(trimmed) {
+return true
+}
+if is_struct_declaration(trimmed) {
+return true
+}
+if is_enum_declaration(trimmed) {
+return true
+}
+if is_type_declaration(trimmed) {
+return true
+}
+return is_trait_declaration(trimmed)
+}
+
+fn doc_kind_from_signature(line: &str): string {
+let trimmed: string = string_trim_start(line)
+if is_function_declaration(trimmed) {
+return "function"
+}
+if is_struct_declaration(trimmed) {
+return "struct"
+}
+if is_enum_declaration(trimmed) {
+return "enum"
+}
+if is_type_declaration(trimmed) {
+return "type"
+}
+if is_trait_declaration(trimmed) {
+return "trait"
+}
+return "declaration"
+}
+
+fn is_function_declaration(trimmed: &str): bool {
+if string_starts_with(trimmed, "pub async fn ") {
+return true
+}
+if string_starts_with(trimmed, "async fn ") {
+return true
+}
+if string_starts_with(trimmed, "pub fn ") {
+return true
+}
+return string_starts_with(trimmed, "fn ")
+}
+
+fn is_struct_declaration(trimmed: &str): bool {
+if string_starts_with(trimmed, "pub struct ") {
+return true
+}
+return string_starts_with(trimmed, "struct ")
+}
+
+fn is_enum_declaration(trimmed: &str): bool {
+if string_starts_with(trimmed, "pub enum ") {
+return true
+}
+return string_starts_with(trimmed, "enum ")
+}
+
+fn is_type_declaration(trimmed: &str): bool {
+if string_starts_with(trimmed, "pub type ") {
+return true
+}
+return string_starts_with(trimmed, "type ")
+}
+
+fn is_trait_declaration(trimmed: &str): bool {
+if string_starts_with(trimmed, "pub trait ") {
+return true
+}
+return string_starts_with(trimmed, "trait ")
+}
+
+fn escape_html(text: &str): string {
+let raw: string = string_clone(text)
+let amp: string = regex_replace_all("&", raw, "&amp;")
+let lt: string = regex_replace_all("<", amp, "&lt;")
+return regex_replace_all(">", lt, "&gt;")
+}
+
+fn escape_html_attr(text: &str): string {
+let escaped: string = escape_html(text)
+return regex_replace_all("\"", escaped, "&quot;")
 }


### PR DESCRIPTION
## Summary

- Adds borrowed string scan helpers used by AxiOM stdlib doc extraction.
- Extends `std/doc.ax` with Markdown and HTML renderers that extract adjacent `///` comments from `.ax` source text and attach them to declarations.
- Expands the checked-in `stdlib_doc` fixture to cover item rendering, source extraction, HTML output, and indented doc comments.

## Governing Issue

Refs #563.

This is not a full completion of issue 563 yet. The remaining Phase-K gate still requires the `axiomc doc --json` and `axiomc doc --md` command paths to be AxiOM-owned, and K.2/K.3 remain review-gated follow-up slices.

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Commands run:

- `cargo fmt --manifest-path stage1/Cargo.toml --all` - passed
- `git diff --check` - passed
- `cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/examples/stdlib_doc --json` - passed, 1 unit test
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc std_doc --features run-native-tests -- --nocapture` - passed, 1 matching test
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc checked_in_stdlib_doc_example_renders_docs --features run-native-tests -- --nocapture` - passed, 1 matching test
- `SSL_CERT_FILE=/Users/johnteneyckjr./Library/Python/3.10/lib/python/site-packages/certifi/cacert.pem bash scripts/ci/run-fast-checks.sh` - passed

No checks were intentionally skipped.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Owner lane: artifact generation, stdlib/capability.

Semantic node types: none.

Schemas: none.

Evidence: `stage1/examples/stdlib_doc` now covers existing DocItem rendering plus source Markdown/HTML extraction from adjacent `///` comments.

Rust capture risk: this adds bootstrap string intrinsics in Rust so the AxiOM scanner can walk source text. Doc extraction and rendering behavior lives in `std/doc.ax`; `axiomc doc` is still not fully AxiOM-owned.

Agent-facing inspection impact: agents can inspect and exercise doc source extraction/rendering through the checked-in AxiOM stdlib fixture.

## Flow Contract

- Owner lane: artifact generation
- Repair owner: Codex
- Autonomy class: supervised
- Risk class: medium

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

## Merge Automation

- [x] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

Auto-merge will be enabled after PR creation. Non-author approval is still required by repo policy.

## Notes

- Generated `stage1/examples/proof_worker/scratch/` output from local fast checks was left unstaged.
