### PR TITLE
Add direct-native clock ABI evidence

### DIFF
--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -134,11 +134,6 @@ The sync-primitives row has partial direct-native evidence: the Cranelift spike
 now evaluates ownership-shaped `std/sync.ax` mutex, once, and channel wrappers
 and emits the expected native output. Concurrent execution, blocking behavior,
 and host runtime synchronization remain tracked by issue #928.
-The `env.read` row now has partial Cranelift evidence for `std/env.ax`
-`get_env` on present and missing environment names, plus denial evidence that a
-package without the `env` capability fails before backend lowering. Full
-runtime-time lookup, manifest allowlist parity, and audit parity remain open
-under #928.
 
 The `Result<T, E>` row has partial direct-native evidence: the Cranelift spike
 now builds and runs a package importing `std/outcome.ax`, using result
@@ -152,25 +147,6 @@ access to disjoint sibling projections. Broader move-state, lifetime, and host
 ABI coverage remain tracked by issue #928.
 
 The logging/stdio row has partial direct-native evidence: the Cranelift spike
-now evaluates `std/io.ax` stderr writes and emits the resulting stdout and
-stderr streams from the native binary. Stdin reads, `std/log.ax` wrappers, and
-broader streaming/runtime buffering remain tracked by issue #928.
-The `env.read` row now has partial Cranelift evidence for `std/env.ax`
-`get_env` on present and missing environment names, plus denial evidence that a
-package without the `env` capability fails before backend lowering. Full
-runtime-time lookup, manifest allowlist parity, and audit parity remain open
-under #928.
-
-The `Result<T, E>` row has partial direct-native evidence: the Cranelift spike
-now builds and runs a package importing `std/outcome.ax`, using result
-predicates, fallback unwrap helpers, direct match arms over `Result<T, E>`
-values, scalar payloads, string errors, and struct payloads. Broader runtime
-ABI and capability-shim coverage remain tracked by issue #928.
-
-The owned move-state row has partial direct-native evidence: the Cranelift
-spike builds and runs projection-sensitive owned field moves while preserving
-access to disjoint sibling projections. Broader move-state, lifetime, and host
-ABI coverage remain tracked by issue #928.
 now evaluates `std/io.ax` stderr writes and emits the resulting stdout and
 stderr streams from the native binary. Stdin reads, `std/log.ax` wrappers, and
 broader streaming/runtime buffering remain tracked by issue #928.

--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -176,10 +176,11 @@ stderr streams from the native binary. Stdin reads, `std/log.ax` wrappers, and
 broader streaming/runtime buffering remain tracked by issue #928.
 
 The `clock.now_sleep` row now has partial Cranelift evidence for `std/time.ax`
-`now_ms`, `now`, `elapsed_ms`, and zero-duration `sleep`, plus denial evidence
-that a package without the `clock` capability fails before backend lowering.
-Full runtime-time clock/sleep execution, timer scheduling, async clock
-integration, and audit parity remain open under #928.
+`now_ms`, `now`, `elapsed_ms`, and zero-duration `sleep`, plus guards that a
+package without the `clock` capability fails before backend lowering and that
+nonzero sleep fails fast instead of waiting during compiler-side spike
+evaluation. Full runtime-time clock/sleep execution, timer scheduling, async
+clock integration, and audit parity remain open under #928.
 
 ## Rust Capture Check
 

--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -154,11 +154,11 @@ broader streaming/runtime buffering remain tracked by issue #928.
 The `clock.now_sleep` row now has partial Cranelift evidence for `std/time.ax`
 `now_ms`, `now`, `elapsed_ms`, and zero-duration `sleep`, plus guards that a
 package without the `clock` capability fails before backend lowering and that
-nonzero sleep fails fast instead of waiting during compiler-side spike
-evaluation. The spike intentionally keeps the supported sleep shape limited to
-zero-duration calls until the real runtime clock path lands. Full runtime-time
-clock/sleep execution, timer scheduling, async clock integration, and audit
-parity remain open under #928.
+nonzero sleep fails fast instead of ever reaching host sleep during
+compiler-side spike evaluation. The spike intentionally keeps the supported
+sleep shape limited to zero-duration calls until the real runtime clock path
+lands. Full runtime-time clock/sleep execution, timer scheduling, async clock
+integration, and audit parity remain open under #928.
 
 ## Rust Capture Check
 

--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -175,6 +175,13 @@ now evaluates `std/io.ax` stderr writes and emits the resulting stdout and
 stderr streams from the native binary. Stdin reads, `std/log.ax` wrappers, and
 broader streaming/runtime buffering remain tracked by issue #928.
 
+The `clock.now_sleep` row now has partial Cranelift evidence for `std/time.ax`
+`now_ms`, `now`, `elapsed_ms`, and zero-duration `sleep`, plus denial evidence
+that a package without the `clock` capability fails before backend lowering.
+Full runtime-time clock/sleep execution, timer scheduling, async clock
+integration, and audit parity remain open under #928.
+
+## Rust Capture Check
 
 This ABI describes Axiom runtime values and host-service effects. Rust may
 remain the current implementation host while this contract is incomplete, but

--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -155,8 +155,10 @@ The `clock.now_sleep` row now has partial Cranelift evidence for `std/time.ax`
 `now_ms`, `now`, `elapsed_ms`, and zero-duration `sleep`, plus guards that a
 package without the `clock` capability fails before backend lowering and that
 nonzero sleep fails fast instead of waiting during compiler-side spike
-evaluation. Full runtime-time clock/sleep execution, timer scheduling, async
-clock integration, and audit parity remain open under #928.
+evaluation. The spike intentionally keeps the supported sleep shape limited to
+zero-duration calls until the real runtime clock path lands. Full runtime-time
+clock/sleep execution, timer scheduling, async clock integration, and audit
+parity remain open under #928.
 
 ## Rust Capture Check
 

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -531,6 +531,15 @@ fn eval_call(
     if name == "env_get" {
         return eval_env_get_call(args, functions, env, lines);
     }
+    if name == "clock_now_ms" {
+        return eval_clock_now_ms_call(args);
+    }
+    if name == "clock_elapsed_ms" {
+        return eval_clock_elapsed_ms_call(args, functions, env, lines);
+    }
+    if name == "clock_sleep_ms" {
+        return eval_clock_sleep_ms_call(args, functions, env, lines);
+    }
     let function = functions
         .get(name)
         .ok_or_else(|| unsupported(&format!("unsupported cranelift spike call {name:?}")))?;
@@ -775,6 +784,55 @@ fn eval_io_eprintln_call(
     let written = text.len() as i64 + 1;
     lines.push(OutputLine::stderr(text));
     Ok(SpikeValue::Int(written))
+}
+
+fn eval_clock_now_ms_call(args: &[Expr]) -> Result<SpikeValue, Diagnostic> {
+    let [] = args else {
+        return Err(unsupported("clock_now_ms expects no arguments"));
+    };
+    current_time_ms().map(SpikeValue::Int)
+}
+
+fn eval_clock_elapsed_ms_call(
+    args: &[Expr],
+    functions: &HashMap<&str, &Function>,
+    env: &SpikeEnv,
+    lines: &mut Vec<OutputLine>,
+) -> Result<SpikeValue, Diagnostic> {
+    let [start] = args else {
+        return Err(unsupported("clock_elapsed_ms expects exactly one argument"));
+    };
+    let start = expect_signed_integer(eval_expr(start, functions, env, lines)?)?;
+    let now = current_time_ms()?;
+    Ok(SpikeValue::Int(if now < start { -1 } else { now - start }))
+}
+
+fn eval_clock_sleep_ms_call(
+    args: &[Expr],
+    functions: &HashMap<&str, &Function>,
+    env: &SpikeEnv,
+    lines: &mut Vec<OutputLine>,
+) -> Result<SpikeValue, Diagnostic> {
+    let [milliseconds] = args else {
+        return Err(unsupported("clock_sleep_ms expects exactly one argument"));
+    };
+    let milliseconds = expect_signed_integer(eval_expr(milliseconds, functions, env, lines)?)?;
+    if milliseconds < 0 {
+        return Ok(SpikeValue::Int(-1));
+    }
+    if milliseconds > 0 {
+        return Err(unsupported(
+            "nonzero clock_sleep_ms is not supported by the cranelift spike",
+        ));
+    }
+    Ok(SpikeValue::Int(0))
+}
+
+fn current_time_ms() -> Result<i64, Diagnostic> {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|_| unsupported("system clock must be after unix epoch"))?;
+    Ok(now.as_millis() as i64)
 }
 
 fn eval_arithmetic(

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -820,12 +820,12 @@ fn eval_clock_sleep_ms_call(
     if milliseconds < 0 {
         return Ok(SpikeValue::Int(-1));
     }
-    if milliseconds > 0 {
-        return Err(unsupported(
-            "nonzero clock_sleep_ms is not supported by the cranelift spike",
-        ));
+    if milliseconds == 0 {
+        return Ok(SpikeValue::Int(0));
     }
-    Ok(SpikeValue::Int(0))
+    Err(unsupported(
+        "nonzero clock_sleep_ms is not supported by the cranelift spike",
+    ))
 }
 
 fn current_time_ms() -> Result<i64, Diagnostic> {

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -1005,6 +1005,134 @@ fn cranelift_backend_rejects_http_client_denial_before_backend_lowering() {
     );
 }
 
+#[cfg(not(windows))]
+#[test]
+fn cranelift_backend_rejects_nonzero_clock_sleep() {
+    if which::which("cc").is_err() {
+        eprintln!("skipping cranelift backend smoke test because cc is unavailable");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("clock-nonzero-sleep");
+    write_clock_nonzero_sleep_project(&project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+
+    assert!(
+        !output.status.success(),
+        "cranelift nonzero clock sleep build unexpectedly succeeded: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("nonzero clock_sleep_ms is not supported by the cranelift spike"),
+        "expected nonzero sleep rejection, got: {combined}"
+    );
+}
+
+#[cfg(not(windows))]
+#[test]
+fn cranelift_backend_builds_clock_binary() {
+    if which::which("cc").is_err() {
+        eprintln!("skipping cranelift backend smoke test because cc is unavailable");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("clock");
+    write_clock_project(&project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+    assert!(
+        output.status.success(),
+        "cranelift clock build failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
+    assert_eq!(payload["backend"], "cranelift");
+    let binary = payload["binary"].as_str().expect("binary path");
+    let run = Command::new(binary)
+        .output()
+        .expect("run cranelift clock binary");
+    assert!(
+        run.status.success(),
+        "cranelift clock binary failed: stderr={}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "true
+true
+true
+true
+"
+    );
+}
+
+#[test]
+fn cranelift_backend_rejects_clock_denial_before_backend_lowering() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("clock-denied");
+    write_clock_denial_project(&project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+
+    assert!(
+        !output.status.success(),
+        "cranelift clock-denied build unexpectedly succeeded: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("requires [capabilities].clock = true"),
+        "expected clock capability denial before backend lowering, got: {combined}"
+    );
+    assert!(
+        !combined.contains("unsupported by --backend cranelift spike"),
+        "clock capability denial should happen before cranelift unsupported-feature lowering: {combined}"
+    );
+}
+
 #[test]
 fn cranelift_backend_rejects_capability_denial_before_backend_lowering() {
     let temp = tempfile::tempdir().expect("tempdir");
@@ -1845,4 +1973,138 @@ fn write_env_denial_project(project: &Path) {
         "import \"std/env.ax\"\nmatch get_env(\"AXIOM_CRANELIFT_ENV_READ\") {\nSome(value) {\nprint value\n}\nNone {\nprint \"missing\"\n}\n}\n",
     )
     .expect("write env denied source");
+}
+
+fn write_clock_nonzero_sleep_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create clock nonzero sleep project src");
+    fs::write(
+        project.join("axiom.toml"),
+        r#"[package]
+name = "cranelift-clock-nonzero-sleep"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = true
+crypto = false
+"#,
+    )
+    .expect("write clock nonzero sleep manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        r#"version = 1
+
+[[package]]
+name = "cranelift-clock-nonzero-sleep"
+version = "0.1.0"
+source = "path"
+"#,
+    )
+    .expect("write clock nonzero sleep lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        r#"import "std/time.ax"
+print sleep(duration_ms(1))
+"#,
+    )
+    .expect("write clock nonzero sleep source");
+}
+
+fn write_clock_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create clock project src");
+    fs::write(
+        project.join("axiom.toml"),
+        r#"[package]
+name = "cranelift-clock"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = true
+crypto = false
+"#,
+    )
+    .expect("write clock manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        r#"version = 1
+
+[[package]]
+name = "cranelift-clock"
+version = "0.1.0"
+source = "path"
+"#,
+    )
+    .expect("write clock lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        r#"import "std/time.ax"
+let start: Instant = now()
+let pause: Duration = duration_ms(0)
+print start.ms > 0
+print now_ms() > 0
+print sleep(pause) == 0
+let elapsed: int = elapsed_ms(start)
+print elapsed == elapsed
+"#,
+    )
+    .expect("write clock source");
+}
+
+fn write_clock_denial_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create clock denied project src");
+    fs::write(
+        project.join("axiom.toml"),
+        r#"[package]
+name = "cranelift-clock-denied"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false
+"#,
+    )
+    .expect("write clock denied manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        r#"version = 1
+
+[[package]]
+name = "cranelift-clock-denied"
+version = "0.1.0"
+source = "path"
+"#,
+    )
+    .expect("write clock denied lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        r#"import "std/time.ax"
+let start: Instant = now()
+print sleep(duration_ms(0))
+print elapsed_ms(start)
+"#,
+    )
+    .expect("write clock denied source");
 }

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -1409,6 +1409,7 @@ fn cranelift_backend_rejects_env_denial_before_backend_lowering() {
     );
 }
 
+
 fn copy_fixture(relative: &str, destination: &Path) {
     let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../../examples/hello")

--- a/stage1/runtime-abi/direct-native-v0.json
+++ b/stage1/runtime-abi/direct-native-v0.json
@@ -153,9 +153,12 @@
     },
     {
       "id": "clock.now_sleep",
-      "status": "blocked",
+      "status": "partial",
       "capability": "clock",
-      "blockers": [928]
+      "evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
+      "denial_evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
+      "blockers": [928],
+      "notes": "The Cranelift spike can build a std/time.ax package covering now_ms, now, elapsed_ms, and zero-duration sleep, and rejects missing clock capability before backend lowering. Full runtime-time clock/sleep execution, timer scheduling, async clock integration, and audit parity remain open."
     },
     {
       "id": "crypto.hash",

--- a/stage1/runtime-abi/direct-native-v0.json
+++ b/stage1/runtime-abi/direct-native-v0.json
@@ -158,7 +158,7 @@
       "evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
       "denial_evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
       "blockers": [928],
-      "notes": "The Cranelift spike can build a std/time.ax package covering now_ms, now, elapsed_ms, and zero-duration sleep, and rejects missing clock capability before backend lowering. Full runtime-time clock/sleep execution, timer scheduling, async clock integration, and audit parity remain open."
+      "notes": "The Cranelift spike can build a std/time.ax package covering now_ms, now, elapsed_ms, and zero-duration sleep, rejects missing clock capability before backend lowering, and fails fast for nonzero sleep to avoid compile-time host waits. Full runtime-time clock/sleep execution, timer scheduling, async clock integration, and audit parity remain open."
     },
     {
       "id": "crypto.hash",

--- a/stage1/runtime-abi/direct-native-v0.json
+++ b/stage1/runtime-abi/direct-native-v0.json
@@ -158,7 +158,7 @@
       "evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
       "denial_evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
       "blockers": [928],
-      "notes": "The Cranelift spike can build a std/time.ax package covering now_ms, now, elapsed_ms, and zero-duration sleep, rejects missing clock capability before backend lowering, and fails fast for nonzero sleep to avoid compile-time host waits. Full runtime-time clock/sleep execution, timer scheduling, async clock integration, and audit parity remain open."
+      "notes": "The Cranelift spike can build a std/time.ax package covering now_ms, now, elapsed_ms, and zero-duration sleep, rejects missing clock capability before backend lowering, and fails fast for nonzero sleep before any host sleep or backend lowering. Full runtime-time clock/sleep execution, timer scheduling, async clock integration, and audit parity remain open."
     },
     {
       "id": "crypto.hash",


### PR DESCRIPTION
## Summary

- add Cranelift/direct-native evaluation for `clock_now_ms`, `clock_elapsed_ms`, and `clock_sleep_ms`
- add a direct-native build/run regression for `std/time.ax` `now_ms`, `now`, `elapsed_ms`, and zero-duration `sleep`
- add a regression proving missing clock capability is rejected before Cranelift backend lowering
- update the direct-native runtime ABI contract so `clock.now_sleep` moves from `blocked` to `partial` with execution and denial evidence

## Governing Issue

Refs #928

This is a progress slice for the broader runtime ABI issue; it keeps #928 open because capability shims and several runtime rows remain blocked or partial.

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Commands run:

- `cargo fmt -p axiomc`
- `python3 -m json.tool stage1/runtime-abi/direct-native-v0.json >/dev/null`
- `cargo test --manifest-path Cargo.toml -p axiomc --test cranelift_backend cranelift_backend_builds_clock_binary -- --nocapture`
- `cargo test --manifest-path Cargo.toml -p axiomc --test cranelift_backend cranelift_backend_rejects_clock_denial_before_backend_lowering -- --nocapture`
- `cargo test -p axiomc --test cranelift_backend clock -- --nocapture`
- `make stage1-direct-native-runtime-abi`
- `make stage1-direct-native-runtime-abi-test`
- `cargo check -p axiomc`
- `git diff --check`

Notes:

- `make stage1-direct-native-runtime-abi` still reports `ready: false`, as expected. The contract remains partial while #928 continues to track remaining blocked runtime and capability-shim rows.
- `cargo check -p axiomc` passes with existing dead-code warnings.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

No contributor, PR guidance, onboarding, secret, auth, or machine-local files changed.

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Semantic node types:

- No new semantic nodes. Existing clock intrinsic calls now have Cranelift/direct-native spike evaluation.

Schemas:

- No schema files changed. `stage1/runtime-abi/direct-native-v0.json` contract data changed: `clock.now_sleep` is now `partial` with execution and denial evidence.

Evidence:

- Added `cranelift_backend_builds_clock_binary` in `stage1/crates/axiomc/tests/cranelift_backend.rs`.
- Added `cranelift_backend_rejects_clock_denial_before_backend_lowering` in `stage1/crates/axiomc/tests/cranelift_backend.rs`.
- Updated `docs/direct-native-runtime-abi-v0.md` to describe the partial `clock.now_sleep` evidence.

Rust capture check:

- The ABI wording remains Axiom/direct-native oriented and does not define semantics through generated Rust, Rust types, Cargo, or `rustc`.
- This PR does not add generated-Rust dependency; it records direct-native evidence while keeping the contract row partial.
- The positive `clock.now_sleep` regression is backend-specific spike evidence: it evaluates clock/sleep calls during Cranelift build evaluation, while full runtime-time clock and timer behavior remains open in #928.

Agent-facing inspection impact:

- Agents inspecting the runtime ABI matrix now see `clock.now_sleep` as partially evidenced instead of blocked, while #928 remains the blocker for broader ABI readiness.

## Flow Contract

- Owner lane: Daedalus runtime/backend lane
- Repair owner: Codex
- Autonomy class: issue-directed implementation slice
- Risk class: medium slice inside high-risk Rust-exit issue

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

Blockers:

- Non-author approval is required after review.
- #928 remains open for remaining runtime ABI and capability-shim rows.

## Merge Automation

- [x] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

Auto-merge is enabled, but the PR is still blocked by an active `CHANGES_REQUESTED` review gate on GitHub. The branch is repaired locally and validated; the remaining unblocker is reviewer refresh or dismissal of the stale requested-changes review.

## Notes

- The positive `std/time.ax` regression covers zero-duration sleep only. Timer scheduling, async clock integration, and audit parity remain explicitly open in the ABI row notes.
