### PR TITLE
Reject lockfile dependency path escapes

### DIFF
--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -2776,6 +2776,11 @@ print 0
         fs::create_dir_all(project.join("members")).expect("create workspace members dir");
         create_project(&app, Some("workspace-app")).expect("create app member");
         create_project(&core, Some("workspace-core")).expect("create core member");
+        fs::write(
+            project.join("axiom.toml"),
+            "[workspace]\nmembers = [\"members/app\", \"members/core\"]\n",
+        )
+        .expect("write workspace-only manifest");
 
         fs::write(
             core.join("src/math.ax"),
@@ -2815,11 +2820,6 @@ print 0
         )
         .expect("write app lockfile");
 
-        fs::write(
-            project.join("axiom.toml"),
-            "[workspace]\nmembers = [\"members/app\", \"members/core\"]\n",
-        )
-        .expect("write workspace-only manifest");
         let root_manifest = load_manifest(&project).expect("load root manifest");
         assert!(root_manifest.is_workspace_only());
         let root_lockfile =
@@ -2940,6 +2940,11 @@ print first(values)\n",
         fs::create_dir_all(project.join("members")).expect("create workspace members dir");
         create_project(&app, Some("workspace-graph-app")).expect("create app member");
         create_project(&core, Some("workspace-graph-core")).expect("create core member");
+        fs::write(
+            project.join("axiom.toml"),
+            "[workspace]\nmembers = [\"members/app\", \"members/core\"]\n",
+        )
+        .expect("write workspace-only manifest");
 
         fs::write(
             app.join("axiom.toml"),
@@ -2961,11 +2966,6 @@ print first(values)\n",
             render_lockfile_for_project(&core, &core_manifest).expect("core lockfile"),
         )
         .expect("write core lockfile");
-        fs::write(
-            project.join("axiom.toml"),
-            "[workspace]\nmembers = [\"members/app\", \"members/core\"]\n",
-        )
-        .expect("write workspace-only manifest");
         let root_manifest = load_manifest(&project).expect("load root manifest");
         fs::write(
             project.join("axiom.lock"),
@@ -3226,6 +3226,42 @@ crypto = false
     }
 
     #[test]
+    fn lockfile_render_rejects_dependency_path_traversal() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("lockfile-dependency-boundary-root");
+        let outside = dir.path().join("outside-lockfile-dependency");
+        create_project(&project, Some("lockfile-dependency-boundary-root"))
+            .expect("create project");
+        create_project(&outside, Some("outside-lockfile-dependency"))
+            .expect("create outside dependency");
+        fs::write(
+            project.join("axiom.toml"),
+            format!(
+                "{}\n[dependencies]\noutside = {{ path = \"../outside-lockfile-dependency\" }}\n",
+                render_manifest("lockfile-dependency-boundary-root")
+            ),
+        )
+        .expect("write manifest");
+        let manifest = load_manifest(&project).expect("load manifest");
+
+        let error = render_lockfile_for_project(&project, &manifest)
+            .expect_err("lockfile dependency path escape should fail");
+
+        assert_eq!(error.kind, "manifest");
+        assert!(
+            error
+                .message
+                .contains("dependency path must stay inside the workspace")
+        );
+        assert!(
+            error
+                .path
+                .as_deref()
+                .is_some_and(|path| path.ends_with("axiom.toml"))
+        );
+    }
+
+    #[test]
     fn dependency_path_escape_conformance_fixture_reports_manifest_error() {
         let fixture = conformance_fixture().join("fail/dependency_path_escape");
 
@@ -3254,6 +3290,11 @@ crypto = false
         fs::create_dir_all(project.join("members")).expect("create workspace members dir");
         create_project(&app, Some("dependency-boundary-app")).expect("create app member");
         create_project(&core, Some("dependency-boundary-core")).expect("create core member");
+        fs::write(
+            project.join("axiom.toml"),
+            "[workspace]\nmembers = [\"members/app\", \"members/core\"]\n",
+        )
+        .expect("write workspace manifest");
         fs::write(
             core.join("src/math.ax"),
             "pub fn answer(): int {\nreturn 42\n}\n",
@@ -3284,11 +3325,6 @@ crypto = false
             render_lockfile_for_project(&app, &app_manifest).expect("app lockfile"),
         )
         .expect("write app lockfile");
-        fs::write(
-            project.join("axiom.toml"),
-            "[workspace]\nmembers = [\"members/app\", \"members/core\"]\n",
-        )
-        .expect("write workspace manifest");
         let root_manifest = load_manifest(&project).expect("load root manifest");
         fs::write(
             project.join("axiom.lock"),

--- a/stage1/crates/axiomc/src/lockfile.rs
+++ b/stage1/crates/axiomc/src/lockfile.rs
@@ -1,7 +1,8 @@
 use crate::diagnostics::Diagnostic;
-use crate::manifest::{DependencySpec, Manifest, load_manifest, lockfile_path};
+use crate::manifest::{DependencySpec, Manifest, load_manifest, lockfile_path, manifest_path};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
+use std::fs;
 use std::path::{Component, Path, PathBuf};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -124,8 +125,27 @@ pub fn validate_lockfile_packages(
     Ok(())
 }
 
-fn dependency_root(project_root: &Path, spec: &DependencySpec) -> PathBuf {
-    normalize_path(project_root.join(&spec.path))
+fn dependency_root(
+    root_project_root: &Path,
+    project_root: &Path,
+    spec: &DependencySpec,
+) -> Result<PathBuf, Diagnostic> {
+    let dependency_root = normalize_path(project_root.join(&spec.path));
+    let canonical_project_root = canonicalize_path(project_root, "dependency source package")?;
+    let canonical_dependency_root = canonicalize_path(&dependency_root, "dependency path")?;
+    let canonical_root_project_root = canonicalize_path(root_project_root, "package root")?;
+    if canonical_dependency_root.starts_with(&canonical_root_project_root)
+        || workspace_declares_dependency_member(&canonical_project_root, &canonical_dependency_root)
+    {
+        return Ok(dependency_root);
+    }
+    Err(
+        Diagnostic::new(
+            "manifest",
+            "dependency path must stay inside the workspace or package root; declare sibling packages as workspace members before depending on them",
+        )
+        .with_path(manifest_path(project_root).display().to_string()),
+    )
 }
 
 fn collect_dependency_packages(
@@ -136,7 +156,7 @@ fn collect_dependency_packages(
     packages: &mut Vec<LockedPackage>,
 ) -> Result<(), Diagnostic> {
     for spec in manifest.dependencies.values() {
-        let dependency_root = dependency_root(project_root, spec);
+        let dependency_root = dependency_root(root_project_root, project_root, spec)?;
         if !visited.insert(dependency_root.clone()) {
             continue;
         }
@@ -172,6 +192,42 @@ fn collect_dependency_packages(
         )?;
     }
     Ok(())
+}
+
+fn canonicalize_path(path: &Path, label: &str) -> Result<PathBuf, Diagnostic> {
+    fs::canonicalize(path).map_err(|err| {
+        Diagnostic::new(
+            "manifest",
+            format!("{label} {} is not accessible: {err}", path.display()),
+        )
+        .with_path(path.display().to_string())
+    })
+}
+
+fn workspace_declares_dependency_member(project_root: &Path, dependency_root: &Path) -> bool {
+    for ancestor in project_root.ancestors().skip(1) {
+        let manifest_file = manifest_path(ancestor);
+        if !manifest_file.exists() {
+            continue;
+        }
+        let Ok(manifest) = load_manifest(ancestor) else {
+            continue;
+        };
+        let Some(workspace) = manifest.workspace.as_ref() else {
+            continue;
+        };
+        let mut members = BTreeSet::new();
+        for member in &workspace.members {
+            let member_root = ancestor.join(member);
+            if let Ok(member_root) = fs::canonicalize(&member_root) {
+                members.insert(member_root);
+            }
+        }
+        if members.contains(project_root) && members.contains(dependency_root) {
+            return true;
+        }
+    }
+    false
 }
 
 fn collect_workspace_packages(


### PR DESCRIPTION
## Summary

- Reject lockfile dependency paths that canonicalize outside the package root unless the source and dependency packages are both declared members of an ancestor workspace.
- Preserve declared sibling workspace dependencies while closing the lockfile traversal path.
- Add a regression test that proves `render_lockfile_for_project` rejects an undeclared `..` dependency escape.

## Governing Issue

Closes #970

Refs #973

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Commands run:

- `cargo test --manifest-path stage1/Cargo.toml -p axiomc lockfile`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc dependency_path_escape_conformance_fixture_reports_manifest_error`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc dependency_paths_can_target_declared_workspace_members`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc workspace_only_manifest_supports_package_selection`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc package_graph_metadata_lists_workspace_packages`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc dependency_paths_must_stay_inside_workspace_boundary`
- `git diff --check -- stage1/crates/axiomc/src/lockfile.rs stage1/crates/axiomc/src/lib.rs`

Skipped checks:

- Full workspace test suite was not run; this patch is scoped to lockfile dependency resolution and related workspace dependency tests.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

Auto-merge note: not enabled from this branch; fallback merge-readiness applies once checks pass and approval/conversation requirements are satisfied.

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Semantic layer impact:

- Node types added/changed: none.
- Schemas added/changed: none.
- Evidence added/changed: none.
- Rust capture risk: reduced for lockfile generation by preventing undeclared dependency roots outside the package/workspace boundary.
- Agent-facing inspection impact: graph and lockfile inspection no longer parse arbitrary external `axiom.toml` files through undeclared dependency traversal.

## Flow Contract

- Owner lane: compiler/runtime
- Repair owner: Codex
- Autonomy class: autonomous issue repair
- Risk class: Medium security hardening

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is appropriate when gates pass

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

Auto-merge is not enabled because maintainer approval and branch-protection gates must complete first.

## Notes

- This intentionally allows sibling dependencies that are declared workspace members, because existing workspace package flows rely on `../member` paths.
