### PR TITLE
Add direct-native crypto hash ABI evidence

### DIFF
--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -88,6 +88,11 @@ builds a package using `std/fs.ax` without the `fs` capability and verifies the
 public capability denial appears before any Cranelift unsupported-feature
 diagnostic.
 
+The direct-native crypto hash slice is still marked partial: the Cranelift
+spike can build and run `std/crypto_hash.ax` `sha256(...)` without generated
+Rust, and crypto capability denials still happen before backend lowering. MAC,
+random, signature, AEAD, and broader crypto audit parity remain blocked.
+
 ## Rust Capture Check
 
 This ABI describes Axiom runtime values and host-service effects. Rust may

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -484,6 +484,9 @@ fn eval_call(
     if name == "contains" || name == "map_contains_key" {
         return eval_map_contains_call(args, functions, env);
     }
+    if name == "crypto_sha256" {
+        return eval_crypto_sha256_call(args, functions, env);
+    }
     let function = functions
         .get(name)
         .ok_or_else(|| unsupported(&format!("unsupported cranelift spike call {name:?}")))?;
@@ -572,6 +575,112 @@ fn eval_map_contains_call(
         Ok::<_, Diagnostic>(found || map_keys_equal(candidate, &key)?)
     })?;
     Ok(SpikeValue::Bool(contains))
+}
+
+fn eval_crypto_sha256_call(
+    args: &[Expr],
+    functions: &HashMap<&str, &Function>,
+    env: &SpikeEnv,
+) -> Result<SpikeValue, Diagnostic> {
+    let [arg] = args else {
+        return Err(unsupported("crypto_sha256 expects exactly one argument"));
+    };
+    let input = match eval_expr(arg, functions, env)? {
+        SpikeValue::Text(value) => value,
+        _ => return Err(unsupported("crypto_sha256 expects a string argument")),
+    };
+    Ok(SpikeValue::Text(sha256_hex(&input)))
+}
+
+fn sha256_hex(input: &str) -> String {
+    const K: [u32; 64] = [
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4,
+        0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe,
+        0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f,
+        0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+        0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc,
+        0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+        0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116,
+        0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7,
+        0xc67178f2,
+    ];
+    let mut state: [u32; 8] = [
+        0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab,
+        0x5be0cd19,
+    ];
+    let mut data = input.as_bytes().to_vec();
+    let bit_len = (data.len() as u64) * 8;
+    data.push(0x80);
+    while data.len() % 64 != 56 {
+        data.push(0);
+    }
+    data.extend_from_slice(&bit_len.to_be_bytes());
+    for chunk in data.chunks(64) {
+        let mut schedule = [0u32; 64];
+        for (index, word) in schedule.iter_mut().take(16).enumerate() {
+            let start = index * 4;
+            *word = u32::from_be_bytes([
+                chunk[start],
+                chunk[start + 1],
+                chunk[start + 2],
+                chunk[start + 3],
+            ]);
+        }
+        for index in 16..64 {
+            let s0 = schedule[index - 15].rotate_right(7)
+                ^ schedule[index - 15].rotate_right(18)
+                ^ (schedule[index - 15] >> 3);
+            let s1 = schedule[index - 2].rotate_right(17)
+                ^ schedule[index - 2].rotate_right(19)
+                ^ (schedule[index - 2] >> 10);
+            schedule[index] = schedule[index - 16]
+                .wrapping_add(s0)
+                .wrapping_add(schedule[index - 7])
+                .wrapping_add(s1);
+        }
+        let mut a = state[0];
+        let mut b = state[1];
+        let mut c = state[2];
+        let mut d = state[3];
+        let mut e = state[4];
+        let mut f = state[5];
+        let mut g = state[6];
+        let mut h = state[7];
+        for index in 0..64 {
+            let sigma1 = e.rotate_right(6) ^ e.rotate_right(11) ^ e.rotate_right(25);
+            let choice = (e & f) ^ ((!e) & g);
+            let temp1 = h
+                .wrapping_add(sigma1)
+                .wrapping_add(choice)
+                .wrapping_add(K[index])
+                .wrapping_add(schedule[index]);
+            let sigma0 = a.rotate_right(2) ^ a.rotate_right(13) ^ a.rotate_right(22);
+            let majority = (a & b) ^ (a & c) ^ (b & c);
+            let temp2 = sigma0.wrapping_add(majority);
+            h = g;
+            g = f;
+            f = e;
+            e = d.wrapping_add(temp1);
+            d = c;
+            c = b;
+            b = a;
+            a = temp1.wrapping_add(temp2);
+        }
+        state[0] = state[0].wrapping_add(a);
+        state[1] = state[1].wrapping_add(b);
+        state[2] = state[2].wrapping_add(c);
+        state[3] = state[3].wrapping_add(d);
+        state[4] = state[4].wrapping_add(e);
+        state[5] = state[5].wrapping_add(f);
+        state[6] = state[6].wrapping_add(g);
+        state[7] = state[7].wrapping_add(h);
+    }
+    let mut output = String::with_capacity(64);
+    for value in state {
+        output.push_str(&format!("{value:08x}"));
+    }
+    output
 }
 
 fn eval_arithmetic(
@@ -803,7 +912,10 @@ fn validate_map_key(value: &SpikeValue) -> Result<(), Diagnostic> {
         SpikeValue::Float(_) => Err(unsupported(
             "map float keys are not supported by the cranelift spike",
         )),
-        SpikeValue::Enum { .. } | SpikeValue::Struct { .. } | SpikeValue::Map(_) | SpikeValue::Array(_) => Err(unsupported(
+        SpikeValue::Enum { .. }
+        | SpikeValue::Struct { .. }
+        | SpikeValue::Map(_)
+        | SpikeValue::Array(_) => Err(unsupported(
             "map keys must be scalar values or scalar tuples in the cranelift spike",
         )),
     }

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -555,6 +555,52 @@ high
 
 #[cfg(not(windows))]
 #[test]
+fn cranelift_backend_builds_crypto_hash_binary() {
+    if which::which("cc").is_err() {
+        eprintln!("skipping cranelift backend smoke test because cc is unavailable");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("crypto-hash");
+    write_crypto_hash_project(&project, true);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+    assert!(
+        output.status.success(),
+        "cranelift crypto hash build failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
+    assert_eq!(payload["backend"], "cranelift");
+    let binary = payload["binary"].as_str().expect("binary path");
+    let run = Command::new(binary)
+        .output()
+        .expect("run cranelift crypto hash binary");
+    assert!(
+        run.status.success(),
+        "cranelift crypto hash binary failed: stderr={}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad\n"
+    );
+}
+
+#[cfg(not(windows))]
+#[test]
 fn cranelift_backend_rejects_float_map_keys() {
     let temp = tempfile::tempdir().expect("tempdir");
     let project = temp.path().join("float-map-key");
@@ -585,6 +631,44 @@ fn cranelift_backend_rejects_float_map_keys() {
     assert!(
         combined.contains("map float keys are not supported by the cranelift spike"),
         "expected float map key diagnostic, got: {combined}"
+    );
+}
+
+#[test]
+fn cranelift_backend_rejects_crypto_hash_denial_before_backend_lowering() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("crypto-hash-denied");
+    write_crypto_hash_project(&project, false);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+
+    assert!(
+        !output.status.success(),
+        "cranelift crypto hash denial build unexpectedly succeeded: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("requires [capabilities].crypto = true"),
+        "expected crypto capability denial before backend lowering, got: {combined}"
+    );
+    assert!(
+        !combined.contains("unsupported by --backend cranelift spike"),
+        "capability denial should happen before cranelift unsupported-feature lowering: {combined}"
     );
 }
 
@@ -807,6 +891,27 @@ fn write_float_map_key_project(project: &Path) {
         "let scores: {f64: int} = {1.5f64: 7}\nprint scores[1.5f64]\n",
     )
     .expect("write float map source");
+}
+
+fn write_crypto_hash_project(project: &Path, crypto: bool) {
+    fs::create_dir_all(project.join("src")).expect("create crypto hash project src");
+    fs::write(
+        project.join("axiom.toml"),
+        format!(
+            "[package]\nname = \"cranelift-crypto-hash\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = {crypto}\n"
+        ),
+    )
+    .expect("write crypto hash manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-crypto-hash\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write crypto hash lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "import \"std/crypto_hash.ax\"\nprint sha256(\"abc\")\n",
+    )
+    .expect("write crypto hash source");
 }
 
 fn write_fs_denial_project(project: &Path) {

--- a/stage1/runtime-abi/direct-native-v0.json
+++ b/stage1/runtime-abi/direct-native-v0.json
@@ -148,9 +148,12 @@
     },
     {
       "id": "crypto.hash",
-      "status": "blocked",
+      "status": "partial",
       "capability": "crypto",
-      "blockers": [928]
+      "evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
+      "denial_evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
+      "blockers": [928],
+      "notes": "The Cranelift spike covers std/crypto_hash.ax sha256 over strings without using generated Rust. MAC, random, signature, AEAD, and broader crypto audit parity remain blocked."
     },
     {
       "id": "crypto.mac",


### PR DESCRIPTION
## Summary

- add Cranelift/direct-native evaluation for the `crypto_sha256` intrinsic
- add a direct-native build/run regression for `std/crypto_hash.ax` `sha256`
- add a regression proving missing crypto capability is rejected before Cranelift backend lowering
- update the direct-native runtime ABI contract so `crypto.hash` moves from `blocked` to `partial` with execution and denial evidence

## Governing Issue

Refs #928

This is a progress slice for the broader runtime ABI issue; it keeps #928 open because capability shims and several runtime rows remain blocked or partial.

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Commands run:

- `cargo fmt -p axiomc`
- `python3 -m json.tool stage1/runtime-abi/direct-native-v0.json >/dev/null`
- `cargo test -p axiomc --test cranelift_backend crypto_hash`
- `make stage1-direct-native-runtime-abi`
- `make stage1-direct-native-runtime-abi-test`
- `cargo check -p axiomc`
- `git diff --check`

Notes:

- `make stage1-direct-native-runtime-abi` still reports `ready: false`, as expected. The contract remains partial while #928 continues to track remaining blocked runtime and capability-shim rows.
- `cargo check -p axiomc` passes with existing dead-code warnings.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

No contributor, PR guidance, onboarding, secret, auth, or machine-local files changed.

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Semantic node types:

- No new semantic nodes. Existing `crypto_sha256` calls now have Cranelift/direct-native spike evaluation.

Schemas:

- No schema files changed. `stage1/runtime-abi/direct-native-v0.json` contract data changed: `crypto.hash` is now `partial` with execution and denial evidence.

Evidence:

- Added `cranelift_backend_builds_crypto_hash_binary` in `stage1/crates/axiomc/tests/cranelift_backend.rs`.
- Added `cranelift_backend_rejects_crypto_hash_denial_before_backend_lowering` in `stage1/crates/axiomc/tests/cranelift_backend.rs`.
- Updated `docs/direct-native-runtime-abi-v0.md` to describe the partial `crypto.hash` evidence.

Rust capture check:

- The ABI wording remains Axiom/direct-native oriented and does not define semantics through generated Rust, Rust types, Cargo, or `rustc`.
- This PR does not add a generated-Rust dependency; it records direct-native evidence while keeping the contract row partial.
- The positive `crypto.hash` regression is backend-specific spike evidence: it evaluates SHA-256 during Cranelift build evaluation, while MAC, random, signature, AEAD, and broader crypto audit parity remain open in #928.

Agent-facing inspection impact:

- Agents inspecting the runtime ABI matrix now see `crypto.hash` as partially evidenced instead of blocked, while #928 remains the blocker for broader ABI readiness.

## Flow Contract

- Owner lane: Daedalus runtime/backend lane
- Repair owner: Codex
- Autonomy class: issue-directed implementation slice
- Risk class: medium slice inside high-risk Rust-exit issue

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

Blockers:

- Non-author approval is required after review.
- #928 remains open for remaining runtime ABI and capability-shim rows.

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

Auto-merge should be enabled after PR creation if GitHub accepts it for this branch.

## Notes

- The positive `std/crypto_hash.ax` regression covers SHA-256 over strings only. MAC, random, signature, AEAD, runtime-time crypto audit parity, and generated-Rust removal remain explicitly open in the ABI row notes.
