### PR TITLE
Add direct-native Result ABI evidence

### DIFF
--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -127,9 +127,9 @@ under #928.
 
 The `Result<T, E>` row has partial direct-native evidence: the Cranelift spike
 now builds and runs a package importing `std/outcome.ax`, using result
-predicates, fallback unwrap helpers, direct match arms, scalar payloads, string
-errors, and struct payloads. Broader runtime ABI and capability-shim coverage
-remain tracked by issue #928.
+predicates, fallback unwrap helpers, direct match arms over `Result<T, E>`
+values, scalar payloads, string errors, and struct payloads. Broader runtime
+ABI and capability-shim coverage remain tracked by issue #928.
 
 ## Rust Capture Check
 

--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -125,10 +125,12 @@ package without the `env` capability fails before backend lowering. Full
 runtime-time lookup, manifest allowlist parity, and audit parity remain open
 under #928.
 
-The sync-primitives row has partial direct-native evidence: the Cranelift spike
-now evaluates ownership-shaped `std/sync.ax` mutex, once, and channel wrappers
-and emits the expected native output. Concurrent execution, blocking behavior,
-and host runtime synchronization remain tracked by issue #928.
+The `Result<T, E>` row has partial direct-native evidence: the Cranelift spike
+now builds and runs a package importing `std/outcome.ax`, using result
+predicates, fallback unwrap helpers, direct match arms, scalar payloads, string
+errors, and struct payloads. Broader runtime ABI and capability-shim coverage
+remain tracked by issue #928.
+
 ## Rust Capture Check
 
 This ABI describes Axiom runtime values and host-service effects. Rust may

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -334,6 +334,52 @@ fn cranelift_backend_builds_enum_match_binary() {
 
 #[cfg(not(windows))]
 #[test]
+fn cranelift_backend_builds_result_helpers_binary() {
+    if which::which("cc").is_err() {
+        eprintln!("skipping cranelift backend smoke test because cc is unavailable");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("result-helpers");
+    write_result_helpers_project(&project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+    assert!(
+        output.status.success(),
+        "cranelift result-helpers build failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
+    assert_eq!(payload["backend"], "cranelift");
+    let binary = payload["binary"].as_str().expect("binary path");
+    let run = Command::new(binary)
+        .output()
+        .expect("run cranelift result-helpers binary");
+    assert!(
+        run.status.success(),
+        "cranelift result-helpers binary failed: stderr={}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "true\ntrue\n7\n9\nbuilt\nboom\n"
+    );
+}
+
+#[cfg(not(windows))]
+#[test]
 fn cranelift_backend_builds_array_helpers_binary() {
     if which::which("cc").is_err() {
         eprintln!("skipping cranelift backend smoke test because cc is unavailable");
@@ -1188,6 +1234,25 @@ fn write_enum_match_project(project: &Path) {
         "enum Message {\nPair(int, string)\nJob { id: int, label: string }\nText(string)\n}\n\nenum Signal {\nRed\nYellow\nGreen\n}\n\nfn render(message: Message): string {\nmatch message {\nPair(count, label) {\nreturn label\n}\nJob { label, id } {\nreturn label\n}\nText(text) {\nreturn text\n}\n}\n}\n\nfn signal_priority(signal: Signal): int {\nreturn match signal { Red => 3, Yellow => 2, Green => 1 }\n}\n\nlet first: Message = Pair(7, \"multi\")\nlet second: Message = Job { id: 9, label: \"named\" }\nlet score: int = match Some(7) {\nSome(value) => value + 1\nNone => 0\n}\n\nprint render(first)\nprint render(second)\nprint render(Text(\"payload\"))\nprint signal_priority(Yellow)\nprint score\n",
     )
     .expect("write enum match source");
+}
+
+fn write_result_helpers_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create result helpers project src");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"cranelift-result-helpers\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
+    )
+    .expect("write result helpers manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-result-helpers\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write result helpers lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "import \"std/outcome.ax\"\n\nstruct BuildInfo {\nlabel: string\n}\n\nfn load(ready: bool): Result<BuildInfo, string> {\nif ready {\nreturn Ok(BuildInfo { label: \"built\" })\n}\nreturn Err(\"boom\")\n}\n\nfn render(result: Result<BuildInfo, string>): string {\nmatch result {\nOk(info) {\nreturn info.label\n}\nErr(message) {\nreturn message\n}\n}\n}\n\nlet ok_check: Result<int, string> = Ok(7)\nlet err_check: Result<int, string> = Err(\"missing\")\nlet ok_value: Result<int, string> = Ok(7)\nlet err_value: Result<int, string> = Err(\"missing\")\nprint result_is_ok<int, string>(ok_check)\nprint result_is_err<int, string>(err_check)\nprint result_unwrap_or<int, string>(ok_value, 0)\nprint result_unwrap_or<int, string>(err_value, 9)\nprint render(load(true))\nprint render(load(false))\n",
+    )
+    .expect("write result helpers source");
 }
 
 fn write_struct_field_project(project: &Path) {

--- a/stage1/runtime-abi/direct-native-v0.json
+++ b/stage1/runtime-abi/direct-native-v0.json
@@ -56,9 +56,10 @@
     },
     {
       "id": "result",
-      "status": "blocked",
-      "evidence": [],
-      "blockers": [928]
+      "status": "partial",
+      "evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
+      "blockers": [928],
+      "notes": "The Cranelift spike evaluates Result<T, E> through std/outcome.ax helpers, direct match arms, scalar payloads, string errors, and struct payloads. Broader ABI payload and capability-shim coverage remain open."
     },
     {
       "id": "enum.payload",


### PR DESCRIPTION
## Summary

- add a Cranelift/direct-native build/run regression for `Result<T, E>` through `std/outcome.ax`
- cover result predicates, fallback unwrap helpers, direct match arms, scalar payloads, string errors, and struct payloads
- update the direct-native runtime ABI contract so `result` moves from `blocked` to `partial` with executable evidence

## Governing Issue

Refs #928

This is a progress slice for the broader runtime ABI issue; it keeps #928 open because capability shims and several runtime rows remain blocked or partial.

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Commands run:

- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend cranelift_backend_builds_result_helpers_binary -- --nocapture`
- `make stage1-direct-native-runtime-abi`
- `make stage1-direct-native-runtime-abi-test`
- `cargo check -p axiomc`
- `python3 -m json.tool stage1/runtime-abi/direct-native-v0.json >/dev/null`
- `git diff --check`

Notes:

- `make stage1-direct-native-runtime-abi` still reports `ready: false`, as expected. The contract remains partial while #928 continues to track remaining blocked runtime and capability-shim rows.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

No contributor, PR guidance, onboarding, secret, auth, or machine-local files changed.

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Semantic node types:

- No new semantic nodes. Existing `Result<T, E>` language forms and `std/outcome.ax` helpers now have direct-native runtime ABI evidence.

Schemas:

- No schema files changed. `stage1/runtime-abi/direct-native-v0.json` contract data changed: `result` is now `partial` with evidence.

Evidence:

- Added `cranelift_backend_builds_result_helpers_binary` in `stage1/crates/axiomc/tests/cranelift_backend.rs`.
- Updated `docs/direct-native-runtime-abi-v0.md` to describe the partial `Result<T, E>` evidence.

Rust capture check:

- The ABI wording remains Axiom/direct-native oriented and does not define semantics through generated Rust, Rust types, Cargo, or `rustc`.
- This PR does not add generated-Rust dependency; it records direct-native evidence while keeping the contract row partial.

Agent-facing inspection impact:

- Agents inspecting the runtime ABI matrix now see `result` as partially evidenced instead of blocked, while #928 remains the blocker for broader ABI readiness.

## Flow Contract

- Owner lane: Daedalus runtime/backend lane
- Repair owner: Codex
- Autonomy class: issue-directed implementation slice
- Risk class: medium slice inside high-risk Rust-exit issue

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

Blockers:

- Non-author approval is required after review.
- #928 remains open for remaining runtime ABI and capability-shim rows.

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

Auto-merge should be enabled after PR creation if GitHub accepts it for this branch.

## Notes

- This PR intentionally does not make direct native the default and does not remove the generated-Rust backend.

