### PR TITLE
Add direct-native HTTP client denial evidence

### DIFF
--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -103,6 +103,12 @@ spike can build and run `std/crypto_hash.ax` `sha256(...)` without generated
 Rust, and crypto capability denials still happen before backend lowering. MAC,
 random, signature, AEAD, and broader crypto audit parity remain blocked.
 
+The HTTP client row remains blocked for positive direct-native runtime support:
+the Cranelift spike does not yet lower `std/http.ax` `get(...)` into a native
+host-service entrypoint. The current evidence proves only that denied `net`
+capability use fails through the manifest policy before Cranelift lowering or
+native execution.
+
 The borrowed-slice row has partial direct-native evidence: the Cranelift spike
 now evaluates array-backed borrowed slices through `len`, `first`, `last`,
 indexing, and function returns. Broader borrowed-slice aliasing and host ABI

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -834,6 +834,44 @@ fn cranelift_backend_rejects_process_denial_before_backend_lowering() {
 }
 
 #[test]
+fn cranelift_backend_rejects_http_client_denial_before_backend_lowering() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("http-client-denied");
+    write_http_client_denial_project(&project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+
+    assert!(
+        !output.status.success(),
+        "cranelift http client denial build unexpectedly succeeded: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("requires [capabilities].net = true"),
+        "expected net capability denial before backend lowering, got: {combined}"
+    );
+    assert!(
+        !combined.contains("unsupported by --backend cranelift spike"),
+        "capability denial should happen before cranelift unsupported-feature lowering: {combined}"
+    );
+}
+
+#[test]
 fn cranelift_backend_rejects_capability_denial_before_backend_lowering() {
     let temp = tempfile::tempdir().expect("tempdir");
     let project = temp.path().join("fs-denied");

--- a/stage1/runtime-abi/direct-native-v0.json
+++ b/stage1/runtime-abi/direct-native-v0.json
@@ -117,7 +117,8 @@
       "id": "network.http.client",
       "status": "blocked",
       "capability": "net",
-      "blockers": [928]
+      "blockers": [928],
+      "denial_evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"]
     },
     {
       "id": "network.http.server",


### PR DESCRIPTION
## Summary

- Add a Cranelift/direct-native regression proving `std/http.ax` HTTP client use without the `net` capability fails through the public manifest-policy denial before backend lowering.
- Record `network.http.client` denial evidence in `stage1/runtime-abi/direct-native-v0.json` while keeping the row blocked for positive direct-native runtime execution.
- Update the direct-native ABI notes so agents can distinguish HTTP client denial coverage from the still-missing direct-native HTTP client runtime shim.

## Governing Issue

Addresses part of #928

## Validation

- [x] Relevant local checks passed
  - `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend http_client_denial -- --nocapture`
  - `python3 -m json.tool stage1/runtime-abi/direct-native-v0.json >/dev/null && make stage1-direct-native-runtime-abi`
  - `cargo check --manifest-path stage1/Cargo.toml -p axiomc`
  - `git diff --check`
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
  - Semantic node types added/changed: none.
- [x] Schemas added/changed are listed, or this PR does not touch schemas
  - Schemas added/changed: none.
- [x] Evidence added/changed is listed, or this PR does not touch evidence
  - Evidence added/changed: `network.http.client` denial evidence in `stage1/crates/axiomc/tests/cranelift_backend.rs` and `stage1/runtime-abi/direct-native-v0.json`.
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
  - Rust capture risk: none; the ABI remains Axiom-neutral and the row stays blocked for positive direct-native runtime execution.
- [x] Agent-facing inspection impact is described, or there is no inspection impact
  - Agent-facing inspection impact: the #928 ABI matrix can now distinguish HTTP client denial coverage from the still-missing positive direct-native HTTP client shim.

## Flow Contract

- Owner lane: compiler/runtime
- Repair owner: Codex
- Autonomy class: issue-scoped repair
- Risk class: low

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

## Merge Automation

- [x] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- `make stage1-direct-native-runtime-abi` is expected to report `ready: false` until the remaining #928 runtime ABI rows are implemented.
- This PR intentionally does not claim positive HTTP client direct-native runtime support.
