### PR TITLE
[codex] Extend Cranelift numeric scalar support

### DIFF
--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -219,9 +219,18 @@ fn eval_numeric_literal(raw: &str, ty: NumericType) -> Result<SpikeValue, Diagno
 
 fn cast_spike_value(value: SpikeValue, ty: &Type) -> Result<SpikeValue, Diagnostic> {
     match ty {
-        Type::Int => cast_to_int(value),
+        Type::Int => cast_to_integer_like(value, NumericType::I64),
         Type::Numeric(numeric_ty) => cast_to_numeric(value, *numeric_ty),
         _ => Ok(value),
+    }
+}
+
+fn cast_to_integer_like(value: SpikeValue, ty: NumericType) -> Result<SpikeValue, Diagnostic> {
+    match value {
+        SpikeValue::Int(value) => Ok(cast_signed_integer(value, ty)),
+        SpikeValue::UInt(value) => Ok(cast_unsigned_integer(value, ty)),
+        SpikeValue::Float(value) => Ok(cast_float(value, ty)),
+        _ => Err(unsupported("only numeric values can be cast to int")),
     }
 }
 
@@ -233,15 +242,6 @@ fn cast_to_numeric(value: SpikeValue, ty: NumericType) -> Result<SpikeValue, Dia
         _ => Err(unsupported(
             "only numeric values can be cast to numeric types",
         )),
-    }
-}
-
-fn cast_to_int(value: SpikeValue) -> Result<SpikeValue, Diagnostic> {
-    match value {
-        SpikeValue::Int(value) => Ok(SpikeValue::Int(value)),
-        SpikeValue::UInt(value) => Ok(SpikeValue::Int(value as i64)),
-        SpikeValue::Float(value) => Ok(SpikeValue::Int(value as i64)),
-        _ => Err(unsupported("only numeric values can be cast to int")),
     }
 }
 

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -1,11 +1,14 @@
 use crate::diagnostics::Diagnostic;
 use crate::mir::{ArithmeticOp, CompareOp, Expr, Function, LiteralValue, Program, Stmt, Type};
+use crate::syntax::NumericType;
 use std::collections::HashMap;
 use std::path::Path;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 enum SpikeValue {
     Int(i64),
+    UInt(u64),
+    Float(f64),
     Bool(bool),
     Text(String),
     Tuple(Vec<SpikeValue>),
@@ -124,10 +127,7 @@ fn eval_expr(
 ) -> Result<SpikeValue, Diagnostic> {
     match expr {
         Expr::Literal(LiteralValue::Int(value)) => Ok(SpikeValue::Int(*value)),
-        Expr::Literal(LiteralValue::Numeric { raw, .. }) => raw
-            .parse::<i64>()
-            .map(SpikeValue::Int)
-            .map_err(|_| unsupported("only integer numeric literals are supported")),
+        Expr::Literal(LiteralValue::Numeric { raw, ty }) => eval_numeric_literal(raw, *ty),
         Expr::Literal(LiteralValue::Bool(value)) => Ok(SpikeValue::Bool(*value)),
         Expr::Literal(LiteralValue::String(value)) | Expr::Literal(LiteralValue::Str(value)) => {
             Ok(SpikeValue::Text(value.clone()))
@@ -154,7 +154,7 @@ fn eval_expr(
                 )),
             }
         }
-        Expr::Cast { expr, .. } => eval_expr(expr, functions, env),
+        Expr::Cast { expr, ty } => cast_spike_value(eval_expr(expr, functions, env)?, ty),
         Expr::TupleLiteral { elements, .. } => elements
             .iter()
             .map(|element| eval_expr(element, functions, env))
@@ -185,6 +185,114 @@ fn eval_expr(
         _ => Err(unsupported(
             "this expression is outside the cranelift hello spike subset",
         )),
+    }
+}
+
+fn eval_numeric_literal(raw: &str, ty: NumericType) -> Result<SpikeValue, Diagnostic> {
+    match ty {
+        NumericType::F32 => raw
+            .parse::<f32>()
+            .map(|value| SpikeValue::Float(value as f64))
+            .map_err(|_| unsupported("invalid f32 numeric literal")),
+        NumericType::F64 => raw
+            .parse::<f64>()
+            .map(SpikeValue::Float)
+            .map_err(|_| unsupported("invalid f64 numeric literal")),
+        NumericType::I8
+        | NumericType::I16
+        | NumericType::I32
+        | NumericType::I64
+        | NumericType::Isize => raw
+            .parse::<i64>()
+            .map(|value| cast_signed_integer(value, ty))
+            .map_err(|_| unsupported("invalid signed integer numeric literal")),
+        NumericType::U8
+        | NumericType::U16
+        | NumericType::U32
+        | NumericType::U64
+        | NumericType::Usize => raw
+            .parse::<u64>()
+            .map(|value| cast_unsigned_integer(value, ty))
+            .map_err(|_| unsupported("invalid unsigned integer numeric literal")),
+    }
+}
+
+fn cast_spike_value(value: SpikeValue, ty: &Type) -> Result<SpikeValue, Diagnostic> {
+    match ty {
+        Type::Int => cast_to_int(value),
+        Type::Numeric(numeric_ty) => cast_to_numeric(value, *numeric_ty),
+        _ => Ok(value),
+    }
+}
+
+fn cast_to_numeric(value: SpikeValue, ty: NumericType) -> Result<SpikeValue, Diagnostic> {
+    match value {
+        SpikeValue::Int(value) => Ok(cast_signed_integer(value, ty)),
+        SpikeValue::UInt(value) => Ok(cast_unsigned_integer(value, ty)),
+        SpikeValue::Float(value) => Ok(cast_float(value, ty)),
+        _ => Err(unsupported(
+            "only numeric values can be cast to numeric types",
+        )),
+    }
+}
+
+fn cast_to_int(value: SpikeValue) -> Result<SpikeValue, Diagnostic> {
+    match value {
+        SpikeValue::Int(value) => Ok(SpikeValue::Int(value)),
+        SpikeValue::UInt(value) => Ok(SpikeValue::Int(value as i64)),
+        SpikeValue::Float(value) => Ok(SpikeValue::Int(value as i64)),
+        _ => Err(unsupported("only numeric values can be cast to int")),
+    }
+}
+
+fn cast_signed_integer(value: i64, ty: NumericType) -> SpikeValue {
+    match ty {
+        NumericType::I8 => SpikeValue::Int(value as i8 as i64),
+        NumericType::I16 => SpikeValue::Int(value as i16 as i64),
+        NumericType::I32 => SpikeValue::Int(value as i32 as i64),
+        NumericType::I64 => SpikeValue::Int(value),
+        NumericType::Isize => SpikeValue::Int(value as isize as i64),
+        NumericType::U8 => SpikeValue::UInt(value as u8 as u64),
+        NumericType::U16 => SpikeValue::UInt(value as u16 as u64),
+        NumericType::U32 => SpikeValue::UInt(value as u32 as u64),
+        NumericType::U64 => SpikeValue::UInt(value as u64),
+        NumericType::Usize => SpikeValue::UInt(value as usize as u64),
+        NumericType::F32 => SpikeValue::Float((value as f32) as f64),
+        NumericType::F64 => SpikeValue::Float(value as f64),
+    }
+}
+
+fn cast_unsigned_integer(value: u64, ty: NumericType) -> SpikeValue {
+    match ty {
+        NumericType::I8 => SpikeValue::Int(value as i8 as i64),
+        NumericType::I16 => SpikeValue::Int(value as i16 as i64),
+        NumericType::I32 => SpikeValue::Int(value as i32 as i64),
+        NumericType::I64 => SpikeValue::Int(value as i64),
+        NumericType::Isize => SpikeValue::Int(value as isize as i64),
+        NumericType::U8 => SpikeValue::UInt(value as u8 as u64),
+        NumericType::U16 => SpikeValue::UInt(value as u16 as u64),
+        NumericType::U32 => SpikeValue::UInt(value as u32 as u64),
+        NumericType::U64 => SpikeValue::UInt(value),
+        NumericType::Usize => SpikeValue::UInt(value as usize as u64),
+        NumericType::F32 => SpikeValue::Float((value as f32) as f64),
+        NumericType::F64 => SpikeValue::Float(value as f64),
+    }
+}
+
+fn cast_float(value: f64, ty: NumericType) -> SpikeValue {
+    match ty {
+        NumericType::I8 => SpikeValue::Int(value as i8 as i64),
+        NumericType::I16 => SpikeValue::Int(value as i16 as i64),
+        NumericType::I32 => SpikeValue::Int(value as i32 as i64),
+        NumericType::I64 => SpikeValue::Int(value as i64),
+        NumericType::Isize => SpikeValue::Int(value as isize as i64),
+        NumericType::U8 => SpikeValue::UInt(value as u8 as u64),
+        NumericType::U16 => SpikeValue::UInt(value as u16 as u64),
+        NumericType::U32 => SpikeValue::UInt(value as u32 as u64),
+        NumericType::U64 => SpikeValue::UInt(value as u64),
+        NumericType::Usize => SpikeValue::UInt(value as usize as u64),
+        NumericType::F32 => SpikeValue::Float((value as f32) as f64),
+        NumericType::F64 => SpikeValue::Float(value),
     }
 }
 
@@ -225,7 +333,7 @@ fn eval_arithmetic(
     let left = eval_expr(lhs, functions, env)?;
     let right = eval_expr(rhs, functions, env)?;
     match (ty, left, right) {
-        (Type::Int | Type::Numeric(_), SpikeValue::Int(left), SpikeValue::Int(right)) => {
+        (Type::Int, SpikeValue::Int(left), SpikeValue::Int(right)) => {
             let value = match op {
                 ArithmeticOp::Add => left + right,
                 ArithmeticOp::Sub => left - right,
@@ -235,6 +343,35 @@ fn eval_arithmetic(
             };
             Ok(SpikeValue::Int(value))
         }
+        (Type::Numeric(numeric_ty), left, right) if is_signed_numeric(*numeric_ty) => {
+            let left = expect_signed_integer(left)?;
+            let right = expect_signed_integer(right)?;
+            let value = match op {
+                ArithmeticOp::Add => left + right,
+                ArithmeticOp::Sub => left - right,
+                ArithmeticOp::Mul => left * right,
+                ArithmeticOp::Div if right != 0 => left / right,
+                ArithmeticOp::Div => return Err(unsupported("integer division by zero")),
+            };
+            Ok(cast_signed_integer(value, *numeric_ty))
+        }
+        (Type::Numeric(numeric_ty), left, right) if is_unsigned_numeric(*numeric_ty) => {
+            let left = expect_unsigned_integer(left)?;
+            let right = expect_unsigned_integer(right)?;
+            let value = match op {
+                ArithmeticOp::Add => left + right,
+                ArithmeticOp::Sub => left - right,
+                ArithmeticOp::Mul => left * right,
+                ArithmeticOp::Div if right != 0 => left / right,
+                ArithmeticOp::Div => return Err(unsupported("integer division by zero")),
+            };
+            Ok(cast_unsigned_integer(value, *numeric_ty))
+        }
+        (
+            Type::Numeric(numeric_ty @ (NumericType::F32 | NumericType::F64)),
+            SpikeValue::Float(left),
+            SpikeValue::Float(right),
+        ) => eval_float_arithmetic(op, left, right, *numeric_ty),
         (Type::String | Type::Str, left, right) if op == ArithmeticOp::Add => Ok(SpikeValue::Text(
             format!("{}{}", render_value(&left), render_value(&right)),
         )),
@@ -244,6 +381,79 @@ fn eval_arithmetic(
         _ => Err(unsupported(
             "unsupported cranelift spike arithmetic operands",
         )),
+    }
+}
+
+fn eval_float_arithmetic(
+    op: ArithmeticOp,
+    left: f64,
+    right: f64,
+    ty: NumericType,
+) -> Result<SpikeValue, Diagnostic> {
+    match ty {
+        NumericType::F32 => {
+            let left = left as f32;
+            let right = right as f32;
+            let value = match op {
+                ArithmeticOp::Add => left + right,
+                ArithmeticOp::Sub => left - right,
+                ArithmeticOp::Mul => left * right,
+                ArithmeticOp::Div if right != 0.0 => left / right,
+                ArithmeticOp::Div => return Err(unsupported("floating-point division by zero")),
+            };
+            Ok(SpikeValue::Float(value as f64))
+        }
+        NumericType::F64 => {
+            let value = match op {
+                ArithmeticOp::Add => left + right,
+                ArithmeticOp::Sub => left - right,
+                ArithmeticOp::Mul => left * right,
+                ArithmeticOp::Div if right != 0.0 => left / right,
+                ArithmeticOp::Div => return Err(unsupported("floating-point division by zero")),
+            };
+            Ok(SpikeValue::Float(value))
+        }
+        _ => Err(unsupported(
+            "floating-point arithmetic requires a float type",
+        )),
+    }
+}
+
+fn is_signed_numeric(ty: NumericType) -> bool {
+    matches!(
+        ty,
+        NumericType::I8
+            | NumericType::I16
+            | NumericType::I32
+            | NumericType::I64
+            | NumericType::Isize
+    )
+}
+
+fn is_unsigned_numeric(ty: NumericType) -> bool {
+    matches!(
+        ty,
+        NumericType::U8
+            | NumericType::U16
+            | NumericType::U32
+            | NumericType::U64
+            | NumericType::Usize
+    )
+}
+
+fn expect_signed_integer(value: SpikeValue) -> Result<i64, Diagnostic> {
+    match value {
+        SpikeValue::Int(value) => Ok(value),
+        SpikeValue::UInt(value) => Ok(value as i64),
+        _ => Err(unsupported("expected integer operands")),
+    }
+}
+
+fn expect_unsigned_integer(value: SpikeValue) -> Result<u64, Diagnostic> {
+    match value {
+        SpikeValue::Int(value) => Ok(value as u64),
+        SpikeValue::UInt(value) => Ok(value),
+        _ => Err(unsupported("expected integer operands")),
     }
 }
 
@@ -258,6 +468,8 @@ fn eval_compare(
     let right = eval_expr(rhs, functions, env)?;
     let result = match (left, right) {
         (SpikeValue::Int(left), SpikeValue::Int(right)) => compare_ord(op, left, right),
+        (SpikeValue::UInt(left), SpikeValue::UInt(right)) => compare_ord(op, left, right),
+        (SpikeValue::Float(left), SpikeValue::Float(right)) => compare_float(op, left, right)?,
         (SpikeValue::Bool(left), SpikeValue::Bool(right)) => compare_eq(op, left, right)?,
         (SpikeValue::Text(left), SpikeValue::Text(right)) => compare_eq(op, left, right)?,
         _ => return Err(unsupported("mismatched comparison operands")),
@@ -274,6 +486,20 @@ fn compare_ord<T: Ord>(op: CompareOp, left: T, right: T) -> bool {
         CompareOp::Gt => left > right,
         CompareOp::Ge => left >= right,
     }
+}
+
+fn compare_float(op: CompareOp, left: f64, right: f64) -> Result<bool, Diagnostic> {
+    if !left.is_finite() || !right.is_finite() {
+        return Err(unsupported("non-finite float comparison"));
+    }
+    Ok(match op {
+        CompareOp::Eq => left == right,
+        CompareOp::Ne => left != right,
+        CompareOp::Lt => left < right,
+        CompareOp::Le => left <= right,
+        CompareOp::Gt => left > right,
+        CompareOp::Ge => left >= right,
+    })
 }
 
 fn compare_eq<T: Eq>(op: CompareOp, left: T, right: T) -> Result<bool, Diagnostic> {
@@ -295,6 +521,8 @@ fn expect_non_negative_index(value: SpikeValue) -> Result<usize, Diagnostic> {
     match value {
         SpikeValue::Int(value) if value >= 0 => Ok(value as usize),
         SpikeValue::Int(_) => Err(unsupported("array index cannot be negative")),
+        SpikeValue::UInt(value) => usize::try_from(value)
+            .map_err(|_| unsupported("array index is outside the host usize range")),
         _ => Err(unsupported("array index must be an integer")),
     }
 }
@@ -302,6 +530,8 @@ fn expect_non_negative_index(value: SpikeValue) -> Result<usize, Diagnostic> {
 fn render_value(value: &SpikeValue) -> String {
     match value {
         SpikeValue::Int(value) => value.to_string(),
+        SpikeValue::UInt(value) => value.to_string(),
+        SpikeValue::Float(value) => value.to_string(),
         SpikeValue::Bool(true) => String::from("true"),
         SpikeValue::Bool(false) => String::from("false"),
         SpikeValue::Text(value) => value.clone(),

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -211,15 +211,24 @@ fn eval_numeric_literal(raw: &str, ty: NumericType) -> Result<SpikeValue, Diagno
         | NumericType::U32
         | NumericType::U64
         | NumericType::Usize => raw
-            .parse::<u64>()
-            .map(|value| cast_unsigned_integer(value, ty))
-            .map_err(|_| unsupported("invalid unsigned integer numeric literal")),
+            .parse::<u128>()
+            .map_err(|_| unsupported("invalid unsigned integer numeric literal"))
+            .and_then(|value| {
+                u64::try_from(value)
+                    .map(|value| cast_unsigned_integer(value, ty))
+                    .map_err(|_| unsupported("invalid unsigned integer numeric literal"))
+            }),
     }
 }
 
 fn cast_spike_value(value: SpikeValue, ty: &Type) -> Result<SpikeValue, Diagnostic> {
     match ty {
-        Type::Int => cast_to_integer_like(value, NumericType::I64),
+        Type::Int => match value {
+            SpikeValue::Int(value) => Ok(SpikeValue::Int(value)),
+            SpikeValue::UInt(value) => Ok(SpikeValue::UInt(value)),
+            SpikeValue::Float(value) => Ok(SpikeValue::Int(value as i64)),
+            _ => Err(unsupported("only numeric values can be cast to int")),
+        },
         Type::Numeric(numeric_ty) => cast_to_numeric(value, *numeric_ty),
         _ => Ok(value),
     }

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -147,7 +147,7 @@ fn cranelift_backend_builds_numeric_cross_width_binary() {
     );
     assert_eq!(
         String::from_utf8_lossy(&run.stdout),
-        "7\n255\n3\n-4\n42\n255\n44\n-126\n18446744073709551615\n255\n0\n16777216\n"
+        "7\n255\n3\n-4\n42\n255\n44\n-126\n-1\n18446744073709551615\n255\n0\n16777216\n"
     );
 }
 
@@ -197,7 +197,7 @@ fn write_numeric_cross_width_project(project: &Path) {
     .expect("write numeric lockfile");
     fs::write(
         project.join("src/main.ax"),
-        "let wide_signed: i64 = 7i64\nlet narrow_signed: i32 = wide_signed as i32\n\nlet byte: u8 = 255u8\nlet widened_unsigned: i32 = byte as i32\n\nlet signed32: i32 = 3i32\nlet float32: f32 = signed32 as f32\n\nlet float64: f64 = -4.75f64\nlet signed64: i64 = float64 as i64\n\nlet same: i32 = 42i32 as i32\n\nlet signed_to_unsigned: u8 = -1i64 as u8\nlet narrowed_unsigned: u8 = 300i64 as u8\nlet narrowed_signed: i8 = 130i64 as i8\nlet max_u64: u64 = 18446744073709551615u64\nlet saturated_float_unsigned: u8 = 300.0f64 as u8\nlet negative_float_unsigned: u8 = -1.0f64 as u8\nlet rounded_f32: f32 = 16777216f32 + 1f32\n\nprint narrow_signed\nprint widened_unsigned\nprint float32 as int\nprint signed64\nprint same\nprint signed_to_unsigned\nprint narrowed_unsigned\nprint narrowed_signed\nprint max_u64\nprint saturated_float_unsigned\nprint negative_float_unsigned\nprint rounded_f32 as int\n",
+        "let wide_signed: i64 = 7i64\nlet narrow_signed: i32 = wide_signed as i32\n\nlet byte: u8 = 255u8\nlet widened_unsigned: i32 = byte as i32\n\nlet signed32: i32 = 3i32\nlet float32: f32 = signed32 as f32\n\nlet float64: f64 = -4.75f64\nlet signed64: i64 = float64 as i64\n\nlet same: i32 = 42i32 as i32\n\nlet signed_to_unsigned: u8 = -1i64 as u8\nlet narrowed_unsigned: u8 = 300i64 as u8\nlet narrowed_signed: i8 = 130i64 as i8\nlet wrapped_int: int = 18446744073709551615u64 as int\nlet max_u64: u64 = 18446744073709551615u64\nlet saturated_float_unsigned: u8 = 300.0f64 as u8\nlet negative_float_unsigned: u8 = -1.0f64 as u8\nlet rounded_f32: f32 = 16777216f32 + 1f32\n\nprint narrow_signed\nprint widened_unsigned\nprint float32 as int\nprint signed64\nprint same\nprint signed_to_unsigned\nprint narrowed_unsigned\nprint narrowed_signed\nprint wrapped_int\nprint max_u64\nprint saturated_float_unsigned\nprint negative_float_unsigned\nprint rounded_f32 as int\n",
     )
     .expect("write numeric source");
 }

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -147,7 +147,7 @@ fn cranelift_backend_builds_numeric_cross_width_binary() {
     );
     assert_eq!(
         String::from_utf8_lossy(&run.stdout),
-        "7\n255\n3\n-4\n42\n255\n44\n-126\n-1\n18446744073709551615\n255\n0\n16777216\n"
+        "7\n255\n3\n-4\n42\n255\n44\n-126\n18446744073709551615\n18446744073709551615\n255\n0\n16777216\n"
     );
 }
 

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -105,6 +105,52 @@ fn cranelift_backend_builds_scalar_aggregate_binary() {
     assert_eq!(String::from_utf8_lossy(&run.stdout), "native\n7\n12\n10\n");
 }
 
+#[cfg(not(windows))]
+#[test]
+fn cranelift_backend_builds_numeric_cross_width_binary() {
+    if which::which("cc").is_err() {
+        eprintln!("skipping cranelift backend smoke test because cc is unavailable");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("numeric-cross-width");
+    write_numeric_cross_width_project(&project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+    assert!(
+        output.status.success(),
+        "cranelift numeric build failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
+    assert_eq!(payload["backend"], "cranelift");
+    let binary = payload["binary"].as_str().expect("binary path");
+    let run = Command::new(binary)
+        .output()
+        .expect("run cranelift numeric binary");
+    assert!(
+        run.status.success(),
+        "cranelift numeric binary failed: stderr={}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "7\n255\n3\n-4\n42\n255\n44\n-126\n18446744073709551615\n255\n0\n16777216\n"
+    );
+}
+
 fn copy_fixture(relative: &str, destination: &Path) {
     let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../../examples/hello")
@@ -135,4 +181,23 @@ fn write_scalar_project(project: &Path) {
         "fn sum_tail(values: [int; 3]): int {\nreturn values[1] * values[2]\n}\n\nfn adjust(value: int): int {\nreturn value / 2\n}\n\nlet label: (string, int) = (\"native\", 7)\nlet values: [int; 3] = [2, 3, 4]\nprint label.0\nprint label.1\nprint sum_tail(values)\nprint adjust(20)\n",
     )
     .expect("write scalar source");
+}
+
+fn write_numeric_cross_width_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create numeric project src");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"cranelift-numeric-cross-width\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
+    )
+    .expect("write numeric manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-numeric-cross-width\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write numeric lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "let wide_signed: i64 = 7i64\nlet narrow_signed: i32 = wide_signed as i32\n\nlet byte: u8 = 255u8\nlet widened_unsigned: i32 = byte as i32\n\nlet signed32: i32 = 3i32\nlet float32: f32 = signed32 as f32\n\nlet float64: f64 = -4.75f64\nlet signed64: i64 = float64 as i64\n\nlet same: i32 = 42i32 as i32\n\nlet signed_to_unsigned: u8 = -1i64 as u8\nlet narrowed_unsigned: u8 = 300i64 as u8\nlet narrowed_signed: i8 = 130i64 as i8\nlet max_u64: u64 = 18446744073709551615u64\nlet saturated_float_unsigned: u8 = 300.0f64 as u8\nlet negative_float_unsigned: u8 = -1.0f64 as u8\nlet rounded_f32: f32 = 16777216f32 + 1f32\n\nprint narrow_signed\nprint widened_unsigned\nprint float32 as int\nprint signed64\nprint same\nprint signed_to_unsigned\nprint narrowed_unsigned\nprint narrowed_signed\nprint max_u64\nprint saturated_float_unsigned\nprint negative_float_unsigned\nprint rounded_f32 as int\n",
+    )
+    .expect("write numeric source");
 }


### PR DESCRIPTION
## Summary

- Extend the Cranelift spike evaluator to parse typed numeric literals instead of treating every numeric literal as an i64.
- Add backend-only int/float cast handling plus float arithmetic and comparisons for existing MIR expressions.
- Cover cross-width signed, unsigned, full-range unsigned literal, and float casts with a native backend regression.

## Governing Issue

Part of #692. Part of #105.

## Validation

- [x] `cargo fmt --manifest-path stage1/Cargo.toml --all`
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend -- --nocapture`
- [x] `cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build stage1/conformance/pass/numeric_cross_width_casts --backend cranelift --json`
- [x] `./stage1/conformance/pass/numeric_cross_width_casts/dist/conformance-numeric-cross-width-casts`
- [x] `cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build stage1/conformance/pass/numeric_float_mean --backend cranelift --json`
- [x] `./stage1/conformance/pass/numeric_float_mean/dist/conformance-numeric-float-mean`
- [x] `cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build stage1/conformance/pass/numeric_literal_suffixes --backend cranelift --json`
- [x] `./stage1/conformance/pass/numeric_literal_suffixes/dist/conformance-numeric-literal-suffixes`
- [x] `git diff --check`
- [x] `AXIOM_PYTHON_EXIT_ISSUE_STATES_JSON='{"266":"closed","267":"closed","268":"closed","269":"closed","270":"closed","271":"closed"}' bash scripts/ci/run-fast-checks.sh`
- [x] Required PR checks are green on the current head.
- [x] Skipped checks are explained below.

## Bootstrap Governance

- [x] Changes are scoped to the linked issues as a native backend feature slice.
- [x] Contributor or PR guidance changes are not applicable.
- [x] Auto-merge is enabled.
- [x] No real secrets, runtime auth, or machine-local env files are committed.

## Semantic Layer Checklist

- [x] Semantic node types: none added or changed; this is backend handling for existing MIR numeric literals, casts, arithmetic, and comparisons.
- [x] Schemas: none added or changed.
- [x] Evidence: Cranelift backend regression, native conformance build/run evidence for `numeric_cross_width_casts`, `numeric_float_mean`, and `numeric_literal_suffixes`, plus the fast PR gate.
- [x] Rust capture check: backend-specific spike evaluator behavior only; this does not redefine Axiom numeric semantics.
- [x] Agent-facing inspection impact: native backend evidence expands, but no schema or inspection contract changes.

## Flow Contract

- Owner lane: compiler/runtime
- Repair owner: codex
- Autonomy class: issue-linked feature slice
- Risk class: medium; backend spike evaluator scalar numeric coverage expands but remains isolated to the Cranelift native backend path.

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action.
- [ ] Requested-changes review state remains active; next actor is a non-author reviewer to re-review the resolved/outdated feedback on the current green head.
- [ ] Non-author approval is present when required.
- [x] Auto-merge is appropriate when gates and review state pass.

## Merge Automation

- [x] Auto-merge is enabled.

## Notes

- This intentionally avoids claiming full native backend parity; remaining #692 and #105 work continues in smaller backend slices.
