### PR TITLE
Cranelift backend: enum variants with statement + expression match

### DIFF
--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -317,11 +317,12 @@ still far from the stated 1.0 target for service and agent workloads.
   native-backend expansion. `generated-rust` is still the default and only broad
   backend; `cranelift` is intentionally limited to scalar print-line programs,
   typed numeric scalars with width- and signedness-aware casts, static scalar
-  globals, struct literals and field access, tuple/array indexing, function
-  calls, the collection helpers `len(...)` over in-memory strings (encoded byte
-  length, matching the generated-Rust backend) and arrays plus
-  `first(...)`/`last(...)` over in-memory arrays, and scalar branching, so this
-  is not closure for #105 or the later full-surface native backend slices.
+  globals, struct literals and field access, enum variants with statement and
+  expression `match`, tuple/array indexing, function calls, the collection
+  helpers `len(...)` over in-memory strings (encoded byte length, matching the
+  generated-Rust backend) and arrays plus `first(...)`/`last(...)` over
+  in-memory arrays, and scalar branching, so this is not closure for #105 or
+  the later full-surface native backend slices.
 - Generated-Rust builds now use a persistent per-artifact cache keyed by
   compiler version, target, debug mode, manifest/lockfile hash, rendered Rust,
   module source hashes, and dependency imports. Cache hits skip `rustc`, cache

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -15,6 +15,13 @@ enum SpikeValue {
         name: String,
         fields: Vec<(String, SpikeValue)>,
     },
+    Enum {
+        enum_name: String,
+        variant: String,
+        // Payloads, paired with their field name for named-payload variants
+        // (`None` for tuple-style variants).
+        fields: Vec<(Option<String>, SpikeValue)>,
+    },
     Tuple(Vec<SpikeValue>),
     Array(Vec<SpikeValue>),
 }
@@ -45,11 +52,6 @@ pub fn compile_cranelift_hello_spike(
 }
 
 fn collect_print_lines(program: &Program) -> Result<Vec<String>, Diagnostic> {
-    if !program.enums.is_empty() {
-        return Err(unsupported(
-            "enums are not part of the cranelift hello spike",
-        ));
-    }
     let functions = program
         .functions
         .iter()
@@ -120,12 +122,95 @@ fn eval_stmt(
             _ => Err(unsupported("while conditions must be boolean")),
         },
         Stmt::Return { expr, .. } => Ok(Some(eval_expr(expr, functions, env)?)),
-        Stmt::Assign { .. } | Stmt::Panic { .. } | Stmt::Defer { .. } | Stmt::Match { .. } => {
-            Err(unsupported(
-                "only let, print, if, while false, and return statements are supported by the cranelift hello spike",
-            ))
+        Stmt::Match { expr, arms, .. } => eval_match(expr, arms, functions, env, lines),
+        Stmt::Assign { .. } | Stmt::Panic { .. } | Stmt::Defer { .. } => Err(unsupported(
+            "only let, print, if, while false, match, and return statements are supported by the cranelift hello spike",
+        )),
+    }
+}
+
+fn eval_match(
+    scrutinee: &Expr,
+    arms: &[crate::mir::MatchArm],
+    functions: &HashMap<&str, &Function>,
+    env: &mut SpikeEnv,
+    lines: &mut Vec<String>,
+) -> Result<Option<SpikeValue>, Diagnostic> {
+    let (enum_name, variant, fields) = expect_enum(eval_expr(scrutinee, functions, env)?)?;
+    let arm = arms
+        .iter()
+        .find(|arm| arm_matches(&arm.enum_name, &arm.variant, &enum_name, &variant))
+        .ok_or_else(|| no_arm(&enum_name, &variant))?;
+    let mut arm_env = bind_match_arm(
+        env,
+        &fields,
+        &arm.bindings,
+        arm.is_named,
+        arm.ignore_payloads,
+        &enum_name,
+        &variant,
+    )?;
+    eval_block(&arm.body, functions, &mut arm_env, lines)
+}
+
+fn expect_enum(
+    value: SpikeValue,
+) -> Result<(String, String, Vec<(Option<String>, SpikeValue)>), Diagnostic> {
+    match value {
+        SpikeValue::Enum {
+            enum_name,
+            variant,
+            fields,
+        } => Ok((enum_name, variant, fields)),
+        _ => Err(unsupported("match scrutinee must be an enum value")),
+    }
+}
+
+fn arm_matches(arm_enum: &str, arm_variant: &str, enum_name: &str, variant: &str) -> bool {
+    arm_variant == variant && (arm_enum.is_empty() || arm_enum == enum_name)
+}
+
+fn no_arm(enum_name: &str, variant: &str) -> Diagnostic {
+    unsupported(&format!(
+        "no cranelift spike match arm for {enum_name}::{variant}"
+    ))
+}
+
+// Bind an arm's payloads in a fresh child scope so bindings do not leak into
+// the surrounding environment.
+fn bind_match_arm(
+    base_env: &SpikeEnv,
+    fields: &[(Option<String>, SpikeValue)],
+    bindings: &[String],
+    is_named: bool,
+    ignore_payloads: bool,
+    enum_name: &str,
+    variant: &str,
+) -> Result<SpikeEnv, Diagnostic> {
+    let mut arm_env = base_env.clone();
+    if ignore_payloads {
+        return Ok(arm_env);
+    }
+    if is_named {
+        for binding in bindings {
+            let value = fields
+                .iter()
+                .find_map(|(name, value)| {
+                    (name.as_deref() == Some(binding.as_str())).then(|| value.clone())
+                })
+                .ok_or_else(|| {
+                    unsupported(&format!(
+                        "named payload {binding:?} is missing on {enum_name}::{variant}"
+                    ))
+                })?;
+            arm_env.insert(binding.clone(), value);
+        }
+    } else {
+        for (binding, (_, value)) in bindings.iter().zip(fields) {
+            arm_env.insert(binding.clone(), value.clone());
         }
     }
+    Ok(arm_env)
 }
 
 fn eval_expr(
@@ -182,6 +267,45 @@ fn eval_expr(
                 }),
             _ => Err(unsupported("field access requires a struct value")),
         },
+        Expr::EnumVariant {
+            enum_name,
+            variant,
+            field_names,
+            payloads,
+            ..
+        } => {
+            let values = payloads
+                .iter()
+                .map(|payload| eval_expr(payload, functions, env))
+                .collect::<Result<Vec<_>, _>>()?;
+            let fields = if field_names.is_empty() {
+                values.into_iter().map(|value| (None, value)).collect()
+            } else {
+                field_names.iter().cloned().map(Some).zip(values).collect()
+            };
+            Ok(SpikeValue::Enum {
+                enum_name: enum_name.clone(),
+                variant: variant.clone(),
+                fields,
+            })
+        }
+        Expr::Match { expr, arms, .. } => {
+            let (enum_name, variant, fields) = expect_enum(eval_expr(expr, functions, env)?)?;
+            let arm = arms
+                .iter()
+                .find(|arm| arm_matches(&arm.enum_name, &arm.variant, &enum_name, &variant))
+                .ok_or_else(|| no_arm(&enum_name, &variant))?;
+            let arm_env = bind_match_arm(
+                env,
+                &fields,
+                &arm.bindings,
+                arm.is_named,
+                false,
+                &enum_name,
+                &variant,
+            )?;
+            eval_expr(&arm.expr, functions, &arm_env)
+        }
         Expr::TupleLiteral { elements, .. } => elements
             .iter()
             .map(|element| eval_expr(element, functions, env))
@@ -628,8 +752,34 @@ fn render_value(value: &SpikeValue) -> String {
         SpikeValue::Bool(false) => String::from("false"),
         SpikeValue::Text(value) => value.clone(),
         SpikeValue::Struct { name, fields } => render_struct(name, fields),
+        SpikeValue::Enum {
+            variant, fields, ..
+        } => render_enum(variant, fields),
         SpikeValue::Tuple(values) => render_sequence("(", ")", values),
         SpikeValue::Array(values) => render_sequence("[", "]", values),
+    }
+}
+
+fn render_enum(variant: &str, fields: &[(Option<String>, SpikeValue)]) -> String {
+    if fields.is_empty() {
+        return variant.to_string();
+    }
+    let named = fields.iter().all(|(name, _)| name.is_some());
+    if named {
+        let mut rendered = format!("{variant} {{ ");
+        for (index, (name, value)) in fields.iter().enumerate() {
+            if index > 0 {
+                rendered.push_str(", ");
+            }
+            rendered.push_str(name.as_deref().unwrap_or(""));
+            rendered.push_str(": ");
+            rendered.push_str(&render_value(value));
+        }
+        rendered.push_str(" }");
+        rendered
+    } else {
+        let values: Vec<SpikeValue> = fields.iter().map(|(_, value)| value.clone()).collect();
+        format!("{variant}{}", render_sequence("(", ")", &values))
     }
 }
 

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -329,6 +329,49 @@ fn cranelift_backend_builds_array_helpers_binary() {
     assert_eq!(String::from_utf8_lossy(&run.stdout), "3\n10\n30\n40\n");
 }
 
+#[cfg(not(windows))]
+#[test]
+fn cranelift_backend_builds_enum_match_binary() {
+    if which::which("cc").is_err() {
+        eprintln!("skipping cranelift backend smoke test because cc is unavailable");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("enum-match");
+    write_enum_match_project(&project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+    assert!(
+        output.status.success(),
+        "cranelift enum-match build failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
+    assert_eq!(payload["backend"], "cranelift");
+    let binary = payload["binary"].as_str().expect("binary path");
+    let run = Command::new(binary)
+        .output()
+        .expect("run cranelift enum-match binary");
+    assert!(
+        run.status.success(),
+        "cranelift enum-match binary failed: stderr={}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&run.stdout), "9\n20\n0\n3\n2\n1\n");
+}
+
 fn copy_fixture(relative: &str, destination: &Path) {
     let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../../examples/hello")
@@ -453,4 +496,23 @@ fn write_array_helpers_project(project: &Path) {
         "let values: [int; 3] = [10, 20, 30]\nprint len(values)\nprint first(values)\nprint last(values)\nprint first(values) + last(values)\n",
     )
     .expect("write array-helpers source");
+}
+
+fn write_enum_match_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create enum-match project src");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"cranelift-enum-match\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
+    )
+    .expect("write enum-match manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-enum-match\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write enum-match lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "enum Shape {\nCircle(int)\nRect { width: int, height: int }\nEmpty\n}\n\nenum Signal {\nRed\nYellow\nGreen\n}\n\nfn area(shape: Shape): int {\nmatch shape {\nCircle(radius) {\nreturn radius * radius\n}\nRect { width, height } {\nreturn width * height\n}\nEmpty {\nreturn 0\n}\n}\n}\n\nfn rank(signal: Signal): int {\nreturn match signal { Red => 3, Yellow => 2, Green => 1 }\n}\n\nprint area(Circle(3))\nprint area(Rect { width: 4, height: 5 })\nprint area(Empty)\nprint rank(Red)\nprint rank(Yellow)\nprint rank(Green)\n",
+    )
+    .expect("write enum-match source");
 }


### PR DESCRIPTION
## Summary

Next verified native-backend slice for #692/#105: **enum variants with `match`** in the Cranelift spike evaluator — pure tagged-union control flow (no borrows, loops, or heap).

- Evaluate `EnumVariant` constructors into backend-local enum values, covering all three variant shapes: tuple-style (`Circle(int)`), named-payload (`Rect { width: int, height: int }`), and unit (`Empty`).
- Resolve **statement-level `match`** (block arms with `return`) and **expression `match`** (`=>` arms) by selecting the arm for the scrutinee's variant and binding its payloads in a fresh child scope (positional for tuple-style, by-name for named-payload, none for `ignore_payloads`).
- Drop the blanket "enums are not part of the spike" rejection (mirrors how structs were enabled in #920); unsupported enum *operations* still error precisely at evaluation.

## Validation

- [x] `cargo fmt --manifest-path stage1/Cargo.toml --all` (no changes)
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend` — **8 passed** (incl. new `enum_match` regression)
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib cranelift` — 2 passed

## Regression added

`cranelift_backend_builds_enum_match_binary` — a `Shape` enum (tuple/named/unit variants) consumed by a statement `match`, and a `Signal` enum consumed by an expression `match`:
`area(Circle 3)=9`, `area(Rect 4×5)=20`, `area(Empty)=0`, `rank(Red)=3`, `rank(Yellow)=2`, `rank(Green)=1`.

## Scope

Part of #692. Part of #105. Narrow slice; does not close either issue. Gated/destructive roadmap epics (#693/#694/#721, #704/#230, #562–#565/#731) remain out of scope pending human approval.

https://claude.ai/code/session_01KyAe5Mx1PAbhMfawEpH2Zp

---
_Generated by [Claude Code](https://claude.ai/code/session_01KyAe5Mx1PAbhMfawEpH2Zp)_