### PR TITLE
[codex] Add Cranelift debug sidecars

### DIFF
--- a/docs/stage1-debug-map.md
+++ b/docs/stage1-debug-map.md
@@ -1,17 +1,19 @@
 # Stage1 Debug Map
 
-`axiomc build --debug` currently emits Rust debuginfo for the generated Rust
-shim and writes Axiom source-position sidecars next to the generated artifact:
+`axiomc build --debug` writes Axiom source-position sidecars next to the
+generated artifact. The generated-Rust backend also asks `rustc` for native
+debuginfo; the Cranelift spike currently emits sidecars only and records that
+native Axiom DWARF is not present yet.
 
 - `<artifact>.debug-map.json` maps generated Rust statement lines back to
   `.ax` source file, line, and column positions.
 - `<artifact>.debug-manifest.json` binds the native binary, generated Rust,
-  debug map, rustc debug settings, source hashes, and mapping counts.
+  debug map, backend-native debug settings, source hashes, and mapping counts.
 
-This is an interim generated-Rust bridge. Native DWARF line tables still point
-at generated Rust, so debugger integrations should translate generated Rust
-frames through the debug map instead of assuming the binary contains native
-`.ax` line records.
+This is an interim sidecar bridge. Generated-Rust DWARF line tables still point
+at generated Rust, and Cranelift debug builds do not emit Axiom DWARF yet, so
+debugger integrations should translate generated Rust frames through the debug
+map instead of assuming the binary contains native `.ax` line records.
 
 ## Build
 
@@ -76,9 +78,12 @@ Consumers should treat `debug_manifest` as the integrity envelope:
 
 - `binary_hash` and `generated_rust_hash` identify the exact artifacts.
 - `source_files[*].source_hash` identifies the `.ax` inputs.
-- `rustc.axiom_dwarf` is `false` for the generated-Rust backend.
+- `native_debug.axiom_dwarf` is the backend-neutral signal for whether the
+  binary contains native Axiom DWARF line tables.
+- `rustc` is retained for generated-Rust compatibility; Cranelift debug
+  manifests omit it because `rustc` is not the native debug producer.
 - `source_files[*].mapping_count` lets tools detect missing or unexpectedly
   sparse source mappings.
 
-If `rustc.axiom_dwarf` is `false`, tools must report that stepping is mediated
-through the sidecar map and not through native Axiom DWARF.
+If `native_debug.axiom_dwarf` is `false`, tools must report that stepping is
+mediated through the sidecar map and not through native Axiom DWARF.

--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -179,8 +179,8 @@ requested/resolved target, debug mode, package lockfile, lockfile hash, and
 aggregate source hash inspection. Debug builds report `debug_map`, a JSON
 sidecar that maps generated Rust statement lines back to Axiom file/line/column
 positions, plus `debug_manifest`, a JSON sidecar that binds the native binary
-hash, generated Rust hash, rustc debug-mode settings, source file hashes, and
-mapping counts for debugger/tooling consumers. See
+hash, generated Rust hash, backend-native debug settings, source file hashes,
+and mapping counts for debugger/tooling consumers. See
 `docs/stage1-debug-map.md` for the LLDB/GDB sidecar translation workflow.
 `axiomc build --timings` prints total build time, cache hit/miss counts, and
 per-package compile timing/cache status for the incremental generated-Rust
@@ -323,6 +323,8 @@ still far from the stated 1.0 target for service and agent workloads.
   generated-Rust backend) and arrays plus
   `first(...)`/`last(...)` over in-memory arrays, and scalar branching, so this
   is not closure for #105 or the later full-surface native backend slices.
+  Cranelift debug builds emit the shared debug map and manifest sidecars, but
+  the manifest explicitly reports that native Axiom DWARF is not emitted yet.
 - Generated-Rust builds now use a persistent per-artifact cache keyed by
   compiler version, target, debug mode, manifest/lockfile hash, rendered Rust,
   module source hashes, and dependency imports. Cache hits skip `rustc`, cache

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -35,16 +35,11 @@ pub fn compile_cranelift_hello_spike(
     object_path: &Path,
     binary_path: &Path,
     target: Option<&str>,
-    debug: bool,
+    _debug: bool,
 ) -> Result<(), Diagnostic> {
     if target.is_some() {
         return Err(unsupported(
             "the cranelift backend spike currently supports only the host target",
-        ));
-    }
-    if debug {
-        return Err(unsupported(
-            "the cranelift backend spike does not emit debug sidecars yet",
         ));
     }
     let lines = collect_print_lines(program)?;

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -12664,9 +12664,14 @@ print takes_two(three)
         )
         .expect("parse debug manifest");
         assert_eq!(manifest["schema_version"], "axiom.stage1.debug_manifest.v1");
+        assert_eq!(manifest["backend"], "generated-rust");
         assert_eq!(manifest["binary"], debug.binary);
         assert_eq!(manifest["generated_rust"], debug.generated_rust);
         assert_eq!(manifest["debug_map"], debug_map.display().to_string());
+        assert_eq!(manifest["native_debug"]["producer"], "rustc");
+        assert_eq!(manifest["native_debug"]["debuginfo"], 2);
+        assert_eq!(manifest["native_debug"]["opt_level"], 0);
+        assert_eq!(manifest["native_debug"]["axiom_dwarf"], false);
         assert_eq!(manifest["rustc"]["debuginfo"], 2);
         assert_eq!(manifest["rustc"]["opt_level"], 0);
         assert_eq!(manifest["rustc"]["axiom_dwarf"], false);

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -2010,7 +2010,7 @@ fn build_artifacts(
         .is_some_and(|stored| cache_matches(stored, &cache, generated_rust, binary))
     {
         if options.debug {
-            write_debug_artifacts(generated_rust, binary, analyzed)?;
+            write_debug_artifacts(generated_rust, binary, analyzed, options.backend)?;
         }
         write_provenance_artifact(package_root, analyzed, generated_rust, binary)?;
         return Ok(BuildArtifactReport {
@@ -2053,7 +2053,7 @@ fn build_artifacts(
     }
     let compile_ms = started.elapsed().as_millis() as u64;
     if options.debug {
-        write_debug_artifacts(generated_rust, binary, analyzed)?;
+        write_debug_artifacts(generated_rust, binary, analyzed, options.backend)?;
     }
     let mut cache = cache;
     cache.binary_hash = Some(hash_file_bytes(binary)?);
@@ -2478,13 +2478,25 @@ struct DebugSourceMapping {
 #[derive(Debug, Serialize)]
 struct DebugManifest<'a> {
     schema_version: &'static str,
+    backend: NativeBackendKind,
     binary: &'a str,
     binary_hash: String,
     generated_rust: &'a str,
     generated_rust_hash: String,
     debug_map: &'a str,
-    rustc: DebugRustcInfo,
+    native_debug: DebugNativeInfo,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rustc: Option<DebugRustcInfo>,
     source_files: Vec<DebugSourceFile>,
+}
+
+#[derive(Debug, Serialize)]
+struct DebugNativeInfo {
+    producer: &'static str,
+    debuginfo: u8,
+    opt_level: u8,
+    native_debug_info: &'static str,
+    axiom_dwarf: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -2507,6 +2519,7 @@ fn write_debug_artifacts(
     generated_rust: &Path,
     binary: &Path,
     analyzed: &AnalyzedProject,
+    backend: NativeBackendKind,
 ) -> Result<(), Diagnostic> {
     let debug_map = debug_source_map_path(generated_rust);
     write_debug_source_map(generated_rust, &debug_map)?;
@@ -2515,6 +2528,7 @@ fn write_debug_artifacts(
         binary,
         &debug_map,
         &debug_manifest_path(generated_rust),
+        backend,
         analyzed,
     )
 }
@@ -2548,6 +2562,7 @@ fn write_debug_manifest(
     binary: &Path,
     debug_map: &Path,
     debug_manifest: &Path,
+    backend: NativeBackendKind,
     analyzed: &AnalyzedProject,
 ) -> Result<(), Diagnostic> {
     let generated_source = fs::read_to_string(generated_rust).map_err(|err| {
@@ -2561,17 +2576,14 @@ fn write_debug_manifest(
     let debug_map_path = debug_map.display().to_string();
     let manifest = DebugManifest {
         schema_version: "axiom.stage1.debug_manifest.v1",
+        backend,
         binary: &binary_path,
         binary_hash: hash_file_bytes(binary)?,
         generated_rust: &generated_rust_path,
         generated_rust_hash: hash_file(generated_rust)?,
         debug_map: &debug_map_path,
-        rustc: DebugRustcInfo {
-            debuginfo: 2,
-            opt_level: 0,
-            native_debug_info: "rustc DWARF points at generated Rust",
-            axiom_dwarf: false,
-        },
+        native_debug: debug_native_info(backend),
+        rustc: rustc_debug_info(backend),
         source_files: debug_source_files(analyzed, &generated_source)?,
     };
     let content = serde_json::to_string_pretty(&manifest).map_err(|err| {
@@ -2583,6 +2595,37 @@ fn write_debug_manifest(
             format!("failed to write {}: {err}", debug_manifest.display()),
         )
     })
+}
+
+fn debug_native_info(backend: NativeBackendKind) -> DebugNativeInfo {
+    match backend {
+        NativeBackendKind::GeneratedRust => DebugNativeInfo {
+            producer: "rustc",
+            debuginfo: 2,
+            opt_level: 0,
+            native_debug_info: "rustc DWARF points at generated Rust",
+            axiom_dwarf: false,
+        },
+        NativeBackendKind::Cranelift => DebugNativeInfo {
+            producer: "cranelift",
+            debuginfo: 0,
+            opt_level: 0,
+            native_debug_info: "cranelift object does not emit native Axiom DWARF yet; sidecar debug map carries Axiom source spans",
+            axiom_dwarf: false,
+        },
+    }
+}
+
+fn rustc_debug_info(backend: NativeBackendKind) -> Option<DebugRustcInfo> {
+    match backend {
+        NativeBackendKind::GeneratedRust => Some(DebugRustcInfo {
+            debuginfo: 2,
+            opt_level: 0,
+            native_debug_info: "rustc DWARF points at generated Rust",
+            axiom_dwarf: false,
+        }),
+        NativeBackendKind::Cranelift => None,
+    }
 }
 
 fn debug_source_files(

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -375,6 +375,125 @@ fn cranelift_backend_builds_array_helpers_binary() {
     assert_eq!(String::from_utf8_lossy(&run.stdout), "3\n10\n30\n40\n");
 }
 
+#[cfg(not(windows))]
+#[test]
+fn cranelift_backend_debug_build_emits_sidecars_without_axiom_dwarf() {
+    if which::which("cc").is_err() {
+        eprintln!("skipping cranelift backend smoke test because cc is unavailable");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("hello-debug");
+    fs::create_dir_all(project.join("src")).expect("create project src");
+    copy_fixture("axiom.toml", &project.join("axiom.toml"));
+    copy_fixture("axiom.lock", &project.join("axiom.lock"));
+    copy_fixture("src/main.ax", &project.join("src/main.ax"));
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--debug",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift --debug");
+    assert!(
+        output.status.success(),
+        "cranelift debug build failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
+    assert_eq!(payload["backend"], "cranelift");
+    assert_eq!(payload["debug"], true);
+    let binary = payload["binary"].as_str().expect("binary path");
+    let generated_rust = payload["generated_rust"]
+        .as_str()
+        .expect("generated Rust path");
+    let debug_map = payload["debug_map"].as_str().expect("debug map path");
+    let debug_manifest = payload["debug_manifest"]
+        .as_str()
+        .expect("debug manifest path");
+    assert!(Path::new(binary).exists(), "cranelift binary exists");
+    assert!(
+        Path::new(generated_rust)
+            .with_extension("cranelift.o")
+            .exists(),
+        "cranelift object exists"
+    );
+    assert!(Path::new(debug_map).exists(), "debug map exists");
+    assert!(Path::new(debug_manifest).exists(), "debug manifest exists");
+
+    let source = project
+        .join("src/main.ax")
+        .canonicalize()
+        .expect("canonical source path")
+        .display()
+        .to_string();
+    let map: Value =
+        serde_json::from_str(&fs::read_to_string(debug_map).expect("read cranelift debug map"))
+            .expect("parse cranelift debug map");
+    assert!(
+        map["mappings"]
+            .as_array()
+            .expect("debug mappings")
+            .iter()
+            .any(|mapping| mapping["source"] == source),
+        "debug map should retain Axiom source spans for cranelift builds"
+    );
+
+    let manifest: Value = serde_json::from_str(
+        &fs::read_to_string(debug_manifest).expect("read cranelift debug manifest"),
+    )
+    .expect("parse cranelift debug manifest");
+    assert_eq!(manifest["schema_version"], "axiom.stage1.debug_manifest.v1");
+    assert_eq!(manifest["backend"], "cranelift");
+    assert_eq!(manifest["binary"], binary);
+    assert_eq!(manifest["generated_rust"], generated_rust);
+    assert_eq!(manifest["debug_map"], debug_map);
+    assert_eq!(manifest["native_debug"]["producer"], "cranelift");
+    assert_eq!(manifest["native_debug"]["debuginfo"], 0);
+    assert_eq!(manifest["native_debug"]["opt_level"], 0);
+    assert_eq!(manifest["native_debug"]["axiom_dwarf"], false);
+    assert!(
+        manifest["native_debug"]["native_debug_info"]
+            .as_str()
+            .expect("native debug info")
+            .contains("does not emit native Axiom DWARF yet")
+    );
+    assert!(
+        manifest.get("rustc").is_none(),
+        "cranelift debug manifests should not claim rustc debug settings"
+    );
+    assert!(
+        manifest["source_files"]
+            .as_array()
+            .expect("source files")
+            .iter()
+            .any(|source_file| source_file["path"] == source
+                && source_file["mapping_count"].as_u64().unwrap_or(0) > 0),
+        "debug manifest should count Axiom source mappings for cranelift builds"
+    );
+
+    let run = Command::new(binary)
+        .output()
+        .expect("run cranelift debug binary");
+    assert!(
+        run.status.success(),
+        "cranelift debug binary failed: stderr={}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "hello from stage1\n42\ntrue\n"
+    );
+}
+
 fn copy_fixture(relative: &str, destination: &Path) {
     let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../../examples/hello")


### PR DESCRIPTION
## Summary

- Allow `axiomc build --backend cranelift --debug` to build and emit the existing debug map and debug manifest sidecars.
- Add backend-aware debug manifest metadata with a `native_debug` object; generated-Rust manifests retain the existing `rustc` block, while Cranelift manifests omit it and report `axiom_dwarf: false`.
- Cover the Cranelift debug sidecar path with an end-to-end build/run regression and update the debug-map docs to describe the honest DWARF boundary.

## Governing Issue

Part of #704. Part of #230. Part of #105.

## Validation

- [x] `cargo fmt --manifest-path stage1/Cargo.toml --all`
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend -- --nocapture` (8 passed)
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib build_project_debug_mode_emits_source_markers_and_uses_separate_cache_key -- --nocapture` (1 passed)
- [x] `git diff --check`
- [x] Required PR checks are expected to satisfy `CI Gate`.
- [x] Skipped checks are explained below.

## Bootstrap Governance

- [x] Changes are scoped to debugger metadata for the native-backend spike and do not change repo bootstrap policy.
- [x] Contributor and PR guidance changes are not applicable.
- [x] Auto-merge is appropriate after required checks pass and non-author approval is present.
- [x] No real secrets, runtime auth, or machine-local env files are committed.

## Semantic Layer Checklist

- [x] Semantic node types: none added or changed.
- [x] Schemas: debug manifest payload grows backend-aware `backend` and `native_debug` fields while retaining generated-Rust `rustc` compatibility.
- [x] Evidence: Cranelift debug build/run regression, generated-Rust debug manifest regression, and debug-map documentation updates.
- [x] Rust capture check: generated-Rust source markers remain the sidecar source; Cranelift does not claim native Axiom DWARF.
- [x] Agent-facing inspection impact: debugger/tooling consumers should read `native_debug.axiom_dwarf` instead of assuming `rustc` is present for every backend.

## Flow Contract

- Owner lane: compiler/runtime
- Repair owner: codex
- Autonomy class: issue-linked feature slice
- Risk class: medium; debug manifest contract expands but remains backward-compatible for generated-Rust consumers.

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action.
- [x] No active blocking requested changes remain.
- [ ] Non-author approval is present when required.
- [x] Auto-merge is appropriate when gates pass.

## Merge Automation

- [x] Auto-merge is enabled.

## Notes

- This does not close #704 or #230: native Axiom DWARF line tables, function DIEs, line stepping, and locals are still future direct-backend work.
- This does not close #105: generated-Rust remains the default and only broad backend.
- Cranelift debug sidecars are intentionally honest interim metadata: `native_debug.axiom_dwarf` is `false`.
