### PR TITLE
Add direct-native stdio ABI evidence

### DIFF
--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -123,7 +123,6 @@ The sync-primitives row has partial direct-native evidence: the Cranelift spike
 now evaluates ownership-shaped `std/sync.ax` mutex, once, and channel wrappers
 and emits the expected native output. Concurrent execution, blocking behavior,
 and host runtime synchronization remain tracked by issue #928.
-
 The `env.read` row now has partial Cranelift evidence for `std/env.ax`
 `get_env` on present and missing environment names, plus denial evidence that a
 package without the `env` capability fails before backend lowering. Full
@@ -141,7 +140,30 @@ spike builds and runs projection-sensitive owned field moves while preserving
 access to disjoint sibling projections. Broader move-state, lifetime, and host
 ABI coverage remain tracked by issue #928.
 
-## Rust Capture Check
+The logging/stdio row has partial direct-native evidence: the Cranelift spike
+now evaluates `std/io.ax` stderr writes and emits the resulting stdout and
+stderr streams from the native binary. Stdin reads, `std/log.ax` wrappers, and
+broader streaming/runtime buffering remain tracked by issue #928.
+The `env.read` row now has partial Cranelift evidence for `std/env.ax`
+`get_env` on present and missing environment names, plus denial evidence that a
+package without the `env` capability fails before backend lowering. Full
+runtime-time lookup, manifest allowlist parity, and audit parity remain open
+under #928.
+
+The `Result<T, E>` row has partial direct-native evidence: the Cranelift spike
+now builds and runs a package importing `std/outcome.ax`, using result
+predicates, fallback unwrap helpers, direct match arms over `Result<T, E>`
+values, scalar payloads, string errors, and struct payloads. Broader runtime
+ABI and capability-shim coverage remain tracked by issue #928.
+
+The owned move-state row has partial direct-native evidence: the Cranelift
+spike builds and runs projection-sensitive owned field moves while preserving
+access to disjoint sibling projections. Broader move-state, lifetime, and host
+ABI coverage remain tracked by issue #928.
+now evaluates `std/io.ax` stderr writes and emits the resulting stdout and
+stderr streams from the native binary. Stdin reads, `std/log.ax` wrappers, and
+broader streaming/runtime buffering remain tracked by issue #928.
+
 
 This ABI describes Axiom runtime values and host-service effects. Rust may
 remain the current implementation host while this contract is incomplete, but

--- a/stage1/crates/axiomc-backend-cranelift/src/lib.rs
+++ b/stage1/crates/axiomc-backend-cranelift/src/lib.rs
@@ -15,6 +15,34 @@ pub struct CraneliftBackendError {
     message: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputStream {
+    Stdout,
+    Stderr,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutputLine {
+    pub stream: OutputStream,
+    pub text: String,
+}
+
+impl OutputLine {
+    pub fn stdout(text: impl Into<String>) -> Self {
+        Self {
+            stream: OutputStream::Stdout,
+            text: text.into(),
+        }
+    }
+
+    pub fn stderr(text: impl Into<String>) -> Self {
+        Self {
+            stream: OutputStream::Stderr,
+            text: text.into(),
+        }
+    }
+}
+
 impl CraneliftBackendError {
     fn new(message: impl Into<String>) -> Self {
         Self {
@@ -36,12 +64,25 @@ pub fn compile_print_lines(
     object_path: &Path,
     binary_path: &Path,
 ) -> Result<(), CraneliftBackendError> {
+    let lines = lines
+        .iter()
+        .cloned()
+        .map(OutputLine::stdout)
+        .collect::<Vec<_>>();
+    compile_output_lines(&lines, object_path, binary_path)
+}
+
+pub fn compile_output_lines(
+    lines: &[OutputLine],
+    object_path: &Path,
+    binary_path: &Path,
+) -> Result<(), CraneliftBackendError> {
     emit_cranelift_object(lines, object_path)?;
     link_object(object_path, binary_path)
 }
 
 fn emit_cranelift_object(
-    lines: &[String],
+    lines: &[OutputLine],
     object_path: &Path,
 ) -> Result<(), CraneliftBackendError> {
     let isa_builder = host_isa_builder()?;
@@ -60,12 +101,16 @@ fn emit_cranelift_object(
     let mut module = ObjectModule::new(builder);
     let pointer_type = module.target_config().pointer_type();
 
-    let mut puts_sig = module.make_signature();
-    puts_sig.params.push(AbiParam::new(pointer_type));
-    puts_sig.returns.push(AbiParam::new(types::I32));
-    let puts_id = module
-        .declare_function("puts", Linkage::Import, &puts_sig)
-        .map_err(|message| CraneliftBackendError::new(format!("declare puts import: {message}")))?;
+    let mut write_sig = module.make_signature();
+    write_sig.params.push(AbiParam::new(types::I32));
+    write_sig.params.push(AbiParam::new(pointer_type));
+    write_sig.params.push(AbiParam::new(pointer_type));
+    write_sig.returns.push(AbiParam::new(pointer_type));
+    let write_id = module
+        .declare_function("write", Linkage::Import, &write_sig)
+        .map_err(|message| {
+            CraneliftBackendError::new(format!("declare write import: {message}"))
+        })?;
 
     let mut data_ids = Vec::new();
     for (index, line) in lines.iter().enumerate() {
@@ -78,13 +123,14 @@ fn emit_cranelift_object(
             )
             .map_err(|message| CraneliftBackendError::new(format!("declare data: {message}")))?;
         let mut description = DataDescription::new();
-        let mut bytes = line.as_bytes().to_vec();
-        bytes.push(0);
+        let mut bytes = line.text.as_bytes().to_vec();
+        bytes.push(b'\n');
+        let byte_len = bytes.len();
         description.define(bytes.into_boxed_slice());
         module
             .define_data(data_id, &description)
             .map_err(|message| CraneliftBackendError::new(format!("define data: {message}")))?;
-        data_ids.push(data_id);
+        data_ids.push((line.stream, data_id, byte_len));
     }
 
     let mut context = module.make_context();
@@ -102,11 +148,19 @@ fn emit_cranelift_object(
         let block = builder.create_block();
         builder.switch_to_block(block);
         builder.seal_block(block);
-        let puts_ref = module.declare_func_in_func(puts_id, builder.func);
-        for data_id in data_ids {
+        let write_ref = module.declare_func_in_func(write_id, builder.func);
+        for (stream, data_id, byte_len) in data_ids {
             let data_ref = module.declare_data_in_func(data_id, builder.func);
             let pointer = builder.ins().global_value(pointer_type, data_ref);
-            builder.ins().call(puts_ref, &[pointer]);
+            let fd = builder.ins().iconst(
+                types::I32,
+                match stream {
+                    OutputStream::Stdout => 1,
+                    OutputStream::Stderr => 2,
+                },
+            );
+            let len = builder.ins().iconst(pointer_type, byte_len as i64);
+            builder.ins().call(write_ref, &[fd, pointer, len]);
         }
         let ok = builder.ins().iconst(types::I32, 0);
         builder.ins().return_(&[ok]);
@@ -201,5 +255,33 @@ mod tests {
             String::from_utf8_lossy(&output.stdout),
             "hello from stage1\n42\ntrue\n"
         );
+    }
+
+    #[test]
+    fn links_stdout_and_stderr_lines() {
+        if std::env::var_os("AXIOM_SKIP_CRANELIFT_LINK_TEST").is_some() {
+            return;
+        }
+        if Command::new("cc").arg("--version").output().is_err() {
+            eprintln!("skipping cranelift link test because cc is unavailable");
+            return;
+        }
+        let temp = tempfile::tempdir().expect("tempdir");
+        let object = temp.path().join("stdio.o");
+        let binary = temp.path().join("stdio");
+        compile_output_lines(
+            &[
+                OutputLine::stdout("ready"),
+                OutputLine::stderr("audit"),
+                OutputLine::stdout("done"),
+            ],
+            &object,
+            &binary,
+        )
+        .expect("compile output lines");
+        let output = Command::new(&binary).output().expect("run binary");
+        assert!(output.status.success(), "binary exits successfully");
+        assert_eq!(String::from_utf8_lossy(&output.stdout), "ready\ndone\n");
+        assert_eq!(String::from_utf8_lossy(&output.stderr), "audit\n");
     }
 }

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -4,6 +4,7 @@ use crate::mir::{
     Type,
 };
 use crate::syntax::NumericType;
+use axiomc_backend_cranelift::OutputLine;
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -43,24 +44,26 @@ pub fn compile_cranelift_hello_spike(
             "the cranelift backend spike currently supports only the host target",
         ));
     }
-    let lines = collect_print_lines(program)?;
-    axiomc_backend_cranelift::compile_print_lines(&lines, object_path, binary_path).map_err(|err| {
-        Diagnostic::new("build", err.to_string()).with_path(object_path.display().to_string())
-    })
+    let lines = collect_output_lines(program)?;
+    axiomc_backend_cranelift::compile_output_lines(&lines, object_path, binary_path).map_err(
+        |err| {
+            Diagnostic::new("build", err.to_string()).with_path(object_path.display().to_string())
+        },
+    )
 }
 
-fn collect_print_lines(program: &Program) -> Result<Vec<String>, Diagnostic> {
+fn collect_output_lines(program: &Program) -> Result<Vec<OutputLine>, Diagnostic> {
     let functions = program
         .functions
         .iter()
         .map(|function| (function.name.as_str(), function))
         .collect::<HashMap<_, _>>();
     let mut env = SpikeEnv::new();
+    let mut lines = Vec::new();
     for static_def in &program.statics {
-        let value = eval_expr(&static_def.expr, &functions, &env)?;
+        let value = eval_expr(&static_def.expr, &functions, &env, &mut lines)?;
         env.insert(static_def.name.clone(), value);
     }
-    let mut lines = Vec::new();
     eval_block(&program.stmts, &functions, &mut env, &mut lines)?;
     Ok(lines)
 }
@@ -69,7 +72,7 @@ fn eval_block(
     stmts: &[Stmt],
     functions: &HashMap<&str, &Function>,
     env: &mut SpikeEnv,
-    lines: &mut Vec<String>,
+    lines: &mut Vec<OutputLine>,
 ) -> Result<Option<SpikeValue>, Diagnostic> {
     for stmt in stmts {
         if let Some(value) = eval_stmt(stmt, functions, env, lines)? {
@@ -83,16 +86,17 @@ fn eval_stmt(
     stmt: &Stmt,
     functions: &HashMap<&str, &Function>,
     env: &mut SpikeEnv,
-    lines: &mut Vec<String>,
+    lines: &mut Vec<OutputLine>,
 ) -> Result<Option<SpikeValue>, Diagnostic> {
     match stmt {
         Stmt::Let { name, expr, .. } => {
-            let value = eval_expr(expr, functions, env)?;
+            let value = eval_expr(expr, functions, env, lines)?;
             env.insert(name.clone(), value);
             Ok(None)
         }
         Stmt::Print { expr, .. } => {
-            lines.push(render_value(&eval_expr(expr, functions, env)?));
+            let value = eval_expr(expr, functions, env, lines)?;
+            lines.push(OutputLine::stdout(render_value(&value)));
             Ok(None)
         }
         Stmt::If {
@@ -101,7 +105,7 @@ fn eval_stmt(
             else_block,
             ..
         } => {
-            let branch = match eval_expr(cond, functions, env)? {
+            let branch = match eval_expr(cond, functions, env, lines)? {
                 SpikeValue::Bool(true) => Some(then_block.as_slice()),
                 SpikeValue::Bool(false) => else_block.as_deref(),
                 _ => return Err(unsupported("if conditions must be boolean")),
@@ -112,7 +116,7 @@ fn eval_stmt(
                 Ok(None)
             }
         }
-        Stmt::While { cond, .. } => match eval_expr(cond, functions, env)? {
+        Stmt::While { cond, .. } => match eval_expr(cond, functions, env, lines)? {
             SpikeValue::Bool(false) => Ok(None),
             SpikeValue::Bool(true) => Err(unsupported(
                 "runtime loops are not part of the cranelift hello spike",
@@ -120,7 +124,7 @@ fn eval_stmt(
             _ => Err(unsupported("while conditions must be boolean")),
         },
         Stmt::Match { expr, arms, .. } => eval_match_stmt(expr, arms, functions, env, lines),
-        Stmt::Return { expr, .. } => Ok(Some(eval_expr(expr, functions, env)?)),
+        Stmt::Return { expr, .. } => Ok(Some(eval_expr(expr, functions, env, lines)?)),
         Stmt::Assign { .. } | Stmt::Panic { .. } | Stmt::Defer { .. } => Err(unsupported(
             "only let, print, if, while false, match, and return statements are supported by the cranelift hello spike",
         )),
@@ -131,6 +135,7 @@ fn eval_expr(
     expr: &Expr,
     functions: &HashMap<&str, &Function>,
     env: &SpikeEnv,
+    lines: &mut Vec<OutputLine>,
 ) -> Result<SpikeValue, Diagnostic> {
     match expr {
         Expr::Literal(LiteralValue::Int(value)) => Ok(SpikeValue::Int(*value)),
@@ -143,34 +148,41 @@ fn eval_expr(
             .get(name)
             .cloned()
             .ok_or_else(|| unsupported(&format!("unknown cranelift spike variable {name:?}"))),
-        Expr::Call { name, args, .. } => eval_call(name, args, functions, env),
-        Expr::BinaryAdd { op, lhs, rhs, ty } => eval_arithmetic(*op, lhs, rhs, ty, functions, env),
+        Expr::Call { name, args, .. } => eval_call(name, args, functions, env, lines),
+        Expr::BinaryAdd { op, lhs, rhs, ty } => {
+            eval_arithmetic(*op, lhs, rhs, ty, functions, env, lines)
+        }
         Expr::BinaryCompare {
             op,
             lhs,
             rhs,
             ty: _,
-        } => eval_compare(*op, lhs, rhs, functions, env),
+        } => eval_compare(*op, lhs, rhs, functions, env, lines),
         Expr::BinaryLogic { op, lhs, rhs, .. } => {
-            let left = expect_bool(eval_expr(lhs, functions, env)?)?;
+            let left = expect_bool(eval_expr(lhs, functions, env, lines)?)?;
             match op {
                 crate::mir::LogicOp::And if !left => Ok(SpikeValue::Bool(false)),
                 crate::mir::LogicOp::Or if left => Ok(SpikeValue::Bool(true)),
                 crate::mir::LogicOp::And | crate::mir::LogicOp::Or => Ok(SpikeValue::Bool(
-                    expect_bool(eval_expr(rhs, functions, env)?)?,
+                    expect_bool(eval_expr(rhs, functions, env, lines)?)?,
                 )),
             }
         }
-        Expr::Cast { expr, ty } => cast_spike_value(eval_expr(expr, functions, env)?, ty),
+        Expr::Cast { expr, ty } => cast_spike_value(eval_expr(expr, functions, env, lines)?, ty),
         Expr::StructLiteral { name, fields, .. } => fields
             .iter()
-            .map(|field| Ok((field.name.clone(), eval_expr(&field.expr, functions, env)?)))
+            .map(|field| {
+                Ok((
+                    field.name.clone(),
+                    eval_expr(&field.expr, functions, env, lines)?,
+                ))
+            })
             .collect::<Result<Vec<_>, _>>()
             .map(|fields| SpikeValue::Struct {
                 name: name.clone(),
                 fields,
             }),
-        Expr::FieldAccess { base, field, .. } => match eval_expr(base, functions, env)? {
+        Expr::FieldAccess { base, field, .. } => match eval_expr(base, functions, env, lines)? {
             SpikeValue::Struct { name, fields } => fields
                 .into_iter()
                 .find_map(|(candidate, value)| (candidate == *field).then_some(value))
@@ -189,7 +201,7 @@ fn eval_expr(
             ..
         } => payloads
             .iter()
-            .map(|payload| eval_expr(payload, functions, env))
+            .map(|payload| eval_expr(payload, functions, env, lines))
             .collect::<Result<Vec<_>, _>>()
             .map(|payloads| SpikeValue::Enum {
                 enum_name: enum_name.clone(),
@@ -197,13 +209,13 @@ fn eval_expr(
                 field_names: field_names.clone(),
                 payloads,
             }),
-        Expr::Match { expr, arms, .. } => eval_match_expr(expr, arms, functions, env),
+        Expr::Match { expr, arms, .. } => eval_match_expr(expr, arms, functions, env, lines),
         Expr::TupleLiteral { elements, .. } => elements
             .iter()
-            .map(|element| eval_expr(element, functions, env))
+            .map(|element| eval_expr(element, functions, env, lines))
             .collect::<Result<Vec<_>, _>>()
             .map(SpikeValue::Tuple),
-        Expr::TupleIndex { base, index, .. } => match eval_expr(base, functions, env)? {
+        Expr::TupleIndex { base, index, .. } => match eval_expr(base, functions, env, lines)? {
             SpikeValue::Tuple(elements) => elements
                 .get(*index)
                 .cloned()
@@ -213,22 +225,22 @@ fn eval_expr(
         Expr::MapLiteral { entries, .. } => {
             let mut values = Vec::new();
             for entry in entries {
-                let key = eval_expr(&entry.key, functions, env)?;
+                let key = eval_expr(&entry.key, functions, env, lines)?;
                 validate_map_key(&key)?;
-                let value = eval_expr(&entry.value, functions, env)?;
+                let value = eval_expr(&entry.value, functions, env, lines)?;
                 insert_map_entry(&mut values, key, value)?;
             }
             Ok(SpikeValue::Map(values))
         }
         Expr::ArrayLiteral { elements, .. } => elements
             .iter()
-            .map(|element| eval_expr(element, functions, env))
+            .map(|element| eval_expr(element, functions, env, lines))
             .collect::<Result<Vec<_>, _>>()
             .map(SpikeValue::Array),
         Expr::Slice {
             base, start, end, ..
         } => {
-            let elements = match eval_expr(base, functions, env)? {
+            let elements = match eval_expr(base, functions, env, lines)? {
                 SpikeValue::Array(elements) => elements,
                 _ => {
                     return Err(unsupported(
@@ -237,11 +249,11 @@ fn eval_expr(
                 }
             };
             let start = match start {
-                Some(expr) => expect_non_negative_index(eval_expr(expr, functions, env)?)?,
+                Some(expr) => expect_non_negative_index(eval_expr(expr, functions, env, lines)?)?,
                 None => 0,
             };
             let end = match end {
-                Some(expr) => expect_non_negative_index(eval_expr(expr, functions, env)?)?,
+                Some(expr) => expect_non_negative_index(eval_expr(expr, functions, env, lines)?)?,
                 None => elements.len(),
             };
             if start > end || end > elements.len() {
@@ -249,16 +261,16 @@ fn eval_expr(
             }
             Ok(SpikeValue::Array(elements[start..end].to_vec()))
         }
-        Expr::Index { base, index, .. } => match eval_expr(base, functions, env)? {
+        Expr::Index { base, index, .. } => match eval_expr(base, functions, env, lines)? {
             SpikeValue::Array(elements) => {
-                let index = expect_non_negative_index(eval_expr(index, functions, env)?)?;
+                let index = expect_non_negative_index(eval_expr(index, functions, env, lines)?)?;
                 elements
                     .get(index)
                     .cloned()
                     .ok_or_else(|| unsupported("array index is outside the array length"))
             }
             SpikeValue::Map(entries) => {
-                let key = eval_expr(index, functions, env)?;
+                let key = eval_expr(index, functions, env, lines)?;
                 validate_map_key(&key)?;
                 for (candidate, value) in entries {
                     if map_keys_equal(&candidate, &key)? {
@@ -280,9 +292,9 @@ fn eval_match_stmt(
     arms: &[MatchArm],
     functions: &HashMap<&str, &Function>,
     env: &SpikeEnv,
-    lines: &mut Vec<String>,
+    lines: &mut Vec<OutputLine>,
 ) -> Result<Option<SpikeValue>, Diagnostic> {
-    let matched = expect_enum_value(eval_expr(expr, functions, env)?)?;
+    let matched = expect_enum_value(eval_expr(expr, functions, env, lines)?)?;
     let arm = arms
         .iter()
         .find(|arm| arm.enum_name == matched.enum_name && arm.variant == matched.variant)
@@ -305,8 +317,9 @@ fn eval_match_expr(
     arms: &[MatchExprArm],
     functions: &HashMap<&str, &Function>,
     env: &SpikeEnv,
+    lines: &mut Vec<OutputLine>,
 ) -> Result<SpikeValue, Diagnostic> {
-    let matched = expect_enum_value(eval_expr(expr, functions, env)?)?;
+    let matched = expect_enum_value(eval_expr(expr, functions, env, lines)?)?;
     let arm = arms
         .iter()
         .find(|arm| arm.enum_name == matched.enum_name && arm.variant == matched.variant)
@@ -319,7 +332,7 @@ fn eval_match_expr(
         &matched.field_names,
         &matched.payloads,
     )?;
-    eval_expr(&arm.expr, functions, &arm_env)
+    eval_expr(&arm.expr, functions, &arm_env, lines)
 }
 
 struct MatchedEnum {
@@ -498,18 +511,22 @@ fn eval_call(
     args: &[Expr],
     functions: &HashMap<&str, &Function>,
     env: &SpikeEnv,
+    lines: &mut Vec<OutputLine>,
 ) -> Result<SpikeValue, Diagnostic> {
     if name == "len" {
-        return eval_len_call(args, functions, env);
+        return eval_len_call(args, functions, env, lines);
     }
     if name == "first" || name == "last" {
-        return eval_first_last_call(name, args, functions, env);
+        return eval_first_last_call(name, args, functions, env, lines);
     }
     if name == "contains" || name == "map_contains_key" {
-        return eval_map_contains_call(args, functions, env);
+        return eval_map_contains_call(args, functions, env, lines);
+    }
+    if name == "io_eprintln" {
+        return eval_io_eprintln_call(args, functions, env, lines);
     }
     if name == "crypto_sha256" {
-        return eval_crypto_sha256_call(args, functions, env);
+        return eval_crypto_sha256_call(args, functions, env, lines);
     }
     if name == "env_get" {
         return eval_env_get_call(args, functions, env);
@@ -522,15 +539,9 @@ fn eval_call(
     }
     let mut local_env = env.clone();
     for (param, arg) in function.params.iter().zip(args) {
-        local_env.insert(param.name.clone(), eval_expr(arg, functions, env)?);
+        local_env.insert(param.name.clone(), eval_expr(arg, functions, env, lines)?);
     }
-    let mut lines = Vec::new();
-    let returned = eval_block(&function.body, functions, &mut local_env, &mut lines)?;
-    if !lines.is_empty() {
-        return Err(unsupported(
-            "functions with print side effects are not part of the cranelift hello spike",
-        ));
-    }
+    let returned = eval_block(&function.body, functions, &mut local_env, lines)?;
     returned.ok_or_else(|| unsupported("cranelift spike functions must return a value"))
 }
 
@@ -538,11 +549,12 @@ fn eval_len_call(
     args: &[Expr],
     functions: &HashMap<&str, &Function>,
     env: &SpikeEnv,
+    lines: &mut Vec<OutputLine>,
 ) -> Result<SpikeValue, Diagnostic> {
     let [arg] = args else {
         return Err(unsupported("len expects exactly one argument"));
     };
-    let value = eval_expr(arg, functions, env)?;
+    let value = eval_expr(arg, functions, env, lines)?;
     let len = match value {
         // Match the generated-Rust backend, which lowers `len(...)` to Rust
         // `.len()` (encoded byte length). Using char count here would diverge
@@ -559,6 +571,7 @@ fn eval_first_last_call(
     args: &[Expr],
     functions: &HashMap<&str, &Function>,
     env: &SpikeEnv,
+    lines: &mut Vec<OutputLine>,
 ) -> Result<SpikeValue, Diagnostic> {
     let [arg] = args else {
         return Err(unsupported(&format!("{name} expects exactly one argument")));
@@ -566,7 +579,7 @@ fn eval_first_last_call(
     // HIR restricts `first`/`last` to arrays and slices and returns the element
     // directly (it panics at runtime on an empty collection). The spike models
     // owned arrays and evaluated array slices with the same value shape.
-    let elements = match eval_expr(arg, functions, env)? {
+    let elements = match eval_expr(arg, functions, env, lines)? {
         SpikeValue::Array(elements) => elements,
         _ => {
             return Err(unsupported(&format!(
@@ -588,15 +601,16 @@ fn eval_map_contains_call(
     args: &[Expr],
     functions: &HashMap<&str, &Function>,
     env: &SpikeEnv,
+    lines: &mut Vec<OutputLine>,
 ) -> Result<SpikeValue, Diagnostic> {
     let [map, key] = args else {
         return Err(unsupported("map contains expects exactly two arguments"));
     };
-    let entries = match eval_expr(map, functions, env)? {
+    let entries = match eval_expr(map, functions, env, lines)? {
         SpikeValue::Map(entries) => entries,
         _ => return Err(unsupported("map contains expects a map value")),
     };
-    let key = eval_expr(key, functions, env)?;
+    let key = eval_expr(key, functions, env, lines)?;
     validate_map_key(&key)?;
     let contains = entries.iter().try_fold(false, |found, (candidate, _)| {
         Ok::<_, Diagnostic>(found || map_keys_equal(candidate, &key)?)
@@ -608,11 +622,12 @@ fn eval_crypto_sha256_call(
     args: &[Expr],
     functions: &HashMap<&str, &Function>,
     env: &SpikeEnv,
+    lines: &mut Vec<OutputLine>,
 ) -> Result<SpikeValue, Diagnostic> {
     let [arg] = args else {
         return Err(unsupported("crypto_sha256 expects exactly one argument"));
     };
-    let input = match eval_expr(arg, functions, env)? {
+    let input = match eval_expr(arg, functions, env, lines)? {
         SpikeValue::Text(value) => value,
         _ => return Err(unsupported("crypto_sha256 expects a string argument")),
     };
@@ -710,7 +725,6 @@ fn sha256_hex(input: &str) -> String {
     output
 }
 
-fn eval_env_get_call(
     args: &[Expr],
     functions: &HashMap<&str, &Function>,
     env: &SpikeEnv,
@@ -743,16 +757,33 @@ fn option_text(value: Option<String>) -> SpikeValue {
     }
 }
 
-fn eval_arithmetic(
+fn eval_io_eprintln_call(
+    functions: &HashMap<&str, &Function>,
+    env: &SpikeEnv,
+    lines: &mut Vec<OutputLine>,
+) -> Result<SpikeValue, Diagnostic> {
+    let [arg] = args else {
+        return Err(unsupported("io_eprintln expects exactly one argument"));
+    };
+    let text = match eval_expr(arg, functions, env, lines)? {
+        SpikeValue::Text(value) => value,
+        _ => return Err(unsupported("io_eprintln expects a string")),
+    };
+    let written = text.len() as i64 + 1;
+    lines.push(OutputLine::stderr(text));
+    Ok(SpikeValue::Int(written))
+}
+
     op: ArithmeticOp,
     lhs: &Expr,
     rhs: &Expr,
     ty: &Type,
     functions: &HashMap<&str, &Function>,
     env: &SpikeEnv,
+    lines: &mut Vec<OutputLine>,
 ) -> Result<SpikeValue, Diagnostic> {
-    let left = eval_expr(lhs, functions, env)?;
-    let right = eval_expr(rhs, functions, env)?;
+    let left = eval_expr(lhs, functions, env, lines)?;
+    let right = eval_expr(rhs, functions, env, lines)?;
     match (ty, left, right) {
         (Type::Int, SpikeValue::Int(left), SpikeValue::Int(right)) => {
             let value = match op {
@@ -884,9 +915,10 @@ fn eval_compare(
     rhs: &Expr,
     functions: &HashMap<&str, &Function>,
     env: &SpikeEnv,
+    lines: &mut Vec<OutputLine>,
 ) -> Result<SpikeValue, Diagnostic> {
-    let left = eval_expr(lhs, functions, env)?;
-    let right = eval_expr(rhs, functions, env)?;
+    let left = eval_expr(lhs, functions, env, lines)?;
+    let right = eval_expr(rhs, functions, env, lines)?;
     let result = match (left, right) {
         (SpikeValue::Int(left), SpikeValue::Int(right)) => compare_ord(op, left, right),
         (SpikeValue::UInt(left), SpikeValue::UInt(right)) => compare_ord(op, left, right),
@@ -1192,8 +1224,11 @@ mod tests {
     #[test]
     fn folds_hello_subset_into_print_lines() {
         assert_eq!(
-            collect_print_lines(&hello_program()).expect("fold hello"),
-            vec![String::from("hello from stage1"), String::from("42")]
+            collect_output_lines(&hello_program()).expect("fold hello"),
+            vec![
+                OutputLine::stdout("hello from stage1"),
+                OutputLine::stdout("42")
+            ]
         );
     }
 }

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -529,7 +529,7 @@ fn eval_call(
         return eval_crypto_sha256_call(args, functions, env, lines);
     }
     if name == "env_get" {
-        return eval_env_get_call(args, functions, env);
+        return eval_env_get_call(args, functions, env, lines);
     }
     let function = functions
         .get(name)
@@ -725,14 +725,16 @@ fn sha256_hex(input: &str) -> String {
     output
 }
 
+fn eval_env_get_call(
     args: &[Expr],
     functions: &HashMap<&str, &Function>,
     env: &SpikeEnv,
+    lines: &mut Vec<OutputLine>,
 ) -> Result<SpikeValue, Diagnostic> {
     let [name] = args else {
         return Err(unsupported("env_get expects exactly one argument"));
     };
-    let name = match eval_expr(name, functions, env)? {
+    let name = match eval_expr(name, functions, env, lines)? {
         SpikeValue::Text(value) => value,
         _ => return Err(unsupported("env_get expects a string argument")),
     };
@@ -758,6 +760,7 @@ fn option_text(value: Option<String>) -> SpikeValue {
 }
 
 fn eval_io_eprintln_call(
+    args: &[Expr],
     functions: &HashMap<&str, &Function>,
     env: &SpikeEnv,
     lines: &mut Vec<OutputLine>,
@@ -774,6 +777,7 @@ fn eval_io_eprintln_call(
     Ok(SpikeValue::Int(written))
 }
 
+fn eval_arithmetic(
     op: ArithmeticOp,
     lhs: &Expr,
     rhs: &Expr,

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -1482,19 +1482,115 @@ fn write_sync_primitives_project(project: &Path) {
     fs::create_dir_all(project.join("src")).expect("create sync primitives project src");
     fs::write(
         project.join("axiom.toml"),
-        "[package]\nname = \"cranelift-sync-primitives\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
+        r#"[package]
+name = "cranelift-sync-primitives"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false
+"#,
     )
     .expect("write sync primitives manifest");
     fs::write(
         project.join("axiom.lock"),
-        "version = 1\n\n[[package]]\nname = \"cranelift-sync-primitives\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+        r#"version = 1
+
+[[package]]
+name = "cranelift-sync-primitives"
+version = "0.1.0"
+source = "path"
+"#,
     )
     .expect("write sync primitives lockfile");
     fs::write(
         project.join("src/main.ax"),
-        "import \"std/sync.ax\"\n\nlet counter: Mutex<int> = mutex<int>(1)\nlet guard: MutexGuard<int> = lock<int>(counter)\nlet updated: Mutex<int> = replace<int>(guard, 2)\nlet final_guard: MutexGuard<int> = lock<int>(updated)\nprint into_inner<int>(final_guard)\n\nlet ready: Once<string> = once_with<string>(\"configured\")\nprint once_is_set<string>(ready)\n\nlet empty: Once<int> = once<int>(None)\nmatch once_take<int>(empty) {\nSome(value) {\nprint value\n}\nNone {\nprint \"empty\"\n}\n}\n\nlet channel: Channel<string> = channel<string>(None)\nlet sent: Channel<string> = send<string>(channel, \"message\")\nmatch try_recv<string>(sent) {\nSome(message) {\nprint message\n}\nNone {\nprint \"missing\"\n}\n}\n",
+        r#"import "std/sync.ax"
+
+let counter: Mutex<int> = mutex<int>(1)
+let guard: MutexGuard<int> = lock<int>(counter)
+let updated: Mutex<int> = replace<int>(guard, 2)
+let final_guard: MutexGuard<int> = lock<int>(updated)
+print into_inner<int>(final_guard)
+
+let ready: Once<string> = once_with<string>("configured")
+print once_is_set<string>(ready)
+
+let empty: Once<int> = once<int>(None)
+match once_take<int>(empty) {
+Some(value) {
+print value
+}
+None {
+print "empty"
+}
+}
+
+let channel: Channel<string> = channel<string>(None)
+let sent: Channel<string> = send<string>(channel, "message")
+match try_recv<string>(sent) {
+Some(message) {
+print message
+}
+None {
+print "missing"
+}
+}
+"#,
     )
     .expect("write sync primitives source");
+}
+
+fn write_logging_stdio_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create logging stdio project src");
+    fs::write(
+        project.join("axiom.toml"),
+        r#"[package]
+name = "cranelift-logging-stdio"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false
+"#,
+    )
+    .expect("write logging stdio manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        r#"version = 1
+
+[[package]]
+name = "cranelift-logging-stdio"
+version = "0.1.0"
+source = "path"
+"#,
+    )
+    .expect("write logging stdio lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        r#"import "std/io.ax"
+
+let direct: int = eprintln("hello stderr")
+print direct > 0
+"#,
+    )
+    .expect("write logging stdio source");
 }
 
 fn write_fs_denial_project(project: &Path) {

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -813,6 +813,50 @@ fn cranelift_backend_builds_sync_primitives_binary() {
 
 #[cfg(not(windows))]
 #[test]
+fn cranelift_backend_builds_logging_stdio_binary() {
+    if which::which("cc").is_err() {
+        eprintln!("skipping cranelift backend smoke test because cc is unavailable");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("logging-stdio");
+    write_logging_stdio_project(&project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+    assert!(
+        output.status.success(),
+        "cranelift logging stdio build failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
+    assert_eq!(payload["backend"], "cranelift");
+    let binary = payload["binary"].as_str().expect("binary path");
+    let run = Command::new(binary)
+        .output()
+        .expect("run cranelift logging stdio binary");
+    assert!(
+        run.status.success(),
+        "cranelift logging stdio binary failed: stderr={}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&run.stdout), "true\n");
+    assert_eq!(String::from_utf8_lossy(&run.stderr), "hello stderr\n");
+}
+
+#[cfg(not(windows))]
+#[test]
 fn cranelift_backend_rejects_float_map_keys() {
     let temp = tempfile::tempdir().expect("tempdir");
     let project = temp.path().join("float-map-key");

--- a/stage1/runtime-abi/direct-native-v0.json
+++ b/stage1/runtime-abi/direct-native-v0.json
@@ -223,9 +223,11 @@
     },
     {
       "id": "io.logging_stdio",
-      "status": "blocked",
+      "status": "partial",
       "capability": null,
-      "blockers": [928]
+      "evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
+      "blockers": [928],
+      "notes": "The Cranelift spike now builds and runs std/io eprintln with stdout and stderr output from the native binary. Stdin reads, std/log wrappers, and broader streaming/runtime buffering remain open."
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add stream-aware Cranelift output lines so the direct-native spike can emit stdout and stderr from the native binary.
- Add a focused `std/io.ax` `eprintln` Cranelift smoke test for the `io.logging_stdio` runtime ABI row.
- Mark `io.logging_stdio` partial in the ABI matrix and document the remaining stdin, `std/log.ax`, and broader streaming gaps.

## Governing Issue

Refs #928

## Validation

- [x] Relevant local checks passed
  - `cargo test --manifest-path stage1/Cargo.toml -p axiomc-backend-cranelift links_stdout_and_stderr_lines -- --nocapture`
  - `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend logging_stdio -- --nocapture`
  - `python3 -m json.tool stage1/runtime-abi/direct-native-v0.json >/dev/null && make stage1-direct-native-runtime-abi`
  - `cargo check --manifest-path stage1/Cargo.toml -p axiomc -p axiomc-backend-cranelift`
  - `git diff --check`
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
  - No semantic node types added or changed.
- [x] Schemas added/changed are listed, or this PR does not touch schemas
  - No schemas added or changed.
- [x] Evidence added/changed is listed, or this PR does not touch evidence
  - Added Cranelift backend evidence for native stdout/stderr stream emission and `std/io.ax` `eprintln`.
  - Updated `stage1/runtime-abi/direct-native-v0.json` and `docs/direct-native-runtime-abi-v0.md` for `io.logging_stdio`.
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
  - Backend-specific behavior is documented as Cranelift/direct-native partial evidence; Axiom runtime semantics are not defined in Rust-specific terms.
- [x] Agent-facing inspection impact is described, or there is no inspection impact
  - Agent-facing ABI inspection now reports partial `io.logging_stdio` evidence instead of a fully blocked row.

## Flow Contract

- Owner lane: daedalus
- Repair owner: codex
- Autonomy class: agent-executed issue slice
- Risk class: medium

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

## Merge Automation

- [x] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- This intentionally leaves stdin reads, `std/log.ax` wrappers, and broader streaming/runtime buffering open under #928.
