### PR TITLE
Define command LSP package boundary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test smoke supply-chain docs-python-exit docs-python-exit-test python-exit-readiness python-exit-readiness-github rust-exit-readiness rust-exit-readiness-github rust-exit-readiness-test stage1-direct-native-runtime-abi stage1-direct-native-runtime-abi-test stage1-package-graph-boundary stage1-package-graph-boundary-test stage1-test stage1-proof-test stage1-stdlib-test stage1-compiler-property-test stage1-conformance stage1-smoke stage1-bench stage1-bench-update-baseline stage1-bench-gate stage1-crap-proposal stage1-crap-thresholds stage1-crap-thresholds-test mutation-rust-smoke mutation-survivor-report stage1-run
+.PHONY: test smoke supply-chain docs-python-exit docs-python-exit-test python-exit-readiness python-exit-readiness-github rust-exit-readiness rust-exit-readiness-github rust-exit-readiness-test stage1-direct-native-runtime-abi stage1-direct-native-runtime-abi-test stage1-package-graph-boundary stage1-package-graph-boundary-test stage1-command-lsp-boundary stage1-command-lsp-boundary-test stage1-test stage1-proof-test stage1-stdlib-test stage1-compiler-property-test stage1-conformance stage1-smoke stage1-bench stage1-bench-update-baseline stage1-bench-gate stage1-crap-proposal stage1-crap-thresholds stage1-crap-thresholds-test mutation-rust-smoke mutation-survivor-report stage1-run
 
 test: docs-python-exit python-exit-readiness stage1-test
 
@@ -41,6 +41,12 @@ stage1-package-graph-boundary:
 
 stage1-package-graph-boundary-test:
 	bash scripts/ci/test-check-package-graph-boundary.sh
+
+stage1-command-lsp-boundary:
+	python3 scripts/ci/check-command-lsp-boundary.py --json
+
+stage1-command-lsp-boundary-test:
+	bash scripts/ci/test-check-command-lsp-boundary.sh
 
 stage1-test:
 	RUST_MIN_STACK=8388608 cargo test --manifest-path stage1/Cargo.toml --features run-native-tests

--- a/docs/axiom-compiler-source-layout.md
+++ b/docs/axiom-compiler-source-layout.md
@@ -38,8 +38,8 @@ compiler architecture, not the current implementation language.
 | 8 | `compiler.backend.generated_rust` | `codegen.rs` | Legacy generated-Rust projection and `rustc` invocation compatibility. | Daedalus | `cargo test --manifest-path stage1/Cargo.toml -p axiomc render_rust` | High: this package is legacy-only and must not be a dependency of self-hosted semantics. |
 | 9 | `compiler.backend.native` | `cranelift_backend.rs`, direct-native tests | Direct MIR-to-native lowering, native ABI shims, native binary artifacts, native backend diagnostics. | Daedalus | `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend` | High: Cranelift details must stay backend-local; direct-native evidence must not require generated Rust. |
 | 10 | `compiler.evidence` | provenance/debug/reporting portions of `project.rs`, `stage1-debug-map.md`, `provenance-trace-v0.md` | Build provenance, debug sidecars, evidence records, trace output, source-to-artifact relationships. | Pheidon | `cargo test --manifest-path stage1/Cargo.toml -p axiomc provenance` | Medium: evidence may reference Rust artifacts only when the selected backend emitted them. |
-| 11 | `compiler.commands` | `main.rs`, command orchestration in `project.rs`, `new_project.rs`, `json_contract.rs` | `axiomc` command dispatch, JSON envelopes, starter project generation, build/run/test/doc/check/caps/trace flows. | Pheidon | `cargo test --manifest-path stage1/Cargo.toml -p axiomc json_contract` | Medium: command contracts must not require Cargo except on the temporary developer path. |
-| 12 | `compiler.services.lsp` | `lsp.rs`, `dap.rs`, `stage1-lsp.md` | LSP/DAP protocol handling, document state, diagnostics publication, future completion and navigation APIs. | Daedalus | `cargo test --manifest-path stage1/Cargo.toml -p axiomc lsp` | Medium: protocol structs can mirror LSP JSON, but compiler analysis must call package APIs instead of Rust internals. |
+| 11 | `compiler.commands` | `main.rs`, command orchestration in `project.rs`, `new_project.rs`, `json_contract.rs` | `axiomc` command dispatch, JSON envelopes, starter project generation, build/run/test/doc/check/caps/trace flows. The public package APIs are defined in [Compiler Command and LSP Packages](compiler-command-lsp-packages.md). | Pheidon | `make stage1-command-lsp-boundary` and `cargo test --manifest-path stage1/Cargo.toml -p axiomc json_contract` | Medium: command contracts must not require Cargo except on the temporary developer path. |
+| 12 | `compiler.services.lsp` | `lsp.rs`, `dap.rs`, `stage1-lsp.md` | LSP/DAP protocol handling, document state, diagnostics publication, future completion and navigation APIs. The LSP service package APIs are defined in [Compiler Command and LSP Packages](compiler-command-lsp-packages.md). | Daedalus | `make stage1-command-lsp-boundary` and `cargo test --manifest-path stage1/Cargo.toml -p axiomc lsp` | Medium: protocol structs can mirror LSP JSON, but compiler analysis must call package APIs instead of Rust internals. |
 
 ## Public Self-Hosted Compiler API
 
@@ -104,7 +104,8 @@ The following child issues own source migration slices:
 - #937 Diagnostics and syntax package freeze: migrate parser and diagnostic
   fixtures behind `compiler.diagnostics` and `compiler.syntax` APIs.
 - #938 Command and LSP package split: route CLI and LSP through package APIs
-  instead of Rust module internals.
+  instead of Rust module internals. See
+  [Compiler Command and LSP Packages](compiler-command-lsp-packages.md).
 - #939 MIR and backend contract package: expose MIR-to-target inputs without
   generated-Rust assumptions.
 - #940 HIR and ownership package: migrate typed declarations, capability checks,

--- a/docs/compiler-command-lsp-packages.md
+++ b/docs/compiler-command-lsp-packages.md
@@ -1,0 +1,83 @@
+# Compiler Command and LSP Packages
+
+This document defines the self-hosted package boundary for `compiler.commands`
+and `compiler.services.lsp`. It is the contract for #938 and a child slice of
+the Rust-exit roadmap in [AxiOM Compiler Source Layout and Self-Hosting
+Boundary](axiom-compiler-source-layout.md).
+
+The current implementation is still hosted by the Rust `stage1/axiomc`
+binary. The package APIs below define the self-hosted compiler ownership
+surface that future AxiOM packages must provide. Rust modules, Cargo metadata,
+Clap structs, and generated Rust backend helpers are implementation details,
+not command or service contracts.
+
+## Package Ownership
+
+`compiler.commands` owns user-facing command dispatch and stable machine
+envelopes. It receives source roots, selected package names, command options,
+and forwarded runtime arguments, then delegates analysis and artifact work to
+compiler packages instead of reaching into host-language internals.
+
+`compiler.services.lsp` owns JSON-RPC framing, bounded document state, LSP
+lifecycle handling, diagnostic publication, and future editor semantic
+features. It delegates parsing, package graph discovery, HIR analysis,
+diagnostic normalization, and evidence lookup to package APIs.
+
+## Command APIs
+
+| Command | API | Required package calls | Stable output |
+|---|---|---|---|
+| `axiomc check` | `compiler.commands.check_package(root, package, options)` | `compiler.package_graph.load_workspace`, `compiler.syntax.parse_program`, `compiler.hir.analyze`, `compiler.diagnostics.diagnostic` | `axiom.stage1.v1` check envelope with diagnostics, package records, capability records, warnings, optional macro expansions, and optional debug symbols. |
+| `axiomc build` | `compiler.commands.build_package(root, package, target, debug, locked, offline)` | `compiler.package_graph.resolve_locked`, `compiler.hir.analyze`, `compiler.mir.lower_package`, `compiler.backend.contracts.select_target`, `compiler.evidence.record_build` | `axiom.stage1.v1` build envelope with artifact plan, selected backend, build metadata, cache metadata, provenance, and optional debug sidecars. |
+| `axiomc run` | `compiler.commands.run_artifact(root, package, args, options)` | `compiler.commands.build_package`, `compiler.evidence.record_run` | Text streaming by default; `axiom.stage1.v1` run envelope with exit code, stdout, stderr, result, forwarded args, and selected package when JSON is requested. |
+| `axiomc test` | `compiler.commands.test_package(root, package, filter, options)` | `compiler.package_graph.load_workspace`, `compiler.commands.build_package`, `compiler.evidence.record_test` | `axiom.stage1.v1` test envelope with discovered tests, per-case results, property totals, golden stream evidence, duration, and filter metadata. |
+| `axiomc doc` | `compiler.commands.render_docs(root, package, options)` | `compiler.package_graph.load_workspace`, `compiler.hir.export_public_api`, `compiler.evidence.record_artifact` | Versioned doc JSON plus Markdown/HTML artifact paths, symbol extraction records, source comments, signatures, and package capabilities. |
+| `axiomc caps` | `compiler.commands.describe_capabilities(root, package, options)` | `compiler.package_graph.load_workspace`, `compiler.hir.infer_capability_use` | `axiom.stage1.v1` caps envelope with manifest capability policy, inferred uses, unsafe escape hatches, owners, and rationales. |
+| `axiomc trace` | `compiler.evidence.trace(root, query)` | `compiler.package_graph.load_workspace`, `compiler.evidence.trace_graph` | `axiom.trace.v0` provenance graph with stable `axiom://` node IDs, artifacts, and relationships. |
+
+The command APIs deliberately exclude Cargo and `rustc` from official
+self-hosted command behavior. Cargo remains allowed only for the temporary
+developer path while the Rust bootstrap host and generated-Rust backend remain
+checked in.
+
+## LSP Service APIs
+
+| Flow | API | Required package calls | Stable protocol |
+|---|---|---|---|
+| Stdio server | `compiler.services.lsp.serve_stdio()` | `compiler.services.lsp.initialize`, document handlers, shutdown handlers | LSP messages framed with `Content-Length` headers and JSON-RPC 2.0 bodies. |
+| Initialize | `compiler.services.lsp.initialize(params)` | package capability registry for advertised features | JSON-RPC response with bounded text document sync and additive future capabilities. |
+| Open document | `compiler.services.lsp.open_document(uri, version, text)` | `compiler.syntax.parse_program`, `compiler.diagnostics.diagnostic` | `textDocument/publishDiagnostics` notification for the opened document. |
+| Change document | `compiler.services.lsp.change_document(uri, version, text)` | `compiler.syntax.parse_program`, `compiler.package_graph.resolve_document`, `compiler.hir.analyze` when package context is available | Updated `textDocument/publishDiagnostics` notification. |
+| Publish diagnostics | `compiler.services.lsp.publish_diagnostics(uri, diagnostics)` | `compiler.diagnostics.to_lsp_range`, diagnostic code normalization, and `compiler.evidence.lookup_related` when related evidence is available | LSP diagnostic array preserving source ranges, messages, severity, stable codes, and additive related context. |
+| Shutdown | `compiler.services.lsp.shutdown()` | service state drain only | JSON-RPC shutdown response with `null` result. |
+| Exit | `compiler.services.lsp.exit()` | service state drain only | Clean process exit after shutdown or bounded best-effort exit otherwise. |
+
+Future completion, hover, definition, and semantic-token APIs must flow through
+the package graph, syntax, HIR, diagnostics, and evidence packages. They must
+not inspect Rust-only parser, checker, or LSP module internals as their public
+contract.
+
+## Stable Envelope Rules
+
+- Commands keep their human-readable behavior unless `--json` is requested.
+- JSON command payloads keep stable schema names and `command` labels while
+  package implementations migrate.
+- LSP framing remains standard `Content-Length` delimited JSON-RPC messages.
+- Protocol payloads may add fields only when existing clients can ignore them.
+- Backend-specific paths such as generated Rust files are compatibility
+  metadata, not requirements for direct-native or self-hosted command behavior.
+
+## Validation
+
+The package boundary snapshot lives in
+`stage1/compiler-contracts/snapshots/command-lsp.json` and validates against
+`stage1/compiler-contracts/schemas/axiom.compiler.command_lsp.v1.schema.json`.
+
+Use these commands for #938:
+
+```bash
+make stage1-command-lsp-boundary
+make stage1-command-lsp-boundary-test
+cargo test --manifest-path stage1/Cargo.toml -p axiomc json_contract
+cargo test --manifest-path stage1/Cargo.toml -p axiomc lsp
+```

--- a/docs/rust-bootstrap-boundary.md
+++ b/docs/rust-bootstrap-boundary.md
@@ -42,4 +42,5 @@ capabilities, effects, evidence, artifacts, or backend contracts:
 
 - [Axiom Vision](vision.md)
 - [Compiler Package Graph Boundary](compiler-package-graph.md)
+- [Compiler Command and LSP Packages](compiler-command-lsp-packages.md)
 - [Implementation Language Positioning](positioning/implementation-languages.md)

--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -165,6 +165,12 @@ duration, stdout, stderr, forwarded args, and selected package without changing
 the default human-readable streaming behavior.
 `axiomc mutation-report --json` reports survivor counts and grouped recommended
 fixtures in the same versioned envelope used by the other command contracts.
+The self-hosted command and LSP package boundary is frozen in
+`docs/compiler-command-lsp-packages.md`, with the validation snapshot at
+`stage1/compiler-contracts/snapshots/command-lsp.json`. Use
+`make stage1-command-lsp-boundary` to verify that command dispatch, JSON
+envelopes, and LSP service flows stay package-oriented while the Rust bootstrap
+host remains the temporary developer path.
 `axiomc test --json` additionally reports `filter`, `properties_only`,
 property totals, and per-run/per-case `duration_ms` plus `passed` / `failed` /
 `skipped`. Build payloads report the

--- a/scripts/ci/check-command-lsp-boundary.py
+++ b/scripts/ci/check-command-lsp-boundary.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Validate the compiler.commands and compiler.services.lsp boundary fixture."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = "axiom.compiler.command_lsp.v1"
+CONTRACT = "compiler.commands_lsp"
+DEFAULT_SCHEMA = Path("stage1/compiler-contracts/schemas/axiom.compiler.command_lsp.v1.schema.json")
+DEFAULT_SNAPSHOT = Path("stage1/compiler-contracts/snapshots/command-lsp.json")
+EXPECTED_COMMAND_APIS = {
+    "check": "compiler.commands.check_package",
+    "build": "compiler.commands.build_package",
+    "run": "compiler.commands.run_artifact",
+    "test": "compiler.commands.test_package",
+    "doc": "compiler.commands.render_docs",
+    "caps": "compiler.commands.describe_capabilities",
+    "trace": "compiler.evidence.trace",
+}
+EXPECTED_LSP_APIS = {
+    "serve_stdio": "compiler.services.lsp.serve_stdio",
+    "initialize": "compiler.services.lsp.initialize",
+    "open_document": "compiler.services.lsp.open_document",
+    "change_document": "compiler.services.lsp.change_document",
+    "publish_diagnostics": "compiler.services.lsp.publish_diagnostics",
+    "shutdown": "compiler.services.lsp.shutdown",
+    "exit": "compiler.services.lsp.exit",
+}
+REQUIRED_LSP_PACKAGES = {
+    "compiler.package_graph",
+    "compiler.syntax",
+    "compiler.hir",
+    "compiler.diagnostics",
+    "compiler.evidence",
+}
+RUST_CAPTURE_TERMS = {
+    "cargo",
+    "main.rs",
+    "lsp.rs",
+    "project.rs",
+    "clap",
+    "serde",
+    "rustc",
+    "rust module",
+    "rust-only",
+}
+
+
+def load_json(path: Path) -> Any:
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def fail(message: str) -> None:
+    print(message, file=sys.stderr)
+    raise SystemExit(1)
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        fail(message)
+
+
+def validate_against_schema(value: Any, schema: dict[str, Any]) -> None:
+    validate_schema_node(value, schema, "$", schema.get("$defs", {}))
+
+
+def validate_schema_node(value: Any, schema: dict[str, Any], path: str, defs: dict[str, Any]) -> None:
+    if "$ref" in schema:
+        ref = schema["$ref"]
+        prefix = "#/$defs/"
+        require(ref.startswith(prefix), f"{path} uses unsupported schema ref {ref}")
+        name = ref[len(prefix):]
+        require(name in defs, f"{path} references unknown schema def {name}")
+        validate_schema_node(value, defs[name], path, defs)
+        return
+
+    if "const" in schema:
+        require(value == schema["const"], f"{path} must equal {schema['const']!r}")
+    if "enum" in schema:
+        require(value in schema["enum"], f"{path} must be one of {schema['enum']!r}")
+
+    expected_type = schema.get("type")
+    if expected_type == "object":
+        require(isinstance(value, dict), f"{path} must be an object")
+        required = set(schema.get("required", []))
+        missing = sorted(required - set(value))
+        require(not missing, f"{path} is missing required fields: {', '.join(missing)}")
+        properties = schema.get("properties", {})
+        if schema.get("additionalProperties") is False:
+            unexpected = sorted(set(value) - set(properties))
+            require(not unexpected, f"{path} has unexpected fields: {', '.join(unexpected)}")
+        for key, nested in value.items():
+            if key in properties:
+                validate_schema_node(nested, properties[key], f"{path}.{key}", defs)
+    elif expected_type == "array":
+        require(isinstance(value, list), f"{path} must be an array")
+        if "minItems" in schema:
+            require(len(value) >= schema["minItems"], f"{path} must have at least {schema['minItems']} items")
+        item_schema = schema.get("items")
+        if item_schema:
+            for index, item in enumerate(value):
+                validate_schema_node(item, item_schema, f"{path}[{index}]", defs)
+    elif expected_type == "string":
+        require(isinstance(value, str), f"{path} must be a string")
+        if "minLength" in schema:
+            require(len(value) >= schema["minLength"], f"{path} must not be empty")
+    elif expected_type == "integer":
+        require(isinstance(value, int) and not isinstance(value, bool), f"{path} must be an integer")
+    elif expected_type == "boolean":
+        require(isinstance(value, bool), f"{path} must be a boolean")
+    elif expected_type is not None:
+        fail(f"{path} uses unsupported schema type {expected_type}")
+
+
+def reject_rust_capture_terms(values: list[str], path: str) -> None:
+    for value in values:
+        lowered = value.lower()
+        for term in RUST_CAPTURE_TERMS:
+            require(term not in lowered, f"{path} must not expose Rust capture term {term!r}: {value}")
+
+
+def validate_command_contract(snapshot: dict[str, Any]) -> None:
+    commands = {command["name"]: command for command in snapshot["commands"]}
+    require(set(commands) == set(EXPECTED_COMMAND_APIS), "command API set mismatch")
+
+    for name, expected_api in EXPECTED_COMMAND_APIS.items():
+        command = commands[name]
+        require(command["api"] == expected_api, f"{name} API mismatch")
+        expected_package = "compiler.evidence" if name == "trace" else "compiler.commands"
+        require(command["package"] == expected_package, f"{name} package owner mismatch")
+        require(command["api"].startswith("compiler."), f"{name} API must be package-qualified")
+        reject_rust_capture_terms(
+            [command["api"], command["stable_output"], *command["inputs"], *command["delegates_to"]],
+            f"commands.{name}",
+        )
+        for fixture in command.get("fixtures", []):
+            path = Path(fixture)
+            require(path.exists(), f"{name} fixture path does not exist: {fixture}")
+
+    require("compiler.evidence.trace_graph" in commands["trace"]["delegates_to"], "trace must delegate to evidence trace graph")
+    require(commands["trace"]["stable_output"] == "axiom.trace.v0", "trace must preserve axiom.trace.v0")
+
+
+def validate_lsp_contract(snapshot: dict[str, Any]) -> None:
+    services = {service["flow"]: service for service in snapshot["lsp_services"]}
+    require(set(services) == set(EXPECTED_LSP_APIS), "LSP service API set mismatch")
+
+    delegated_packages: set[str] = set()
+    for flow, expected_api in EXPECTED_LSP_APIS.items():
+        service = services[flow]
+        require(service["api"] == expected_api, f"{flow} LSP API mismatch")
+        reject_rust_capture_terms(
+            [service["api"], service["protocol"], *service["delegates_to"]],
+            f"lsp_services.{flow}",
+        )
+        for delegated in service["delegates_to"]:
+            parts = delegated.split(".")
+            if len(parts) >= 2:
+                delegated_packages.add(".".join(parts[:2]))
+
+    require(REQUIRED_LSP_PACKAGES.issubset(delegated_packages), "LSP services must call package graph, syntax, HIR, diagnostics, and evidence packages")
+    framing = snapshot["protocols"]["lsp_framing"]
+    require(framing["transport"] == "stdio", "LSP transport must remain stdio")
+    require(framing["header"] == "Content-Length", "LSP framing must preserve Content-Length")
+    require(framing["body"] == "JSON-RPC 2.0", "LSP body must remain JSON-RPC 2.0")
+
+
+def validate_protocols(snapshot: dict[str, Any]) -> None:
+    envelope_map = {
+        envelope["schema"]: set(envelope["commands"])
+        for envelope in snapshot["protocols"]["json_envelopes"]
+    }
+    require(envelope_map.get("axiom.stage1.v1") == {"check", "build", "run", "test", "doc", "caps"}, "stage1 JSON envelope command set mismatch")
+    require(envelope_map.get("axiom.trace.v0") == {"trace"}, "trace JSON envelope command set mismatch")
+
+    release = snapshot["official_release"]
+    require(release["requires_cargo"] is False, "official release command behavior must not require Cargo")
+    require(release["requires_rustc"] is False, "official release command behavior must not require rustc")
+    require(release["temporary_developer_path"] is True, "temporary developer path must remain explicit while Rust host exists")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    parser.add_argument("--snapshot", type=Path, default=DEFAULT_SNAPSHOT)
+    parser.add_argument("--json", action="store_true", help="emit a JSON validation result")
+    args = parser.parse_args()
+
+    schema = load_json(args.schema)
+    snapshot = load_json(args.snapshot)
+
+    require(schema.get("$id", "").endswith("/axiom.compiler.command_lsp.v1.schema.json"), "schema $id must name command/LSP v1")
+    require(schema.get("title") == "Axiom compiler command and LSP package contract", "schema title changed unexpectedly")
+    validate_against_schema(snapshot, schema)
+    require(snapshot["schema_version"] == SCHEMA_VERSION, "snapshot schema_version mismatch")
+    require(snapshot["contract"] == CONTRACT, "snapshot contract mismatch")
+    require(snapshot["issue"] == 938, "snapshot issue mismatch")
+    validate_command_contract(snapshot)
+    validate_lsp_contract(snapshot)
+    validate_protocols(snapshot)
+
+    result = {
+        "schema": SCHEMA_VERSION,
+        "ok": True,
+        "commands": len(snapshot["commands"]),
+        "lsp_services": len(snapshot["lsp_services"]),
+        "fixture": str(args.snapshot),
+    }
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(f"command/LSP boundary fixture ok: {result['commands']} commands, {result['lsp_services']} services")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/test-check-command-lsp-boundary.sh
+++ b/scripts/ci/test-check-command-lsp-boundary.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+script="$repo_root/scripts/ci/check-command-lsp-boundary.py"
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "$temp_dir"' EXIT
+
+python3 "$script" --json >"$temp_dir/result.json"
+
+python3 - "$temp_dir/result.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    payload = json.load(handle)
+
+assert payload["schema"] == "axiom.compiler.command_lsp.v1"
+assert payload["ok"] is True
+assert payload["commands"] == 7
+assert payload["lsp_services"] == 7
+PY
+
+python3 - "$repo_root/stage1/compiler-contracts/snapshots/command-lsp.json" "$temp_dir/unexpected-field.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    payload = json.load(handle)
+
+payload["commands"][0]["rust_module"] = "main.rs"
+
+with open(sys.argv[2], "w", encoding="utf-8") as handle:
+    json.dump(payload, handle)
+PY
+
+if python3 "$script" --snapshot "$temp_dir/unexpected-field.json" >"$temp_dir/unexpected.out" 2>"$temp_dir/unexpected.err"; then
+  echo "expected schema-invalid command boundary output to fail" >&2
+  exit 1
+fi
+
+grep -q "unexpected fields" "$temp_dir/unexpected.err"
+
+python3 - "$repo_root/stage1/compiler-contracts/snapshots/command-lsp.json" "$temp_dir/cargo-release.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    payload = json.load(handle)
+
+payload["official_release"]["requires_cargo"] = True
+
+with open(sys.argv[2], "w", encoding="utf-8") as handle:
+    json.dump(payload, handle)
+PY
+
+if python3 "$script" --snapshot "$temp_dir/cargo-release.json" >"$temp_dir/cargo.out" 2>"$temp_dir/cargo.err"; then
+  echo "expected Cargo-required release output to fail" >&2
+  exit 1
+fi
+
+grep -q "must not require Cargo" "$temp_dir/cargo.err"
+
+python3 - "$repo_root/stage1/compiler-contracts/snapshots/command-lsp.json" "$temp_dir/missing-lsp-package.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    payload = json.load(handle)
+
+for service in payload["lsp_services"]:
+    service["delegates_to"] = [
+        delegated for delegated in service["delegates_to"]
+        if not delegated.startswith("compiler.hir.")
+    ]
+
+with open(sys.argv[2], "w", encoding="utf-8") as handle:
+    json.dump(payload, handle)
+PY
+
+if python3 "$script" --snapshot "$temp_dir/missing-lsp-package.json" >"$temp_dir/lsp.out" 2>"$temp_dir/lsp.err"; then
+  echo "expected missing LSP package delegation to fail" >&2
+  exit 1
+fi
+
+grep -q "LSP services must call package graph, syntax, HIR, diagnostics, and evidence packages" "$temp_dir/lsp.err"
+
+python3 - "$repo_root/stage1/compiler-contracts/snapshots/command-lsp.json" "$temp_dir/rust-capture.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    payload = json.load(handle)
+
+payload["commands"][0]["delegates_to"].append("main.rs::check_project")
+
+with open(sys.argv[2], "w", encoding="utf-8") as handle:
+    json.dump(payload, handle)
+PY
+
+if python3 "$script" --snapshot "$temp_dir/rust-capture.json" >"$temp_dir/rust.out" 2>"$temp_dir/rust.err"; then
+  echo "expected Rust-captured command delegation to fail" >&2
+  exit 1
+fi
+
+grep -q "Rust capture term" "$temp_dir/rust.err"
+
+python3 - "$repo_root/stage1/compiler-contracts/snapshots/command-lsp.json" "$temp_dir/cargo-rustc-capture.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    payload = json.load(handle)
+
+payload["commands"][0]["inputs"].append("cargo_metadata")
+payload["commands"][1]["delegates_to"].append("rustc.invoke")
+
+with open(sys.argv[2], "w", encoding="utf-8") as handle:
+    json.dump(payload, handle)
+PY
+
+if python3 "$script" --snapshot "$temp_dir/cargo-rustc-capture.json" >"$temp_dir/cargo-rustc.out" 2>"$temp_dir/cargo-rustc.err"; then
+  echo "expected Cargo/rustc-captured command delegation to fail" >&2
+  exit 1
+fi
+
+grep -q "Rust capture term 'cargo'" "$temp_dir/cargo-rustc.err"
+
+echo "check-command-lsp-boundary regression cases passed"

--- a/stage1/compiler-contracts/schemas/axiom.compiler.command_lsp.v1.schema.json
+++ b/stage1/compiler-contracts/schemas/axiom.compiler.command_lsp.v1.schema.json
@@ -1,0 +1,227 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://omt-global.github.io/axiom/schemas/axiom.compiler.command_lsp.v1.schema.json",
+  "title": "Axiom compiler command and LSP package contract",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "contract",
+    "issue",
+    "commands",
+    "lsp_services",
+    "protocols",
+    "official_release"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "axiom.compiler.command_lsp.v1"
+    },
+    "contract": {
+      "const": "compiler.commands_lsp"
+    },
+    "issue": {
+      "const": 938
+    },
+    "commands": {
+      "type": "array",
+      "minItems": 7,
+      "items": {
+        "$ref": "#/$defs/command"
+      }
+    },
+    "lsp_services": {
+      "type": "array",
+      "minItems": 7,
+      "items": {
+        "$ref": "#/$defs/lspService"
+      }
+    },
+    "protocols": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "json_envelopes",
+        "lsp_framing"
+      ],
+      "properties": {
+        "json_envelopes": {
+          "type": "array",
+          "minItems": 2,
+          "items": {
+            "$ref": "#/$defs/jsonEnvelope"
+          }
+        },
+        "lsp_framing": {
+          "$ref": "#/$defs/lspFraming"
+        }
+      }
+    },
+    "official_release": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "requires_cargo",
+        "requires_rustc",
+        "temporary_developer_path"
+      ],
+      "properties": {
+        "requires_cargo": {
+          "type": "boolean"
+        },
+        "requires_rustc": {
+          "type": "boolean"
+        },
+        "temporary_developer_path": {
+          "type": "boolean"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "command": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "package",
+        "api",
+        "inputs",
+        "delegates_to",
+        "stable_output",
+        "fixtures"
+      ],
+      "properties": {
+        "name": {
+          "enum": [
+            "check",
+            "build",
+            "run",
+            "test",
+            "doc",
+            "caps",
+            "trace"
+          ]
+        },
+        "package": {
+          "enum": [
+            "compiler.commands",
+            "compiler.evidence"
+          ]
+        },
+        "api": {
+          "type": "string",
+          "minLength": 1
+        },
+        "inputs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "delegates_to": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "stable_output": {
+          "type": "string",
+          "minLength": 1
+        },
+        "fixtures": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "lspService": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "flow",
+        "api",
+        "delegates_to",
+        "protocol"
+      ],
+      "properties": {
+        "flow": {
+          "enum": [
+            "serve_stdio",
+            "initialize",
+            "open_document",
+            "change_document",
+            "publish_diagnostics",
+            "shutdown",
+            "exit"
+          ]
+        },
+        "api": {
+          "type": "string",
+          "minLength": 1
+        },
+        "delegates_to": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "protocol": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "jsonEnvelope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema",
+        "commands"
+      ],
+      "properties": {
+        "schema": {
+          "type": "string",
+          "minLength": 1
+        },
+        "commands": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "lspFraming": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "transport",
+        "header",
+        "body"
+      ],
+      "properties": {
+        "transport": {
+          "const": "stdio"
+        },
+        "header": {
+          "const": "Content-Length"
+        },
+        "body": {
+          "const": "JSON-RPC 2.0"
+        }
+      }
+    }
+  }
+}
+

--- a/stage1/compiler-contracts/snapshots/command-lsp.json
+++ b/stage1/compiler-contracts/snapshots/command-lsp.json
@@ -1,0 +1,245 @@
+{
+  "schema_version": "axiom.compiler.command_lsp.v1",
+  "contract": "compiler.commands_lsp",
+  "issue": 938,
+  "commands": [
+    {
+      "name": "check",
+      "package": "compiler.commands",
+      "api": "compiler.commands.check_package",
+      "inputs": [
+        "root",
+        "package",
+        "options"
+      ],
+      "delegates_to": [
+        "compiler.package_graph.load_workspace",
+        "compiler.syntax.parse_program",
+        "compiler.hir.analyze",
+        "compiler.diagnostics.diagnostic"
+      ],
+      "stable_output": "axiom.stage1.v1",
+      "fixtures": [
+        "stage1/json-fixtures/check/success.json",
+        "stage1/json-fixtures/check/parse-error.json",
+        "stage1/json-fixtures/check/type-error.json",
+        "stage1/json-fixtures/check/borrow-error.json",
+        "stage1/json-fixtures/check/capability-denial.json"
+      ]
+    },
+    {
+      "name": "build",
+      "package": "compiler.commands",
+      "api": "compiler.commands.build_package",
+      "inputs": [
+        "root",
+        "package",
+        "target",
+        "debug",
+        "locked",
+        "offline"
+      ],
+      "delegates_to": [
+        "compiler.package_graph.resolve_locked",
+        "compiler.hir.analyze",
+        "compiler.mir.lower_package",
+        "compiler.backend.contracts.select_target",
+        "compiler.evidence.record_build"
+      ],
+      "stable_output": "axiom.stage1.v1",
+      "fixtures": [
+        "stage1/json-fixtures/build/success.json",
+        "stage1/json-fixtures/build/failure.json",
+        "stage1/compiler-contracts/snapshots/build.json"
+      ]
+    },
+    {
+      "name": "run",
+      "package": "compiler.commands",
+      "api": "compiler.commands.run_artifact",
+      "inputs": [
+        "root",
+        "package",
+        "args",
+        "options"
+      ],
+      "delegates_to": [
+        "compiler.commands.build_package",
+        "compiler.evidence.record_run"
+      ],
+      "stable_output": "axiom.stage1.v1",
+      "fixtures": [
+        "stage1/compiler-contracts/snapshots/run.json"
+      ]
+    },
+    {
+      "name": "test",
+      "package": "compiler.commands",
+      "api": "compiler.commands.test_package",
+      "inputs": [
+        "root",
+        "package",
+        "filter",
+        "options"
+      ],
+      "delegates_to": [
+        "compiler.package_graph.load_workspace",
+        "compiler.commands.build_package",
+        "compiler.evidence.record_test"
+      ],
+      "stable_output": "axiom.stage1.v1",
+      "fixtures": [
+        "stage1/json-fixtures/test/filter-success.json",
+        "stage1/json-fixtures/test/failure.json",
+        "stage1/compiler-contracts/snapshots/test.json"
+      ]
+    },
+    {
+      "name": "doc",
+      "package": "compiler.commands",
+      "api": "compiler.commands.render_docs",
+      "inputs": [
+        "root",
+        "package",
+        "options"
+      ],
+      "delegates_to": [
+        "compiler.package_graph.load_workspace",
+        "compiler.hir.export_public_api",
+        "compiler.evidence.record_artifact"
+      ],
+      "stable_output": "axiom.stage1.v1",
+      "fixtures": [
+        "stage1/compiler-contracts/snapshots/doc-md.md"
+      ]
+    },
+    {
+      "name": "caps",
+      "package": "compiler.commands",
+      "api": "compiler.commands.describe_capabilities",
+      "inputs": [
+        "root",
+        "package",
+        "options"
+      ],
+      "delegates_to": [
+        "compiler.package_graph.load_workspace",
+        "compiler.hir.infer_capability_use"
+      ],
+      "stable_output": "axiom.stage1.v1",
+      "fixtures": [
+        "stage1/json-fixtures/caps/unsafe-env.json",
+        "stage1/compiler-contracts/snapshots/caps.json"
+      ]
+    },
+    {
+      "name": "trace",
+      "package": "compiler.evidence",
+      "api": "compiler.evidence.trace",
+      "inputs": [
+        "root",
+        "query"
+      ],
+      "delegates_to": [
+        "compiler.package_graph.load_workspace",
+        "compiler.evidence.trace_graph"
+      ],
+      "stable_output": "axiom.trace.v0",
+      "fixtures": []
+    }
+  ],
+  "lsp_services": [
+    {
+      "flow": "serve_stdio",
+      "api": "compiler.services.lsp.serve_stdio",
+      "delegates_to": [
+        "compiler.services.lsp.initialize",
+        "compiler.services.lsp.open_document",
+        "compiler.services.lsp.shutdown",
+        "compiler.services.lsp.exit"
+      ],
+      "protocol": "Content-Length framed JSON-RPC 2.0 over stdio"
+    },
+    {
+      "flow": "initialize",
+      "api": "compiler.services.lsp.initialize",
+      "delegates_to": [
+        "compiler.package_graph.available_capabilities"
+      ],
+      "protocol": "JSON-RPC response with bounded textDocumentSync"
+    },
+    {
+      "flow": "open_document",
+      "api": "compiler.services.lsp.open_document",
+      "delegates_to": [
+        "compiler.syntax.parse_program",
+        "compiler.diagnostics.diagnostic"
+      ],
+      "protocol": "textDocument/publishDiagnostics notification"
+    },
+    {
+      "flow": "change_document",
+      "api": "compiler.services.lsp.change_document",
+      "delegates_to": [
+        "compiler.package_graph.resolve_document",
+        "compiler.syntax.parse_program",
+        "compiler.hir.analyze",
+        "compiler.diagnostics.diagnostic"
+      ],
+      "protocol": "textDocument/publishDiagnostics notification"
+    },
+    {
+      "flow": "publish_diagnostics",
+      "api": "compiler.services.lsp.publish_diagnostics",
+      "delegates_to": [
+        "compiler.diagnostics.to_lsp_range",
+        "compiler.diagnostics.normalize_code",
+        "compiler.evidence.lookup_related"
+      ],
+      "protocol": "LSP Diagnostic array with additive related context"
+    },
+    {
+      "flow": "shutdown",
+      "api": "compiler.services.lsp.shutdown",
+      "delegates_to": [],
+      "protocol": "JSON-RPC response with null result"
+    },
+    {
+      "flow": "exit",
+      "api": "compiler.services.lsp.exit",
+      "delegates_to": [],
+      "protocol": "clean service exit"
+    }
+  ],
+  "protocols": {
+    "json_envelopes": [
+      {
+        "schema": "axiom.stage1.v1",
+        "commands": [
+          "check",
+          "build",
+          "run",
+          "test",
+          "doc",
+          "caps"
+        ]
+      },
+      {
+        "schema": "axiom.trace.v0",
+        "commands": [
+          "trace"
+        ]
+      }
+    ],
+    "lsp_framing": {
+      "transport": "stdio",
+      "header": "Content-Length",
+      "body": "JSON-RPC 2.0"
+    }
+  },
+  "official_release": {
+    "requires_cargo": false,
+    "requires_rustc": false,
+    "temporary_developer_path": true
+  }
+}


### PR DESCRIPTION
## Summary

- Define the self-hosted `compiler.commands` and `compiler.services.lsp` package boundary for #938.
- Add a schema-backed command/LSP contract snapshot plus a CI validator and negative regression cases.
- Wire `make stage1-command-lsp-boundary` and document the boundary against the compiler source-layout map.

## Governing Issue

Closes #938

## Validation

- [x] Relevant local checks passed
  - `make stage1-command-lsp-boundary`
  - `make stage1-command-lsp-boundary-test`
  - `cargo test --manifest-path stage1/Cargo.toml -p axiomc json_contract`
  - `cargo test --manifest-path stage1/Cargo.toml -p axiomc lsp`
  - `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test json_contract_snapshots`
  - `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test json_command_fixtures`
  - `git diff --check`
  - `python3 -m json.tool stage1/compiler-contracts/schemas/axiom.compiler.command_lsp.v1.schema.json`
  - `python3 -m json.tool stage1/compiler-contracts/snapshots/command-lsp.json`
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Skipped checks: none locally. GitHub automation may skip optional Claude jobs according to repo policy.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
  - Changed contract nodes: `compiler.commands`, `compiler.services.lsp`, and `compiler.evidence.trace` command ownership.
- [x] Schemas added/changed are listed, or this PR does not touch schemas
  - Added `stage1/compiler-contracts/schemas/axiom.compiler.command_lsp.v1.schema.json`.
- [x] Evidence added/changed is listed, or this PR does not touch evidence
  - Added `stage1/compiler-contracts/snapshots/command-lsp.json`.
  - Added `scripts/ci/check-command-lsp-boundary.py` and `scripts/ci/test-check-command-lsp-boundary.sh`.
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
  - The public APIs are package-qualified and the validator rejects Rust module names, Cargo-required official release behavior, and Rust-captured command delegations.
- [x] Agent-facing inspection impact is described, or there is no inspection impact
  - Agents now have a stable documented command/LSP package boundary and a make target for checking command dispatch, JSON envelopes, LSP framing, and package delegation before Rust-hosted internals are replaced.

## Flow Contract

- Owner lane: Pheidon for command dispatch, Daedalus for LSP service migration
- Repair owner: Codex
- Autonomy class: issue-scoped implementation PR
- Risk class: high roadmap slice, contract-only behavior change

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

## Merge Automation

- [x] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- This PR does not remove Rust yet. It freezes the command and LSP package APIs that later self-hosted implementations must satisfy.
- The current developer validation still uses Cargo because stage1 is Rust-hosted; the contract marks Cargo and rustc as non-requirements for the official self-hosted release path.
