### PR TITLE
Add direct-native borrowed slice coverage

### DIFF
--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -88,6 +88,11 @@ builds a package using `std/fs.ax` without the `fs` capability and verifies the
 public capability denial appears before any Cranelift unsupported-feature
 diagnostic.
 
+The borrowed-slice row has partial direct-native evidence: the Cranelift spike
+now evaluates array-backed borrowed slices through `len`, `first`, `last`,
+indexing, and function returns. Broader borrowed-slice aliasing and host ABI
+coverage remain tracked by issue #928.
+
 ## Rust Capture Check
 
 This ABI describes Axiom runtime values and host-service effects. Rust may

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -225,6 +225,30 @@ fn eval_expr(
             .map(|element| eval_expr(element, functions, env))
             .collect::<Result<Vec<_>, _>>()
             .map(SpikeValue::Array),
+        Expr::Slice {
+            base, start, end, ..
+        } => {
+            let elements = match eval_expr(base, functions, env)? {
+                SpikeValue::Array(elements) => elements,
+                _ => {
+                    return Err(unsupported(
+                        "slicing supports arrays in the cranelift spike",
+                    ));
+                }
+            };
+            let start = match start {
+                Some(expr) => expect_non_negative_index(eval_expr(expr, functions, env)?)?,
+                None => 0,
+            };
+            let end = match end {
+                Some(expr) => expect_non_negative_index(eval_expr(expr, functions, env)?)?,
+                None => elements.len(),
+            };
+            if start > end || end > elements.len() {
+                return Err(unsupported("slice range is outside the array length"));
+            }
+            Ok(SpikeValue::Array(elements[start..end].to_vec()))
+        }
         Expr::Index { base, index, .. } => match eval_expr(base, functions, env)? {
             SpikeValue::Array(elements) => {
                 let index = expect_non_negative_index(eval_expr(index, functions, env)?)?;
@@ -535,7 +559,7 @@ fn eval_first_last_call(
     };
     // HIR restricts `first`/`last` to arrays and slices and returns the element
     // directly (it panics at runtime on an empty collection). The spike models
-    // owned arrays only; borrowed slices are outside the spike subset.
+    // owned arrays and evaluated array slices with the same value shape.
     let elements = match eval_expr(arg, functions, env)? {
         SpikeValue::Array(elements) => elements,
         _ => {
@@ -803,7 +827,10 @@ fn validate_map_key(value: &SpikeValue) -> Result<(), Diagnostic> {
         SpikeValue::Float(_) => Err(unsupported(
             "map float keys are not supported by the cranelift spike",
         )),
-        SpikeValue::Enum { .. } | SpikeValue::Struct { .. } | SpikeValue::Map(_) | SpikeValue::Array(_) => Err(unsupported(
+        SpikeValue::Enum { .. }
+        | SpikeValue::Struct { .. }
+        | SpikeValue::Map(_)
+        | SpikeValue::Array(_) => Err(unsupported(
             "map keys must be scalar values or scalar tuples in the cranelift spike",
         )),
     }

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -377,6 +377,49 @@ fn cranelift_backend_builds_array_helpers_binary() {
 
 #[cfg(not(windows))]
 #[test]
+fn cranelift_backend_builds_borrowed_slice_binary() {
+    if which::which("cc").is_err() {
+        eprintln!("skipping cranelift backend smoke test because cc is unavailable");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("borrowed-slice");
+    write_borrowed_slice_project(&project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+    assert!(
+        output.status.success(),
+        "cranelift borrowed-slice build failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
+    assert_eq!(payload["backend"], "cranelift");
+    let binary = payload["binary"].as_str().expect("binary path");
+    let run = Command::new(binary)
+        .output()
+        .expect("run cranelift borrowed-slice binary");
+    assert!(
+        run.status.success(),
+        "cranelift borrowed-slice binary failed: stderr={}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&run.stdout), "3\n4\n8\n6\n3\n");
+}
+
+#[cfg(not(windows))]
+#[test]
 fn cranelift_backend_debug_build_emits_sidecars_without_axiom_dwarf() {
     if which::which("cc").is_err() {
         eprintln!("skipping cranelift backend smoke test because cc is unavailable");
@@ -769,6 +812,25 @@ fn write_array_helpers_project(project: &Path) {
         "let values: [int; 3] = [10, 20, 30]\nprint len(values)\nprint first(values)\nprint last(values)\nprint first(values) + last(values)\n",
     )
     .expect("write array-helpers source");
+}
+
+fn write_borrowed_slice_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create borrowed-slice project src");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"cranelift-borrowed-slice\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
+    )
+    .expect("write borrowed-slice manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-borrowed-slice\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write borrowed-slice lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "fn tail(values: &[int]): &[int] {\nreturn values[1:]\n}\n\nlet values: [int] = [2, 4, 6, 8]\nlet window: &[int] = values[1:]\nprint len(window)\nprint first(window)\nprint last(window)\nprint window[1]\nlet nested: &[int] = tail(values[:])\nprint len(nested)\n",
+    )
+    .expect("write borrowed-slice source");
 }
 
 fn write_map_index_project(project: &Path) {

--- a/stage1/runtime-abi/direct-native-v0.json
+++ b/stage1/runtime-abi/direct-native-v0.json
@@ -31,9 +31,10 @@
     },
     {
       "id": "slice.borrowed",
-      "status": "blocked",
-      "evidence": [],
-      "blockers": [928]
+      "status": "partial",
+      "evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
+      "blockers": [928],
+      "notes": "The Cranelift spike evaluates borrowed array slices for len, first, last, indexing, and function returns. Broader borrowed-slice aliasing and host ABI coverage remain open."
     },
     {
       "id": "map.lookup",


### PR DESCRIPTION
## Summary

- implement Cranelift/direct-native evaluation for array-backed MIR slice expressions
- add a direct-native build/run regression for borrowed slices through `len`, `first`, `last`, indexing, and function returns
- update the direct-native runtime ABI contract so `slice.borrowed` moves from `blocked` to `partial` with executable evidence

## Governing Issue

Refs #928

This is a progress slice for the broader runtime ABI issue; it keeps #928 open because capability shims and several runtime rows remain blocked or partial.

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Commands run:

- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend cranelift_backend_builds_borrowed_slice_binary -- --nocapture`
- `make stage1-direct-native-runtime-abi`
- `make stage1-direct-native-runtime-abi-test`
- `cargo check -p axiomc`
- `python3 -m json.tool stage1/runtime-abi/direct-native-v0.json >/dev/null`
- `git diff --check`

Notes:

- `make stage1-direct-native-runtime-abi` still reports `ready: false`, as expected. The contract remains partial while #928 continues to track the remaining blocked runtime and capability-shim rows.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

No contributor, PR guidance, onboarding, secret, auth, or machine-local files changed.

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Semantic node types:

- No new semantic nodes. Existing MIR `Expr::Slice` now has Cranelift/direct-native spike evaluation for array-backed values.

Schemas:

- No schema files changed. `stage1/runtime-abi/direct-native-v0.json` contract data changed: `slice.borrowed` is now `partial` with evidence.

Evidence:

- Added `cranelift_backend_builds_borrowed_slice_binary` in `stage1/crates/axiomc/tests/cranelift_backend.rs`.
- Updated `docs/direct-native-runtime-abi-v0.md` to describe the partial borrowed-slice evidence.

Rust capture check:

- The ABI wording remains Axiom/direct-native oriented and does not define semantics through generated Rust, Rust types, Cargo, or `rustc`.
- The code change is backend-specific Cranelift spike evaluation and keeps the contract row partial.

Agent-facing inspection impact:

- Agents inspecting the runtime ABI matrix now see `slice.borrowed` as partially evidenced instead of blocked, while #928 remains the blocker for broader ABI readiness.

## Flow Contract

- Owner lane: Daedalus runtime/backend lane
- Repair owner: Codex
- Autonomy class: issue-directed implementation slice
- Risk class: medium slice inside high-risk Rust-exit issue

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

Blockers:

- Non-author approval is required after review.
- #928 remains open for remaining runtime ABI and capability-shim rows.

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

Auto-merge should be enabled after PR creation if GitHub accepts it for this branch.

## Notes

- This PR intentionally does not make direct native the default and does not remove the generated-Rust backend.

