### PR TITLE
[codex] Add Cranelift struct field support

### DIFF
--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -11,6 +11,10 @@ enum SpikeValue {
     Float(f64),
     Bool(bool),
     Text(String),
+    Struct {
+        name: String,
+        fields: Vec<(String, SpikeValue)>,
+    },
     Tuple(Vec<SpikeValue>),
     Array(Vec<SpikeValue>),
 }
@@ -41,9 +45,9 @@ pub fn compile_cranelift_hello_spike(
 }
 
 fn collect_print_lines(program: &Program) -> Result<Vec<String>, Diagnostic> {
-    if !program.structs.is_empty() || !program.enums.is_empty() || !program.statics.is_empty() {
+    if !program.enums.is_empty() || !program.statics.is_empty() {
         return Err(unsupported(
-            "structs, enums, and statics are not part of the cranelift hello spike",
+            "enums and statics are not part of the cranelift hello spike",
         ));
     }
     let functions = program
@@ -155,6 +159,25 @@ fn eval_expr(
             }
         }
         Expr::Cast { expr, ty } => cast_spike_value(eval_expr(expr, functions, env)?, ty),
+        Expr::StructLiteral { name, fields, .. } => fields
+            .iter()
+            .map(|field| Ok((field.name.clone(), eval_expr(&field.expr, functions, env)?)))
+            .collect::<Result<Vec<_>, _>>()
+            .map(|fields| SpikeValue::Struct {
+                name: name.clone(),
+                fields,
+            }),
+        Expr::FieldAccess { base, field, .. } => match eval_expr(base, functions, env)? {
+            SpikeValue::Struct { name, fields } => fields
+                .into_iter()
+                .find_map(|(candidate, value)| (candidate == *field).then_some(value))
+                .ok_or_else(|| {
+                    unsupported(&format!(
+                        "struct {name:?} has no field {field:?} in the cranelift spike"
+                    ))
+                }),
+            _ => Err(unsupported("field access requires a struct value")),
+        },
         Expr::TupleLiteral { elements, .. } => elements
             .iter()
             .map(|element| eval_expr(element, functions, env))
@@ -567,9 +590,24 @@ fn render_value(value: &SpikeValue) -> String {
         SpikeValue::Bool(true) => String::from("true"),
         SpikeValue::Bool(false) => String::from("false"),
         SpikeValue::Text(value) => value.clone(),
+        SpikeValue::Struct { name, fields } => render_struct(name, fields),
         SpikeValue::Tuple(values) => render_sequence("(", ")", values),
         SpikeValue::Array(values) => render_sequence("[", "]", values),
     }
+}
+
+fn render_struct(name: &str, fields: &[(String, SpikeValue)]) -> String {
+    let mut rendered = format!("{name} {{ ");
+    for (index, (field, value)) in fields.iter().enumerate() {
+        if index > 0 {
+            rendered.push_str(", ");
+        }
+        rendered.push_str(field);
+        rendered.push_str(": ");
+        rendered.push_str(&render_value(value));
+    }
+    rendered.push_str(" }");
+    rendered
 }
 
 fn render_sequence(open: &str, close: &str, values: &[SpikeValue]) -> String {

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -194,6 +194,52 @@ fn cranelift_backend_builds_const_sized_array_conformance_binary() {
     assert_eq!(String::from_utf8_lossy(&run.stdout), "3\n6\n");
 }
 
+#[cfg(not(windows))]
+#[test]
+fn cranelift_backend_builds_struct_field_binary() {
+    if which::which("cc").is_err() {
+        eprintln!("skipping cranelift backend smoke test because cc is unavailable");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("struct-field");
+    write_struct_field_project(&project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+    assert!(
+        output.status.success(),
+        "cranelift struct build failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
+    assert_eq!(payload["backend"], "cranelift");
+    let binary = payload["binary"].as_str().expect("binary path");
+    let run = Command::new(binary)
+        .output()
+        .expect("run cranelift struct binary");
+    assert!(
+        run.status.success(),
+        "cranelift struct binary failed: stderr={}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "3\ntrue\nstage1 structs\n"
+    );
+}
+
 fn copy_fixture(relative: &str, destination: &Path) {
     let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../../examples/hello")
@@ -261,4 +307,23 @@ fn write_numeric_cross_width_project(project: &Path) {
         "let wide_signed: i64 = 7i64\nlet narrow_signed: i32 = wide_signed as i32\n\nlet byte: u8 = 255u8\nlet widened_unsigned: i32 = byte as i32\n\nlet signed32: i32 = 3i32\nlet float32: f32 = signed32 as f32\n\nlet float64: f64 = -4.75f64\nlet signed64: i64 = float64 as i64\n\nlet same: i32 = 42i32 as i32\n\nlet signed_to_unsigned: u8 = -1i64 as u8\nlet narrowed_unsigned: u8 = 300i64 as u8\nlet narrowed_signed: i8 = 130i64 as i8\nlet wrapped_int: int = 18446744073709551615u64 as int\nlet max_u64: u64 = 18446744073709551615u64\nlet saturated_float_unsigned: u8 = 300.0f64 as u8\nlet negative_float_unsigned: u8 = -1.0f64 as u8\nlet rounded_f32: f32 = 16777216f32 + 1f32\n\nprint narrow_signed\nprint widened_unsigned\nprint float32 as int\nprint signed64\nprint same\nprint signed_to_unsigned\nprint narrowed_unsigned\nprint narrowed_signed\nprint wrapped_int\nprint max_u64\nprint saturated_float_unsigned\nprint negative_float_unsigned\nprint rounded_f32 as int\n",
     )
     .expect("write numeric source");
+}
+
+fn write_struct_field_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create struct project src");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"cranelift-struct-field\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
+    )
+    .expect("write struct manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-struct-field\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write struct lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "struct Pipeline {\nname: string\nsteps: int\nready: bool\n}\n\nfn label(pipeline: Pipeline): string {\nreturn pipeline.name\n}\n\nlet pipeline: Pipeline = Pipeline { name: \"stage1 structs\", steps: 3, ready: true }\nprint pipeline.steps\nprint pipeline.ready\nprint label(pipeline)\n",
+    )
+    .expect("write struct source");
 }


### PR DESCRIPTION
## Summary

- Allow struct declarations through the Cranelift spike evaluator instead of rejecting every program with a struct definition.
- Evaluate struct literals into backend-local field maps and resolve direct field access expressions.
- Add a native backend regression that builds and runs a struct field access program.

## Governing Issue

Part of #692. Part of #105.

## Validation

- [x] `cargo fmt --manifest-path stage1/Cargo.toml --all`
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend -- --nocapture`
- [x] `cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build stage1/conformance/pass/struct_field_access --backend cranelift --json`
- [x] `./stage1/conformance/pass/struct_field_access/dist/conformance-struct-field-access`
- [x] `git diff --check`
- [x] `AXIOM_PYTHON_EXIT_ISSUE_STATES_JSON='{"266":"closed","267":"closed","268":"closed","269":"closed","270":"closed","271":"closed"}' bash scripts/ci/run-fast-checks.sh`
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

## Bootstrap Governance

- [x] Changes are scoped to the linked issues as a native backend feature slice.
- [x] Contributor or PR guidance changes are not applicable.
- [x] Auto-merge is enabled.
- [x] No real secrets, runtime auth, or machine-local env files are committed.

## Semantic Layer Checklist

- [x] Semantic node types: none added or changed; this is backend handling for existing MIR struct literals and field access.
- [x] Schemas: none added or changed.
- [x] Evidence: Cranelift backend regression, native conformance build/run evidence for `struct_field_access`, and the fast PR gate.
- [x] Rust capture check: backend-specific spike evaluator behavior only; this does not redefine Axiom struct semantics.
- [x] Agent-facing inspection impact: native backend evidence expands, but no schema or inspection contract changes.

## Flow Contract

- Owner lane: compiler/runtime
- Repair owner: codex
- Autonomy class: issue-linked feature slice
- Risk class: medium; backend spike evaluator aggregate coverage expands but remains isolated to the Cranelift native backend path.

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

## Merge Automation

- [x] Auto-merge is enabled.

## Notes

- This intentionally avoids claiming full native backend parity; remaining #692 and #105 work continues in smaller backend slices.
- Rebased onto `main` after #918 merged so the struct-field slice includes the current numeric and const-sized-array backend checks.
