### PR TITLE
[codex] Add Cranelift statics, structs, and array helpers

### DIFF
--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -316,11 +316,12 @@ still far from the stated 1.0 target for service and agent workloads.
 - The backend-selection surface remains preparatory backend plumbing for later
   native-backend expansion. `generated-rust` is still the default and only broad
   backend; `cranelift` is intentionally limited to scalar print-line programs,
-  typed numeric scalars with width- and signedness-aware casts, tuple/array
-  indexing, function calls, `len(...)` over in-memory strings (encoded byte
-  length, matching the generated-Rust backend) and arrays, and scalar
-  branching, so this is not closure for #105 or the later full-surface native
-  backend slices.
+  typed numeric scalars with width- and signedness-aware casts, static scalar
+  globals, struct literals and field access, tuple/array indexing, function
+  calls, the collection helpers `len(...)` over in-memory strings (encoded byte
+  length, matching the generated-Rust backend) and arrays plus
+  `first(...)`/`last(...)` over in-memory arrays, and scalar branching, so this
+  is not closure for #105 or the later full-surface native backend slices.
 - Generated-Rust builds now use a persistent per-artifact cache keyed by
   compiler version, target, debug mode, manifest/lockfile hash, rendered Rust,
   module source hashes, and dependency imports. Cache hits skip `rustc`, cache

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -11,6 +11,10 @@ enum SpikeValue {
     Float(f64),
     Bool(bool),
     Text(String),
+    Struct {
+        name: String,
+        fields: Vec<(String, SpikeValue)>,
+    },
     Tuple(Vec<SpikeValue>),
     Array(Vec<SpikeValue>),
 }
@@ -41,9 +45,9 @@ pub fn compile_cranelift_hello_spike(
 }
 
 fn collect_print_lines(program: &Program) -> Result<Vec<String>, Diagnostic> {
-    if !program.structs.is_empty() || !program.enums.is_empty() || !program.statics.is_empty() {
+    if !program.enums.is_empty() {
         return Err(unsupported(
-            "structs, enums, and statics are not part of the cranelift hello spike",
+            "enums are not part of the cranelift hello spike",
         ));
     }
     let functions = program
@@ -52,6 +56,10 @@ fn collect_print_lines(program: &Program) -> Result<Vec<String>, Diagnostic> {
         .map(|function| (function.name.as_str(), function))
         .collect::<HashMap<_, _>>();
     let mut env = SpikeEnv::new();
+    for static_def in &program.statics {
+        let value = eval_expr(&static_def.expr, &functions, &env)?;
+        env.insert(static_def.name.clone(), value);
+    }
     let mut lines = Vec::new();
     eval_block(&program.stmts, &functions, &mut env, &mut lines)?;
     Ok(lines)
@@ -155,6 +163,25 @@ fn eval_expr(
             }
         }
         Expr::Cast { expr, ty } => cast_spike_value(eval_expr(expr, functions, env)?, ty),
+        Expr::StructLiteral { name, fields, .. } => fields
+            .iter()
+            .map(|field| Ok((field.name.clone(), eval_expr(&field.expr, functions, env)?)))
+            .collect::<Result<Vec<_>, _>>()
+            .map(|fields| SpikeValue::Struct {
+                name: name.clone(),
+                fields,
+            }),
+        Expr::FieldAccess { base, field, .. } => match eval_expr(base, functions, env)? {
+            SpikeValue::Struct { name, fields } => fields
+                .into_iter()
+                .find_map(|(candidate, value)| (candidate == *field).then_some(value))
+                .ok_or_else(|| {
+                    unsupported(&format!(
+                        "struct {name:?} has no field {field:?} in the cranelift spike"
+                    ))
+                }),
+            _ => Err(unsupported("field access requires a struct value")),
+        },
         Expr::TupleLiteral { elements, .. } => elements
             .iter()
             .map(|element| eval_expr(element, functions, env))
@@ -314,13 +341,16 @@ fn eval_call(
     if name == "len" {
         return eval_len_call(args, functions, env);
     }
+    if name == "first" || name == "last" {
+        return eval_first_last_call(name, args, functions, env);
+    }
     let function = functions
         .get(name)
         .ok_or_else(|| unsupported(&format!("unsupported cranelift spike call {name:?}")))?;
     if function.params.len() != args.len() {
         return Err(unsupported("function argument count mismatch"));
     }
-    let mut local_env = SpikeEnv::new();
+    let mut local_env = env.clone();
     for (param, arg) in function.params.iter().zip(args) {
         local_env.insert(param.name.clone(), eval_expr(arg, functions, env)?);
     }
@@ -352,6 +382,36 @@ fn eval_len_call(
         _ => return Err(unsupported("len supports strings, tuples, and arrays")),
     };
     Ok(SpikeValue::Int(len as i64))
+}
+
+fn eval_first_last_call(
+    name: &str,
+    args: &[Expr],
+    functions: &HashMap<&str, &Function>,
+    env: &SpikeEnv,
+) -> Result<SpikeValue, Diagnostic> {
+    let [arg] = args else {
+        return Err(unsupported(&format!("{name} expects exactly one argument")));
+    };
+    // HIR restricts `first`/`last` to arrays and slices and returns the element
+    // directly (it panics at runtime on an empty collection). The spike models
+    // owned arrays only; borrowed slices are outside the spike subset.
+    let elements = match eval_expr(arg, functions, env)? {
+        SpikeValue::Array(elements) => elements,
+        _ => {
+            return Err(unsupported(&format!(
+                "{name} supports arrays in the cranelift spike"
+            )));
+        }
+    };
+    let selected = if name == "first" {
+        elements.first()
+    } else {
+        elements.last()
+    };
+    selected
+        .cloned()
+        .ok_or_else(|| unsupported(&format!("{name} on an empty array")))
 }
 
 fn eval_arithmetic(
@@ -567,9 +627,24 @@ fn render_value(value: &SpikeValue) -> String {
         SpikeValue::Bool(true) => String::from("true"),
         SpikeValue::Bool(false) => String::from("false"),
         SpikeValue::Text(value) => value.clone(),
+        SpikeValue::Struct { name, fields } => render_struct(name, fields),
         SpikeValue::Tuple(values) => render_sequence("(", ")", values),
         SpikeValue::Array(values) => render_sequence("[", "]", values),
     }
+}
+
+fn render_struct(name: &str, fields: &[(String, SpikeValue)]) -> String {
+    let mut rendered = format!("{name} {{ ");
+    for (index, (field, value)) in fields.iter().enumerate() {
+        if index > 0 {
+            rendered.push_str(", ");
+        }
+        rendered.push_str(field);
+        rendered.push_str(": ");
+        rendered.push_str(&render_value(value));
+    }
+    rendered.push_str(" }");
+    rendered
 }
 
 fn render_sequence(open: &str, close: &str, values: &[SpikeValue]) -> String {

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -194,6 +194,141 @@ fn cranelift_backend_builds_const_sized_array_conformance_binary() {
     assert_eq!(String::from_utf8_lossy(&run.stdout), "3\n6\n");
 }
 
+#[cfg(not(windows))]
+#[test]
+fn cranelift_backend_builds_static_scalar_binary() {
+    if which::which("cc").is_err() {
+        eprintln!("skipping cranelift backend smoke test because cc is unavailable");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("static-scalar-globals");
+    write_static_scalar_project(&project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+    assert!(
+        output.status.success(),
+        "cranelift static scalar build failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
+    assert_eq!(payload["backend"], "cranelift");
+    let binary = payload["binary"].as_str().expect("binary path");
+    let run = Command::new(binary)
+        .output()
+        .expect("run cranelift static scalar binary");
+    assert!(
+        run.status.success(),
+        "cranelift static scalar binary failed: stderr={}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "hello static\n42\n43\ntrue\n"
+    );
+}
+
+#[cfg(not(windows))]
+#[test]
+fn cranelift_backend_builds_struct_field_binary() {
+    if which::which("cc").is_err() {
+        eprintln!("skipping cranelift backend smoke test because cc is unavailable");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("struct-field");
+    write_struct_field_project(&project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+    assert!(
+        output.status.success(),
+        "cranelift struct build failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
+    assert_eq!(payload["backend"], "cranelift");
+    let binary = payload["binary"].as_str().expect("binary path");
+    let run = Command::new(binary)
+        .output()
+        .expect("run cranelift struct binary");
+    assert!(
+        run.status.success(),
+        "cranelift struct binary failed: stderr={}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "3\ntrue\nstage1 structs\n"
+    );
+}
+
+#[cfg(not(windows))]
+#[test]
+fn cranelift_backend_builds_array_helpers_binary() {
+    if which::which("cc").is_err() {
+        eprintln!("skipping cranelift backend smoke test because cc is unavailable");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("array-helpers");
+    write_array_helpers_project(&project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+    assert!(
+        output.status.success(),
+        "cranelift array-helpers build failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
+    assert_eq!(payload["backend"], "cranelift");
+    let binary = payload["binary"].as_str().expect("binary path");
+    let run = Command::new(binary)
+        .output()
+        .expect("run cranelift array-helpers binary");
+    assert!(
+        run.status.success(),
+        "cranelift array-helpers binary failed: stderr={}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&run.stdout), "3\n10\n30\n40\n");
+}
+
 fn copy_fixture(relative: &str, destination: &Path) {
     let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../../examples/hello")
@@ -261,4 +396,61 @@ fn write_numeric_cross_width_project(project: &Path) {
         "let wide_signed: i64 = 7i64\nlet narrow_signed: i32 = wide_signed as i32\n\nlet byte: u8 = 255u8\nlet widened_unsigned: i32 = byte as i32\n\nlet signed32: i32 = 3i32\nlet float32: f32 = signed32 as f32\n\nlet float64: f64 = -4.75f64\nlet signed64: i64 = float64 as i64\n\nlet same: i32 = 42i32 as i32\n\nlet signed_to_unsigned: u8 = -1i64 as u8\nlet narrowed_unsigned: u8 = 300i64 as u8\nlet narrowed_signed: i8 = 130i64 as i8\nlet wrapped_int: int = 18446744073709551615u64 as int\nlet max_u64: u64 = 18446744073709551615u64\nlet saturated_float_unsigned: u8 = 300.0f64 as u8\nlet negative_float_unsigned: u8 = -1.0f64 as u8\nlet rounded_f32: f32 = 16777216f32 + 1f32\n\nprint narrow_signed\nprint widened_unsigned\nprint float32 as int\nprint signed64\nprint same\nprint signed_to_unsigned\nprint narrowed_unsigned\nprint narrowed_signed\nprint wrapped_int\nprint max_u64\nprint saturated_float_unsigned\nprint negative_float_unsigned\nprint rounded_f32 as int\n",
     )
     .expect("write numeric source");
+}
+
+fn write_static_scalar_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create static scalar project src");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"cranelift-static-scalar\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
+    )
+    .expect("write static scalar manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-static-scalar\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write static scalar lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "static GREETING: string = \"hello static\"\nstatic ANSWER: int = 42\nstatic READY: bool = true\n\nfn bump(value: int): int {\nreturn value + ANSWER\n}\n\nprint GREETING\nprint ANSWER\nprint bump(1)\nprint READY\n",
+    )
+    .expect("write static scalar source");
+}
+
+fn write_struct_field_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create struct project src");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"cranelift-struct-field\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
+    )
+    .expect("write struct manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-struct-field\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write struct lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "struct Pipeline {\nname: string\nsteps: int\nready: bool\n}\n\nfn label(pipeline: Pipeline): string {\nreturn pipeline.name\n}\n\nlet pipeline: Pipeline = Pipeline { name: \"stage1 structs\", steps: 3, ready: true }\nprint pipeline.steps\nprint pipeline.ready\nprint label(pipeline)\n",
+    )
+    .expect("write struct source");
+}
+
+fn write_array_helpers_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create array-helpers project src");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"cranelift-array-helpers\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
+    )
+    .expect("write array-helpers manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-array-helpers\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write array-helpers lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "let values: [int; 3] = [10, 20, 30]\nprint len(values)\nprint first(values)\nprint last(values)\nprint first(values) + last(values)\n",
+    )
+    .expect("write array-helpers source");
 }


### PR DESCRIPTION
## Summary

- Re-land the Cranelift struct literal and field access slice from superseded #919 on top of current `main`.
- Add Cranelift spike support for scalar static globals, including static reads from helper functions.
- Add Cranelift spike support for `first(...)` and `last(...)` over in-memory arrays.
- Update the stage1 backend-status docs and add native backend regressions for each slice.

## Governing Issue

Part of #692. Part of #105. Supersedes #919.

## Validation

- [x] `cargo fmt --manifest-path stage1/Cargo.toml --all`
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend -- --nocapture` (7 passed)
- [x] `git diff --check origin/main...HEAD`
- [x] Required PR checks are expected to satisfy `CI Gate` after the PR leaves draft.
- [x] Skipped checks are explained below.

## Bootstrap Governance

- [x] Changes are scoped to the linked native-backend issues as narrow Cranelift spike evaluator slices.
- [x] Contributor and PR guidance changes are not applicable; docs-only guidance change is limited to `docs/stage1.md` backend status.
- [x] Auto-merge is enabled.
- [x] No real secrets, runtime auth, or machine-local env files are committed.

## Semantic Layer Checklist

- [x] Semantic node types: none added or changed; this handles existing MIR static definitions, struct literals, field access, and `first`/`last` calls in the Cranelift backend.
- [x] Schemas: none added or changed.
- [x] Evidence: Cranelift backend regressions for scalar static globals, struct fields, and array helpers, plus the backend status doc update.
- [x] Rust capture check: backend-specific spike evaluator behavior only; this does not redefine Axiom aggregate or collection semantics.
- [x] Agent-facing inspection impact: no schema or inspection contract changes.

## Flow Contract

- Owner lane: compiler/runtime
- Repair owner: codex
- Autonomy class: issue-linked feature slice
- Risk class: medium; native backend surface expands but remains isolated to the Cranelift spike path.

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action.
- [x] No active blocking requested changes remain.
- [ ] Non-author approval is present when required.
- [x] Auto-merge is appropriate when gates pass.

## Merge Automation

- [x] Auto-merge is enabled.

## Notes

- This intentionally does not close #692 or #105; full native backend parity remains larger follow-up work.
- Downstream default-backend, generated-Rust removal, DWARF, and self-hosting roadmap issues remain out of scope for this PR.
