### PR TITLE
[codex] Add Cranelift map literal support

### DIFF
--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -318,13 +318,15 @@ still far from the stated 1.0 target for service and agent workloads.
   backend; `cranelift` is intentionally limited to scalar print-line programs,
   typed numeric scalars with width- and signedness-aware casts, static scalar
   globals, enum variants with direct match arms, struct literals and field
-  access, tuple/array indexing, function calls, the collection helpers
-  `len(...)` over in-memory strings (encoded byte length, matching the
-  generated-Rust backend) and arrays plus
-  `first(...)`/`last(...)` over in-memory arrays, and scalar branching, so this
-  is not closure for #105 or the later full-surface native backend slices.
+  access, tuple/array indexing, function calls, map literals with scalar keys,
+  map indexing, `map_contains_key(...)`, the collection helpers `len(...)` over
+  in-memory strings (encoded byte length, matching the generated-Rust backend)
+  and arrays plus `first(...)`/`last(...)` over in-memory arrays, and scalar
+  branching, so this is not closure for #105 or the later full-surface native
+  backend slices.
   Cranelift debug builds emit the shared debug map and manifest sidecars, but
   the manifest explicitly reports that native Axiom DWARF is not emitted yet.
+
 - Generated-Rust builds now use a persistent per-artifact cache keyed by
   compiler version, target, debug mode, manifest/lockfile hash, rendered Rust,
   module source hashes, and dependency imports. Cache hits skip `rustc`, cache

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -803,7 +803,7 @@ fn validate_map_key(value: &SpikeValue) -> Result<(), Diagnostic> {
         SpikeValue::Float(_) => Err(unsupported(
             "map float keys are not supported by the cranelift spike",
         )),
-        SpikeValue::Struct { .. } | SpikeValue::Map(_) | SpikeValue::Array(_) => Err(unsupported(
+        SpikeValue::Enum { .. } | SpikeValue::Struct { .. } | SpikeValue::Map(_) | SpikeValue::Array(_) => Err(unsupported(
             "map keys must be scalar values or scalar tuples in the cranelift spike",
         )),
     }

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -25,6 +25,7 @@ enum SpikeValue {
         payloads: Vec<SpikeValue>,
     },
     Tuple(Vec<SpikeValue>),
+    Map(Vec<(SpikeValue, SpikeValue)>),
     Array(Vec<SpikeValue>),
 }
 
@@ -209,21 +210,41 @@ fn eval_expr(
                 .ok_or_else(|| unsupported("tuple index is outside the tuple width")),
             _ => Err(unsupported("tuple indexing requires a tuple value")),
         },
+        Expr::MapLiteral { entries, .. } => {
+            let mut values = Vec::new();
+            for entry in entries {
+                let key = eval_expr(&entry.key, functions, env)?;
+                validate_map_key(&key)?;
+                let value = eval_expr(&entry.value, functions, env)?;
+                insert_map_entry(&mut values, key, value)?;
+            }
+            Ok(SpikeValue::Map(values))
+        }
         Expr::ArrayLiteral { elements, .. } => elements
             .iter()
             .map(|element| eval_expr(element, functions, env))
             .collect::<Result<Vec<_>, _>>()
             .map(SpikeValue::Array),
-        Expr::Index { base, index, .. } => {
-            let index = expect_non_negative_index(eval_expr(index, functions, env)?)?;
-            match eval_expr(base, functions, env)? {
-                SpikeValue::Array(elements) => elements
+        Expr::Index { base, index, .. } => match eval_expr(base, functions, env)? {
+            SpikeValue::Array(elements) => {
+                let index = expect_non_negative_index(eval_expr(index, functions, env)?)?;
+                elements
                     .get(index)
                     .cloned()
-                    .ok_or_else(|| unsupported("array index is outside the array length")),
-                _ => Err(unsupported("array indexing requires an array value")),
+                    .ok_or_else(|| unsupported("array index is outside the array length"))
             }
-        }
+            SpikeValue::Map(entries) => {
+                let key = eval_expr(index, functions, env)?;
+                validate_map_key(&key)?;
+                for (candidate, value) in entries {
+                    if map_keys_equal(&candidate, &key)? {
+                        return Ok(value);
+                    }
+                }
+                Err(unsupported("map key not found"))
+            }
+            _ => Err(unsupported("indexing requires an array or map value")),
+        },
         _ => Err(unsupported(
             "this expression is outside the cranelift hello spike subset",
         )),
@@ -460,6 +481,9 @@ fn eval_call(
     if name == "first" || name == "last" {
         return eval_first_last_call(name, args, functions, env);
     }
+    if name == "contains" || name == "map_contains_key" {
+        return eval_map_contains_call(args, functions, env);
+    }
     let function = functions
         .get(name)
         .ok_or_else(|| unsupported(&format!("unsupported cranelift spike call {name:?}")))?;
@@ -528,6 +552,26 @@ fn eval_first_last_call(
     selected
         .cloned()
         .ok_or_else(|| unsupported(&format!("{name} on an empty array")))
+}
+
+fn eval_map_contains_call(
+    args: &[Expr],
+    functions: &HashMap<&str, &Function>,
+    env: &SpikeEnv,
+) -> Result<SpikeValue, Diagnostic> {
+    let [map, key] = args else {
+        return Err(unsupported("map contains expects exactly two arguments"));
+    };
+    let entries = match eval_expr(map, functions, env)? {
+        SpikeValue::Map(entries) => entries,
+        _ => return Err(unsupported("map contains expects a map value")),
+    };
+    let key = eval_expr(key, functions, env)?;
+    validate_map_key(&key)?;
+    let contains = entries.iter().try_fold(false, |found, (candidate, _)| {
+        Ok::<_, Diagnostic>(found || map_keys_equal(candidate, &key)?)
+    })?;
+    Ok(SpikeValue::Bool(contains))
 }
 
 fn eval_arithmetic(
@@ -735,6 +779,55 @@ fn expect_non_negative_index(value: SpikeValue) -> Result<usize, Diagnostic> {
     }
 }
 
+fn insert_map_entry(
+    entries: &mut Vec<(SpikeValue, SpikeValue)>,
+    key: SpikeValue,
+    value: SpikeValue,
+) -> Result<(), Diagnostic> {
+    for (candidate, existing) in entries.iter_mut() {
+        if map_keys_equal(candidate, &key)? {
+            *existing = value;
+            return Ok(());
+        }
+    }
+    entries.push((key, value));
+    Ok(())
+}
+
+fn validate_map_key(value: &SpikeValue) -> Result<(), Diagnostic> {
+    match value {
+        SpikeValue::Int(_) | SpikeValue::UInt(_) | SpikeValue::Bool(_) | SpikeValue::Text(_) => {
+            Ok(())
+        }
+        SpikeValue::Tuple(values) => values.iter().try_for_each(validate_map_key),
+        SpikeValue::Float(_) => Err(unsupported(
+            "map float keys are not supported by the cranelift spike",
+        )),
+        SpikeValue::Struct { .. } | SpikeValue::Map(_) | SpikeValue::Array(_) => Err(unsupported(
+            "map keys must be scalar values or scalar tuples in the cranelift spike",
+        )),
+    }
+}
+
+fn map_keys_equal(left: &SpikeValue, right: &SpikeValue) -> Result<bool, Diagnostic> {
+    match (left, right) {
+        (SpikeValue::Int(left), SpikeValue::Int(right)) => Ok(left == right),
+        (SpikeValue::UInt(left), SpikeValue::UInt(right)) => Ok(left == right),
+        (SpikeValue::Bool(left), SpikeValue::Bool(right)) => Ok(left == right),
+        (SpikeValue::Text(left), SpikeValue::Text(right)) => Ok(left == right),
+        (SpikeValue::Tuple(left), SpikeValue::Tuple(right)) if left.len() == right.len() => left
+            .iter()
+            .zip(right.iter())
+            .try_fold(true, |matches, (left, right)| {
+                Ok::<_, Diagnostic>(matches && map_keys_equal(left, right)?)
+            }),
+        (SpikeValue::Tuple(_), SpikeValue::Tuple(_)) => Ok(false),
+        _ => Err(unsupported(
+            "map key types must match in the cranelift spike",
+        )),
+    }
+}
+
 fn render_value(value: &SpikeValue) -> String {
     match value {
         SpikeValue::Int(value) => value.to_string(),
@@ -748,6 +841,7 @@ fn render_value(value: &SpikeValue) -> String {
             variant, payloads, ..
         } => render_enum(variant, payloads),
         SpikeValue::Tuple(values) => render_sequence("(", ")", values),
+        SpikeValue::Map(entries) => render_map(entries),
         SpikeValue::Array(values) => render_sequence("[", "]", values),
     }
 }
@@ -782,6 +876,20 @@ fn render_sequence(open: &str, close: &str, values: &[SpikeValue]) -> String {
         rendered.push_str(&render_value(value));
     }
     rendered.push_str(close);
+    rendered
+}
+
+fn render_map(entries: &[(SpikeValue, SpikeValue)]) -> String {
+    let mut rendered = String::from("{");
+    for (index, (key, value)) in entries.iter().enumerate() {
+        if index > 0 {
+            rendered.push_str(", ");
+        }
+        rendered.push_str(&render_value(key));
+        rendered.push_str(": ");
+        rendered.push_str(&render_value(value));
+    }
+    rendered.push('}');
     rendered
 }
 

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -490,7 +490,95 @@ fn cranelift_backend_debug_build_emits_sidecars_without_axiom_dwarf() {
     );
     assert_eq!(
         String::from_utf8_lossy(&run.stdout),
-        "hello from stage1\n42\ntrue\n"
+        "hello from stage1
+42
+true
+"
+    );
+}
+
+#[cfg(not(windows))]
+#[test]
+fn cranelift_backend_builds_map_index_binary() {
+    if which::which("cc").is_err() {
+        eprintln!("skipping cranelift backend smoke test because cc is unavailable");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("map-index");
+    write_map_index_project(&project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+    assert!(
+        output.status.success(),
+        "cranelift map build failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
+    assert_eq!(payload["backend"], "cranelift");
+    let binary = payload["binary"].as_str().expect("binary path");
+    let run = Command::new(binary)
+        .output()
+        .expect("run cranelift map binary");
+    assert!(
+        run.status.success(),
+        "cranelift map binary failed: stderr={}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "11
+true
+false
+high
+"
+    );
+}
+
+#[cfg(not(windows))]
+#[test]
+fn cranelift_backend_rejects_float_map_keys() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("float-map-key");
+    write_float_map_key_project(&project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+
+    assert!(
+        !output.status.success(),
+        "cranelift float-keyed map build unexpectedly succeeded: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("map float keys are not supported by the cranelift spike"),
+        "expected float map key diagnostic, got: {combined}"
     );
 }
 
@@ -637,4 +725,42 @@ fn write_array_helpers_project(project: &Path) {
         "let values: [int; 3] = [10, 20, 30]\nprint len(values)\nprint first(values)\nprint last(values)\nprint first(values) + last(values)\n",
     )
     .expect("write array-helpers source");
+}
+
+fn write_map_index_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create map project src");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"cranelift-map-index\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
+    )
+    .expect("write map manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-map-index\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write map lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "let scores: {string: int} = {\"build\": 7, \"deploy\": 9, \"deploy\": 11}\nprint scores[\"deploy\"]\n\nlet available: {string: int} = {\"build\": 7, \"deploy\": 9}\nprint map_contains_key<string, int>(available, \"build\")\n\nlet missing: {string: int} = {\"build\": 7, \"deploy\": 9}\nprint map_contains_key<string, int>(missing, \"test\")\n\nlet labels: {int: string} = {1: \"low\", 2: \"high\"}\nprint labels[2]\n",
+    )
+    .expect("write map source");
+}
+
+fn write_float_map_key_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create float map project src");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"cranelift-float-map-key\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
+    )
+    .expect("write float map manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-float-map-key\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write float map lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "let scores: {f64: int} = {1.5f64: 7}\nprint scores[1.5f64]\n",
+    )
+    .expect("write float map source");
 }


### PR DESCRIPTION
## Summary

- Evaluate map literals in the Cranelift spike, including duplicate-key replacement to mirror the generated-Rust projection.
- Add Cranelift spike support for map indexing plus `map_contains_key(...)` / `contains(...)`.
- Add an end-to-end Cranelift native build/run test for map indexing and document the expanded spike subset.

## Governing Issue

Part of #105.

This does not close #105. The direct native backend still needs broad MIR/runtime parity before `axiomc build` can stop relying on generated Rust by default.

## Validation

- [x] `cargo fmt --manifest-path stage1/Cargo.toml --all`
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend -- --nocapture` (8 passed)
- [x] `cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build stage1/examples/maps --backend cranelift --json`
- [x] `stage1/examples/maps/dist/maps-stage1` (printed `9`)
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib build_project_emits_native_binary_with_maps -- --nocapture` (1 passed)
- [x] `git diff --check`
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

No checks were skipped.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

No contributor or bootstrap guidance changes were needed.

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Semantic node types added/changed: none. This is backend-only support for existing MIR shapes: `Expr::MapLiteral`, `Expr::Index` over maps, and `Expr::Call` for map containment.

Schemas added/changed: none.

Evidence added/changed: `stage1/crates/axiomc/tests/cranelift_backend.rs` now covers Cranelift map literal/index/contains native build output.

Rust capture risk: low. The docs mark this as backend-specific Cranelift spike behavior and do not redefine Axiom map semantics in Rust-specific terms.

Agent-facing inspection impact: none. Build JSON and schema outputs are unchanged.

## Flow Contract

- Owner lane: daedalus / compiler-runtime
- Repair owner: Codex
- Autonomy class: issue-enabled backend slice
- Risk class: low

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

Current blocker: non-author review approval is still required before merge.

## Merge Automation

- [x] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

Auto-merge is enabled for squash merge once required checks and review requirements are satisfied.

## Notes

- This PR intentionally does not claim closure for #105, #230, #704, #693, or #694.
- The Cranelift path remains an opt-in print-line spike; generated Rust remains the production backend.
