### PR TITLE
[codex] Extend Cranelift len helper slice

### DIFF
--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -316,8 +316,9 @@ still far from the stated 1.0 target for service and agent workloads.
 - The backend-selection surface remains preparatory backend plumbing for later
   native-backend expansion. `generated-rust` is still the default and only broad
   backend; `cranelift` is intentionally limited to scalar print-line programs,
-  tuple/array indexing, function calls, and scalar branching, so this is not
-  closure for #105 or the later full-surface native backend slices.
+  tuple/array indexing, function calls, `len(...)` over in-memory strings,
+  tuples, and arrays, and scalar branching, so this is not closure for #105 or
+  the later full-surface native backend slices.
 - Generated-Rust builds now use a persistent per-artifact cache keyed by
   compiler version, target, debug mode, manifest/lockfile hash, rendered Rust,
   module source hashes, and dependency imports. Cache hits skip `rustc`, cache

--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -316,8 +316,8 @@ still far from the stated 1.0 target for service and agent workloads.
 - The backend-selection surface remains preparatory backend plumbing for later
   native-backend expansion. `generated-rust` is still the default and only broad
   backend; `cranelift` is intentionally limited to scalar print-line programs,
-  tuple/array indexing, function calls, `len(...)` over in-memory strings,
-  tuples, and arrays, and scalar branching, so this is not closure for #105 or
+  tuple/array indexing, function calls, `len(...)` over in-memory strings and
+  arrays, and scalar branching, so this is not closure for #105 or
   the later full-surface native backend slices.
 - Generated-Rust builds now use a persistent per-artifact cache keyed by
   compiler version, target, debug mode, manifest/lockfile hash, rendered Rust,

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -194,6 +194,9 @@ fn eval_call(
     functions: &HashMap<&str, &Function>,
     env: &SpikeEnv,
 ) -> Result<SpikeValue, Diagnostic> {
+    if name == "len" {
+        return eval_len_call(args, functions, env);
+    }
     let function = functions
         .get(name)
         .ok_or_else(|| unsupported(&format!("unsupported cranelift spike call {name:?}")))?;
@@ -212,6 +215,23 @@ fn eval_call(
         ));
     }
     returned.ok_or_else(|| unsupported("cranelift spike functions must return a value"))
+}
+
+fn eval_len_call(
+    args: &[Expr],
+    functions: &HashMap<&str, &Function>,
+    env: &SpikeEnv,
+) -> Result<SpikeValue, Diagnostic> {
+    let [arg] = args else {
+        return Err(unsupported("len expects exactly one argument"));
+    };
+    let value = eval_expr(arg, functions, env)?;
+    let len = match value {
+        SpikeValue::Text(value) => value.chars().count(),
+        SpikeValue::Tuple(values) | SpikeValue::Array(values) => values.len(),
+        _ => return Err(unsupported("len supports strings, tuples, and arrays")),
+    };
+    Ok(SpikeValue::Int(len as i64))
 }
 
 fn eval_arithmetic(

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -227,7 +227,7 @@ fn eval_len_call(
     };
     let value = eval_expr(arg, functions, env)?;
     let len = match value {
-        SpikeValue::Text(value) => value.chars().count(),
+        SpikeValue::Text(value) => value.len(),
         SpikeValue::Tuple(values) | SpikeValue::Array(values) => values.len(),
         _ => return Err(unsupported("len supports strings, tuples, and arrays")),
     };

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -107,6 +107,56 @@ fn cranelift_backend_builds_scalar_aggregate_binary() {
 
 #[cfg(not(windows))]
 #[test]
+fn cranelift_backend_builds_non_ascii_string_len_binary() {
+    if which::which("cc").is_err() {
+        eprintln!("skipping cranelift backend smoke test because cc is unavailable");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("non-ascii-len");
+    fs::create_dir_all(project.join("src")).expect("create project src");
+    copy_fixture("axiom.toml", &project.join("axiom.toml"));
+    copy_fixture("axiom.lock", &project.join("axiom.lock"));
+    fs::write(
+        project.join("src/main.ax"),
+        "let value: string = \"é\"\nprint len(value)\n",
+    )
+    .expect("write non-ascii source");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+    assert!(
+        output.status.success(),
+        "cranelift non-ascii build failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
+    assert_eq!(payload["backend"], "cranelift");
+    let binary = payload["binary"].as_str().expect("binary path");
+    let run = Command::new(binary)
+        .output()
+        .expect("run cranelift non-ascii binary");
+    assert!(
+        run.status.success(),
+        "cranelift non-ascii binary failed: stderr={}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&run.stdout), "2\n");
+}
+
+#[cfg(not(windows))]
+#[test]
 fn cranelift_backend_builds_const_sized_array_conformance_binary() {
     if which::which("cc").is_err() {
         eprintln!("skipping cranelift backend smoke test because cc is unavailable");

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -105,6 +105,49 @@ fn cranelift_backend_builds_scalar_aggregate_binary() {
     assert_eq!(String::from_utf8_lossy(&run.stdout), "native\n7\n12\n10\n");
 }
 
+#[cfg(not(windows))]
+#[test]
+fn cranelift_backend_builds_const_sized_array_conformance_binary() {
+    if which::which("cc").is_err() {
+        eprintln!("skipping cranelift backend smoke test because cc is unavailable");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("const-sized-array");
+    copy_conformance_fixture("const_sized_arrays", &project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+    assert!(
+        output.status.success(),
+        "cranelift const-sized-array build failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
+    assert_eq!(payload["backend"], "cranelift");
+    let binary = payload["binary"].as_str().expect("binary path");
+    let run = Command::new(binary)
+        .output()
+        .expect("run cranelift const-sized-array binary");
+    assert!(
+        run.status.success(),
+        "cranelift const-sized-array binary failed: stderr={}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&run.stdout), "3\n6\n");
+}
+
 fn copy_fixture(relative: &str, destination: &Path) {
     let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../../examples/hello")
@@ -116,6 +159,24 @@ fn copy_fixture(relative: &str, destination: &Path) {
             destination.display()
         )
     });
+}
+
+fn copy_conformance_fixture(fixture_name: &str, destination: &Path) {
+    let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../conformance/pass")
+        .join(fixture_name);
+    fs::create_dir_all(destination.join("src")).expect("create conformance project src");
+    for relative in ["axiom.toml", "axiom.lock", "src/main_test.ax"] {
+        let source = fixture.join(relative);
+        let target = destination.join(relative);
+        fs::copy(&source, &target).unwrap_or_else(|err| {
+            panic!(
+                "copy fixture {} to {}: {err}",
+                source.display(),
+                target.display()
+            )
+        });
+    }
 }
 
 fn write_scalar_project(project: &Path) {


### PR DESCRIPTION
## Summary

- Add Cranelift spike evaluation for `len(...)` over in-memory strings, tuples, and arrays.
- Add a Cranelift backend regression that builds and runs the const-sized-array conformance fixture.
- Update the stage1 backend gap notes to include the new limited `len(...)` support while keeping full native backend closure out of scope.

## Governing Issue

Part of #692.
Part of #105.

## Validation

- [x] `cargo fmt --manifest-path stage1/Cargo.toml --all`
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend -- --nocapture`
- [x] `cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build stage1/conformance/pass/const_sized_arrays --backend cranelift --json`
- [x] `./stage1/conformance/pass/const_sized_arrays/dist/conformance-const-sized-arrays`
- [x] `git diff --check`
- [x] `AXIOM_PYTHON_EXIT_ISSUE_STATES_JSON='{"266":"closed","267":"closed","268":"closed","269":"closed","270":"closed","271":"closed"}' bash scripts/ci/run-fast-checks.sh`
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below: no checks were intentionally skipped. The first sandboxed fast-check attempt hit local Python CA validation, and the sandboxed proof HTTP run hit `Operation not permitted`; the same fast gate passed elevated with live issue states from `gh`.

## Bootstrap Governance

- [x] Changes are scoped to the linked issues.
- [x] Contributor or PR guidance changes are not applicable.
- [x] Auto-merge will be enabled after PR creation, or GitHub plan-limit evidence will be recorded if unavailable.
- [x] No real secrets, runtime auth, or machine-local env files are committed.

## Semantic Layer Checklist

- [x] Semantic node types added/changed: none. This extends backend handling for the existing `len(...)` call path.
- [x] Schemas added/changed: none.
- [x] Evidence added/changed: Cranelift backend regression coverage now builds and runs the const-sized-array conformance fixture.
- [x] Rust capture check: satisfied as backend-specific behavior; it does not redefine the Axiom semantic contract.
- [x] Agent-facing inspection impact: Cranelift build/test evidence now covers `len(...)` for aggregate-backed values; no schema or inspection contract changes.

## Flow Contract

- Owner lane: compiler/runtime
- Repair owner: codex
- Autonomy class: issue-linked feature slice
- Risk class: low, backend spike evaluator scope with regression coverage

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action.
- [x] No active blocking requested changes remain.
- [ ] Non-author approval is present when required.
- [x] Auto-merge is appropriate when gates pass.

## Merge Automation

- [x] Auto-merge will be enabled after PR creation, or the reason it is unavailable or unsafe will be noted below.

## Notes

- This is a narrow native backend parity slice. It does not close #692 or #105 by itself.
