### PR TITLE
Emit direct-native debug evidence without Rust

### DIFF
--- a/docs/rust-exit-readiness.md
+++ b/docs/rust-exit-readiness.md
@@ -36,7 +36,7 @@ satisfied.
 | --- | --- | --- | --- |
 | Direct native parity matrix | Every supported stage1 surface has a direct-native status row and linked blocker when incomplete. | `blocked` | [#927](https://github.com/OMT-Global/axiom/issues/927) |
 | Direct native runtime ABI | Supported values, ownership shapes, stdlib calls, and capability host calls lower through backend-neutral direct-native runtime entrypoints. | `blocked` | [#928](https://github.com/OMT-Global/axiom/issues/928) |
-| Direct native diagnostics and evidence | Direct native builds preserve source diagnostics, provenance, debug manifests, and operator evidence without generated Rust. | `blocked` | [#929](https://github.com/OMT-Global/axiom/issues/929) |
+| Direct native diagnostics and evidence | Direct native builds preserve source diagnostics, provenance, debug manifests, and operator evidence without generated Rust. | Implemented for the Cranelift direct-native spike; broader coverage remains gated by runtime ABI and default-backend blockers. | [#929](https://github.com/OMT-Global/axiom/issues/929) |
 | Default backend | `axiomc build` defaults to direct native output and no longer invokes `rustc` for supported broad builds. | `blocked` | [#693](https://github.com/OMT-Global/axiom/issues/693) |
 | Generated-Rust removal | The generated-Rust backend and `--backend rust` compatibility path are removed after a release with direct native as default. | `blocked` | [#694](https://github.com/OMT-Global/axiom/issues/694) |
 

--- a/docs/stage1-debug-map.md
+++ b/docs/stage1-debug-map.md
@@ -9,20 +9,27 @@ native Axiom DWARF is not present yet.
   `.ax` source file, line, and column positions.
 - `<artifact>.debug-manifest.json` binds the native binary, generated Rust,
   debug map, backend-native debug settings, source hashes, and mapping counts.
+- Direct-native debug maps use
+  `axiom.stage1.direct_native.debug_map.v1` and bind Axiom module, function,
+  and statement spans directly to the native binary. They do not contain
+  `generated_rust` or generated line records.
+- Direct-native debug manifests use
+  `axiom.stage1.direct_native.debug_manifest.v1`, set
+  `artifact_class = "native_binary"`, and omit `generated_rust`,
+  `generated_rust_hash`, and `rustc`.
 
 This is an interim sidecar bridge. Generated-Rust DWARF line tables still point
 at generated Rust, and Cranelift debug builds do not emit Axiom DWARF yet, so
 debugger integrations should translate generated Rust frames through the debug
 map instead of assuming the binary contains native `.ax` line records.
 
-This PR does not change the debug sidecar schema. `axiom.stage1.debug_manifest.v1`
-continues to require `generated_rust` and `generated_rust_hash` because debug
-mapping is still mediated through generated Rust line records. A future
-direct-native debug manifest that removes generated Rust from the debug
-integrity envelope must use a successor schema version. The provenance sidecar
-is separate: generated Rust is not a required direct-native provenance artifact,
-so provenance for direct-native builds follows the native artifacts actually
-emitted by the backend.
+`axiom.stage1.debug_manifest.v1` continues to require `generated_rust` and
+`generated_rust_hash` because that legacy mapping is mediated through generated
+Rust line records. Direct-native builds use the successor direct-native schema
+versions above, so generated Rust is not part of their debug integrity
+envelope. The provenance sidecar is separate: generated Rust is not a required
+direct-native provenance artifact, so provenance for direct-native builds
+follows the native artifacts actually emitted by the backend.
 
 ## Build
 
@@ -31,8 +38,9 @@ axiomc build --debug --json
 ```
 
 The JSON payload includes `binary`, `generated_rust`, `debug_map`, and
-`debug_manifest`. Use those paths as the source of truth; do not derive sidecar
-paths by hand in tooling.
+`debug_manifest`. `generated_rust` is a path for generated-Rust builds and
+`null` for direct-native builds. Use those paths as the source of truth; do not
+derive sidecar paths by hand in tooling.
 
 ## LLDB
 
@@ -88,11 +96,13 @@ Consumers should treat `debug_manifest` as the integrity envelope:
 
 - `binary_hash` and `generated_rust_hash` identify the exact artifacts.
 - `generated_rust` and `generated_rust_hash` remain required in
-  `axiom.stage1.debug_manifest.v1`, including for Cranelift debug builds.
+  `axiom.stage1.debug_manifest.v1`.
+- Direct-native manifests identify the native artifact with `binary_hash` and
+  `artifact_class = "native_binary"` instead of a generated Rust hash.
 - `source_files[*].source_hash` identifies the `.ax` inputs.
 - `native_debug.axiom_dwarf` is the backend-neutral signal for whether the
   binary contains native Axiom DWARF line tables.
-- `rustc` is retained for generated-Rust compatibility; Cranelift debug
+- `rustc` is retained for generated-Rust compatibility; direct-native debug
   manifests omit it because `rustc` is not the native debug producer.
 - `source_files[*].mapping_count` lets tools detect missing or unexpectedly
   sparse source mappings.

--- a/stage1/compiler-contracts/schemas/axiom.stage1.command.schema.json
+++ b/stage1/compiler-contracts/schemas/axiom.stage1.command.schema.json
@@ -193,7 +193,14 @@
           "$ref": "#/$defs/path"
         },
         "generated_rust": {
-          "$ref": "#/$defs/path"
+          "oneOf": [
+            {
+              "$ref": "#/$defs/path"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "debug_map": {
           "type": [
@@ -268,7 +275,14 @@
           "$ref": "#/$defs/path"
         },
         "generated_rust": {
-          "$ref": "#/$defs/path"
+          "oneOf": [
+            {
+              "$ref": "#/$defs/path"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "ok": {
           "type": "boolean"

--- a/stage1/compiler-contracts/schemas/axiom.stage1.command.schema.json
+++ b/stage1/compiler-contracts/schemas/axiom.stage1.command.schema.json
@@ -534,7 +534,10 @@
           "$ref": "#/$defs/path"
         },
         "generated_rust": {
-          "$ref": "#/$defs/path"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "debug_map": {
           "type": [

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -51,6 +51,13 @@ mod tests {
     #[cfg(unix)]
     const PROCESS_FIXTURE_EXECUTABLE_MODE: u32 = 0o700;
 
+    fn generated_rust_path(output: &crate::project::BuildOutput) -> &str {
+        output
+            .generated_rust
+            .as_deref()
+            .expect("generated Rust path")
+    }
+
     fn render_manifest_with_capabilities(
         name: &str,
         fs: bool,
@@ -2520,7 +2527,8 @@ print 0
         .expect("write source");
 
         let built = build_project(&project).expect("build async timeout project");
-        let generated = fs::read_to_string(&built.generated_rust).expect("read generated rust");
+        let generated =
+            fs::read_to_string(generated_rust_path(&built)).expect("read generated rust");
         assert!(generated.contains("match receiver.recv_timeout(remaining)"));
         assert!(
             generated.contains("Err(std::sync::mpsc::RecvTimeoutError::Timeout) => return None")
@@ -2901,7 +2909,7 @@ print first(values)\n",
         .expect("write cli args program");
 
         let built = build_project(&project).expect("build cli args project");
-        let build_output_dir = Path::new(&built.generated_rust)
+        let build_output_dir = Path::new(generated_rust_path(&built))
             .parent()
             .expect("build output directory");
         let output = command_for_build_output(&built.binary, build_output_dir)
@@ -7022,7 +7030,8 @@ true
         .expect("write golden");
 
         let built = build_project(&project).expect("build project");
-        let generated = fs::read_to_string(&built.generated_rust).expect("read generated rust");
+        let generated =
+            fs::read_to_string(generated_rust_path(&built)).expect("read generated rust");
         assert!(generated.contains("axiom_task_deferred(move ||"));
         assert!(generated.contains("struct AxiomRuntimeScheduler"));
         assert!(
@@ -7176,7 +7185,8 @@ let _listener_closed: int = close_listener(listener)
         fs::write(project.join("src/main.ax"), source).expect("write source");
 
         let built = build_project(&project).expect("build project");
-        let generated = fs::read_to_string(&built.generated_rust).expect("read generated rust");
+        let generated =
+            fs::read_to_string(generated_rust_path(&built)).expect("read generated rust");
         assert!(generated.contains("axiom_net_tcp_read_string"));
         assert!(generated.contains("axiom_net_tcp_write_string"));
         assert!(generated.contains("net_tcp_accept(listener)"));
@@ -7267,7 +7277,8 @@ let _listener_closed: int = close_listener(listener)
         fs::write(project.join("src/main.ax"), source).expect("write source");
 
         let built = build_project(&project).expect("build single-worker async project");
-        let generated = fs::read_to_string(&built.generated_rust).expect("read generated rust");
+        let generated =
+            fs::read_to_string(generated_rust_path(&built)).expect("read generated rust");
         assert!(generated.contains("const AXIOM_RUNTIME_MAX_THREADS_CONFIG: usize = 1;"));
         assert!(generated.contains("fn axiom_runtime_recv<T>("));
         assert!(generated.contains("fn try_run_one(&self) -> bool"));
@@ -7326,7 +7337,8 @@ let _listener_closed: int = close_listener(listener)
         fs::write(project.join("src/main.ax"), source).expect("write source");
 
         let built = build_project(&project).expect("build project");
-        let generated = fs::read_to_string(&built.generated_rust).expect("read generated rust");
+        let generated =
+            fs::read_to_string(generated_rust_path(&built)).expect("read generated rust");
         assert!(generated.contains("const AXIOM_RUNTIME_MAX_THREADS_CONFIG: usize = 32;"));
         assert!(generated.contains("AxiomTimerWheel"));
         assert!(generated.contains("AxiomRuntimePool"));
@@ -10400,7 +10412,8 @@ print takes_two(three)
         )
         .expect("write source");
         let built = build_project(&project).expect("build project with static globals");
-        let generated = fs::read_to_string(&built.generated_rust).expect("read generated rust");
+        let generated =
+            fs::read_to_string(generated_rust_path(&built)).expect("read generated rust");
         assert!(generated.contains("static static_globals_app_main_LIMIT: i64 = 40 + 2;"));
         assert!(generated.contains("static static_globals_app_main_READY: bool = 40 + 2 == 42;"));
         assert!(
@@ -10427,7 +10440,8 @@ print takes_two(three)
         .expect("write source");
 
         let built = build_project(&project).expect("build project with static string comparisons");
-        let generated = fs::read_to_string(&built.generated_rust).expect("read generated rust");
+        let generated =
+            fs::read_to_string(generated_rust_path(&built)).expect("read generated rust");
         assert!(generated.contains("static static_string_comparison_app_main_SAME: bool = true;"));
         assert!(
             generated.contains("static static_string_comparison_app_main_DIFFERENT: bool = true;")
@@ -10450,7 +10464,8 @@ print takes_two(three)
         .expect("write source");
 
         let built = build_project(&project).expect("static names should not false-recurse");
-        let generated = fs::read_to_string(&built.generated_rust).expect("read generated rust");
+        let generated =
+            fs::read_to_string(generated_rust_path(&built)).expect("read generated rust");
         assert!(generated.contains("static p_main_A: i64 = 1;"));
         assert!(generated.contains("static p_main_p_main_A: i64 = 1;"));
         let output = compiled_binary_command(&built.binary)
@@ -10475,7 +10490,8 @@ print takes_two(three)
         )
         .expect("write values");
         let built = build_project(&project).expect("build project with imported static globals");
-        let generated = fs::read_to_string(&built.generated_rust).expect("read generated rust");
+        let generated =
+            fs::read_to_string(generated_rust_path(&built)).expect("read generated rust");
         assert!(generated.contains("static public_static_globals_app_values_LIMIT: i64 = 40 + 2;"));
         assert!(
             generated
@@ -11514,7 +11530,8 @@ print takes_two(three)
         .expect("write source");
 
         let built = build_project(&project).expect("build project");
-        let generated = fs::read_to_string(&built.generated_rust).expect("read generated rust");
+        let generated =
+            fs::read_to_string(generated_rust_path(&built)).expect("read generated rust");
         assert!(generated.contains("let mut value: String"));
         assert!(generated.contains("let local: &mut String = &mut value;"));
         assert!(generated.contains("*local = String::from(\"beta\");"));
@@ -12617,7 +12634,7 @@ print takes_two(three)
         assert_eq!(release.cache_misses, 1);
         assert!(!release.debug);
         let release_generated =
-            fs::read_to_string(&release.generated_rust).expect("read release generated rust");
+            fs::read_to_string(generated_rust_path(&release)).expect("read release generated rust");
         assert!(!release_generated.contains("// axiom-source:"));
 
         let debug = build_project_with_options(
@@ -12641,7 +12658,8 @@ print takes_two(three)
         assert_eq!(debug.cache_hits, 0);
         assert_eq!(debug.cache_misses, 1);
 
-        let generated = fs::read_to_string(&debug.generated_rust).expect("read generated rust");
+        let generated =
+            fs::read_to_string(generated_rust_path(&debug)).expect("read generated rust");
         let source = project
             .join("src/main.ax")
             .canonicalize()
@@ -12654,7 +12672,7 @@ print takes_two(three)
             serde_json::from_str(&fs::read_to_string(&debug_map).expect("read debug map"))
                 .expect("parse debug map");
         assert_eq!(map["schema_version"], "axiom.stage1.debug_map.v1");
-        assert_eq!(map["generated_rust"], debug.generated_rust);
+        assert_eq!(map["generated_rust"], generated_rust_path(&debug));
         assert_eq!(map["mappings"][0]["source"], source);
         assert_eq!(map["mappings"][0]["line"], 1);
         assert_eq!(map["mappings"][0]["column"], 1);
@@ -12666,7 +12684,7 @@ print takes_two(three)
         assert_eq!(manifest["schema_version"], "axiom.stage1.debug_manifest.v1");
         assert_eq!(manifest["backend"], "generated-rust");
         assert_eq!(manifest["binary"], debug.binary);
-        assert_eq!(manifest["generated_rust"], debug.generated_rust);
+        assert_eq!(manifest["generated_rust"], generated_rust_path(&debug));
         assert_eq!(manifest["debug_map"], debug_map.display().to_string());
         assert_eq!(manifest["native_debug"]["producer"], "rustc");
         assert_eq!(manifest["native_debug"]["debuginfo"], 2);
@@ -12692,7 +12710,7 @@ print takes_two(three)
                 "readelf --debug-dump=decodedline failed"
             );
             let dwarf_lines = String::from_utf8_lossy(&output.stdout);
-            let generated_file = PathBuf::from(&debug.generated_rust)
+            let generated_file = PathBuf::from(generated_rust_path(&debug))
                 .file_name()
                 .expect("generated rust file name")
                 .to_string_lossy()
@@ -12792,6 +12810,99 @@ print takes_two(three)
     }
 
     #[test]
+    fn cranelift_debug_build_emits_direct_native_evidence_without_generated_rust() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("cranelift-debug-build");
+        create_project(&project, Some("cranelift-debug-build-app")).expect("create project");
+        fs::write(
+            project.join("src/main.ax"),
+            "let answer: int = 42\nprint answer\n",
+        )
+        .expect("write source");
+
+        let output = build_project_with_options(
+            &project,
+            &BuildOptions {
+                backend: NativeBackendKind::Cranelift,
+                target: None,
+                package: None,
+                debug: true,
+                ..BuildOptions::default()
+            },
+        )
+        .expect("cranelift debug build");
+
+        assert!(output.generated_rust.is_none());
+        let manifest = load_manifest(&project).expect("load manifest");
+        let legacy_generated = crate::manifest::generated_rust_path(&project, &manifest);
+        assert!(
+            !legacy_generated.exists(),
+            "direct-native debug builds must not write generated Rust"
+        );
+        let debug_map = PathBuf::from(output.debug_map.as_ref().expect("debug map path"));
+        let debug_manifest =
+            PathBuf::from(output.debug_manifest.as_ref().expect("debug manifest path"));
+        assert!(debug_map.exists());
+        assert!(debug_manifest.exists());
+
+        let map: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&debug_map).expect("read debug map"))
+                .expect("parse debug map");
+        assert_eq!(
+            map["schema_version"],
+            "axiom.stage1.direct_native.debug_map.v1"
+        );
+        assert_eq!(map["backend"], "cranelift");
+        assert_eq!(map["binary"], output.binary);
+        assert!(map.get("generated_rust").is_none());
+        assert!(map["source_spans"].as_array().is_some_and(|spans| {
+            spans.iter().any(|span| {
+                span["kind"] == "statement"
+                    && span["source"]
+                        .as_str()
+                        .is_some_and(|path| path.ends_with("src/main.ax"))
+                    && span["line"] == 2
+            })
+        }));
+
+        let manifest_json: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(&debug_manifest).expect("read debug manifest"),
+        )
+        .expect("parse debug manifest");
+        assert_eq!(
+            manifest_json["schema_version"],
+            "axiom.stage1.direct_native.debug_manifest.v1"
+        );
+        assert_eq!(manifest_json["backend"], "cranelift");
+        assert_eq!(manifest_json["artifact_class"], "native_binary");
+        assert_eq!(manifest_json["binary"], output.binary);
+        assert_eq!(manifest_json["debug_map"], debug_map.display().to_string());
+        assert_eq!(manifest_json["native_debug"]["producer"], "cranelift");
+        assert_eq!(manifest_json["native_debug"]["axiom_dwarf"], false);
+        assert!(manifest_json.get("generated_rust").is_none());
+        assert!(manifest_json.get("generated_rust_hash").is_none());
+        assert!(
+            manifest_json["source_files"]
+                .as_array()
+                .is_some_and(|files| {
+                    files.iter().any(|file| {
+                        file["path"]
+                            .as_str()
+                            .is_some_and(|path| path.ends_with("src/main.ax"))
+                            && file["mapping_count"]
+                                .as_u64()
+                                .is_some_and(|count| count >= 2)
+                    })
+                })
+        );
+
+        let payload = json_contract::build_success(&project, &output);
+        assert!(payload["generated_rust"].is_null());
+        assert_eq!(payload["backend"], "cranelift");
+        assert!(payload["debug_manifest"].is_string());
+    }
+
+    #[test]
     fn build_project_reuses_incremental_cache_until_module_changes() {
         let dir = tempdir().expect("tempdir");
         let project = dir.path().join("cached-build");
@@ -12811,18 +12922,19 @@ print takes_two(three)
         assert_eq!(first.cache_hits, 0);
         assert_eq!(first.cache_misses, 1);
         assert_eq!(first.packages[0].cache_status, BuildCacheStatus::Miss);
-        let generated = fs::read_to_string(&first.generated_rust).expect("read generated rust");
+        let generated =
+            fs::read_to_string(generated_rust_path(&first)).expect("read generated rust");
 
         let second = build_project(&project).expect("cached build");
         assert_eq!(second.cache_hits, 1);
         assert_eq!(second.cache_misses, 0);
         assert_eq!(second.packages[0].cache_status, BuildCacheStatus::Hit);
         assert_eq!(
-            fs::read_to_string(&second.generated_rust).expect("read cached generated rust"),
+            fs::read_to_string(generated_rust_path(&second)).expect("read cached generated rust"),
             generated
         );
 
-        fs::write(&second.generated_rust, "// stale generated rust\n")
+        fs::write(generated_rust_path(&second), "// stale generated rust\n")
             .expect("corrupt generated rust");
         let repaired_rust = build_project(&project).expect("repair generated rust");
         assert_eq!(repaired_rust.cache_hits, 0);
@@ -12832,7 +12944,7 @@ print takes_two(three)
             BuildCacheStatus::Miss
         );
         assert_eq!(
-            fs::read_to_string(&repaired_rust.generated_rust).expect("read repaired rust"),
+            fs::read_to_string(generated_rust_path(&repaired_rust)).expect("read repaired rust"),
             generated
         );
 

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -12983,6 +12983,53 @@ print takes_two(three)
     }
 
     #[test]
+    #[cfg_attr(not(feature = "run-native-tests"), ignore)]
+    fn cranelift_build_reuses_cache_without_generated_rust_artifact() {
+        if which::which("cc").is_err() {
+            eprintln!("skipping Cranelift cache reuse test because cc is unavailable");
+            return;
+        }
+
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("cranelift-cached-build");
+        create_project(&project, Some("cranelift-cached-build-app")).expect("create project");
+
+        let options = BuildOptions {
+            backend: NativeBackendKind::Cranelift,
+            debug: true,
+            ..BuildOptions::default()
+        };
+
+        let first =
+            build_project_with_options(&project, &options).expect("initial cranelift build");
+        assert_eq!(first.cache_hits, 0);
+        assert_eq!(first.cache_misses, 1);
+        assert_eq!(first.packages[0].cache_status, BuildCacheStatus::Miss);
+        assert!(first.generated_rust.is_none());
+        assert!(first.packages[0].generated_rust.is_none());
+
+        let second =
+            build_project_with_options(&project, &options).expect("cached cranelift build");
+        assert_eq!(second.cache_hits, 1);
+        assert_eq!(second.cache_misses, 0);
+        assert_eq!(second.packages[0].cache_status, BuildCacheStatus::Hit);
+        assert!(second.generated_rust.is_none());
+        assert!(second.packages[0].generated_rust.is_none());
+        assert!(
+            second
+                .debug_map
+                .as_ref()
+                .is_some_and(|path| Path::new(path).exists())
+        );
+        assert!(
+            second
+                .debug_manifest
+                .as_ref()
+                .is_some_and(|path| Path::new(path).exists())
+        );
+    }
+
+    #[test]
     fn run_project_tests_supports_name_filtering() {
         let dir = tempdir().expect("tempdir");
         let project = dir.path().join("filtered-tests");

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -12839,6 +12839,10 @@ print takes_two(three)
             !legacy_generated.exists(),
             "direct-native debug builds must not write generated Rust"
         );
+        assert!(
+            legacy_generated.with_extension("build-cache.toml").exists(),
+            "direct-native builds should still create the cache sidecar"
+        );
         let debug_map = PathBuf::from(output.debug_map.as_ref().expect("debug map path"));
         let debug_manifest =
             PathBuf::from(output.debug_manifest.as_ref().expect("debug manifest path"));

--- a/stage1/crates/axiomc/src/main.rs
+++ b/stage1/crates/axiomc/src/main.rs
@@ -7998,7 +7998,7 @@ return "ok"
             manifest: String::from("axiom.toml"),
             entry: String::from("src/main.ax"),
             binary: String::from("dist/app"),
-            generated_rust: String::from("target/main.rs"),
+            generated_rust: Some(String::from("target/main.rs")),
             debug_map,
             debug_manifest,
             statement_count: 1,

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -7907,6 +7907,55 @@ mod tests {
         }));
     }
 
+    #[test]
+    fn generated_rust_cache_matches_hashed_source_not_raw_source() {
+        let dir = tempdir().unwrap_or_else(|err| panic!("tempdir: {err}"));
+        let generated_rust = dir.path().join("dist/main.rs");
+        let binary = dir.path().join("dist/main");
+        fs::create_dir_all(generated_rust.parent().expect("generated parent"))
+            .expect("create dist");
+        let generated_source = "fn main() { println!(\"cache\"); }\n";
+        fs::write(&generated_rust, generated_source).expect("write generated rust");
+        fs::write(&binary, b"binary").expect("write binary");
+
+        let stored = BuildCacheFile {
+            version: BUILD_CACHE_VERSION,
+            backend: NativeBackendKind::GeneratedRust,
+            compiler: String::from("test-generated-rust"),
+            target: None,
+            debug: false,
+            manifest_hash: String::from("manifest"),
+            lockfile_hash: String::from("lockfile"),
+            rust_hash: hash_text(generated_source),
+            binary_hash: Some(hash_file_bytes(&binary).expect("binary hash")),
+            modules: Vec::new(),
+        };
+        let expected = BuildCacheFile {
+            binary_hash: None,
+            ..stored.clone()
+        };
+
+        assert!(cache_matches(
+            &stored,
+            &expected,
+            NativeBackendKind::GeneratedRust,
+            &generated_rust,
+            &binary,
+        ));
+
+        let raw_source_expected = BuildCacheFile {
+            rust_hash: generated_source.to_string(),
+            ..expected
+        };
+        assert!(!cache_matches(
+            &stored,
+            &raw_source_expected,
+            NativeBackendKind::GeneratedRust,
+            &generated_rust,
+            &binary,
+        ));
+    }
+
     #[cfg(not(windows))]
     #[test]
     fn cranelift_build_cache_creates_output_parent_without_generated_rust() {

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -158,7 +158,7 @@ pub struct BuiltPackage {
     pub manifest: String,
     pub entry: String,
     pub binary: String,
-    pub generated_rust: String,
+    pub generated_rust: Option<String>,
     pub debug_map: Option<String>,
     pub debug_manifest: Option<String>,
     pub statement_count: usize,
@@ -178,7 +178,7 @@ pub struct BuildOutput {
     pub manifest: String,
     pub entry: String,
     pub binary: String,
-    pub generated_rust: String,
+    pub generated_rust: Option<String>,
     pub debug_map: Option<String>,
     pub debug_manifest: Option<String>,
     pub statement_count: usize,
@@ -534,13 +534,17 @@ pub fn build_project_with_options(
             manifest: manifest_path(&package_root).display().to_string(),
             entry: analyzed.entry_path.display().to_string(),
             binary: binary.display().to_string(),
-            generated_rust: generated_rust.display().to_string(),
-            debug_map: options
-                .debug
-                .then(|| debug_source_map_path(&generated_rust).display().to_string()),
-            debug_manifest: options
-                .debug
-                .then(|| debug_manifest_path(&generated_rust).display().to_string()),
+            generated_rust: generated_rust_output(options.backend, &generated_rust),
+            debug_map: options.debug.then(|| {
+                debug_source_map_path(options.backend, &generated_rust, &binary)
+                    .display()
+                    .to_string()
+            }),
+            debug_manifest: options.debug.then(|| {
+                debug_manifest_path(options.backend, &generated_rust, &binary)
+                    .display()
+                    .to_string()
+            }),
             statement_count: analyzed.mir.statement_count(),
             target: resolved_target.clone(),
             debug: options.debug,
@@ -629,7 +633,12 @@ pub fn run_project_report_with_options(
         manifest: built.manifest,
         entry: built.entry,
         binary: built.binary,
-        generated_rust: built.generated_rust,
+        generated_rust: built.generated_rust.ok_or_else(|| {
+            Diagnostic::new(
+                "run",
+                "generated-Rust build did not report a generated Rust artifact",
+            )
+        })?,
         package: options.package.clone(),
         args: options.args.clone(),
         exit_code,
@@ -672,7 +681,13 @@ fn prepare_run_project(
             offline: true,
         },
     )?;
-    let build_output_dir = Path::new(&built.generated_rust).parent().ok_or_else(|| {
+    let generated_rust = built.generated_rust.as_ref().ok_or_else(|| {
+        Diagnostic::new(
+            "run",
+            "generated-Rust run requires a generated Rust artifact",
+        )
+    })?;
+    let build_output_dir = Path::new(generated_rust).parent().ok_or_else(|| {
         Diagnostic::new(
             "run",
             format!(
@@ -1983,23 +1998,23 @@ fn build_artifacts(
     resolved_target: Option<&str>,
     options: &BuildOptions,
 ) -> Result<BuildArtifactReport, Diagnostic> {
-    ensure_output_path_stays_inside_package(package_root, generated_rust, "generated Rust output")?;
+    if matches!(options.backend, NativeBackendKind::GeneratedRust) {
+        ensure_output_path_stays_inside_package(
+            package_root,
+            generated_rust,
+            "generated Rust output",
+        )?;
+        ensure_writable_output_parent(generated_rust, "generated Rust output")?;
+    }
     ensure_output_path_stays_inside_package(package_root, binary, "binary output")?;
-    ensure_writable_output_parent(generated_rust, "generated Rust output")?;
     ensure_writable_output_parent(binary, "binary output")?;
-    let fs_root = fs_root_path_for_package(package_root, &analyzed.manifest)?;
-    let rust_source = try_render_generated_rust(
-        &GeneratedRustBackendInput::from_mir(analyzed.mir.clone())
-            .with_debug(options.debug)
-            .with_paths(package_root, fs_root)
-            .with_capabilities(analyzed.manifest.capabilities.clone())
-            .with_runtime_max_threads(analyzed.manifest.runtime.max_threads),
-    )?;
+    let generated_source = generated_rust_source_for_backend(package_root, analyzed, options)?;
+    let backend_input_hash = backend_input_hash(analyzed, generated_source.as_deref())?;
     let cache = build_cache_file(
         graph,
         package_root,
         analyzed,
-        &rust_source,
+        &backend_input_hash,
         options.backend,
         resolved_target.map(str::to_string),
         options.debug,
@@ -2007,7 +2022,9 @@ fn build_artifacts(
     let cache_path = build_cache_path(generated_rust);
     if read_build_cache(&cache_path)
         .as_ref()
-        .is_some_and(|stored| cache_matches(stored, &cache, generated_rust, binary))
+        .is_some_and(|stored| {
+            cache_matches(stored, &cache, options.backend, generated_rust, binary)
+        })
     {
         if options.debug {
             write_debug_artifacts(generated_rust, binary, analyzed, options.backend)?;
@@ -2026,12 +2043,14 @@ fn build_artifacts(
             compile_ms: 0,
         });
     }
-    fs::write(generated_rust, rust_source).map_err(|err| {
-        Diagnostic::new(
-            "build",
-            format!("failed to write {}: {err}", generated_rust.display()),
-        )
-    })?;
+    if let Some(rust_source) = generated_source {
+        fs::write(generated_rust, rust_source).map_err(|err| {
+            Diagnostic::new(
+                "build",
+                format!("failed to write {}: {err}", generated_rust.display()),
+            )
+        })?;
+    }
     let started = Instant::now();
     match options.backend {
         NativeBackendKind::GeneratedRust => compile_native(
@@ -2042,7 +2061,7 @@ fn build_artifacts(
             options.debug,
         )?,
         NativeBackendKind::Cranelift => {
-            let object_path = generated_rust.with_extension("cranelift.o");
+            let object_path = binary.with_extension("cranelift.o");
             ensure_output_path_stays_inside_package(
                 package_root,
                 &object_path,
@@ -2077,6 +2096,39 @@ fn build_artifacts(
         cache_key: build_cache_metadata(&cache),
         compile_ms,
     })
+}
+
+fn generated_rust_source_for_backend(
+    package_root: &Path,
+    analyzed: &AnalyzedProject,
+    options: &BuildOptions,
+) -> Result<Option<String>, Diagnostic> {
+    match options.backend {
+        NativeBackendKind::GeneratedRust => {
+            let fs_root = fs_root_path_for_package(package_root, &analyzed.manifest)?;
+            try_render_generated_rust(
+                &GeneratedRustBackendInput::from_mir(analyzed.mir.clone())
+                    .with_debug(options.debug)
+                    .with_paths(package_root, fs_root)
+                    .with_capabilities(analyzed.manifest.capabilities.clone())
+                    .with_runtime_max_threads(analyzed.manifest.runtime.max_threads),
+            )
+            .map(Some)
+        }
+        NativeBackendKind::Cranelift => Ok(None),
+    }
+}
+
+fn backend_input_hash(
+    analyzed: &AnalyzedProject,
+    generated_source: Option<&str>,
+) -> Result<String, Diagnostic> {
+    if let Some(generated_source) = generated_source {
+        return Ok(hash_text(generated_source));
+    }
+    let mir = serde_json::to_string(&analyzed.mir)
+        .map_err(|err| Diagnostic::new("build", format!("failed to hash MIR input: {err}")))?;
+    Ok(hash_text(&mir))
 }
 
 pub fn provenance_path_for_project(project_root: &Path) -> Result<PathBuf, Diagnostic> {
@@ -2467,12 +2519,33 @@ fn build_cache_path(generated_rust: &Path) -> PathBuf {
     generated_rust.with_extension("build-cache.toml")
 }
 
-fn debug_source_map_path(generated_rust: &Path) -> PathBuf {
-    generated_rust.with_extension("debug-map.json")
+fn generated_rust_output(backend: NativeBackendKind, generated_rust: &Path) -> Option<String> {
+    match backend {
+        NativeBackendKind::GeneratedRust => Some(generated_rust.display().to_string()),
+        NativeBackendKind::Cranelift => None,
+    }
 }
 
-fn debug_manifest_path(generated_rust: &Path) -> PathBuf {
-    generated_rust.with_extension("debug-manifest.json")
+fn debug_source_map_path(
+    backend: NativeBackendKind,
+    generated_rust: &Path,
+    binary: &Path,
+) -> PathBuf {
+    match backend {
+        NativeBackendKind::GeneratedRust => generated_rust.with_extension("debug-map.json"),
+        NativeBackendKind::Cranelift => binary.with_extension("debug-map.json"),
+    }
+}
+
+fn debug_manifest_path(
+    backend: NativeBackendKind,
+    generated_rust: &Path,
+    binary: &Path,
+) -> PathBuf {
+    match backend {
+        NativeBackendKind::GeneratedRust => generated_rust.with_extension("debug-manifest.json"),
+        NativeBackendKind::Cranelift => binary.with_extension("debug-manifest.json"),
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -2491,6 +2564,23 @@ struct DebugSourceMapping {
 }
 
 #[derive(Debug, Serialize)]
+struct DirectNativeDebugSourceMap {
+    schema_version: &'static str,
+    backend: NativeBackendKind,
+    binary: String,
+    source_spans: Vec<DirectNativeDebugSourceSpan>,
+}
+
+#[derive(Debug, Serialize)]
+struct DirectNativeDebugSourceSpan {
+    kind: &'static str,
+    name: String,
+    source: String,
+    line: usize,
+    column: usize,
+}
+
+#[derive(Debug, Serialize)]
 struct DebugManifest<'a> {
     schema_version: &'static str,
     backend: NativeBackendKind,
@@ -2502,6 +2592,18 @@ struct DebugManifest<'a> {
     native_debug: DebugNativeInfo,
     #[serde(skip_serializing_if = "Option::is_none")]
     rustc: Option<DebugRustcInfo>,
+    source_files: Vec<DebugSourceFile>,
+}
+
+#[derive(Debug, Serialize)]
+struct DirectNativeDebugManifest<'a> {
+    schema_version: &'static str,
+    backend: NativeBackendKind,
+    artifact_class: &'static str,
+    binary: &'a str,
+    binary_hash: String,
+    debug_map: &'a str,
+    native_debug: DebugNativeInfo,
     source_files: Vec<DebugSourceFile>,
 }
 
@@ -2536,16 +2638,30 @@ fn write_debug_artifacts(
     analyzed: &AnalyzedProject,
     backend: NativeBackendKind,
 ) -> Result<(), Diagnostic> {
-    let debug_map = debug_source_map_path(generated_rust);
-    write_debug_source_map(generated_rust, &debug_map)?;
-    write_debug_manifest(
-        generated_rust,
-        binary,
-        &debug_map,
-        &debug_manifest_path(generated_rust),
-        backend,
-        analyzed,
-    )
+    let debug_map = debug_source_map_path(backend, generated_rust, binary);
+    let debug_manifest = debug_manifest_path(backend, generated_rust, binary);
+    match backend {
+        NativeBackendKind::GeneratedRust => {
+            write_debug_source_map(generated_rust, &debug_map)?;
+            write_debug_manifest(
+                generated_rust,
+                binary,
+                &debug_map,
+                &debug_manifest,
+                analyzed,
+            )
+        }
+        NativeBackendKind::Cranelift => {
+            write_direct_native_debug_source_map(binary, &debug_map, analyzed, backend)?;
+            write_direct_native_debug_manifest(
+                binary,
+                &debug_map,
+                &debug_manifest,
+                backend,
+                analyzed,
+            )
+        }
+    }
 }
 
 fn write_debug_source_map(generated_rust: &Path, debug_map: &Path) -> Result<(), Diagnostic> {
@@ -2577,7 +2693,6 @@ fn write_debug_manifest(
     binary: &Path,
     debug_map: &Path,
     debug_manifest: &Path,
-    backend: NativeBackendKind,
     analyzed: &AnalyzedProject,
 ) -> Result<(), Diagnostic> {
     let generated_source = fs::read_to_string(generated_rust).map_err(|err| {
@@ -2591,18 +2706,77 @@ fn write_debug_manifest(
     let debug_map_path = debug_map.display().to_string();
     let manifest = DebugManifest {
         schema_version: "axiom.stage1.debug_manifest.v1",
-        backend,
+        backend: NativeBackendKind::GeneratedRust,
         binary: &binary_path,
         binary_hash: hash_file_bytes(binary)?,
         generated_rust: &generated_rust_path,
         generated_rust_hash: hash_file(generated_rust)?,
         debug_map: &debug_map_path,
-        native_debug: debug_native_info(backend),
-        rustc: rustc_debug_info(backend),
+        native_debug: debug_native_info(NativeBackendKind::GeneratedRust),
+        rustc: rustc_debug_info(NativeBackendKind::GeneratedRust),
         source_files: debug_source_files(analyzed, &generated_source)?,
     };
     let content = serde_json::to_string_pretty(&manifest).map_err(|err| {
         Diagnostic::new("build", format!("failed to render debug manifest: {err}"))
+    })?;
+    fs::write(debug_manifest, format!("{content}\n")).map_err(|err| {
+        Diagnostic::new(
+            "build",
+            format!("failed to write {}: {err}", debug_manifest.display()),
+        )
+    })
+}
+
+fn write_direct_native_debug_source_map(
+    binary: &Path,
+    debug_map: &Path,
+    analyzed: &AnalyzedProject,
+    backend: NativeBackendKind,
+) -> Result<(), Diagnostic> {
+    let map = DirectNativeDebugSourceMap {
+        schema_version: "axiom.stage1.direct_native.debug_map.v1",
+        backend,
+        binary: binary.display().to_string(),
+        source_spans: direct_native_debug_source_spans(analyzed),
+    };
+    let content = serde_json::to_string_pretty(&map).map_err(|err| {
+        Diagnostic::new(
+            "build",
+            format!("failed to render direct-native debug source map: {err}"),
+        )
+    })?;
+    fs::write(debug_map, format!("{content}\n")).map_err(|err| {
+        Diagnostic::new(
+            "build",
+            format!("failed to write {}: {err}", debug_map.display()),
+        )
+    })
+}
+
+fn write_direct_native_debug_manifest(
+    binary: &Path,
+    debug_map: &Path,
+    debug_manifest: &Path,
+    backend: NativeBackendKind,
+    analyzed: &AnalyzedProject,
+) -> Result<(), Diagnostic> {
+    let binary_path = binary.display().to_string();
+    let debug_map_path = debug_map.display().to_string();
+    let manifest = DirectNativeDebugManifest {
+        schema_version: "axiom.stage1.direct_native.debug_manifest.v1",
+        backend,
+        artifact_class: "native_binary",
+        binary: &binary_path,
+        binary_hash: hash_file_bytes(binary)?,
+        debug_map: &debug_map_path,
+        native_debug: debug_native_info(backend),
+        source_files: direct_native_debug_source_files(analyzed)?,
+    };
+    let content = serde_json::to_string_pretty(&manifest).map_err(|err| {
+        Diagnostic::new(
+            "build",
+            format!("failed to render direct-native debug manifest: {err}"),
+        )
     })?;
     fs::write(debug_manifest, format!("{content}\n")).map_err(|err| {
         Diagnostic::new(
@@ -2667,6 +2841,29 @@ fn debug_source_files(
         .collect()
 }
 
+fn direct_native_debug_source_files(
+    analyzed: &AnalyzedProject,
+) -> Result<Vec<DebugSourceFile>, Diagnostic> {
+    let mut span_counts = BTreeMap::<String, usize>::new();
+    for span in direct_native_debug_source_spans(analyzed) {
+        *span_counts.entry(span.source).or_default() += 1;
+    }
+    analyzed
+        .modules
+        .iter()
+        .map(|module| {
+            let source = module_source(&module.path)?;
+            let path = module.path.display().to_string();
+            Ok(DebugSourceFile {
+                mapping_count: span_counts.get(&path).copied().unwrap_or(0),
+                path,
+                source_hash: hash_text(&source),
+                line_count: source.lines().count(),
+            })
+        })
+        .collect()
+}
+
 fn debug_source_mappings(generated_source: &str) -> Vec<DebugSourceMapping> {
     generated_source
         .lines()
@@ -2682,6 +2879,130 @@ fn debug_source_mappings(generated_source: &str) -> Vec<DebugSourceMapping> {
             })
         })
         .collect()
+}
+
+fn direct_native_debug_source_spans(
+    analyzed: &AnalyzedProject,
+) -> Vec<DirectNativeDebugSourceSpan> {
+    let mut spans = Vec::new();
+    for module in &analyzed.modules {
+        let source = module.path.display().to_string();
+        spans.push(DirectNativeDebugSourceSpan {
+            kind: "module",
+            name: source.clone(),
+            source: source.clone(),
+            line: 1,
+            column: 1,
+        });
+    }
+    for function in &analyzed.mir.functions {
+        spans.push(DirectNativeDebugSourceSpan {
+            kind: "function",
+            name: function.source_name.clone(),
+            source: function.path.clone(),
+            line: function.line,
+            column: function.column,
+        });
+        collect_direct_native_stmt_spans(
+            &function.body,
+            &function.path,
+            &format!("{}::stmt", function.source_name),
+            &mut spans,
+        );
+    }
+    collect_direct_native_stmt_spans(
+        &analyzed.mir.stmts,
+        &analyzed.mir.path,
+        "module::stmt",
+        &mut spans,
+    );
+    spans.sort_by(|left, right| {
+        left.source
+            .cmp(&right.source)
+            .then_with(|| left.line.cmp(&right.line))
+            .then_with(|| left.column.cmp(&right.column))
+            .then_with(|| left.kind.cmp(&right.kind))
+            .then_with(|| left.name.cmp(&right.name))
+    });
+    spans
+}
+
+fn collect_direct_native_stmt_spans(
+    statements: &[mir::Stmt],
+    source: &str,
+    name_prefix: &str,
+    spans: &mut Vec<DirectNativeDebugSourceSpan>,
+) {
+    for (index, statement) in statements.iter().enumerate() {
+        let span = stmt_source_span(statement);
+        spans.push(DirectNativeDebugSourceSpan {
+            kind: "statement",
+            name: format!("{name_prefix}/{index}"),
+            source: source.to_string(),
+            line: span.line,
+            column: span.column,
+        });
+        match statement {
+            mir::Stmt::If {
+                then_block,
+                else_block,
+                ..
+            } => {
+                collect_direct_native_stmt_spans(
+                    then_block,
+                    source,
+                    &format!("{name_prefix}/{index}/then"),
+                    spans,
+                );
+                if let Some(else_block) = else_block {
+                    collect_direct_native_stmt_spans(
+                        else_block,
+                        source,
+                        &format!("{name_prefix}/{index}/else"),
+                        spans,
+                    );
+                }
+            }
+            mir::Stmt::While { body, .. } => {
+                collect_direct_native_stmt_spans(
+                    body,
+                    source,
+                    &format!("{name_prefix}/{index}/while"),
+                    spans,
+                );
+            }
+            mir::Stmt::Match { arms, .. } => {
+                for (arm_index, arm) in arms.iter().enumerate() {
+                    collect_direct_native_stmt_spans(
+                        &arm.body,
+                        source,
+                        &format!("{name_prefix}/{index}/match/{arm_index}"),
+                        spans,
+                    );
+                }
+            }
+            mir::Stmt::Let { .. }
+            | mir::Stmt::Assign { .. }
+            | mir::Stmt::Print { .. }
+            | mir::Stmt::Panic { .. }
+            | mir::Stmt::Defer { .. }
+            | mir::Stmt::Return { .. } => {}
+        }
+    }
+}
+
+fn stmt_source_span(statement: &mir::Stmt) -> mir::SourceSpan {
+    match statement {
+        mir::Stmt::Let { span, .. }
+        | mir::Stmt::Assign { span, .. }
+        | mir::Stmt::Print { span, .. }
+        | mir::Stmt::Panic { span, .. }
+        | mir::Stmt::Defer { span, .. }
+        | mir::Stmt::If { span, .. }
+        | mir::Stmt::While { span, .. }
+        | mir::Stmt::Match { span, .. }
+        | mir::Stmt::Return { span, .. } => *span,
+    }
 }
 
 fn parse_debug_source_marker(marker: &str) -> Option<(String, usize, usize)> {
@@ -2700,14 +3021,17 @@ fn read_build_cache(path: &Path) -> Option<BuildCacheFile> {
 fn cache_matches(
     stored: &BuildCacheFile,
     expected: &BuildCacheFile,
+    backend: NativeBackendKind,
     generated_rust: &Path,
     binary: &Path,
 ) -> bool {
     let Some(binary_hash) = stored.binary_hash.as_ref() else {
         return false;
     };
-    let Ok(generated_rust_source) = fs::read_to_string(generated_rust) else {
-        return false;
+    let generated_rust_matches = match backend {
+        NativeBackendKind::GeneratedRust => fs::read_to_string(generated_rust)
+            .is_ok_and(|source| hash_text(&source) == expected.rust_hash),
+        NativeBackendKind::Cranelift => true,
     };
     let Ok(actual_binary_hash) = hash_file_bytes(binary) else {
         return false;
@@ -2716,9 +3040,7 @@ fn cache_matches(
     let mut expected_key = expected.clone();
     stored_key.binary_hash = None;
     expected_key.binary_hash = None;
-    stored_key == expected_key
-        && hash_text(&generated_rust_source) == expected.rust_hash
-        && actual_binary_hash == *binary_hash
+    stored_key == expected_key && generated_rust_matches && actual_binary_hash == *binary_hash
 }
 
 fn write_build_cache(path: &Path, cache: &BuildCacheFile) -> Result<(), Diagnostic> {
@@ -2753,7 +3075,7 @@ fn build_cache_file(
         debug,
         manifest_hash: hash_file(&manifest_path(package_root))?,
         lockfile_hash: hash_file(&crate::manifest::lockfile_path(package_root))?,
-        rust_hash: hash_text(rust_source),
+        rust_hash: rust_source.to_string(),
         binary_hash: None,
         modules: cached_modules(graph, &analyzed.modules)?,
     })

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -3077,7 +3077,7 @@ fn build_cache_file(
         debug,
         manifest_hash: hash_file(&manifest_path(package_root))?,
         lockfile_hash: hash_file(&crate::manifest::lockfile_path(package_root))?,
-        rust_hash: rust_source.to_string(),
+        rust_hash: hash_text(rust_source),
         binary_hash: None,
         modules: cached_modules(graph, &analyzed.modules)?,
     })

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -7907,6 +7907,61 @@ mod tests {
         }));
     }
 
+    #[cfg(not(windows))]
+    #[test]
+    fn cranelift_build_cache_creates_output_parent_without_generated_rust() {
+        if which::which("cc").is_err() {
+            eprintln!("skipping Cranelift build cache test because cc is unavailable");
+            return;
+        }
+
+        let dir = tempdir().unwrap_or_else(|err| panic!("tempdir: {err}"));
+        let root = dir.path();
+        fs::create_dir_all(root.join("src")).expect("create src");
+        fs::write(
+            root.join("axiom.toml"),
+            "[package]\nname = \"demo\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n",
+        )
+        .expect("write manifest");
+        fs::write(
+            root.join("axiom.lock"),
+            crate::lockfile::render_lockfile(&package_manifest()).expect("render lockfile"),
+        )
+        .expect("write lockfile");
+        fs::write(root.join("src/main.ax"), "print \"cache parent\"\n").expect("write source");
+
+        let package_root =
+            canonicalize_existing_path(root, "project root").expect("canonical root");
+        let manifest = load_manifest(&package_root).expect("load manifest");
+        let generated_rust = generated_rust_path(&package_root, &manifest);
+        let cache_path = build_cache_path(&generated_rust);
+
+        assert!(!root.join("dist").exists());
+        let output = build_project_with_options(
+            root,
+            &BuildOptions {
+                backend: NativeBackendKind::Cranelift,
+                ..BuildOptions::default()
+            },
+        )
+        .expect("cranelift build");
+
+        assert_eq!(output.backend, NativeBackendKind::Cranelift);
+        assert!(output.generated_rust.is_none());
+        assert!(
+            Path::new(&output.binary).exists(),
+            "cranelift binary exists"
+        );
+        assert!(
+            cache_path.exists(),
+            "cranelift build cache should be written even without generated Rust"
+        );
+        assert!(
+            !generated_rust.exists(),
+            "cranelift build should not emit generated Rust"
+        );
+    }
+
     #[cfg(unix)]
     #[test]
     fn property_tests_recover_read_only_artifact_directory() {

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -2008,6 +2008,9 @@ fn build_artifacts(
     }
     ensure_output_path_stays_inside_package(package_root, binary, "binary output")?;
     ensure_writable_output_parent(binary, "binary output")?;
+    let cache_path = build_cache_path(generated_rust);
+    ensure_output_path_stays_inside_package(package_root, &cache_path, "build cache output")?;
+    ensure_writable_output_parent(&cache_path, "build cache output")?;
     let generated_source = generated_rust_source_for_backend(package_root, analyzed, options)?;
     let backend_input_hash = backend_input_hash(analyzed, generated_source.as_deref())?;
     let cache = build_cache_file(
@@ -2019,7 +2022,6 @@ fn build_artifacts(
         resolved_target.map(str::to_string),
         options.debug,
     )?;
-    let cache_path = build_cache_path(generated_rust);
     if read_build_cache(&cache_path)
         .as_ref()
         .is_some_and(|stored| {

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -1695,6 +1695,25 @@ fn write_fs_denial_project(project: &Path) {
     .expect("write fs denied source");
 }
 
+fn write_http_client_denial_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create http client denied project src");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"cranelift-http-client-denied\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
+    )
+    .expect("write http client denied manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-http-client-denied\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write http client denied lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "import \"std/http.ax\"\nmatch get(\"http://127.0.0.1/\") {\nSome(_body) {\nprint true\n}\nNone {\nprint false\n}\n}\n",
+    )
+    .expect("write http client denied source");
+}
+
 fn write_tcp_denial_project(project: &Path) {
     fs::create_dir_all(project.join("src")).expect("create tcp denied project src");
     fs::write(
@@ -1712,25 +1731,6 @@ fn write_tcp_denial_project(project: &Path) {
         "import \"std/net.ax\"\nmatch tcp_listen_loopback_once(\"pong\", 1000) {\nSome(_port) {\nprint true\n}\nNone {\nprint false\n}\n}\n",
     )
     .expect("write tcp denied source");
-}
-
-fn write_http_client_denial_project(project: &Path) {
-    fs::create_dir_all(project.join("src")).expect("create http client denied project src");
-    fs::write(
-        project.join("axiom.toml"),
-        "[package]\nname = \"cranelift-http-client-denied\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
-    )
-    .expect("write http client denied manifest");
-    fs::write(
-        project.join("axiom.lock"),
-        "version = 1\n\n[[package]]\nname = \"cranelift-http-client-denied\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
-    )
-    .expect("write http client denied lockfile");
-    fs::write(
-        project.join("src/main.ax"),
-        "import \"std/http.ax\"\nmatch get(\"https://example.com\") {\nOk(response) {\nprint response.status\n}\nErr(message) {\nprint message\n}\n}\n",
-    )
-    .expect("write http client denied source");
 }
 
 fn write_udp_denial_project(project: &Path) {

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -39,14 +39,10 @@ fn cranelift_backend_builds_hello_binary() {
     assert_eq!(payload["backend"], "cranelift");
     assert_eq!(payload["packages"][0]["backend"], "cranelift");
     let binary = payload["binary"].as_str().expect("binary path");
-    let generated_rust = payload["generated_rust"]
-        .as_str()
-        .expect("generated Rust path");
+    assert!(payload["generated_rust"].is_null());
     assert!(Path::new(binary).exists(), "cranelift binary exists");
     assert!(
-        Path::new(generated_rust)
-            .with_extension("cranelift.o")
-            .exists(),
+        Path::new(binary).with_extension("cranelift.o").exists(),
         "cranelift object exists"
     );
 

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -577,21 +577,13 @@ fn cranelift_backend_debug_build_emits_sidecars_without_axiom_dwarf() {
     let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
     assert_eq!(payload["backend"], "cranelift");
     assert_eq!(payload["debug"], true);
+    assert!(payload["generated_rust"].is_null());
     let binary = payload["binary"].as_str().expect("binary path");
-    let generated_rust = payload["generated_rust"]
-        .as_str()
-        .expect("generated Rust path");
     let debug_map = payload["debug_map"].as_str().expect("debug map path");
     let debug_manifest = payload["debug_manifest"]
         .as_str()
         .expect("debug manifest path");
     assert!(Path::new(binary).exists(), "cranelift binary exists");
-    assert!(
-        Path::new(generated_rust)
-            .with_extension("cranelift.o")
-            .exists(),
-        "cranelift object exists"
-    );
     assert!(Path::new(debug_map).exists(), "debug map exists");
     assert!(Path::new(debug_manifest).exists(), "debug manifest exists");
 
@@ -604,30 +596,43 @@ fn cranelift_backend_debug_build_emits_sidecars_without_axiom_dwarf() {
     let map: Value =
         serde_json::from_str(&fs::read_to_string(debug_map).expect("read cranelift debug map"))
             .expect("parse cranelift debug map");
+    assert_eq!(
+        map["schema_version"],
+        "axiom.stage1.direct_native.debug_map.v1"
+    );
+    assert_eq!(map["backend"], "cranelift");
+    assert_eq!(map["binary"], binary);
     assert!(
-        map["mappings"]
+        map["source_spans"]
             .as_array()
-            .expect("debug mappings")
+            .expect("direct-native debug source spans")
             .iter()
-            .any(|mapping| mapping["source"] == source),
-        "debug map should retain Axiom source spans for cranelift builds"
+            .any(|span| span["source"] == source),
+        "direct-native debug map should retain Axiom source spans for cranelift builds"
     );
 
     let manifest: Value = serde_json::from_str(
         &fs::read_to_string(debug_manifest).expect("read cranelift debug manifest"),
     )
     .expect("parse cranelift debug manifest");
-    assert_eq!(manifest["schema_version"], "axiom.stage1.debug_manifest.v1");
+    assert_eq!(
+        manifest["schema_version"],
+        "axiom.stage1.direct_native.debug_manifest.v1"
+    );
+    assert_eq!(manifest["artifact_class"], "native_binary");
     assert_eq!(manifest["backend"], "cranelift");
     assert_eq!(manifest["binary"], binary);
-    assert_eq!(manifest["generated_rust"], generated_rust);
-    assert!(
-        manifest["generated_rust_hash"]
-            .as_str()
-            .is_some_and(|hash| !hash.is_empty()),
-        "debug manifest v1 should keep generated_rust_hash in the integrity envelope"
-    );
+    assert!(manifest.get("generated_rust").is_none());
+    assert!(manifest.get("generated_rust_hash").is_none());
     assert_eq!(manifest["debug_map"], debug_map);
+    assert!(
+        manifest["source_files"]
+            .as_array()
+            .expect("direct-native manifest source files")
+            .iter()
+            .any(|file| file["path"] == source),
+        "direct-native debug manifest should retain Axiom source files"
+    );
     assert_eq!(manifest["native_debug"]["producer"], "cranelift");
     assert_eq!(manifest["native_debug"]["debuginfo"], 0);
     assert_eq!(manifest["native_debug"]["opt_level"], 0);

--- a/stage1/crates/axiomc/tests/json_contract_snapshots.rs
+++ b/stage1/crates/axiomc/tests/json_contract_snapshots.rs
@@ -121,9 +121,11 @@ fn cranelift_debug_build_emits_direct_native_debug_sidecars() {
         debug_map["schema_version"],
         "axiom.stage1.direct_native.debug_map.v1"
     );
-    assert!(debug_map["binary"]
-        .as_str()
-        .is_some_and(|path| path.contains("cranelift-debug-contract-app")));
+    assert!(
+        debug_map["binary"]
+            .as_str()
+            .is_some_and(|path| path.contains("cranelift-debug-contract-app"))
+    );
 
     let debug_manifest = read_json(Path::new(debug_manifest_path));
     assert_eq!(
@@ -278,11 +280,13 @@ fn doc_json_output_validates_against_doc_schema() {
     assert_eq!(output["types"][0]["kind"], "struct");
     assert_eq!(output["items"][0]["kind"], "function");
     assert_eq!(output["items"][0]["examples"][0], "route(\"/health\")");
-    assert!(output["capabilities"]
-        .as_array()
-        .expect("capabilities array")
-        .iter()
-        .any(|capability| capability["name"] == "env"));
+    assert!(
+        output["capabilities"]
+            .as_array()
+            .expect("capabilities array")
+            .iter()
+            .any(|capability| capability["name"] == "env")
+    );
 }
 
 #[test]

--- a/stage1/crates/axiomc/tests/json_contract_snapshots.rs
+++ b/stage1/crates/axiomc/tests/json_contract_snapshots.rs
@@ -81,6 +81,61 @@ fn cranelift_build_json_validates_against_command_schema() {
     assert_payload_matches_schema(&validator, "cranelift build", &output);
 }
 
+#[cfg(not(windows))]
+#[test]
+fn cranelift_debug_build_emits_direct_native_debug_sidecars() {
+    if which::which("cc").is_err() {
+        eprintln!("skipping Cranelift debug build test because cc is unavailable");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("cranelift-debug-contract-app");
+
+    run_axiomc(&[
+        "new",
+        project.to_str().expect("project path"),
+        "--name",
+        "cranelift-debug-contract-app",
+    ]);
+
+    let output = run_axiomc_json(&[
+        "build",
+        project.to_str().expect("project path"),
+        "--backend",
+        "cranelift",
+        "--debug",
+        "--json",
+    ]);
+
+    assert!(output["generated_rust"].is_null());
+    let debug_map_path = output["debug_map"]
+        .as_str()
+        .expect("cranelift debug build should emit debug_map");
+    let debug_manifest_path = output["debug_manifest"]
+        .as_str()
+        .expect("cranelift debug build should emit debug_manifest");
+
+    let debug_map = read_json(Path::new(debug_map_path));
+    assert_eq!(
+        debug_map["schema_version"],
+        "axiom.stage1.direct_native.debug_map.v1"
+    );
+    assert!(debug_map["binary"]
+        .as_str()
+        .is_some_and(|path| path.contains("cranelift-debug-contract-app")));
+
+    let debug_manifest = read_json(Path::new(debug_manifest_path));
+    assert_eq!(
+        debug_manifest["schema_version"],
+        "axiom.stage1.direct_native.debug_manifest.v1"
+    );
+    assert_eq!(debug_manifest["artifact_class"], "native_binary");
+    assert!(debug_manifest.get("generated_rust").is_none());
+    assert!(debug_manifest.get("generated_rust_hash").is_none());
+    assert!(debug_manifest.get("rustc").is_none());
+}
+
 #[test]
 fn debug_map_sidecar_matches_checked_in_contract_snapshot() {
     let contracts = contract_root();
@@ -223,13 +278,11 @@ fn doc_json_output_validates_against_doc_schema() {
     assert_eq!(output["types"][0]["kind"], "struct");
     assert_eq!(output["items"][0]["kind"], "function");
     assert_eq!(output["items"][0]["examples"][0], "route(\"/health\")");
-    assert!(
-        output["capabilities"]
-            .as_array()
-            .expect("capabilities array")
-            .iter()
-            .any(|capability| capability["name"] == "env")
-    );
+    assert!(output["capabilities"]
+        .as_array()
+        .expect("capabilities array")
+        .iter()
+        .any(|capability| capability["name"] == "env"));
 }
 
 #[test]

--- a/stage1/crates/axiomc/tests/json_contract_snapshots.rs
+++ b/stage1/crates/axiomc/tests/json_contract_snapshots.rs
@@ -49,6 +49,38 @@ fn cli_json_outputs_match_checked_in_contract_snapshots() {
     }
 }
 
+#[cfg(not(windows))]
+#[test]
+fn cranelift_build_json_validates_against_command_schema() {
+    if which::which("cc").is_err() {
+        eprintln!("skipping Cranelift build JSON schema test because cc is unavailable");
+        return;
+    }
+
+    let contracts = contract_root();
+    let schema = read_json(&contracts.join("schemas/axiom.stage1.command.schema.json"));
+    let validator = jsonschema::validator_for(&schema).expect("compile JSON contract schema");
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("cranelift-contract-app");
+
+    run_axiomc(&[
+        "new",
+        project.to_str().expect("project path"),
+        "--name",
+        "cranelift-contract-app",
+    ]);
+
+    let output = run_axiomc_json(&[
+        "build",
+        project.to_str().expect("project path"),
+        "--backend",
+        "cranelift",
+        "--json",
+    ]);
+    assert!(output["generated_rust"].is_null());
+    assert_payload_matches_schema(&validator, "cranelift build", &output);
+}
+
 #[test]
 fn debug_map_sidecar_matches_checked_in_contract_snapshot() {
     let contracts = contract_root();


### PR DESCRIPTION
## Summary

- Emit Cranelift/direct-native debug sidecars from Axiom MIR/source spans without writing or reporting a generated Rust artifact.
- Add direct-native debug map and manifest schema versions, and keep generated-Rust debug manifest v1 unchanged for the legacy backend.
- Allow build JSON `generated_rust` to be `null` for native-only outputs and update Rust-exit readiness for #929.

## Governing Issue

Closes #929

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Commands run:

- `cargo check -p axiomc` passed with existing dead-code warnings.
- `cargo test -p axiomc --lib cranelift_debug_build_emits_direct_native_evidence_without_generated_rust -- --nocapture` passed.
- `cargo test -p axiomc --lib cranelift_provenance_does_not_require_rust_source_artifact -- --nocapture` passed.
- `cargo test -p axiomc --lib build_project_debug_mode_emits_source_markers_and_uses_separate_cache_key -- --nocapture` passed.
- `cargo test -p axiomc --lib json_contract_build_payload_includes_target -- --nocapture` passed.
- `python3 -m json.tool stage1/compiler-contracts/schemas/axiom.stage1.command.schema.json >/dev/null` passed.
- `make rust-exit-readiness-test` passed.
- `git diff --check` passed.

Full `cargo test -p axiomc` was attempted and stopped on `tests::stage1_project_imports_synthetic_stdlib_serdes_module`: the fixture printed ten zero lines while the assertion expects four. The focused checks above cover this PR's changed direct-native evidence, generated-Rust debug compatibility, provenance, JSON payload, and readiness surfaces.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Semantic node types added/changed: direct-native debug source-map spans now expose Axiom module, function, and statement coordinates for Cranelift/native evidence.

Schemas added/changed: `axiom.stage1.command.schema.json` now permits build `generated_rust` to be `null` for native-only outputs; generated-Rust paths remain valid for the legacy backend. Direct-native debug map/manifest schema versions are documented as `axiom.stage1.direct_native.debug_map.v1` and `axiom.stage1.direct_native.debug_manifest.v1`.

Evidence added/changed: Cranelift debug builds emit source-correlated debug sidecars without `generated_rust`, `generated_rust_hash`, or `rustc` fields; generated-Rust debug manifest v1 remains unchanged.

Rust capture risk: direct-native evidence is keyed to `native_binary` and Axiom source spans. Generated Rust remains documented only as the legacy backend path.

Agent-facing inspection impact: consumers must treat build `generated_rust` as nullable and use `debug_manifest`/`debug_map` paths as the source of truth for backend-specific evidence.

## Flow Contract

- Owner lane: Pheidon
- Repair owner: Codex
- Autonomy class: issue-scoped implementation
- Risk class: medium; build JSON and debug evidence contracts change for Cranelift/direct-native builds while generated-Rust behavior is covered by regression tests

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [ ] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- Auto-merge will be enabled after the PR is created if GitHub allows it.
