### PR TITLE
[codex] Add LSP stdio integration harness

### DIFF
--- a/stage1/crates/axiom-lsp/src/lib.rs
+++ b/stage1/crates/axiom-lsp/src/lib.rs
@@ -1,5 +1,5 @@
 use serde_json::{Value, json};
-use std::io::{BufRead, Read, Write};
+use std::io::{BufRead, Write};
 
 pub const TEXT_DOCUMENT_SYNC_KIND_FULL: u8 = 1;
 

--- a/stage1/crates/axiomc/tests/lsp_stdio.rs
+++ b/stage1/crates/axiomc/tests/lsp_stdio.rs
@@ -1,0 +1,175 @@
+use serde_json::{Value, json};
+use std::io::{self, BufRead, BufReader, Read, Write};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::sync::mpsc::{self, Receiver};
+use std::time::{Duration, Instant};
+
+#[test]
+fn lsp_stdio_publishes_diagnostics_and_exits_cleanly() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .arg("lsp")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn axiomc lsp");
+
+    let mut stdin = child.stdin.take().expect("lsp stdin");
+    let stdout = child.stdout.take().expect("lsp stdout");
+    let messages = spawn_lsp_reader(stdout);
+
+    write_lsp_message(
+        &mut stdin,
+        json!({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}),
+    )
+    .expect("write initialize");
+    let initialize = recv_lsp_message(&messages, "initialize response");
+    assert_eq!(initialize["id"], json!(1));
+    assert_eq!(
+        initialize["result"]["capabilities"]["textDocumentSync"]["change"],
+        json!(1)
+    );
+
+    write_lsp_message(
+        &mut stdin,
+        json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+                "textDocument": {
+                    "uri": "file:///tmp/axiom-lsp-bad.ax",
+                    "languageId": "axiom",
+                    "version": 1,
+                    "text": "}\n"
+                }
+            }
+        }),
+    )
+    .expect("write didOpen");
+    let diagnostics = recv_lsp_message(&messages, "publishDiagnostics");
+    assert_eq!(
+        diagnostics["method"],
+        json!("textDocument/publishDiagnostics")
+    );
+    assert_eq!(
+        diagnostics["params"]["uri"],
+        json!("file:///tmp/axiom-lsp-bad.ax")
+    );
+    let diagnostic_items = diagnostics["params"]["diagnostics"]
+        .as_array()
+        .expect("diagnostics array");
+    assert_eq!(diagnostic_items.len(), 1);
+    assert_eq!(diagnostic_items[0]["code"], json!("parse"));
+    assert!(
+        diagnostic_items[0]["message"]
+            .as_str()
+            .expect("diagnostic message")
+            .contains("unexpected closing brace")
+    );
+
+    write_lsp_message(
+        &mut stdin,
+        json!({"jsonrpc": "2.0", "id": 2, "method": "shutdown", "params": null}),
+    )
+    .expect("write shutdown");
+    let shutdown = recv_lsp_message(&messages, "shutdown response");
+    assert_eq!(shutdown["id"], json!(2));
+    assert!(shutdown["result"].is_null());
+
+    write_lsp_message(
+        &mut stdin,
+        json!({"jsonrpc": "2.0", "method": "exit", "params": null}),
+    )
+    .expect("write exit");
+    drop(stdin);
+
+    let status = wait_for_child(&mut child, Duration::from_secs(2)).expect("wait for lsp exit");
+    assert!(status.success(), "lsp exited with status {status}");
+}
+
+fn spawn_lsp_reader(stdout: ChildStdout) -> Receiver<Result<Value, String>> {
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let mut reader = BufReader::new(stdout);
+        loop {
+            match read_lsp_message(&mut reader) {
+                Ok(Some(message)) => {
+                    if tx.send(Ok(message)).is_err() {
+                        break;
+                    }
+                }
+                Ok(None) => break,
+                Err(error) => {
+                    let _ = tx.send(Err(error.to_string()));
+                    break;
+                }
+            }
+        }
+    });
+    rx
+}
+
+fn recv_lsp_message(rx: &Receiver<Result<Value, String>>, label: &str) -> Value {
+    rx.recv_timeout(Duration::from_secs(2))
+        .unwrap_or_else(|_| panic!("timed out waiting for {label}"))
+        .unwrap_or_else(|error| panic!("failed to read {label}: {error}"))
+}
+
+fn write_lsp_message(stdin: &mut ChildStdin, payload: Value) -> io::Result<()> {
+    let body = serde_json::to_string(&payload)?;
+    write!(stdin, "Content-Length: {}\r\n\r\n{}", body.len(), body)?;
+    stdin.flush()
+}
+
+fn read_lsp_message<R>(reader: &mut R) -> io::Result<Option<Value>>
+where
+    R: BufRead + Read,
+{
+    let mut content_length = None;
+    loop {
+        let mut line = String::new();
+        let bytes = reader.read_line(&mut line)?;
+        if bytes == 0 {
+            return Ok(None);
+        }
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if trimmed.is_empty() {
+            break;
+        }
+        if let Some((name, value)) = trimmed.split_once(':') {
+            if name.trim().eq_ignore_ascii_case("Content-Length") {
+                content_length = Some(value.trim().parse::<usize>().map_err(|error| {
+                    io::Error::new(io::ErrorKind::InvalidData, error.to_string())
+                })?);
+            }
+        }
+    }
+
+    let length = content_length
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing Content-Length"))?;
+    let mut body = vec![0; length];
+    reader.read_exact(&mut body)?;
+    serde_json::from_slice(&body).map(Some).map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid JSON-RPC body: {error}"),
+        )
+    })
+}
+
+fn wait_for_child(child: &mut Child, timeout: Duration) -> io::Result<std::process::ExitStatus> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(status) = child.try_wait()? {
+            return Ok(status);
+        }
+        if Instant::now() >= deadline {
+            child.kill()?;
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                format!("child did not exit within {timeout:?}"),
+            ));
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}


### PR DESCRIPTION
## Summary

- Add an in-tree `axiomc lsp` stdio integration harness that speaks real Content-Length framed JSON-RPC to the compiled CLI.
- Verify initialize capability negotiation, `textDocument/didOpen` diagnostics for a deliberate parse error, and clean shutdown plus exit behavior within a deterministic timeout.
- Remove the stale `Read` import from the LSP crate.

## Governing Issue

Refs #731.
Refs #564.

## Validation

- [x] Relevant local checks passed
  - `cargo fmt --manifest-path stage1/Cargo.toml --all`
  - `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test lsp_stdio -- --nocapture`
  - `git diff --check origin/main...HEAD`
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

No local checks were intentionally skipped. This PR is not a full Phase-L.3 completion because the production `axiomc lsp` implementation is still Rust-backed until the native backend can compile the full LSP stdlib surface.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
  - Adds deterministic LSP stdio integration evidence for diagnostics and clean exit behavior.
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
  - This is a transitional Rust test harness around the current Rust-backed LSP driver, not a new semantic primitive.
- [x] Agent-facing inspection impact is described, or there is no inspection impact
  - Agent-facing impact is a repeatable `axiomc lsp` acceptance harness for later Phase-L.3 cutover work.

## Flow Contract

- Owner lane: daedalus
- Repair owner: codex
- Autonomy class: bounded implementation
- Risk class: low for this harness slice; governing issue remains high risk

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

## Merge Automation

- [x] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

Auto-merge should be enabled after PR creation if GitHub allows it.

## Notes

- This PR advances the issue 731 acceptance harness. It is not a completion of issue 731 or issue 564.
