### PR TITLE
Add direct-native fs write denial evidence

### DIFF
--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -93,6 +93,11 @@ now has denial evidence: a package that calls `std/net.ax`
 `tcp_listen_loopback_once(...)` without the `net` capability must receive the
 public manifest-policy denial before any backend-specific lowering diagnostic.
 
+The filesystem write row is still blocked for positive direct-native runtime
+execution, but now has denial evidence: a package with `fs = true` and
+`"fs:write" = false` that calls `std/fs.ax` `write_file(...)` must receive the
+public manifest-policy denial before any backend-specific lowering diagnostic.
+
 The direct-native crypto hash slice is still marked partial: the Cranelift
 spike can build and run `std/crypto_hash.ax` `sha256(...)` without generated
 Rust, and crypto capability denials still happen before backend lowering. MAC,

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -909,6 +909,82 @@ fn cranelift_backend_rejects_tcp_denial_before_backend_lowering() {
     );
 }
 
+#[test]
+fn cranelift_backend_rejects_fs_write_denial_before_backend_lowering() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("fs-write-denied");
+    write_fs_write_denial_project(&project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+
+    assert!(
+        !output.status.success(),
+        "cranelift fs-write denied build unexpectedly succeeded: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("requires [capabilities].fs:write = true"),
+        "expected fs:write capability denial before backend lowering, got: {combined}"
+    );
+    assert!(
+        !combined.contains("unsupported by --backend cranelift spike"),
+        "capability denial should happen before cranelift unsupported-feature lowering: {combined}"
+    );
+}
+
+#[test]
+fn cranelift_backend_rejects_process_denial_before_backend_lowering() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("process-denied");
+    write_process_denial_project(&project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+
+    assert!(
+        !output.status.success(),
+        "cranelift process denied build unexpectedly succeeded: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("requires [capabilities].process = true"),
+        "expected process capability denial before backend lowering, got: {combined}"
+    );
+    assert!(
+        !combined.contains("unsupported by --backend cranelift spike"),
+        "capability denial must happen before backend lowering: {combined}"
+    );
+}
+
 fn copy_fixture(relative: &str, destination: &Path) {
     let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../../examples/hello")
@@ -1225,4 +1301,23 @@ fn write_process_denial_project(project: &Path) {
         "import \"std/process.ax\"\nprint run_status(\"/usr/bin/true\")\n",
     )
     .expect("write process denied source");
+}
+
+fn write_fs_write_denial_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create fs write denied project src");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"cranelift-fs-write-denied\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = true\n\"fs:write\" = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
+    )
+    .expect("write fs write denied manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-fs-write-denied\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write fs write denied lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "import \"std/fs.ax\"\nprint write_file(\"out.txt\", \"content\")\n",
+    )
+    .expect("write fs write denied source");
 }

--- a/stage1/runtime-abi/direct-native-v0.json
+++ b/stage1/runtime-abi/direct-native-v0.json
@@ -91,7 +91,8 @@
       "id": "fs.write",
       "status": "blocked",
       "capability": "fs:write",
-      "blockers": [928]
+      "blockers": [928],
+      "denial_evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"]
     },
     {
       "id": "network.dns.resolve",


### PR DESCRIPTION
## Summary

- Add a Cranelift/direct-native regression proving `std/fs.ax` write helpers with `fs = true` and `"fs:write" = false` fail through the public manifest-policy denial before backend lowering.
- Record `fs.write` denial evidence in `stage1/runtime-abi/direct-native-v0.json` while keeping the row blocked for positive direct-native runtime execution.
- Update the direct-native ABI notes so the blocked/denial split is visible to agents tracking Rust-exit progress.

## Governing Issue

Addresses part of #928

## Validation

- [x] Relevant local checks passed
  - `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend fs_write -- --nocapture`
  - `python3 -m json.tool stage1/runtime-abi/direct-native-v0.json >/dev/null && make stage1-direct-native-runtime-abi`
  - `cargo check --manifest-path stage1/Cargo.toml -p axiomc`
  - `git diff --check`
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
  - Semantic node types added/changed: none.
- [x] Schemas added/changed are listed, or this PR does not touch schemas
  - Schemas added/changed: none.
- [x] Evidence added/changed is listed, or this PR does not touch evidence
  - Evidence added/changed: `fs.write` denial evidence in `stage1/crates/axiomc/tests/cranelift_backend.rs` and `stage1/runtime-abi/direct-native-v0.json`.
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
  - Rust capture risk: none; the ABI remains Axiom-neutral and the row stays blocked for positive direct-native runtime execution.
- [x] Agent-facing inspection impact is described, or there is no inspection impact
  - Agent-facing inspection impact: the #928 ABI matrix can now distinguish `fs.write` denial coverage from the still-missing positive direct-native write shim.

## Flow Contract

- Owner lane: compiler/runtime
- Repair owner: Codex
- Autonomy class: issue-scoped repair
- Risk class: low

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

## Merge Automation

- [x] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- `make stage1-direct-native-runtime-abi` is expected to report `ready: false` until the remaining #928 runtime ABI rows are implemented.
- This PR intentionally does not claim positive `fs.write` direct-native runtime support.
