### PR TITLE
[codex] Add Cranelift enum match support

### DIFF
--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -317,9 +317,10 @@ still far from the stated 1.0 target for service and agent workloads.
   native-backend expansion. `generated-rust` is still the default and only broad
   backend; `cranelift` is intentionally limited to scalar print-line programs,
   typed numeric scalars with width- and signedness-aware casts, static scalar
-  globals, struct literals and field access, tuple/array indexing, function
-  calls, the collection helpers `len(...)` over in-memory strings (encoded byte
-  length, matching the generated-Rust backend) and arrays plus
+  globals, enum variants with direct match arms, struct literals and field
+  access, tuple/array indexing, function calls, the collection helpers
+  `len(...)` over in-memory strings (encoded byte length, matching the
+  generated-Rust backend) and arrays plus
   `first(...)`/`last(...)` over in-memory arrays, and scalar branching, so this
   is not closure for #105 or the later full-surface native backend slices.
 - Generated-Rust builds now use a persistent per-artifact cache keyed by

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -1,5 +1,8 @@
 use crate::diagnostics::Diagnostic;
-use crate::mir::{ArithmeticOp, CompareOp, Expr, Function, LiteralValue, Program, Stmt, Type};
+use crate::mir::{
+    ArithmeticOp, CompareOp, Expr, Function, LiteralValue, MatchArm, MatchExprArm, Program, Stmt,
+    Type,
+};
 use crate::syntax::NumericType;
 use std::collections::HashMap;
 use std::path::Path;
@@ -14,6 +17,12 @@ enum SpikeValue {
     Struct {
         name: String,
         fields: Vec<(String, SpikeValue)>,
+    },
+    Enum {
+        enum_name: String,
+        variant: String,
+        field_names: Vec<String>,
+        payloads: Vec<SpikeValue>,
     },
     Tuple(Vec<SpikeValue>),
     Array(Vec<SpikeValue>),
@@ -45,11 +54,6 @@ pub fn compile_cranelift_hello_spike(
 }
 
 fn collect_print_lines(program: &Program) -> Result<Vec<String>, Diagnostic> {
-    if !program.enums.is_empty() {
-        return Err(unsupported(
-            "enums are not part of the cranelift hello spike",
-        ));
-    }
     let functions = program
         .functions
         .iter()
@@ -119,12 +123,11 @@ fn eval_stmt(
             )),
             _ => Err(unsupported("while conditions must be boolean")),
         },
+        Stmt::Match { expr, arms, .. } => eval_match_stmt(expr, arms, functions, env, lines),
         Stmt::Return { expr, .. } => Ok(Some(eval_expr(expr, functions, env)?)),
-        Stmt::Assign { .. } | Stmt::Panic { .. } | Stmt::Defer { .. } | Stmt::Match { .. } => {
-            Err(unsupported(
-                "only let, print, if, while false, and return statements are supported by the cranelift hello spike",
-            ))
-        }
+        Stmt::Assign { .. } | Stmt::Panic { .. } | Stmt::Defer { .. } => Err(unsupported(
+            "only let, print, if, while false, match, and return statements are supported by the cranelift hello spike",
+        )),
     }
 }
 
@@ -182,6 +185,23 @@ fn eval_expr(
                 }),
             _ => Err(unsupported("field access requires a struct value")),
         },
+        Expr::EnumVariant {
+            enum_name,
+            variant,
+            field_names,
+            payloads,
+            ..
+        } => payloads
+            .iter()
+            .map(|payload| eval_expr(payload, functions, env))
+            .collect::<Result<Vec<_>, _>>()
+            .map(|payloads| SpikeValue::Enum {
+                enum_name: enum_name.clone(),
+                variant: variant.clone(),
+                field_names: field_names.clone(),
+                payloads,
+            }),
+        Expr::Match { expr, arms, .. } => eval_match_expr(expr, arms, functions, env),
         Expr::TupleLiteral { elements, .. } => elements
             .iter()
             .map(|element| eval_expr(element, functions, env))
@@ -213,6 +233,107 @@ fn eval_expr(
             "this expression is outside the cranelift hello spike subset",
         )),
     }
+}
+
+fn eval_match_stmt(
+    expr: &Expr,
+    arms: &[MatchArm],
+    functions: &HashMap<&str, &Function>,
+    env: &SpikeEnv,
+    lines: &mut Vec<String>,
+) -> Result<Option<SpikeValue>, Diagnostic> {
+    let matched = expect_enum_value(eval_expr(expr, functions, env)?)?;
+    let arm = arms
+        .iter()
+        .find(|arm| arm.enum_name == matched.enum_name && arm.variant == matched.variant)
+        .ok_or_else(|| unsupported("match statement has no matching enum arm"))?;
+    let mut arm_env = env.clone();
+    if !arm.ignore_payloads {
+        bind_match_payloads(
+            &mut arm_env,
+            &arm.bindings,
+            arm.is_named,
+            &matched.field_names,
+            &matched.payloads,
+        )?;
+    }
+    eval_block(&arm.body, functions, &mut arm_env, lines)
+}
+
+fn eval_match_expr(
+    expr: &Expr,
+    arms: &[MatchExprArm],
+    functions: &HashMap<&str, &Function>,
+    env: &SpikeEnv,
+) -> Result<SpikeValue, Diagnostic> {
+    let matched = expect_enum_value(eval_expr(expr, functions, env)?)?;
+    let arm = arms
+        .iter()
+        .find(|arm| arm.enum_name == matched.enum_name && arm.variant == matched.variant)
+        .ok_or_else(|| unsupported("match expression has no matching enum arm"))?;
+    let mut arm_env = env.clone();
+    bind_match_payloads(
+        &mut arm_env,
+        &arm.bindings,
+        arm.is_named,
+        &matched.field_names,
+        &matched.payloads,
+    )?;
+    eval_expr(&arm.expr, functions, &arm_env)
+}
+
+struct MatchedEnum {
+    enum_name: String,
+    variant: String,
+    field_names: Vec<String>,
+    payloads: Vec<SpikeValue>,
+}
+
+fn expect_enum_value(value: SpikeValue) -> Result<MatchedEnum, Diagnostic> {
+    match value {
+        SpikeValue::Enum {
+            enum_name,
+            variant,
+            field_names,
+            payloads,
+        } => Ok(MatchedEnum {
+            enum_name,
+            variant,
+            field_names,
+            payloads,
+        }),
+        _ => Err(unsupported("match requires an enum value")),
+    }
+}
+
+fn bind_match_payloads(
+    env: &mut SpikeEnv,
+    bindings: &[String],
+    is_named: bool,
+    field_names: &[String],
+    payloads: &[SpikeValue],
+) -> Result<(), Diagnostic> {
+    if bindings.len() != payloads.len() {
+        return Err(unsupported("match payload binding count mismatch"));
+    }
+    for (index, binding) in bindings.iter().enumerate() {
+        if binding == "_" {
+            continue;
+        }
+        let payload_index = if is_named {
+            field_names
+                .iter()
+                .position(|field_name| field_name == binding)
+                .ok_or_else(|| unsupported("named enum match binding has no payload field"))?
+        } else {
+            index
+        };
+        let value = payloads
+            .get(payload_index)
+            .ok_or_else(|| unsupported("match payload binding index mismatch"))?;
+        env.insert(binding.clone(), value.clone());
+    }
+    Ok(())
 }
 
 fn eval_numeric_literal(raw: &str, ty: NumericType) -> Result<SpikeValue, Diagnostic> {
@@ -628,9 +749,19 @@ fn render_value(value: &SpikeValue) -> String {
         SpikeValue::Bool(false) => String::from("false"),
         SpikeValue::Text(value) => value.clone(),
         SpikeValue::Struct { name, fields } => render_struct(name, fields),
+        SpikeValue::Enum {
+            variant, payloads, ..
+        } => render_enum(variant, payloads),
         SpikeValue::Tuple(values) => render_sequence("(", ")", values),
         SpikeValue::Array(values) => render_sequence("[", "]", values),
     }
+}
+
+fn render_enum(variant: &str, payloads: &[SpikeValue]) -> String {
+    if payloads.is_empty() {
+        return variant.to_string();
+    }
+    format!("{variant}{}", render_sequence("(", ")", payloads))
 }
 
 fn render_struct(name: &str, fields: &[(String, SpikeValue)]) -> String {

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -288,6 +288,52 @@ fn cranelift_backend_builds_struct_field_binary() {
 
 #[cfg(not(windows))]
 #[test]
+fn cranelift_backend_builds_enum_match_binary() {
+    if which::which("cc").is_err() {
+        eprintln!("skipping cranelift backend smoke test because cc is unavailable");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("enum-match");
+    write_enum_match_project(&project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+    assert!(
+        output.status.success(),
+        "cranelift enum match build failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
+    assert_eq!(payload["backend"], "cranelift");
+    let binary = payload["binary"].as_str().expect("binary path");
+    let run = Command::new(binary)
+        .output()
+        .expect("run cranelift enum match binary");
+    assert!(
+        run.status.success(),
+        "cranelift enum match binary failed: stderr={}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "multi\nnamed\npayload\n2\n8\n"
+    );
+}
+
+#[cfg(not(windows))]
+#[test]
 fn cranelift_backend_builds_array_helpers_binary() {
     if which::which("cc").is_err() {
         eprintln!("skipping cranelift backend smoke test because cc is unavailable");
@@ -415,6 +461,25 @@ fn write_static_scalar_project(project: &Path) {
         "static GREETING: string = \"hello static\"\nstatic ANSWER: int = 42\nstatic READY: bool = true\n\nfn bump(value: int): int {\nreturn value + ANSWER\n}\n\nprint GREETING\nprint ANSWER\nprint bump(1)\nprint READY\n",
     )
     .expect("write static scalar source");
+}
+
+fn write_enum_match_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create enum match project src");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"cranelift-enum-match\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
+    )
+    .expect("write enum match manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-enum-match\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write enum match lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "enum Message {\nPair(int, string)\nJob { id: int, label: string }\nText(string)\n}\n\nenum Signal {\nRed\nYellow\nGreen\n}\n\nfn render(message: Message): string {\nmatch message {\nPair(count, label) {\nreturn label\n}\nJob { label, id } {\nreturn label\n}\nText(text) {\nreturn text\n}\n}\n}\n\nfn signal_priority(signal: Signal): int {\nreturn match signal { Red => 3, Yellow => 2, Green => 1 }\n}\n\nlet first: Message = Pair(7, \"multi\")\nlet second: Message = Job { id: 9, label: \"named\" }\nlet score: int = match Some(7) {\nSome(value) => value + 1\nNone => 0\n}\n\nprint render(first)\nprint render(second)\nprint render(Text(\"payload\"))\nprint signal_priority(Yellow)\nprint score\n",
+    )
+    .expect("write enum match source");
 }
 
 fn write_struct_field_project(project: &Path) {


### PR DESCRIPTION
## Summary

- Allow enum declarations through the Cranelift spike evaluator and represent enum variants with evaluated payloads.
- Evaluate direct statement and expression matches with payload binding for tuple, named, payloadless, and built-in enum variants.
- Add a native backend regression plus docs coverage for the supported enum/match subset.

## Governing Issue

Part of #692. Part of #105.

## Validation

- [x] `cargo fmt --manifest-path stage1/Cargo.toml --all`
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend -- --nocapture` (8 passed)
- [x] `cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build stage1/conformance/pass/typed_match_expressions --backend cranelift --json`
- [x] `./stage1/conformance/pass/typed_match_expressions/dist/conformance-typed-match-expressions`
- [x] `git diff --check`
- [x] Required PR checks are expected to satisfy `CI Gate`.
- [x] Skipped checks are explained below.

## Bootstrap Governance

- [x] Changes are scoped to the linked native-backend issues as a narrow Cranelift spike evaluator slice.
- [x] Contributor and PR guidance changes are not applicable; docs-only guidance change is limited to `docs/stage1.md` backend status.
- [x] Auto-merge is enabled.
- [x] No real secrets, runtime auth, or machine-local env files are committed.

## Semantic Layer Checklist

- [x] Semantic node types: none added or changed; this handles existing MIR enum variants plus statement and expression match forms in the Cranelift backend.
- [x] Schemas: none added or changed.
- [x] Evidence: Cranelift backend enum/match regression, direct build/run of `typed_match_expressions`, and the backend status doc update.
- [x] Rust capture check: backend-specific spike evaluator behavior only; this does not redefine Axiom enum or match semantics.
- [x] Agent-facing inspection impact: no schema or inspection contract changes.

## Flow Contract

- Owner lane: compiler/runtime
- Repair owner: codex
- Autonomy class: issue-linked feature slice
- Risk class: medium; native backend surface expands but remains isolated to the Cranelift spike path.

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action.
- [x] No active blocking requested changes remain.
- [ ] Non-author approval is present when required.
- [x] Auto-merge is appropriate when gates pass.

## Merge Automation

- [x] Auto-merge is enabled.

## Notes

- This intentionally does not close #692 or #105; full native backend parity remains larger follow-up work.
- This does not add match guards, mutation in match arms, async, maps, slices, or side-effecting helper functions to the Cranelift spike subset.
