### PR TITLE
[codex] Add debug map resolver

### DIFF
--- a/docs/stage1-debug-map.md
+++ b/docs/stage1-debug-map.md
@@ -37,19 +37,13 @@ lldb <binary>
 (lldb) frame info
 ```
 
-Use the `line_entry.line` from `frame info` as `generated_line`. A helper script
-can then load the debug map and print the matching Axiom span:
+Use the `line_entry.line` from `frame info` as `generated_line`, then resolve
+that line through the debug manifest:
 
-```python
-import json
-
-def axiom_span(debug_map_path, generated_line):
-    with open(debug_map_path, "r", encoding="utf-8") as handle:
-        payload = json.load(handle)
-    for mapping in payload["mappings"]:
-        if mapping["generated_line"] == generated_line:
-            return f'{mapping["source"]}:{mapping["line"]}:{mapping["column"]}'
-    return None
+```sh
+python3 scripts/debug/axiom-debug-map.py resolve \
+  --manifest <artifact>.debug-manifest.json \
+  --generated-line <line_entry.line>
 ```
 
 LLDB command scripts should keep this translation explicit. Until the direct
@@ -68,9 +62,16 @@ gdb <binary>
 ```
 
 Use the generated Rust line shown by `frame` as `generated_line`, then resolve
-it through `debug_map` with the same JSON lookup shown above. A GDB Python
-command can call `gdb.selected_frame().find_sal().line`, load the debug map,
-and print the mapped `.ax` span.
+it through the checked-in helper:
+
+```sh
+python3 scripts/debug/axiom-debug-map.py resolve \
+  --debug-map <artifact>.debug-map.json \
+  --generated-line <frame-line>
+```
+
+A GDB Python command can call `gdb.selected_frame().find_sal().line`, invoke the
+same resolver, and print the mapped `.ax` span.
 
 ## Tooling Contract
 

--- a/scripts/debug/axiom-debug-map.py
+++ b/scripts/debug/axiom-debug-map.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Resolve generated-Rust debug lines back to Axiom source spans."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except FileNotFoundError:
+        raise SystemExit(f"debug artifact not found: {path}") from None
+    except json.JSONDecodeError as error:
+        raise SystemExit(f"invalid JSON in {path}: {error}") from None
+    if not isinstance(payload, dict):
+        raise SystemExit(f"debug artifact must be a JSON object: {path}")
+    return payload
+
+
+def debug_map_path(args: argparse.Namespace) -> Path:
+    if args.debug_map:
+        return Path(args.debug_map)
+    if args.manifest:
+        manifest_path = Path(args.manifest)
+        manifest = load_json(manifest_path)
+        path = manifest.get("debug_map")
+        if not isinstance(path, str) or not path:
+            raise SystemExit(f"manifest does not contain a debug_map path: {manifest_path}")
+        return Path(path)
+    raise SystemExit("provide --debug-map or --manifest")
+
+
+def resolve_span(debug_map: dict[str, Any], generated_line: int) -> dict[str, Any] | None:
+    mappings = debug_map.get("mappings")
+    if not isinstance(mappings, list):
+        raise SystemExit("debug map does not contain a mappings array")
+    for mapping in mappings:
+        if not isinstance(mapping, dict):
+            continue
+        if mapping.get("generated_line") == generated_line:
+            source = mapping.get("source")
+            line = mapping.get("line")
+            column = mapping.get("column")
+            if not isinstance(source, str) or not isinstance(line, int) or not isinstance(column, int):
+                raise SystemExit("debug map contains a malformed source mapping")
+            return {"source": source, "line": line, "column": column}
+    return None
+
+
+def command_resolve(args: argparse.Namespace) -> int:
+    map_path = debug_map_path(args)
+    debug_map = load_json(map_path)
+    span = resolve_span(debug_map, args.generated_line)
+    if span is None:
+        print(f"no Axiom span for generated line {args.generated_line}", file=sys.stderr)
+        return 1
+    if args.json:
+        print(json.dumps(span, sort_keys=True))
+    else:
+        print(f"{span['source']}:{span['line']}:{span['column']}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Resolve axiomc --debug generated-Rust lines to Axiom source spans.",
+    )
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    resolve = subcommands.add_parser(
+        "resolve",
+        help="Resolve a generated Rust DWARF line through a .debug-map.json sidecar.",
+    )
+    source = resolve.add_mutually_exclusive_group(required=True)
+    source.add_argument("--debug-map", help="Path to <artifact>.debug-map.json")
+    source.add_argument("--manifest", help="Path to <artifact>.debug-manifest.json")
+    resolve.add_argument(
+        "--generated-line",
+        required=True,
+        type=int,
+        help="Generated Rust line reported by LLDB/GDB/readelf.",
+    )
+    resolve.add_argument("--json", action="store_true", help="Emit a JSON span object.")
+    resolve.set_defaults(func=command_resolve)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/debug/test-axiom-debug-map.py
+++ b/scripts/debug/test-axiom-debug-map.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Regression tests for scripts/debug/axiom-debug-map.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOL = REPO_ROOT / "scripts" / "debug" / "axiom-debug-map.py"
+
+
+class AxiomDebugMapTests(unittest.TestCase):
+    def test_resolves_generated_line_from_debug_map(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            debug_map = Path(tmp) / "app.debug-map.json"
+            debug_map.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "axiom.stage1.debug_map.v1",
+                        "generated_rust": "/tmp/generated.rs",
+                        "mappings": [
+                            {
+                                "generated_line": 17,
+                                "source": "/workspace/src/main.ax",
+                                "line": 2,
+                                "column": 1,
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(TOOL),
+                    "resolve",
+                    "--debug-map",
+                    str(debug_map),
+                    "--generated-line",
+                    "17",
+                ],
+                check=True,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+        self.assertEqual(result.stdout.strip(), "/workspace/src/main.ax:2:1")
+
+    def test_resolves_generated_line_from_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            debug_map = Path(tmp) / "app.debug-map.json"
+            manifest = Path(tmp) / "app.debug-manifest.json"
+            debug_map.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "axiom.stage1.debug_map.v1",
+                        "generated_rust": "/tmp/generated.rs",
+                        "mappings": [
+                            {
+                                "generated_line": 31,
+                                "source": "/workspace/src/helper.ax",
+                                "line": 4,
+                                "column": 3,
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            manifest.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "axiom.stage1.debug_manifest.v1",
+                        "debug_map": str(debug_map),
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(TOOL),
+                    "resolve",
+                    "--manifest",
+                    str(manifest),
+                    "--generated-line",
+                    "31",
+                    "--json",
+                ],
+                check=True,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+        self.assertEqual(
+            json.loads(result.stdout),
+            {"column": 3, "line": 4, "source": "/workspace/src/helper.ax"},
+        )
+
+    def test_missing_mapping_exits_nonzero(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            debug_map = Path(tmp) / "app.debug-map.json"
+            debug_map.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "axiom.stage1.debug_map.v1",
+                        "generated_rust": "/tmp/generated.rs",
+                        "mappings": [],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(TOOL),
+                    "resolve",
+                    "--debug-map",
+                    str(debug_map),
+                    "--generated-line",
+                    "99",
+                ],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("no Axiom span for generated line 99", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `scripts/debug/axiom-debug-map.py`, a checked-in resolver for mapping generated-Rust DWARF line numbers through `axiomc build --debug` sidecars to `.ax` source spans.
- Add regression coverage for direct debug-map resolution, manifest-based resolution, JSON output, and missing-line failures.
- Update `docs/stage1-debug-map.md` so LLDB/GDB workflows use the checked-in resolver instead of an inline ad hoc snippet.

## Governing Issue

Refs #230

This is an interim generated-Rust source-map resolver. It does not satisfy the full #230 acceptance bar because direct-native `.ax` DWARF line tables remain future backend work and the debug manifest still reports `rustc.axiom_dwarf = false`.

## Validation

- [x] Relevant local checks passed
  - `python3 -m py_compile scripts/debug/axiom-debug-map.py scripts/debug/test-axiom-debug-map.py`
  - `python3 scripts/debug/test-axiom-debug-map.py`
  - `cargo test --manifest-path stage1/Cargo.toml -p axiomc build_project_debug_mode_emits_source_markers_and_uses_separate_cache_key`
  - `git diff --check`
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

This PR does not change semantic-layer behavior, schemas, evidence models, or agent-facing inspection APIs. It is generated-Rust debug tooling over the existing `axiom.stage1.debug_map.v1` and `axiom.stage1.debug_manifest.v1` sidecars. It does not claim direct-native `.ax` DWARF line tables; the manifest still reports `rustc.axiom_dwarf = false`.

## Flow Contract

- Owner lane: daedalus
- Repair owner: codex
- Autonomy class: issue-scoped implementation
- Risk class: low

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Required pheidon/code-owner approval is present
- [x] Auto-merge is appropriate when gates pass

## Merge Automation

- [x] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

Auto-merge is appropriate after required checks pass. A non-author approval is present from `athena-omt`, but GitHub still reports `REVIEW_REQUIRED` with `pheidon` requested.

## Notes

- This advances the generated-Rust source-map path described in #230 while preserving the documented boundary that direct-native `.ax` DWARF remains future backend work.
