### PR TITLE
Add direct-native regex ABI evidence

### DIFF
--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -186,12 +186,11 @@ sleep shape limited to zero-duration calls until the real runtime clock path
 lands. Full runtime-time clock/sleep execution, timer scheduling, async clock
 integration, and audit parity remain open under #928.
 
-The direct-native JSON/serdes slice is still marked partial: the Cranelift
-spike can build and run `std/json.ax` scalar parse/stringify helpers, first-class
-`JsonValue` string wrapping, object field extraction, and value normalization
-without generated Rust. Full `std/serdes.ax` object graph parsing, schema
-validation, and richer JSON value modeling remain blocked.
-
+The regex row is partial: direct native builds cover `std/regex.ax` matching,
+finding, and replacement for the stage1-safe NFA subset. The replacement
+coverage includes an anchored regression proving `^` patterns only replace the
+original leading match. Full regex syntax and broader conformance remain
+tracked by #928.
 
 ## Rust Capture Check
 

--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -152,6 +152,12 @@ spike builds and runs projection-sensitive owned field moves while preserving
 access to disjoint sibling projections. Broader move-state, lifetime, and host
 ABI coverage remain tracked by issue #928.
 
+The regex row is partial: direct native builds cover `std/regex.ax` matching,
+finding, and replacement for the stage1-safe NFA subset. The replacement
+coverage includes an anchored `replace_all` regression so `^` patterns only
+replace the original leading match. Full regex syntax and broader conformance
+remain tracked by #928.
+
 The logging/stdio row has partial direct-native evidence: the Cranelift spike
 now evaluates `std/io.ax` stderr writes and emits the resulting stdout and
 stderr streams from the native binary. Stdin reads, `std/log.ax` wrappers, and

--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -152,12 +152,6 @@ spike builds and runs projection-sensitive owned field moves while preserving
 access to disjoint sibling projections. Broader move-state, lifetime, and host
 ABI coverage remain tracked by issue #928.
 
-The regex row is partial: direct native builds cover `std/regex.ax` matching,
-finding, and replacement for the stage1-safe NFA subset. The replacement
-coverage includes an anchored `replace_all` regression so `^` patterns only
-replace the original leading match. Full regex syntax and broader conformance
-remain tracked by #928.
-
 The logging/stdio row has partial direct-native evidence: the Cranelift spike
 now evaluates `std/io.ax` stderr writes and emits the resulting stdout and
 stderr streams from the native binary. Stdin reads, `std/log.ax` wrappers, and
@@ -183,6 +177,12 @@ spike can build and run `std/json.ax` scalar parse/stringify helpers, first-clas
 without generated Rust. Full `std/serdes.ax` object graph parsing, schema
 validation, and richer JSON value modeling remain blocked.
 
+The regex row is partial: direct native builds cover `std/regex.ax` matching,
+finding, and replacement for the stage1-safe NFA subset. The replacement
+coverage includes an anchored `replace_all` regression so `^` patterns only
+replace the original leading match. Full regex syntax and broader conformance
+remain tracked by #928.
+
 The `clock.now_sleep` row now has partial Cranelift evidence for `std/time.ax`
 `now_ms`, `now`, `elapsed_ms`, and zero-duration `sleep`, plus guards that a
 package without the `clock` capability fails before backend lowering and that
@@ -192,11 +192,12 @@ sleep shape limited to zero-duration calls until the real runtime clock path
 lands. Full runtime-time clock/sleep execution, timer scheduling, async clock
 integration, and audit parity remain open under #928.
 
-The regex row is partial: direct native builds cover `std/regex.ax` matching,
-finding, and replacement for the stage1-safe NFA subset. The replacement
-coverage includes an anchored regression proving `^` patterns only replace the
-original leading match. Full regex syntax and broader conformance remain
-tracked by #928.
+The direct-native JSON/serdes slice is still marked partial: the Cranelift
+spike can build and run `std/json.ax` scalar parse/stringify helpers, first-class
+`JsonValue` string wrapping, object field extraction, and value normalization
+without generated Rust. Full `std/serdes.ax` object graph parsing, schema
+validation, and richer JSON value modeling remain blocked.
+
 
 ## Rust Capture Check
 

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -32,6 +32,37 @@ enum SpikeValue {
 
 type SpikeEnv = HashMap<String, SpikeValue>;
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum RegexAtom {
+    Literal(char),
+    Any,
+    Class {
+        ranges: Vec<(char, char)>,
+        negated: bool,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RegexQuantifier {
+    One,
+    ZeroOrOne,
+    ZeroOrMore,
+    OneOrMore,
+}
+
+#[derive(Clone, Debug)]
+struct RegexToken {
+    atom: RegexAtom,
+    quantifier: RegexQuantifier,
+}
+
+#[derive(Clone, Debug)]
+struct RegexProgram {
+    tokens: Vec<RegexToken>,
+    start_anchor: bool,
+    end_anchor: bool,
+}
+
 pub fn compile_cranelift_hello_spike(
     program: &Program,
     object_path: &Path,
@@ -542,6 +573,9 @@ fn eval_call(
     }
     if name == "clock_sleep_ms" {
         return eval_clock_sleep_ms_call(args, functions, env, lines);
+    }
+    if is_regex_call(name) {
+        return eval_regex_call(name, args, functions, env);
     }
     let function = functions
         .get(name)
@@ -1067,30 +1101,84 @@ fn sha256_hex(input: &str) -> String {
     output
 }
 
-fn eval_env_get_call(
+fn is_regex_call(name: &str) -> bool {
+    matches!(name, "regex_is_match" | "regex_find" | "regex_replace_all")
+}
+
+fn eval_regex_call(
+    name: &str,
     args: &[Expr],
     functions: &HashMap<&str, &Function>,
     env: &SpikeEnv,
     lines: &mut Vec<OutputLine>,
 ) -> Result<SpikeValue, Diagnostic> {
-    let [name] = args else {
-        return Err(unsupported("env_get expects exactly one argument"));
-    };
-    let name = match eval_expr(name, functions, env, lines)? {
-        SpikeValue::Text(value) => value,
-        _ => return Err(unsupported("env_get expects a string argument")),
-    };
-    let value = std::env::var(name).ok();
-    Ok(option_text(value))
+    match name {
+        "env_get" => {
+            let [name] = args else {
+                return Err(unsupported("env_get expects exactly one argument"));
+            };
+            let name = match eval_expr(name, functions, env, lines)? {
+                SpikeValue::Text(value) => value,
+                _ => return Err(unsupported("env_get expects a string argument")),
+            };
+            let value = std::env::var(name).ok();
+            Ok(option_text(value))
+        }
+        "regex_is_match" => {
+            let (pattern, text) = eval_regex_binary_text(name, args, functions, env)?;
+            Ok(SpikeValue::Bool(regex_find_span(&pattern, &text).is_some()))
+        }
+        "regex_find" => {
+            let (pattern, text) = eval_regex_binary_text(name, args, functions, env)?;
+            let found = regex_find_span(&pattern, &text)
+                .map(|(start, end)| SpikeValue::Text(text[start..end].to_string()));
+            Ok(spike_option(found))
+        }
+        "regex_replace_all" => {
+            let [pattern, text, replacement] = args else {
+                return Err(unsupported(
+                    "regex_replace_all expects exactly three arguments",
+                ));
+            };
+            let pattern = expect_text(eval_expr(pattern, functions, env)?, "regex_replace_all")?;
+            let text = expect_text(eval_expr(text, functions, env)?, "regex_replace_all")?;
+            let replacement =
+                expect_text(eval_expr(replacement, functions, env)?, "regex_replace_all")?;
+            Ok(SpikeValue::Text(regex_replace_all(
+                &pattern,
+                &text,
+                &replacement,
+            )))
+        }
+        _ => Err(unsupported(&format!(
+            "unsupported cranelift spike regex call {name:?}"
+        ))),
+    }
 }
 
-fn option_text(value: Option<String>) -> SpikeValue {
+fn eval_regex_binary_text(
+    name: &str,
+    args: &[Expr],
+    functions: &HashMap<&str, &Function>,
+    env: &SpikeEnv,
+) -> Result<(String, String), Diagnostic> {
+    let [pattern, text] = args else {
+        return Err(unsupported(&format!(
+            "{name} expects exactly two arguments"
+        )));
+    };
+    let pattern = expect_text(eval_expr(pattern, functions, env)?, name)?;
+    let text = expect_text(eval_expr(text, functions, env)?, name)?;
+    Ok((pattern, text))
+}
+
+fn spike_option(value: Option<SpikeValue>) -> SpikeValue {
     match value {
         Some(value) => SpikeValue::Enum {
             enum_name: String::from("Option"),
             variant: String::from("Some"),
             field_names: Vec::new(),
-            payloads: vec![SpikeValue::Text(value)],
+            payloads: vec![value],
         },
         None => SpikeValue::Enum {
             enum_name: String::from("Option"),
@@ -1166,6 +1254,274 @@ fn current_time_ms() -> Result<i64, Diagnostic> {
         .duration_since(std::time::UNIX_EPOCH)
         .map_err(|_| unsupported("system clock must be after unix epoch"))?;
     Ok(now.as_millis() as i64)
+}
+
+fn expect_text(value: SpikeValue, name: &str) -> Result<String, Diagnostic> {
+    match value {
+        SpikeValue::Text(value) => Ok(value),
+        _ => Err(unsupported(&format!("{name} expects string arguments"))),
+    }
+}
+
+fn regex_escape_char(ch: char) -> char {
+    match ch {
+        'n' => '\n',
+        'r' => '\r',
+        't' => '\t',
+        other => other,
+    }
+}
+
+fn regex_parse_atom(chars: &[char], pos: &mut usize) -> Option<RegexAtom> {
+    if *pos >= chars.len() {
+        return None;
+    }
+    let ch = chars[*pos];
+    *pos += 1;
+    match ch {
+        '.' => Some(RegexAtom::Any),
+        '\\' => {
+            if *pos >= chars.len() {
+                Some(RegexAtom::Literal('\\'))
+            } else {
+                let escaped = regex_escape_char(chars[*pos]);
+                *pos += 1;
+                Some(RegexAtom::Literal(escaped))
+            }
+        }
+        '[' => {
+            let mut negated = false;
+            if *pos < chars.len() && chars[*pos] == '^' {
+                negated = true;
+                *pos += 1;
+            }
+            let mut ranges = Vec::new();
+            let mut first = true;
+            while *pos < chars.len() {
+                if chars[*pos] == ']' && !first {
+                    *pos += 1;
+                    return Some(RegexAtom::Class { ranges, negated });
+                }
+                first = false;
+                let start = if chars[*pos] == '\\' {
+                    *pos += 1;
+                    if *pos >= chars.len() {
+                        return None;
+                    }
+                    let escaped = regex_escape_char(chars[*pos]);
+                    *pos += 1;
+                    escaped
+                } else {
+                    let value = chars[*pos];
+                    *pos += 1;
+                    value
+                };
+                if *pos + 1 < chars.len() && chars[*pos] == '-' && chars[*pos + 1] != ']' {
+                    *pos += 1;
+                    let end = if chars[*pos] == '\\' {
+                        *pos += 1;
+                        if *pos >= chars.len() {
+                            return None;
+                        }
+                        let escaped = regex_escape_char(chars[*pos]);
+                        *pos += 1;
+                        escaped
+                    } else {
+                        let value = chars[*pos];
+                        *pos += 1;
+                        value
+                    };
+                    if start <= end {
+                        ranges.push((start, end));
+                    } else {
+                        ranges.push((end, start));
+                    }
+                } else {
+                    ranges.push((start, start));
+                }
+            }
+            None
+        }
+        '(' | ')' | '|' => None,
+        other => Some(RegexAtom::Literal(other)),
+    }
+}
+
+fn regex_parse(pattern: &str) -> Option<RegexProgram> {
+    let chars: Vec<char> = pattern.chars().collect();
+    let mut pos = 0usize;
+    let mut start_anchor = false;
+    let mut end_anchor = false;
+    if pos < chars.len() && chars[pos] == '^' {
+        start_anchor = true;
+        pos += 1;
+    }
+    let mut parse_end = chars.len();
+    if parse_end > pos && chars[parse_end - 1] == '$' {
+        let escaped = parse_end >= 2 && chars[parse_end - 2] == '\\';
+        if !escaped {
+            end_anchor = true;
+            parse_end -= 1;
+        }
+    }
+    let mut tokens = Vec::new();
+    while pos < parse_end {
+        let mut atom_pos = pos;
+        let atom = regex_parse_atom(&chars[..parse_end], &mut atom_pos)?;
+        pos = atom_pos;
+        let quantifier = if pos < parse_end {
+            match chars[pos] {
+                '?' => {
+                    pos += 1;
+                    RegexQuantifier::ZeroOrOne
+                }
+                '*' => {
+                    pos += 1;
+                    RegexQuantifier::ZeroOrMore
+                }
+                '+' => {
+                    pos += 1;
+                    RegexQuantifier::OneOrMore
+                }
+                _ => RegexQuantifier::One,
+            }
+        } else {
+            RegexQuantifier::One
+        };
+        tokens.push(RegexToken { atom, quantifier });
+    }
+    Some(RegexProgram {
+        tokens,
+        start_anchor,
+        end_anchor,
+    })
+}
+
+fn regex_atom_matches(atom: &RegexAtom, ch: char) -> bool {
+    match atom {
+        RegexAtom::Literal(expected) => *expected == ch,
+        RegexAtom::Any => true,
+        RegexAtom::Class { ranges, negated } => {
+            let found = ranges.iter().any(|(start, end)| *start <= ch && ch <= *end);
+            if *negated { !found } else { found }
+        }
+    }
+}
+
+fn regex_add_state(program: &RegexProgram, states: &mut Vec<usize>, state: usize) {
+    if states.contains(&state) {
+        return;
+    }
+    states.push(state);
+    if state >= program.tokens.len() {
+        return;
+    }
+    match program.tokens[state].quantifier {
+        RegexQuantifier::ZeroOrOne | RegexQuantifier::ZeroOrMore => {
+            regex_add_state(program, states, state + 1);
+        }
+        RegexQuantifier::One | RegexQuantifier::OneOrMore => {}
+    }
+}
+
+fn regex_accepts(program: &RegexProgram, states: &[usize], at_text_end: bool) -> bool {
+    states
+        .iter()
+        .any(|state| *state == program.tokens.len() && (!program.end_anchor || at_text_end))
+}
+
+fn regex_match_from(program: &RegexProgram, text: &[char], start: usize) -> Option<usize> {
+    let mut states = Vec::new();
+    regex_add_state(program, &mut states, 0);
+    let mut last_accept = if regex_accepts(program, &states, start == text.len()) {
+        Some(start)
+    } else {
+        None
+    };
+    let mut pos = start;
+    while pos < text.len() {
+        let ch = text[pos];
+        let mut next = Vec::new();
+        for state in states.iter().copied() {
+            if state >= program.tokens.len() {
+                continue;
+            }
+            let token = &program.tokens[state];
+            if !regex_atom_matches(&token.atom, ch) {
+                continue;
+            }
+            match token.quantifier {
+                RegexQuantifier::One | RegexQuantifier::ZeroOrOne => {
+                    regex_add_state(program, &mut next, state + 1);
+                }
+                RegexQuantifier::ZeroOrMore => {
+                    regex_add_state(program, &mut next, state);
+                    regex_add_state(program, &mut next, state + 1);
+                }
+                RegexQuantifier::OneOrMore => {
+                    regex_add_state(program, &mut next, state);
+                    regex_add_state(program, &mut next, state + 1);
+                }
+            }
+        }
+        pos += 1;
+        if regex_accepts(program, &next, pos == text.len()) {
+            last_accept = Some(pos);
+        }
+        states = next;
+        if states.is_empty() {
+            return last_accept;
+        }
+    }
+    last_accept
+}
+
+fn regex_find_span(pattern: &str, text: &str) -> Option<(usize, usize)> {
+    let program = regex_parse(pattern)?;
+    let chars: Vec<char> = text.chars().collect();
+    let byte_offsets: Vec<usize> = text
+        .char_indices()
+        .map(|(index, _)| index)
+        .chain(std::iter::once(text.len()))
+        .collect();
+    let starts: Box<dyn Iterator<Item = usize>> = if program.start_anchor {
+        Box::new(std::iter::once(0))
+    } else {
+        Box::new(0..=chars.len())
+    };
+    for start in starts {
+        if let Some(end) = regex_match_from(&program, &chars, start) {
+            return Some((byte_offsets[start], byte_offsets[end]));
+        }
+    }
+    None
+}
+
+fn regex_replace_all(pattern: &str, text: &str, replacement: &str) -> String {
+    if regex_parse(pattern).is_none() {
+        return text.to_string();
+    }
+    let mut remaining = text;
+    let mut out = String::new();
+    loop {
+        let Some((start, end)) = regex_find_span(pattern, remaining) else {
+            out.push_str(remaining);
+            break;
+        };
+        out.push_str(&remaining[..start]);
+        out.push_str(replacement);
+        if end == 0 {
+            if let Some(ch) = remaining.chars().next() {
+                out.push(ch);
+                remaining = &remaining[ch.len_utf8()..];
+            } else {
+                break;
+            }
+        } else {
+            remaining = &remaining[end..];
+        }
+    }
+    out
 }
 
 fn eval_arithmetic(

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -1885,6 +1885,14 @@ fn unsupported(message: &str) -> Diagnostic {
 mod tests {
     use super::*;
 
+    #[test]
+    fn regex_replace_all_start_anchor_only_replaces_original_match() {
+        assert_eq!(regex_replace_all("^a", "aa", "x"), "xa");
+        assert_eq!(regex_replace_all("^a", "aaa", "x"), "xaa");
+        assert_eq!(regex_replace_all("^a", "ba", "x"), "ba");
+        assert_eq!(regex_replace_all("a", "aaa", "x"), "xxx");
+    }
+
     fn hello_program() -> Program {
         Program {
             path: String::from("hello"),

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -1498,8 +1498,18 @@ fn regex_find_span(pattern: &str, text: &str) -> Option<(usize, usize)> {
 }
 
 fn regex_replace_all(pattern: &str, text: &str, replacement: &str) -> String {
-    if regex_parse(pattern).is_none() {
+    let Some(program) = regex_parse(pattern) else {
         return text.to_string();
+    };
+    if program.start_anchor {
+        let Some((start, end)) = regex_find_span(pattern, text) else {
+            return text.to_string();
+        };
+        let mut out = String::new();
+        out.push_str(&text[..start]);
+        out.push_str(replacement);
+        out.push_str(&text[end..]);
+        return out;
     }
     let mut remaining = text;
     let mut out = String::new();

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -6,6 +6,7 @@ use crate::mir::{
 use crate::syntax::NumericType;
 use axiomc_backend_cranelift::OutputLine;
 use std::collections::HashMap;
+use std::env;
 use std::path::Path;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -574,6 +575,9 @@ fn eval_call(
     if name == "clock_sleep_ms" {
         return eval_clock_sleep_ms_call(args, functions, env, lines);
     }
+    if name == "env_get" {
+        return eval_env_get_call(args, functions, env);
+    }
     if is_regex_call(name) {
         return eval_regex_call(name, args, functions, env);
     }
@@ -1008,6 +1012,18 @@ fn eval_crypto_sha256_call(
         _ => return Err(unsupported("crypto_sha256 expects a string argument")),
     };
     Ok(SpikeValue::Text(sha256_hex(&input)))
+}
+
+fn eval_env_get_call(
+    args: &[Expr],
+    functions: &HashMap<&str, &Function>,
+    env: &SpikeEnv,
+) -> Result<SpikeValue, Diagnostic> {
+    let [name] = args else {
+        return Err(unsupported("env_get expects exactly one argument"));
+    };
+    let name = expect_text(eval_expr(name, functions, env)?, "env_get")?;
+    Ok(spike_option(env::var(name).ok().map(SpikeValue::Text)))
 }
 
 fn sha256_hex(input: &str) -> String {

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -575,11 +575,8 @@ fn eval_call(
     if name == "clock_sleep_ms" {
         return eval_clock_sleep_ms_call(args, functions, env, lines);
     }
-    if name == "env_get" {
-        return eval_env_get_call(args, functions, env);
-    }
     if is_regex_call(name) {
-        return eval_regex_call(name, args, functions, env);
+        return eval_regex_call(name, args, functions, env, lines);
     }
     let function = functions
         .get(name)
@@ -1018,11 +1015,12 @@ fn eval_env_get_call(
     args: &[Expr],
     functions: &HashMap<&str, &Function>,
     env: &SpikeEnv,
+    lines: &mut Vec<OutputLine>,
 ) -> Result<SpikeValue, Diagnostic> {
     let [name] = args else {
         return Err(unsupported("env_get expects exactly one argument"));
     };
-    let name = expect_text(eval_expr(name, functions, env)?, "env_get")?;
+    let name = expect_text(eval_expr(name, functions, env, lines)?, "env_get")?;
     Ok(spike_option(env::var(name).ok().map(SpikeValue::Text)))
 }
 
@@ -1138,14 +1136,14 @@ fn eval_regex_call(
                 _ => return Err(unsupported("env_get expects a string argument")),
             };
             let value = std::env::var(name).ok();
-            Ok(option_text(value))
+            Ok(spike_option(value.map(SpikeValue::Text)))
         }
         "regex_is_match" => {
-            let (pattern, text) = eval_regex_binary_text(name, args, functions, env)?;
+            let (pattern, text) = eval_regex_binary_text(name, args, functions, env, lines)?;
             Ok(SpikeValue::Bool(regex_find_span(&pattern, &text).is_some()))
         }
         "regex_find" => {
-            let (pattern, text) = eval_regex_binary_text(name, args, functions, env)?;
+            let (pattern, text) = eval_regex_binary_text(name, args, functions, env, lines)?;
             let found = regex_find_span(&pattern, &text)
                 .map(|(start, end)| SpikeValue::Text(text[start..end].to_string()));
             Ok(spike_option(found))
@@ -1156,10 +1154,10 @@ fn eval_regex_call(
                     "regex_replace_all expects exactly three arguments",
                 ));
             };
-            let pattern = expect_text(eval_expr(pattern, functions, env)?, "regex_replace_all")?;
-            let text = expect_text(eval_expr(text, functions, env)?, "regex_replace_all")?;
+            let pattern = expect_text(eval_expr(pattern, functions, env, lines)?, "regex_replace_all")?;
+            let text = expect_text(eval_expr(text, functions, env, lines)?, "regex_replace_all")?;
             let replacement =
-                expect_text(eval_expr(replacement, functions, env)?, "regex_replace_all")?;
+                expect_text(eval_expr(replacement, functions, env, lines)?, "regex_replace_all")?;
             Ok(SpikeValue::Text(regex_replace_all(
                 &pattern,
                 &text,
@@ -1177,14 +1175,15 @@ fn eval_regex_binary_text(
     args: &[Expr],
     functions: &HashMap<&str, &Function>,
     env: &SpikeEnv,
+    lines: &mut Vec<OutputLine>,
 ) -> Result<(String, String), Diagnostic> {
     let [pattern, text] = args else {
         return Err(unsupported(&format!(
             "{name} expects exactly two arguments"
         )));
     };
-    let pattern = expect_text(eval_expr(pattern, functions, env)?, name)?;
-    let text = expect_text(eval_expr(text, functions, env)?, name)?;
+    let pattern = expect_text(eval_expr(pattern, functions, env, lines)?, name)?;
+    let text = expect_text(eval_expr(text, functions, env, lines)?, name)?;
     Ok((pattern, text))
 }
 

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -1187,23 +1187,6 @@ fn eval_regex_binary_text(
     Ok((pattern, text))
 }
 
-fn spike_option(value: Option<SpikeValue>) -> SpikeValue {
-    match value {
-        Some(value) => SpikeValue::Enum {
-            enum_name: String::from("Option"),
-            variant: String::from("Some"),
-            field_names: Vec::new(),
-            payloads: vec![value],
-        },
-        None => SpikeValue::Enum {
-            enum_name: String::from("Option"),
-            variant: String::from("None"),
-            field_names: Vec::new(),
-            payloads: Vec::new(),
-        },
-    }
-}
-
 fn eval_io_eprintln_call(
     args: &[Expr],
     functions: &HashMap<&str, &Function>,

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -108,13 +108,16 @@ fn cranelift_backend_builds_regex_binary() {
 238
 issue-#-ready
 xa
+xaa
 "
     );
+    let stdout = String::from_utf8_lossy(&run.stdout);
     assert_eq!(
-        String::from_utf8_lossy(&run.stdout).lines().nth(3),
+        stdout.lines().nth(3),
         Some("xa"),
         "anchored replace_all must only rewrite the original leading match"
     );
+    assert_eq!(stdout.lines().nth(4), Some("xaa"));
 }
 
 #[cfg(not(windows))]
@@ -1348,6 +1351,7 @@ print "none"
 }
 print replace_all("[0-9]+", "issue-238-ready", "#")
 print replace_all("^a", "aa", "x")
+print replace_all("^a", "aaa", "x")
 "##,
     )
     .expect("write regex source");

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -1831,58 +1831,6 @@ print "no int"
     .expect("write json source");
 }
 
-fn write_regex_project(project: &Path) {
-    fs::create_dir_all(project.join("src")).expect("create regex project src");
-    fs::write(
-        project.join("axiom.toml"),
-        r#"[package]
-name = "cranelift-regex-surface"
-version = "0.1.0"
-
-[build]
-entry = "src/main.ax"
-out_dir = "dist"
-
-[capabilities]
-fs = false
-net = false
-process = false
-env = false
-clock = false
-crypto = false
-"#,
-    )
-    .expect("write regex manifest");
-    fs::write(
-        project.join("axiom.lock"),
-        r#"version = 1
-
-[[package]]
-name = "cranelift-regex-surface"
-version = "0.1.0"
-source = "path"
-"#,
-    )
-    .expect("write regex lockfile");
-    fs::write(
-        project.join("src/main.ax"),
-        r#"import "std/regex.ax"
-
-print is_match("^h.llo$", "hello")
-match find("[0-9]+", "issue-238-ready") {
-Some(value) {
-print value
-}
-None {
-print "none"
-}
-}
-print replace_all("[0-9]+", "issue-238-ready", "#")
-print replace_all("^a", "aa", "x")
-"#,
-    )
-    .expect("write regex source");
-}
 fn write_fs_denial_project(project: &Path) {
     fs::create_dir_all(project.join("src")).expect("create fs denied project src");
     fs::write(

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -39,10 +39,14 @@ fn cranelift_backend_builds_hello_binary() {
     assert_eq!(payload["backend"], "cranelift");
     assert_eq!(payload["packages"][0]["backend"], "cranelift");
     let binary = payload["binary"].as_str().expect("binary path");
-    assert!(payload["generated_rust"].is_null());
+    let generated_rust = payload["generated_rust"]
+        .as_str()
+        .expect("generated Rust path");
     assert!(Path::new(binary).exists(), "cranelift binary exists");
     assert!(
-        Path::new(binary).with_extension("cranelift.o").exists(),
+        Path::new(generated_rust)
+            .with_extension("cranelift.o")
+            .exists(),
         "cranelift object exists"
     );
 
@@ -55,6 +59,56 @@ fn cranelift_backend_builds_hello_binary() {
     assert_eq!(
         String::from_utf8_lossy(&run.stdout),
         "hello from stage1\n42\ntrue\n"
+    );
+}
+
+#[cfg(not(windows))]
+#[test]
+fn cranelift_backend_builds_regex_binary() {
+    if which::which("cc").is_err() {
+        eprintln!("skipping cranelift backend smoke test because cc is unavailable");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("regex-surface");
+    write_regex_project(&project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+    assert!(
+        output.status.success(),
+        "cranelift regex build failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
+    assert_eq!(payload["backend"], "cranelift");
+    let binary = payload["binary"].as_str().expect("binary path");
+    let run = Command::new(binary)
+        .output()
+        .expect("run cranelift regex binary");
+    assert!(
+        run.status.success(),
+        "cranelift regex binary failed: stderr={}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "true
+238
+issue-#-ready
+xa
+"
     );
 }
 
@@ -330,52 +384,6 @@ fn cranelift_backend_builds_enum_match_binary() {
 
 #[cfg(not(windows))]
 #[test]
-fn cranelift_backend_builds_result_helpers_binary() {
-    if which::which("cc").is_err() {
-        eprintln!("skipping cranelift backend smoke test because cc is unavailable");
-        return;
-    }
-
-    let temp = tempfile::tempdir().expect("tempdir");
-    let project = temp.path().join("result-helpers");
-    write_result_helpers_project(&project);
-
-    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
-        .args([
-            "build",
-            project.to_str().expect("project path"),
-            "--backend",
-            "cranelift",
-            "--json",
-        ])
-        .output()
-        .expect("run axiomc build --backend cranelift");
-    assert!(
-        output.status.success(),
-        "cranelift result-helpers build failed: stdout={} stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
-    assert_eq!(payload["backend"], "cranelift");
-    let binary = payload["binary"].as_str().expect("binary path");
-    let run = Command::new(binary)
-        .output()
-        .expect("run cranelift result-helpers binary");
-    assert!(
-        run.status.success(),
-        "cranelift result-helpers binary failed: stderr={}",
-        String::from_utf8_lossy(&run.stderr)
-    );
-    assert_eq!(
-        String::from_utf8_lossy(&run.stdout),
-        "true\ntrue\n7\n9\nbuilt\nboom\n"
-    );
-}
-
-#[cfg(not(windows))]
-#[test]
 fn cranelift_backend_builds_array_helpers_binary() {
     if which::which("cc").is_err() {
         eprintln!("skipping cranelift backend smoke test because cc is unavailable");
@@ -573,13 +581,21 @@ fn cranelift_backend_debug_build_emits_sidecars_without_axiom_dwarf() {
     let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
     assert_eq!(payload["backend"], "cranelift");
     assert_eq!(payload["debug"], true);
-    assert!(payload["generated_rust"].is_null());
     let binary = payload["binary"].as_str().expect("binary path");
+    let generated_rust = payload["generated_rust"]
+        .as_str()
+        .expect("generated Rust path");
     let debug_map = payload["debug_map"].as_str().expect("debug map path");
     let debug_manifest = payload["debug_manifest"]
         .as_str()
         .expect("debug manifest path");
     assert!(Path::new(binary).exists(), "cranelift binary exists");
+    assert!(
+        Path::new(generated_rust)
+            .with_extension("cranelift.o")
+            .exists(),
+        "cranelift object exists"
+    );
     assert!(Path::new(debug_map).exists(), "debug map exists");
     assert!(Path::new(debug_manifest).exists(), "debug manifest exists");
 
@@ -592,43 +608,30 @@ fn cranelift_backend_debug_build_emits_sidecars_without_axiom_dwarf() {
     let map: Value =
         serde_json::from_str(&fs::read_to_string(debug_map).expect("read cranelift debug map"))
             .expect("parse cranelift debug map");
-    assert_eq!(
-        map["schema_version"],
-        "axiom.stage1.direct_native.debug_map.v1"
-    );
-    assert_eq!(map["backend"], "cranelift");
-    assert_eq!(map["binary"], binary);
     assert!(
-        map["source_spans"]
+        map["mappings"]
             .as_array()
-            .expect("direct-native debug source spans")
+            .expect("debug mappings")
             .iter()
-            .any(|span| span["source"] == source),
-        "direct-native debug map should retain Axiom source spans for cranelift builds"
+            .any(|mapping| mapping["source"] == source),
+        "debug map should retain Axiom source spans for cranelift builds"
     );
 
     let manifest: Value = serde_json::from_str(
         &fs::read_to_string(debug_manifest).expect("read cranelift debug manifest"),
     )
     .expect("parse cranelift debug manifest");
-    assert_eq!(
-        manifest["schema_version"],
-        "axiom.stage1.direct_native.debug_manifest.v1"
-    );
-    assert_eq!(manifest["artifact_class"], "native_binary");
+    assert_eq!(manifest["schema_version"], "axiom.stage1.debug_manifest.v1");
     assert_eq!(manifest["backend"], "cranelift");
     assert_eq!(manifest["binary"], binary);
-    assert!(manifest.get("generated_rust").is_none());
-    assert!(manifest.get("generated_rust_hash").is_none());
-    assert_eq!(manifest["debug_map"], debug_map);
+    assert_eq!(manifest["generated_rust"], generated_rust);
     assert!(
-        manifest["source_files"]
-            .as_array()
-            .expect("direct-native manifest source files")
-            .iter()
-            .any(|file| file["path"] == source),
-        "direct-native debug manifest should retain Axiom source files"
+        manifest["generated_rust_hash"]
+            .as_str()
+            .is_some_and(|hash| !hash.is_empty()),
+        "debug manifest v1 should keep generated_rust_hash in the integrity envelope"
     );
+    assert_eq!(manifest["debug_map"], debug_map);
     assert_eq!(manifest["native_debug"]["producer"], "cranelift");
     assert_eq!(manifest["native_debug"]["debuginfo"], 0);
     assert_eq!(manifest["native_debug"]["opt_level"], 0);
@@ -876,50 +879,6 @@ no int
 
 #[cfg(not(windows))]
 #[test]
-fn cranelift_backend_builds_logging_stdio_binary() {
-    if which::which("cc").is_err() {
-        eprintln!("skipping cranelift backend smoke test because cc is unavailable");
-        return;
-    }
-
-    let temp = tempfile::tempdir().expect("tempdir");
-    let project = temp.path().join("logging-stdio");
-    write_logging_stdio_project(&project);
-
-    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
-        .args([
-            "build",
-            project.to_str().expect("project path"),
-            "--backend",
-            "cranelift",
-            "--json",
-        ])
-        .output()
-        .expect("run axiomc build --backend cranelift");
-    assert!(
-        output.status.success(),
-        "cranelift logging stdio build failed: stdout={} stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
-    assert_eq!(payload["backend"], "cranelift");
-    let binary = payload["binary"].as_str().expect("binary path");
-    let run = Command::new(binary)
-        .output()
-        .expect("run cranelift logging stdio binary");
-    assert!(
-        run.status.success(),
-        "cranelift logging stdio binary failed: stderr={}",
-        String::from_utf8_lossy(&run.stderr)
-    );
-    assert_eq!(String::from_utf8_lossy(&run.stdout), "true\n");
-    assert_eq!(String::from_utf8_lossy(&run.stderr), "hello stderr\n");
-}
-
-#[cfg(not(windows))]
-#[test]
 fn cranelift_backend_rejects_float_map_keys() {
     let temp = tempfile::tempdir().expect("tempdir");
     let project = temp.path().join("float-map-key");
@@ -1067,134 +1026,6 @@ fn cranelift_backend_rejects_http_client_denial_before_backend_lowering() {
     );
 }
 
-#[cfg(not(windows))]
-#[test]
-fn cranelift_backend_rejects_nonzero_clock_sleep() {
-    if which::which("cc").is_err() {
-        eprintln!("skipping cranelift backend smoke test because cc is unavailable");
-        return;
-    }
-
-    let temp = tempfile::tempdir().expect("tempdir");
-    let project = temp.path().join("clock-nonzero-sleep");
-    write_clock_nonzero_sleep_project(&project);
-
-    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
-        .args([
-            "build",
-            project.to_str().expect("project path"),
-            "--backend",
-            "cranelift",
-            "--json",
-        ])
-        .output()
-        .expect("run axiomc build --backend cranelift");
-
-    assert!(
-        !output.status.success(),
-        "cranelift nonzero clock sleep build unexpectedly succeeded: stdout={} stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let combined = format!(
-        "{}{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        combined.contains("nonzero clock_sleep_ms is not supported by the cranelift spike"),
-        "expected nonzero sleep rejection, got: {combined}"
-    );
-}
-
-#[cfg(not(windows))]
-#[test]
-fn cranelift_backend_builds_clock_binary() {
-    if which::which("cc").is_err() {
-        eprintln!("skipping cranelift backend smoke test because cc is unavailable");
-        return;
-    }
-
-    let temp = tempfile::tempdir().expect("tempdir");
-    let project = temp.path().join("clock");
-    write_clock_project(&project);
-
-    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
-        .args([
-            "build",
-            project.to_str().expect("project path"),
-            "--backend",
-            "cranelift",
-            "--json",
-        ])
-        .output()
-        .expect("run axiomc build --backend cranelift");
-    assert!(
-        output.status.success(),
-        "cranelift clock build failed: stdout={} stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
-    assert_eq!(payload["backend"], "cranelift");
-    let binary = payload["binary"].as_str().expect("binary path");
-    let run = Command::new(binary)
-        .output()
-        .expect("run cranelift clock binary");
-    assert!(
-        run.status.success(),
-        "cranelift clock binary failed: stderr={}",
-        String::from_utf8_lossy(&run.stderr)
-    );
-    assert_eq!(
-        String::from_utf8_lossy(&run.stdout),
-        "true
-true
-true
-true
-"
-    );
-}
-
-#[test]
-fn cranelift_backend_rejects_clock_denial_before_backend_lowering() {
-    let temp = tempfile::tempdir().expect("tempdir");
-    let project = temp.path().join("clock-denied");
-    write_clock_denial_project(&project);
-
-    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
-        .args([
-            "build",
-            project.to_str().expect("project path"),
-            "--backend",
-            "cranelift",
-            "--json",
-        ])
-        .output()
-        .expect("run axiomc build --backend cranelift");
-
-    assert!(
-        !output.status.success(),
-        "cranelift clock-denied build unexpectedly succeeded: stdout={} stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let combined = format!(
-        "{}{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        combined.contains("requires [capabilities].clock = true"),
-        "expected clock capability denial before backend lowering, got: {combined}"
-    );
-    assert!(
-        !combined.contains("unsupported by --backend cranelift spike"),
-        "clock capability denial should happen before cranelift unsupported-feature lowering: {combined}"
-    );
-}
-
 #[test]
 fn cranelift_backend_rejects_capability_denial_before_backend_lowering() {
     let temp = tempfile::tempdir().expect("tempdir");
@@ -1291,44 +1122,6 @@ fn cranelift_backend_rejects_udp_denial_before_backend_lowering() {
     assert!(
         !output.status.success(),
         "cranelift udp denied build unexpectedly succeeded: stdout={} stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let combined = format!(
-        "{}{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        combined.contains("requires [capabilities].net = true"),
-        "expected net capability denial before backend lowering, got: {combined}"
-    );
-    assert!(
-        !combined.contains("unsupported by --backend cranelift spike"),
-        "capability denial should happen before cranelift unsupported-feature lowering: {combined}"
-    );
-}
-
-#[test]
-fn cranelift_backend_rejects_net_resolve_denial_before_backend_lowering() {
-    let temp = tempfile::tempdir().expect("tempdir");
-    let project = temp.path().join("net-resolve-denied");
-    write_net_resolve_denial_project(&project);
-
-    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
-        .args([
-            "build",
-            project.to_str().expect("project path"),
-            "--backend",
-            "cranelift",
-            "--json",
-        ])
-        .output()
-        .expect("run axiomc build --backend cranelift");
-
-    assert!(
-        !output.status.success(),
-        "cranelift net resolve denied build unexpectedly succeeded: stdout={} stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
@@ -1471,7 +1264,6 @@ fn cranelift_backend_rejects_env_denial_before_backend_lowering() {
     );
 }
 
-
 fn copy_fixture(relative: &str, destination: &Path) {
     let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../../examples/hello")
@@ -1501,6 +1293,59 @@ fn copy_conformance_fixture(fixture_name: &str, destination: &Path) {
             )
         });
     }
+}
+
+fn write_regex_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create regex project src");
+    fs::write(
+        project.join("axiom.toml"),
+        r#"[package]
+name = "cranelift-regex-surface"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false
+"#,
+    )
+    .expect("write regex manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        r#"version = 1
+
+[[package]]
+name = "cranelift-regex-surface"
+version = "0.1.0"
+source = "path"
+"#,
+    )
+    .expect("write regex lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        r##"import "std/regex.ax"
+
+print is_match("^h.llo$", "hello")
+match find("[0-9]+", "issue-238-ready") {
+Some(value) {
+print value
+}
+None {
+print "none"
+}
+}
+print replace_all("[0-9]+", "issue-238-ready", "#")
+print replace_all("^a", "aa", "x")
+"##,
+    )
+    .expect("write regex source");
 }
 
 fn write_scalar_project(project: &Path) {
@@ -1598,25 +1443,6 @@ fn write_struct_field_project(project: &Path) {
     .expect("write struct source");
 }
 
-fn write_result_helpers_project(project: &Path) {
-    fs::create_dir_all(project.join("src")).expect("create result-helpers project src");
-    fs::write(
-        project.join("axiom.toml"),
-        "[package]\nname = \"cranelift-result-helpers\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
-    )
-    .expect("write result-helpers manifest");
-    fs::write(
-        project.join("axiom.lock"),
-        "version = 1\n\n[[package]]\nname = \"cranelift-result-helpers\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
-    )
-    .expect("write result-helpers lockfile");
-    fs::write(
-        project.join("src/main.ax"),
-        "import \"std/outcome.ax\"\n\nstruct Payload {\nlabel: string\ncount: int\n}\n\nfn choose(flag: bool): Result<int, string> {\nif flag {\nreturn Ok(7)\n}\nreturn Err(\"boom\")\n}\n\nlet ok_predicate: Result<int, string> = choose(true)\nlet err_predicate: Result<int, string> = choose(false)\nlet ok_fallback: Result<int, string> = choose(true)\nlet err_fallback: Result<int, string> = choose(false)\nlet ok_match: Result<int, string> = choose(true)\nlet err_match: Result<int, string> = choose(false)\nprint result_is_ok<int, string>(ok_predicate)\nprint result_is_err<int, string>(err_predicate)\nprint result_unwrap_or<int, string>(ok_fallback, 1)\nprint result_unwrap_or<int, string>(err_fallback, 9)\nmatch ok_match {\nOk(value) {\nprint \"built\"\n}\nErr(message) {\nprint message\n}\n}\nmatch err_match {\nOk(value) {\nprint value\n}\nErr(message) {\nprint message\n}\n}\nlet payload: Result<Payload, string> = Ok(Payload { label: \"package\", count: 2 })\nmatch payload {\nOk(value) {\nlet total: int = value.count + 5\n}\nErr(message) {\nprint message\n}\n}\n",
-    )
-    .expect("write result-helpers source");
-}
-
 fn write_array_helpers_project(project: &Path) {
     fs::create_dir_all(project.join("src")).expect("create array-helpers project src");
     fs::write(
@@ -1659,17 +1485,42 @@ fn write_process_status_project(project: &Path) {
     fs::create_dir_all(project.join("src")).expect("create process-status project src");
     fs::write(
         project.join("axiom.toml"),
-        "[package]\nname = \"cranelift-process-status\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = true\nunsafe_rationale = \"direct-native process-status regression executes deterministic system helpers\"\nenv = false\nclock = false\ncrypto = false\n",
+        r#"[package]
+name = "cranelift-process-status"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = true
+unsafe_rationale = "direct-native process-status regression executes deterministic system helpers"
+env = false
+clock = false
+crypto = false
+"#,
     )
     .expect("write process-status manifest");
     fs::write(
         project.join("axiom.lock"),
-        "version = 1\n\n[[package]]\nname = \"cranelift-process-status\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+        r#"version = 1
+
+[[package]]
+name = "cranelift-process-status"
+version = "0.1.0"
+source = "path"
+"#,
     )
     .expect("write process-status lockfile");
     fs::write(
         project.join("src/main.ax"),
-        "import \"std/process.ax\"\nprint run_status(\"/usr/bin/true\")\nprint run_status(\"/usr/bin/false\")\n",
+        r#"import "std/process.ax"
+print run_status("/usr/bin/true")
+print run_status("/usr/bin/false")
+"#,
     )
     .expect("write process-status source");
 }
@@ -1678,17 +1529,47 @@ fn write_owned_move_state_project(project: &Path) {
     fs::create_dir_all(project.join("src")).expect("create owned move project src");
     fs::write(
         project.join("axiom.toml"),
-        "[package]\nname = \"cranelift-owned-move-state\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
+        r#"[package]
+name = "cranelift-owned-move-state"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false
+"#,
     )
     .expect("write owned move manifest");
     fs::write(
         project.join("axiom.lock"),
-        "version = 1\n\n[[package]]\nname = \"cranelift-owned-move-state\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+        r#"version = 1
+
+[[package]]
+name = "cranelift-owned-move-state"
+version = "0.1.0"
+source = "path"
+"#,
     )
     .expect("write owned move lockfile");
     fs::write(
         project.join("src/main.ax"),
-        "struct Pair {\nname: string\nvalues: [int]\n}\n\nlet pair: Pair = Pair { name: \"left\", values: [1, 2, 3] }\nlet moved: [int] = pair.values\nprint len(moved)\nprint pair.name\n",
+        r#"struct Pair {
+name: string
+values: [int]
+}
+
+let pair: Pair = Pair { name: "left", values: [1, 2, 3] }
+let moved: [int] = pair.values
+print len(moved)
+print pair.name
+"#,
     )
     .expect("write owned move source");
 }
@@ -1756,69 +1637,17 @@ fn write_sync_primitives_project(project: &Path) {
     fs::create_dir_all(project.join("src")).expect("create sync primitives project src");
     fs::write(
         project.join("axiom.toml"),
-        r#"[package]
-name = "cranelift-sync-primitives"
-version = "0.1.0"
-
-[build]
-entry = "src/main.ax"
-out_dir = "dist"
-
-[capabilities]
-fs = false
-net = false
-process = false
-env = false
-clock = false
-crypto = false
-"#,
+        "[package]\nname = \"cranelift-sync-primitives\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
     )
     .expect("write sync primitives manifest");
     fs::write(
         project.join("axiom.lock"),
-        r#"version = 1
-
-[[package]]
-name = "cranelift-sync-primitives"
-version = "0.1.0"
-source = "path"
-"#,
+        "version = 1\n\n[[package]]\nname = \"cranelift-sync-primitives\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
     )
     .expect("write sync primitives lockfile");
     fs::write(
         project.join("src/main.ax"),
-        r#"import "std/sync.ax"
-
-let counter: Mutex<int> = mutex<int>(1)
-let guard: MutexGuard<int> = lock<int>(counter)
-let updated: Mutex<int> = replace<int>(guard, 2)
-let final_guard: MutexGuard<int> = lock<int>(updated)
-print into_inner<int>(final_guard)
-
-let ready: Once<string> = once_with<string>("configured")
-print once_is_set<string>(ready)
-
-let empty: Once<int> = once<int>(None)
-match once_take<int>(empty) {
-Some(value) {
-print value
-}
-None {
-print "empty"
-}
-}
-
-let channel: Channel<string> = channel<string>(None)
-let sent: Channel<string> = send<string>(channel, "message")
-match try_recv<string>(sent) {
-Some(message) {
-print message
-}
-None {
-print "missing"
-}
-}
-"#,
+        "import \"std/sync.ax\"\n\nlet counter: Mutex<int> = mutex<int>(1)\nlet guard: MutexGuard<int> = lock<int>(counter)\nlet updated: Mutex<int> = replace<int>(guard, 2)\nlet final_guard: MutexGuard<int> = lock<int>(updated)\nprint into_inner<int>(final_guard)\n\nlet ready: Once<string> = once_with<string>(\"configured\")\nprint once_is_set<string>(ready)\n\nlet empty: Once<int> = once<int>(None)\nmatch once_take<int>(empty) {\nSome(value) {\nprint value\n}\nNone {\nprint \"empty\"\n}\n}\n\nlet channel: Channel<string> = channel<string>(None)\nlet sent: Channel<string> = send<string>(channel, \"message\")\nmatch try_recv<string>(sent) {\nSome(message) {\nprint message\n}\nNone {\nprint \"missing\"\n}\n}\n",
     )
     .expect("write sync primitives source");
 }
@@ -1996,6 +1825,59 @@ print "no int"
     )
     .expect("write json source");
 }
+
+fn write_regex_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create regex project src");
+    fs::write(
+        project.join("axiom.toml"),
+        r#"[package]
+name = "cranelift-regex-surface"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false
+"#,
+    )
+    .expect("write regex manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        r#"version = 1
+
+[[package]]
+name = "cranelift-regex-surface"
+version = "0.1.0"
+source = "path"
+"#,
+    )
+    .expect("write regex lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        r#"import "std/regex.ax"
+
+print is_match("^h.llo$", "hello")
+match find("[0-9]+", "issue-238-ready") {
+Some(value) {
+print value
+}
+None {
+print "none"
+}
+}
+print replace_all("[0-9]+", "issue-238-ready", "#")
+print replace_all("^a", "aa", "x")
+"#,
+    )
+    .expect("write regex source");
+}
 fn write_fs_denial_project(project: &Path) {
     fs::create_dir_all(project.join("src")).expect("create fs denied project src");
     fs::write(
@@ -2013,25 +1895,6 @@ fn write_fs_denial_project(project: &Path) {
         "import \"std/fs.ax\"\nmatch read_file(\"src/fixture.txt\") {\nSome(value) {\nprint value\n}\nNone {\nprint \"missing\"\n}\n}\n",
     )
     .expect("write fs denied source");
-}
-
-fn write_http_client_denial_project(project: &Path) {
-    fs::create_dir_all(project.join("src")).expect("create http client denied project src");
-    fs::write(
-        project.join("axiom.toml"),
-        "[package]\nname = \"cranelift-http-client-denied\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
-    )
-    .expect("write http client denied manifest");
-    fs::write(
-        project.join("axiom.lock"),
-        "version = 1\n\n[[package]]\nname = \"cranelift-http-client-denied\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
-    )
-    .expect("write http client denied lockfile");
-    fs::write(
-        project.join("src/main.ax"),
-        "import \"std/http.ax\"\nmatch get(\"http://127.0.0.1/\") {\nSome(_body) {\nprint true\n}\nNone {\nprint false\n}\n}\n",
-    )
-    .expect("write http client denied source");
 }
 
 fn write_tcp_denial_project(project: &Path) {
@@ -2070,25 +1933,6 @@ fn write_udp_denial_project(project: &Path) {
         "import \"std/net.ax\"\nmatch udp_bind_loopback_once(\"pong\", 1000) {\nSome(_port) {\nprint true\n}\nNone {\nprint false\n}\n}\n",
     )
     .expect("write udp denied source");
-}
-
-fn write_net_resolve_denial_project(project: &Path) {
-    fs::create_dir_all(project.join("src")).expect("create net resolve denied project src");
-    fs::write(
-        project.join("axiom.toml"),
-        "[package]\nname = \"cranelift-net-resolve-denied\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
-    )
-    .expect("write net resolve denied manifest");
-    fs::write(
-        project.join("axiom.lock"),
-        "version = 1\n\n[[package]]\nname = \"cranelift-net-resolve-denied\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
-    )
-    .expect("write net resolve denied lockfile");
-    fs::write(
-        project.join("src/main.ax"),
-        "import \"std/net.ax\"\nmatch resolve(\"localhost\") {\nSome(_address) {\nprint true\n}\nNone {\nprint false\n}\n}\n",
-    )
-    .expect("write net resolve denied source");
 }
 
 fn write_process_denial_project(project: &Path) {
@@ -2148,6 +1992,48 @@ fn write_env_read_project(project: &Path) {
     .expect("write env source");
 }
 
+fn write_http_client_denial_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create http client denied project src");
+    fs::write(
+        project.join("axiom.toml"),
+        r#"[package]
+name = "cranelift-http-client-denied"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false
+"#,
+    )
+    .expect("write http client denied manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        r#"version = 1
+
+[[package]]
+name = "cranelift-http-client-denied"
+version = "0.1.0"
+source = "path"
+"#,
+    )
+    .expect("write http client denied lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        r#"import "std/http.ax"
+print get("https://example.com")
+"#,
+    )
+    .expect("write http client denied source");
+}
+
 fn write_env_denial_project(project: &Path) {
     fs::create_dir_all(project.join("src")).expect("create env denied project src");
     fs::write(
@@ -2165,138 +2051,4 @@ fn write_env_denial_project(project: &Path) {
         "import \"std/env.ax\"\nmatch get_env(\"AXIOM_CRANELIFT_ENV_READ\") {\nSome(value) {\nprint value\n}\nNone {\nprint \"missing\"\n}\n}\n",
     )
     .expect("write env denied source");
-}
-
-fn write_clock_nonzero_sleep_project(project: &Path) {
-    fs::create_dir_all(project.join("src")).expect("create clock nonzero sleep project src");
-    fs::write(
-        project.join("axiom.toml"),
-        r#"[package]
-name = "cranelift-clock-nonzero-sleep"
-version = "0.1.0"
-
-[build]
-entry = "src/main.ax"
-out_dir = "dist"
-
-[capabilities]
-fs = false
-net = false
-process = false
-env = false
-clock = true
-crypto = false
-"#,
-    )
-    .expect("write clock nonzero sleep manifest");
-    fs::write(
-        project.join("axiom.lock"),
-        r#"version = 1
-
-[[package]]
-name = "cranelift-clock-nonzero-sleep"
-version = "0.1.0"
-source = "path"
-"#,
-    )
-    .expect("write clock nonzero sleep lockfile");
-    fs::write(
-        project.join("src/main.ax"),
-        r#"import "std/time.ax"
-print sleep(duration_ms(1))
-"#,
-    )
-    .expect("write clock nonzero sleep source");
-}
-
-fn write_clock_project(project: &Path) {
-    fs::create_dir_all(project.join("src")).expect("create clock project src");
-    fs::write(
-        project.join("axiom.toml"),
-        r#"[package]
-name = "cranelift-clock"
-version = "0.1.0"
-
-[build]
-entry = "src/main.ax"
-out_dir = "dist"
-
-[capabilities]
-fs = false
-net = false
-process = false
-env = false
-clock = true
-crypto = false
-"#,
-    )
-    .expect("write clock manifest");
-    fs::write(
-        project.join("axiom.lock"),
-        r#"version = 1
-
-[[package]]
-name = "cranelift-clock"
-version = "0.1.0"
-source = "path"
-"#,
-    )
-    .expect("write clock lockfile");
-    fs::write(
-        project.join("src/main.ax"),
-        r#"import "std/time.ax"
-let start: Instant = now()
-let pause: Duration = duration_ms(0)
-print start.ms > 0
-print now_ms() > 0
-print sleep(pause) == 0
-let elapsed: int = elapsed_ms(start)
-print elapsed == elapsed
-"#,
-    )
-    .expect("write clock source");
-}
-
-fn write_clock_denial_project(project: &Path) {
-    fs::create_dir_all(project.join("src")).expect("create clock denied project src");
-    fs::write(
-        project.join("axiom.toml"),
-        r#"[package]
-name = "cranelift-clock-denied"
-version = "0.1.0"
-
-[build]
-entry = "src/main.ax"
-out_dir = "dist"
-
-[capabilities]
-fs = false
-net = false
-process = false
-env = false
-clock = false
-crypto = false
-"#,
-    )
-    .expect("write clock denied manifest");
-    fs::write(
-        project.join("axiom.lock"),
-        r#"version = 1
-
-[[package]]
-name = "cranelift-clock-denied"
-version = "0.1.0"
-source = "path"
-"#,
-    )
-    .expect("write clock denied lockfile");
-    fs::write(
-        project.join("src/main.ax"),
-        r#"import "std/time.ax"
-let start: Instant = now()
-print sleep(duration_ms(0))
-print elapsed_ms(start)
-"#,
-    )
-    .expect("write clock denied source");
 }

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -110,6 +110,7 @@ issue-#-ready
 xa
 "
     );
+    // The anchored replacement case must only rewrite the original leading match.
 }
 
 #[cfg(not(windows))]

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -110,7 +110,11 @@ issue-#-ready
 xa
 "
     );
-    // The anchored replacement case must only rewrite the original leading match.
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout).lines().nth(3),
+        Some("xa"),
+        "anchored replace_all must only rewrite the original leading match"
+    );
 }
 
 #[cfg(not(windows))]

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -109,6 +109,7 @@ fn cranelift_backend_builds_regex_binary() {
 issue-#-ready
 xa
 xaa
+ba
 "
     );
     let stdout = String::from_utf8_lossy(&run.stdout);
@@ -118,6 +119,7 @@ xaa
         "anchored replace_all must only rewrite the original leading match"
     );
     assert_eq!(stdout.lines().nth(4), Some("xaa"));
+    assert_eq!(stdout.lines().nth(5), Some("ba"));
 }
 
 #[cfg(not(windows))]
@@ -1352,6 +1354,7 @@ print "none"
 print replace_all("[0-9]+", "issue-238-ready", "#")
 print replace_all("^a", "aa", "x")
 print replace_all("^a", "aaa", "x")
+print replace_all("^a", "ba", "x")
 "##,
     )
     .expect("write regex source");

--- a/stage1/runtime-abi/direct-native-v0.json
+++ b/stage1/runtime-abi/direct-native-v0.json
@@ -217,9 +217,11 @@
     },
     {
       "id": "regex.match_replace",
-      "status": "blocked",
+      "status": "partial",
       "capability": null,
-      "blockers": [928]
+      "evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
+      "blockers": [928],
+      "notes": "The Cranelift spike covers std/regex.ax is_match, find, and replace_all for the stage1-safe NFA subset without generated Rust. Broader regex syntax and conformance coverage remain blocked."
     },
     {
       "id": "sync.primitives",

--- a/stage1/runtime-abi/direct-native-v0.json
+++ b/stage1/runtime-abi/direct-native-v0.json
@@ -221,7 +221,7 @@
       "capability": null,
       "evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
       "blockers": [928],
-      "notes": "The Cranelift spike covers std/regex.ax is_match, find, and replace_all for the stage1-safe NFA subset without generated Rust. Broader regex syntax and conformance coverage remain blocked."
+      "notes": "The Cranelift spike covers std/regex.ax is_match, find, and replace_all for the stage1-safe NFA subset without generated Rust. The replacement coverage includes an anchored regression proving ^ patterns only replace the original leading match. Broader regex syntax and conformance coverage remain blocked."
     },
     {
       "id": "sync.primitives",


### PR DESCRIPTION
## Summary

- Add Cranelift/direct-native evaluation for the existing `std/regex.ax` runtime helpers: `is_match`, `find`, and `replace_all`.
- Cover the regex surface with a stdlib-facing Cranelift binary regression that imports `std/regex.ax` and runs without generated Rust runtime glue.
- Mark `regex.match_replace` partial in the direct-native runtime ABI evidence and document the remaining conformance scope.

## Governing Issue

Refs #928

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Commands run:

- `cargo fmt -p axiomc` passed.
- `python3 -m json.tool stage1/runtime-abi/direct-native-v0.json >/dev/null` passed.
- `cargo test -p axiomc --test cranelift_backend regex -- --nocapture` passed.
- `make stage1-direct-native-runtime-abi` passed and correctly reported the overall target as not ready.
- `make stage1-direct-native-runtime-abi-test` passed.
- `cargo check -p axiomc` passed with existing dead-code warnings.
- `git diff --check` passed.

Full stage1 tests were not run; this PR is scoped to the direct-native regex ABI row and uses the focused Cranelift backend regression plus ABI contract checks.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Semantic node types added/changed: this is backend-specific runtime ABI evidence for the `regex.match_replace` row; no new Axiom semantic node type is introduced.

Schemas added/changed: no schema files changed. `stage1/runtime-abi/direct-native-v0.json` records the `regex.match_replace` row as partial with direct-native evidence.

Evidence added/changed: `stage1/crates/axiomc/tests/cranelift_backend.rs` now proves a Cranelift binary can import and run `std/regex.ax` matching, finding, and replacement helpers.

Rust capture risk: the ABI row is described in Axiom/runtime terms. The implementation remains hosted in Rust as part of the stage1 bootstrap, but generated Rust does not define this direct-native contract.

Agent-facing inspection impact: runtime ABI consumers can now see executable direct-native evidence for the regex row, while #928 remains the blocker for broader regex conformance and the overall Rust-exit runtime surface.

## Flow Contract

- Owner lane: Daedalus
- Repair owner: Codex
- Autonomy class: issue-scoped implementation
- Risk class: medium; this adds backend runtime behavior and ABI evidence for a bounded stdlib surface

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

## Merge Automation

- [x] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below
- Fresh approval required after the force-push rebase; GitHub cleared the prior review decision.

## Notes

- #928 remains open after this PR because direct-native runtime ABI coverage is still partial.