### PR TITLE
Add direct-native env read ABI evidence

### DIFF
--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -113,6 +113,12 @@ now evaluates ownership-shaped `std/sync.ax` mutex, once, and channel wrappers
 and emits the expected native output. Concurrent execution, blocking behavior,
 and host runtime synchronization remain tracked by issue #928.
 
+The `env.read` row now has partial Cranelift evidence for `std/env.ax`
+`get_env` on present and missing environment names, plus denial evidence that a
+package without the `env` capability fails before backend lowering. Full
+runtime-time lookup, manifest allowlist parity, and audit parity remain open
+under #928.
+
 ## Rust Capture Check
 
 This ABI describes Axiom runtime values and host-service effects. Rust may

--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -119,6 +119,10 @@ package without the `env` capability fails before backend lowering. Full
 runtime-time lookup, manifest allowlist parity, and audit parity remain open
 under #928.
 
+The sync-primitives row has partial direct-native evidence: the Cranelift spike
+now evaluates ownership-shaped `std/sync.ax` mutex, once, and channel wrappers
+and emits the expected native output. Concurrent execution, blocking behavior,
+and host runtime synchronization remain tracked by issue #928.
 ## Rust Capture Check
 
 This ABI describes Axiom runtime values and host-service effects. Rust may

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -511,6 +511,9 @@ fn eval_call(
     if name == "crypto_sha256" {
         return eval_crypto_sha256_call(args, functions, env);
     }
+    if name == "env_get" {
+        return eval_env_get_call(args, functions, env);
+    }
     let function = functions
         .get(name)
         .ok_or_else(|| unsupported(&format!("unsupported cranelift spike call {name:?}")))?;
@@ -706,6 +709,40 @@ fn sha256_hex(input: &str) -> String {
     }
     output
 }
+
+fn eval_env_get_call(
+    args: &[Expr],
+    functions: &HashMap<&str, &Function>,
+    env: &SpikeEnv,
+) -> Result<SpikeValue, Diagnostic> {
+    let [name] = args else {
+        return Err(unsupported("env_get expects exactly one argument"));
+    };
+    let name = match eval_expr(name, functions, env)? {
+        SpikeValue::Text(value) => value,
+        _ => return Err(unsupported("env_get expects a string argument")),
+    };
+    let value = std::env::var(name).ok();
+    Ok(option_text(value))
+}
+
+fn option_text(value: Option<String>) -> SpikeValue {
+    match value {
+        Some(value) => SpikeValue::Enum {
+            enum_name: String::from("Option"),
+            variant: String::from("Some"),
+            field_names: Vec::new(),
+            payloads: vec![SpikeValue::Text(value)],
+        },
+        None => SpikeValue::Enum {
+            enum_name: String::from("Option"),
+            variant: String::from("None"),
+            field_names: Vec::new(),
+            payloads: Vec::new(),
+        },
+    }
+}
+
 fn eval_arithmetic(
     op: ArithmeticOp,
     lhs: &Expr,

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -876,6 +876,59 @@ fn cranelift_backend_rejects_tcp_denial_before_backend_lowering() {
     let temp = tempfile::tempdir().expect("tempdir");
     let project = temp.path().join("tcp-denied");
     write_tcp_denial_project(&project);
+#[cfg(not(windows))]
+#[test]
+fn cranelift_backend_builds_env_read_binary() {
+    if which::which("cc").is_err() {
+        eprintln!("skipping cranelift backend smoke test because cc is unavailable");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("env-read");
+    write_env_read_project(&project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .env("AXIOM_CRANELIFT_ENV_READ", "native-env")
+        .env_remove("__AXIOM_CRANELIFT_ENV_MISSING__")
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+    assert!(
+        output.status.success(),
+        "cranelift env build failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
+    assert_eq!(payload["backend"], "cranelift");
+    let binary = payload["binary"].as_str().expect("binary path");
+    let run = Command::new(binary)
+        .output()
+        .expect("run cranelift env binary");
+    assert!(
+        run.status.success(),
+        "cranelift env binary failed: stderr={}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "native-env\nmissing\n"
+    );
+}
+
+#[test]
+fn cranelift_backend_rejects_env_denial_before_backend_lowering() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("env-denied");
+    write_env_denial_project(&project);
 
     let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
         .args([
@@ -891,6 +944,7 @@ fn cranelift_backend_rejects_tcp_denial_before_backend_lowering() {
     assert!(
         !output.status.success(),
         "cranelift tcp denied build unexpectedly succeeded: stdout={} stderr={}",
+        "cranelift env-denied build unexpectedly succeeded: stdout={} stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
@@ -982,6 +1036,12 @@ fn cranelift_backend_rejects_process_denial_before_backend_lowering() {
     assert!(
         !combined.contains("unsupported by --backend cranelift spike"),
         "capability denial must happen before backend lowering: {combined}"
+        combined.contains("requires [capabilities].env"),
+        "expected env capability denial before backend lowering, got: {combined}"
+    );
+    assert!(
+        !combined.contains("unsupported by --backend cranelift spike"),
+        "env capability denial should happen before cranelift unsupported-feature lowering: {combined}"
     );
 }
 
@@ -1320,4 +1380,40 @@ fn write_fs_write_denial_project(project: &Path) {
         "import \"std/fs.ax\"\nprint write_file(\"out.txt\", \"content\")\n",
     )
     .expect("write fs write denied source");
+fn write_env_read_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create env project src");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"cranelift-env-read\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = true\nclock = false\ncrypto = false\n\n[unsafe_rationale]\nenv = \"Cranelift ABI regression covers direct-native env.read behavior for issue 928.\"\n",
+    )
+    .expect("write env manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-env-read\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write env lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "import \"std/env.ax\"\nmatch get_env(\"AXIOM_CRANELIFT_ENV_READ\") {\nSome(value) {\nprint value\n}\nNone {\nprint \"missing value\"\n}\n}\nmatch get_env(\"__AXIOM_CRANELIFT_ENV_MISSING__\") {\nSome(value) {\nprint value\n}\nNone {\nprint \"missing\"\n}\n}\n",
+    )
+    .expect("write env source");
+}
+
+fn write_env_denial_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create env denied project src");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"cranelift-env-denied\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
+    )
+    .expect("write env denied manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-env-denied\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write env denied lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "import \"std/env.ax\"\nmatch get_env(\"AXIOM_CRANELIFT_ENV_READ\") {\nSome(value) {\nprint value\n}\nNone {\nprint \"missing\"\n}\n}\n",
+    )
+    .expect("write env denied source");
 }

--- a/stage1/runtime-abi/direct-native-v0.json
+++ b/stage1/runtime-abi/direct-native-v0.json
@@ -139,9 +139,12 @@
     },
     {
       "id": "env.read",
-      "status": "blocked",
+      "status": "partial",
       "capability": "env",
-      "blockers": [928]
+      "evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
+      "denial_evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
+      "blockers": [928],
+      "notes": "The Cranelift spike can build a std/env.ax get_env package for present and missing environment reads, and rejects missing env capability before backend lowering. Full runtime-time environment lookup, manifest allowlist parity, and audit parity remain open."
     },
     {
       "id": "clock.now_sleep",


### PR DESCRIPTION
## Summary

- add Cranelift/direct-native evaluation for the `env_get` intrinsic
- add a direct-native build/run regression for `std/env.ax` `get_env` with present and missing environment names
- add a regression proving missing env capability is rejected before Cranelift backend lowering
- update the direct-native runtime ABI contract so `env.read` moves from `blocked` to `partial` with execution and denial evidence

## Governing Issue

Refs #928

This is a progress slice for the broader runtime ABI issue; it keeps #928 open because capability shims and several runtime rows remain blocked or partial.

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Commands run:

- `cargo fmt -p axiomc`
- `python3 -m json.tool stage1/runtime-abi/direct-native-v0.json >/dev/null`
- `cargo test --manifest-path Cargo.toml -p axiomc --test cranelift_backend cranelift_backend_builds_env_read_binary -- --nocapture`
- `cargo test --manifest-path Cargo.toml -p axiomc --test cranelift_backend cranelift_backend_rejects_env_denial_before_backend_lowering -- --nocapture`
- `make stage1-direct-native-runtime-abi`
- `make stage1-direct-native-runtime-abi-test`
- `cargo check -p axiomc`
- `git diff --check`

Notes:

- `make stage1-direct-native-runtime-abi` still reports `ready: false`, as expected. The contract remains partial while #928 continues to track remaining blocked runtime and capability-shim rows.
- `cargo check -p axiomc` passes with existing dead-code warnings.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

No contributor, PR guidance, onboarding, secret, auth, or machine-local files changed.

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Semantic node types:

- No new semantic nodes. Existing `env_get` calls now have Cranelift/direct-native spike evaluation.

Schemas:

- No schema files changed. `stage1/runtime-abi/direct-native-v0.json` contract data changed: `env.read` is now `partial` with execution and denial evidence.

Evidence:

- Added `cranelift_backend_builds_env_read_binary` in `stage1/crates/axiomc/tests/cranelift_backend.rs`.
- Added `cranelift_backend_rejects_env_denial_before_backend_lowering` in `stage1/crates/axiomc/tests/cranelift_backend.rs`.
- Updated `docs/direct-native-runtime-abi-v0.md` to describe the partial `env.read` evidence.

Rust capture check:

- The ABI wording remains Axiom/direct-native oriented and does not define semantics through generated Rust, Rust types, Cargo, or `rustc`.
- This PR does not add generated-Rust dependency; it records direct-native evidence while keeping the contract row partial.
- The positive `env.read` regression is backend-specific spike evidence: it evaluates the host environment during Cranelift build evaluation, while runtime-time lookup remains open in #928.

Agent-facing inspection impact:

- Agents inspecting the runtime ABI matrix now see `env.read` as partially evidenced instead of blocked, while #928 remains the blocker for broader ABI readiness.

## Flow Contract

- Owner lane: Daedalus runtime/backend lane
- Repair owner: Codex
- Autonomy class: issue-directed implementation slice
- Risk class: medium slice inside high-risk Rust-exit issue

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

Blockers:

- Non-author approval is required after review.
- #928 remains open for remaining runtime ABI and capability-shim rows.

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

Auto-merge should be enabled after PR creation if GitHub accepts it for this branch.

## Notes

- The positive `std/env.ax` regression uses `[capabilities].env = true` with an unsafe rationale because the stdlib wrapper accepts an environment-name parameter. Manifest allowlist parity and audit parity remain explicitly open in the ABI row notes.

