### PR TITLE
Harden generated HTTPS certificate verification

### DIFF
--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -2807,11 +2807,14 @@ fn axiom_openssl_tls_get(host: &str, port: u16, request: &str) -> Result<Vec<u8>
         c_int,
         Option<unsafe extern "C" fn(c_int, *mut c_void) -> c_int>,
     );
+    type SslCtxSetDefaultVerifyPaths = unsafe extern "C" fn(*mut SslCtx) -> c_int;
     type SslNew = unsafe extern "C" fn(*mut SslCtx) -> *mut Ssl;
     type SslFree = unsafe extern "C" fn(*mut Ssl);
     type SslSetFd = unsafe extern "C" fn(*mut Ssl, c_int) -> c_int;
+    type SslSet1Host = unsafe extern "C" fn(*mut Ssl, *const c_char) -> c_int;
     type SslCtrl = unsafe extern "C" fn(*mut Ssl, c_int, c_long, *mut c_void) -> c_long;
     type SslConnect = unsafe extern "C" fn(*mut Ssl) -> c_int;
+    type SslGetVerifyResult = unsafe extern "C" fn(*const Ssl) -> c_long;
     type SslWrite = unsafe extern "C" fn(*mut Ssl, *const c_void, c_int) -> c_int;
     type SslRead = unsafe extern "C" fn(*mut Ssl, *mut c_void, c_int) -> c_int;
     type SslShutdown = unsafe extern "C" fn(*mut Ssl) -> c_int;
@@ -2826,6 +2829,8 @@ fn axiom_openssl_tls_get(host: &str, port: u16, request: &str) -> Result<Vec<u8>
     }
 
     const RTLD_NOW: c_int = 2;
+    const SSL_VERIFY_PEER: c_int = 1;
+    const X509_V_OK: c_long = 0;
 
     struct OpenSsl {
         ssl_handle: *mut c_void,
@@ -2834,11 +2839,14 @@ fn axiom_openssl_tls_get(host: &str, port: u16, request: &str) -> Result<Vec<u8>
         ssl_ctx_new: SslCtxNew,
         ssl_ctx_free: SslCtxFree,
         ssl_ctx_set_verify: SslCtxSetVerify,
+        ssl_ctx_set_default_verify_paths: SslCtxSetDefaultVerifyPaths,
         ssl_new: SslNew,
         ssl_free: SslFree,
         ssl_set_fd: SslSetFd,
+        ssl_set1_host: SslSet1Host,
         ssl_ctrl: SslCtrl,
         ssl_connect: SslConnect,
+        ssl_get_verify_result: SslGetVerifyResult,
         ssl_write: SslWrite,
         ssl_read: SslRead,
         ssl_shutdown: SslShutdown,
@@ -2866,11 +2874,17 @@ fn axiom_openssl_tls_get(host: &str, port: u16, request: &str) -> Result<Vec<u8>
                 ssl_ctx_new: load_symbol(ssl_handle, "SSL_CTX_new")?,
                 ssl_ctx_free: load_symbol(ssl_handle, "SSL_CTX_free")?,
                 ssl_ctx_set_verify: load_symbol(ssl_handle, "SSL_CTX_set_verify")?,
+                ssl_ctx_set_default_verify_paths: load_symbol(
+                    ssl_handle,
+                    "SSL_CTX_set_default_verify_paths",
+                )?,
                 ssl_new: load_symbol(ssl_handle, "SSL_new")?,
                 ssl_free: load_symbol(ssl_handle, "SSL_free")?,
                 ssl_set_fd: load_symbol(ssl_handle, "SSL_set_fd")?,
+                ssl_set1_host: load_symbol(ssl_handle, "SSL_set1_host")?,
                 ssl_ctrl: load_symbol(ssl_handle, "SSL_ctrl")?,
                 ssl_connect: load_symbol(ssl_handle, "SSL_connect")?,
+                ssl_get_verify_result: load_symbol(ssl_handle, "SSL_get_verify_result")?,
                 ssl_write: load_symbol(ssl_handle, "SSL_write")?,
                 ssl_read: load_symbol(ssl_handle, "SSL_read")?,
                 ssl_shutdown: load_symbol(ssl_handle, "SSL_shutdown")?,
@@ -2984,7 +2998,13 @@ fn axiom_openssl_tls_get(host: &str, port: u16, request: &str) -> Result<Vec<u8>
             ctx,
             openssl: &openssl,
         };
-        (openssl.ssl_ctx_set_verify)(ctx.ctx, 0, None);
+        (openssl.ssl_ctx_set_verify)(ctx.ctx, SSL_VERIFY_PEER, None);
+        if (openssl.ssl_ctx_set_default_verify_paths)(ctx.ctx) != 1 {
+            return Err(format!(
+                "https TLS trust store setup failed: {}",
+                openssl_error(&openssl)
+            ));
+        }
 
         let ssl = (openssl.ssl_new)(ctx.ctx);
         if ssl.is_null() {
@@ -3003,11 +3023,23 @@ fn axiom_openssl_tls_get(host: &str, port: u16, request: &str) -> Result<Vec<u8>
                 openssl_error(&openssl)
             ));
         }
+        if (openssl.ssl_set1_host)(ssl.ssl, server_name.as_ptr()) != 1 {
+            return Err(format!(
+                "https TLS hostname setup failed: {}",
+                openssl_error(&openssl)
+            ));
+        }
         let _ = (openssl.ssl_ctrl)(ssl.ssl, 55, 0, server_name.as_ptr() as *mut c_void);
         if (openssl.ssl_connect)(ssl.ssl) != 1 {
             return Err(format!(
                 "https TLS handshake failed: {}",
                 openssl_error(&openssl)
+            ));
+        }
+        let verify_result = (openssl.ssl_get_verify_result)(ssl.ssl);
+        if verify_result != X509_V_OK {
+            return Err(format!(
+                "https TLS certificate verification failed: {verify_result}"
             ));
         }
 

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -1579,6 +1579,37 @@ Variant(
     }
 
     #[test]
+    fn render_rust_verifies_https_tls_certificates() {
+        let source = "match http_get(\"https://example.com/\") {\nSome(_body) {\nprint true\n}\nNone {\nprint false\n}\n}\n";
+        let parsed = parse_program(source, Path::new("main.ax")).expect("parse");
+        let hir = hir::lower_with_capabilities(
+            &parsed,
+            &CapabilityConfig {
+                net: true,
+                ..CapabilityConfig::default()
+            },
+        )
+        .expect("lower");
+        let mir = mir::lower(&hir);
+        let rendered = render_rust(&mir);
+        assert!(rendered.contains("const SSL_VERIFY_PEER: c_int = 1;"));
+        assert!(rendered.contains("const X509_V_OK: c_long = 0;"));
+        assert!(rendered.contains(
+            "ssl_ctx_set_default_verify_paths: load_symbol(\n                    ssl_handle,\n                    \"SSL_CTX_set_default_verify_paths\",\n                )?,"
+        ));
+        assert!(rendered.contains("(openssl.ssl_ctx_set_verify)(ctx.ctx, SSL_VERIFY_PEER, None);"));
+        assert!(rendered.contains("(openssl.ssl_ctx_set_default_verify_paths)(ctx.ctx) != 1"));
+        assert!(rendered.contains("ssl_set1_host: load_symbol(ssl_handle, \"SSL_set1_host\")?"));
+        assert!(rendered.contains("(openssl.ssl_set1_host)(ssl.ssl, server_name.as_ptr()) != 1"));
+        assert!(rendered.contains(
+            "ssl_get_verify_result: load_symbol(ssl_handle, \"SSL_get_verify_result\")?"
+        ));
+        assert!(rendered.contains("let verify_result = (openssl.ssl_get_verify_result)(ssl.ssl);"));
+        assert!(rendered.contains("if verify_result != X509_V_OK"));
+        assert!(!rendered.contains("(openssl.ssl_ctx_set_verify)(ctx.ctx, 0, None);"));
+    }
+
+    #[test]
     fn render_rust_strips_crlf_from_http_request_parts() {
         let source = "match http_get(\"http://example.com/\") {\nSome(_body) {\nprint true\n}\nNone {\nprint false\n}\n}\n";
         let parsed = parse_program(source, Path::new("main.ax")).expect("parse");


### PR DESCRIPTION
## Summary

- Enable OpenSSL peer certificate verification for generated-Rust HTTPS requests.
- Load default OpenSSL trust paths, bind the expected hostname before the handshake, and reject non-`X509_V_OK` verify results.
- Add generated-Rust regression coverage that rejects the previous `SSL_VERIFY_NONE` path.

## Governing Issue

Closes #966

## Validation

- [x] Relevant local checks passed
  - `cargo test --manifest-path stage1/Cargo.toml -p axiomc render_rust_verifies_https_tls_certificates`
  - `cargo test --manifest-path stage1/Cargo.toml -p axiomc render_rust`
- [ ] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below
  - `cargo fmt --manifest-path stage1/Cargo.toml --all --check` currently fails on pre-existing formatting in `stage1/crates/axiomc/src/cranelift_backend.rs` and the older `check_project_rejects_dynamic_stdlib_process_command_with_unrestricted_process` block in `stage1/crates/axiomc/src/lib.rs`; this PR's touched formatting was corrected.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
  - Backend-specific generated-Rust runtime behavior only.
- [x] Agent-facing inspection impact is described, or there is no inspection impact

## Flow Contract

- Owner lane: daedalus
- Repair owner: codex
- Autonomy class: agent-executable security repair
- Risk class: high

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is appropriate when gates pass

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- This keeps the existing dynamic OpenSSL bridge but makes HTTPS authentication fail closed instead of silently accepting arbitrary peer certificates.
