### PR TITLE
Fail closed on dynamic network targets

### DIFF
--- a/.github/workflows/pr-fast-ci.yml
+++ b/.github/workflows/pr-fast-ci.yml
@@ -78,8 +78,18 @@ jobs:
 
       - name: Ensure Rust linker availability
         run: |
+          smoke_linker() {
+            local linker="$1"
+            local smoke_rs smoke_bin
+            smoke_rs="${RUNNER_TEMP:-/tmp}/axiom-fast-ci-linker-smoke.rs"
+            smoke_bin="${RUNNER_TEMP:-/tmp}/axiom-fast-ci-linker-smoke"
+            printf '%s\n' 'fn main() {}' > "$smoke_rs"
+            rustc -C "linker=$linker" "$smoke_rs" -o "$smoke_bin" >/dev/null 2>&1
+          }
+
           for candidate in cc gcc clang; do
-            if command -v "$candidate" >/dev/null 2>&1; then
+            if rust_linker="$(command -v "$candidate" 2>/dev/null)" && [[ -n "$rust_linker" ]] && smoke_linker "$rust_linker"; then
+              echo "AXIOM_FAST_CI_RUST_LINKER=$rust_linker" >> "$GITHUB_ENV"
               echo "AXIOM_FAST_CI_PROOF_WORKLOADS=1" >> "$GITHUB_ENV"
               exit 0
             fi

--- a/.github/workflows/pr-fast-ci.yml
+++ b/.github/workflows/pr-fast-ci.yml
@@ -78,10 +78,12 @@ jobs:
 
       - name: Ensure Rust linker availability
         run: |
-          if command -v cc >/dev/null 2>&1; then
-            echo "AXIOM_FAST_CI_PROOF_WORKLOADS=1" >> "$GITHUB_ENV"
-            exit 0
-          fi
+          for candidate in cc gcc clang; do
+            if command -v "$candidate" >/dev/null 2>&1; then
+              echo "AXIOM_FAST_CI_PROOF_WORKLOADS=1" >> "$GITHUB_ENV"
+              exit 0
+            fi
+          done
 
           rust_lld="$(rustc --print sysroot)/lib/rustlib/$(rustc -vV | awk '/^host:/ { print $2 }')/bin/rust-lld"
           if [[ -x "$rust_lld" ]]; then

--- a/scripts/ci/run-fast-checks.sh
+++ b/scripts/ci/run-fast-checks.sh
@@ -27,16 +27,31 @@ if [[ "${AXIOM_FAST_CI_PROOF_WORKLOADS:-1}" != "1" ]]; then
 fi
 
 rust_linker="${AXIOM_FAST_CI_RUST_LINKER:-}"
-if [[ -z "$rust_linker" ]]; then
+smoke_linker() {
+  local linker="$1"
+  local smoke_rs smoke_bin
+  smoke_rs="${RUNNER_TEMP:-/tmp}/axiom-fast-ci-linker-smoke.rs"
+  smoke_bin="${RUNNER_TEMP:-/tmp}/axiom-fast-ci-linker-smoke"
+  printf '%s\n' 'fn main() {}' > "$smoke_rs"
+  rustc -C "linker=$linker" "$smoke_rs" -o "$smoke_bin" >/dev/null 2>&1
+}
+
+if [[ -n "$rust_linker" ]]; then
+  if [[ ! -x "$rust_linker" ]] || ! smoke_linker "$rust_linker"; then
+    echo "error: AXIOM_FAST_CI_RUST_LINKER must point to a usable Rust linker for PR fast checks." >&2
+    exit 1
+  fi
+else
   for candidate in cc gcc clang; do
-    if rust_linker="$(command -v "$candidate" 2>/dev/null)" && [[ -n "$rust_linker" ]]; then
+    if rust_linker="$(command -v "$candidate" 2>/dev/null)" && [[ -n "$rust_linker" ]] && smoke_linker "$rust_linker"; then
+      export AXIOM_FAST_CI_RUST_LINKER="$rust_linker"
       break
     fi
   done
 fi
 
-if [[ -z "$rust_linker" || ! -x "$rust_linker" ]]; then
-  echo "error: cc, gcc, clang, or AXIOM_FAST_CI_RUST_LINKER is required to run proof workloads in PR fast checks." >&2
+if [[ -z "$rust_linker" ]]; then
+  echo "error: no usable cc, gcc, clang, or AXIOM_FAST_CI_RUST_LINKER was found for PR fast checks." >&2
   exit 1
 fi
 

--- a/scripts/ci/run-fast-checks.sh
+++ b/scripts/ci/run-fast-checks.sh
@@ -26,12 +26,18 @@ if [[ "${AXIOM_FAST_CI_PROOF_WORKLOADS:-1}" != "1" ]]; then
   exit 1
 fi
 
-if ! command -v cc >/dev/null 2>&1; then
-  rust_linker="${AXIOM_FAST_CI_RUST_LINKER:-}"
-  if [[ -z "$rust_linker" || ! -x "$rust_linker" ]]; then
-    echo "error: cc or AXIOM_FAST_CI_RUST_LINKER is required to run proof workloads in PR fast checks." >&2
-    exit 1
-  fi
+rust_linker="${AXIOM_FAST_CI_RUST_LINKER:-}"
+if [[ -z "$rust_linker" ]]; then
+  for candidate in cc gcc clang; do
+    if rust_linker="$(command -v "$candidate" 2>/dev/null)" && [[ -n "$rust_linker" ]]; then
+      break
+    fi
+  done
+fi
+
+if [[ -z "$rust_linker" || ! -x "$rust_linker" ]]; then
+  echo "error: cc, gcc, clang, or AXIOM_FAST_CI_RUST_LINKER is required to run proof workloads in PR fast checks." >&2
+  exit 1
 fi
 
 for example in proof_cli proof_worker proof_http_service; do

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -13891,7 +13891,6 @@ fn validate_net_port_allowlist_hir(
 ) -> Result<(), Diagnostic> {
     if capabilities.net_ports.is_empty() {
         return match port {
-            _ if allow_dynamic_port => Ok(()),
             Expr::Literal {
                 value: LiteralValue::Int(value),
                 ..
@@ -13904,6 +13903,7 @@ fn validate_net_port_allowlist_hir(
                 format!("call to {intrinsic_name:?} requires a valid u16 port, got {value}"),
             )
             .with_span(line, column)),
+            _ if allow_dynamic_port => Ok(()),
             _ => Err(Diagnostic::new(
                 "capability",
                 format!(

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -14024,8 +14024,7 @@ fn validate_stdlib_network_wrapper_call_hir(
             &args[0],
             line,
             column,
-            ctx.current_path.ends_with("proof_http_service/src/server.ax")
-                && ctx.current_function.as_deref() == Some("serve_health"),
+            false,
         ),
         _ => Ok(()),
     }

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -14177,9 +14177,9 @@ mod tests {
             .expect_err("dynamic http target should fail closed");
 
         assert!(
-            error.message.contains(
-                "requires a static URL literal when [capabilities].net is unrestricted"
-            ),
+            error
+                .message
+                .contains("requires a static URL literal when [capabilities].net is unrestricted"),
             "unexpected diagnostic: {error:?}"
         );
     }

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -14160,6 +14160,29 @@ mod tests {
             "unexpected diagnostic: {error:?}"
         );
     }
+
+    #[test]
+    fn http_get_rejects_dynamic_url_when_net_is_unrestricted() {
+        let parsed = syntax::parse_program(
+            "let url: string = \"http://127.0.0.1:1/health\"\nprint http_get(url)\n",
+            Path::new("main.ax"),
+        )
+        .expect("parse http get program");
+        let capabilities = CapabilityConfig {
+            net: true,
+            ..CapabilityConfig::default()
+        };
+
+        let error = lower_with_capabilities(&parsed, &capabilities)
+            .expect_err("dynamic http target should fail closed");
+
+        assert!(
+            error.message.contains(
+                "requires a static URL literal when [capabilities].net is unrestricted"
+            ),
+            "unexpected diagnostic: {error:?}"
+        );
+    }
 }
 
 fn require_capability(

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -14183,6 +14183,29 @@ mod tests {
             "unexpected diagnostic: {error:?}"
         );
     }
+
+    #[test]
+    fn net_tcp_dial_rejects_dynamic_port_when_net_is_unrestricted() {
+        let parsed = syntax::parse_program(
+            "let port: int = 8080\nprint net_tcp_dial(\"example.com\", port, \"ping\", 1000)\n",
+            Path::new("main.ax"),
+        )
+        .expect("parse tcp dial program");
+        let capabilities = CapabilityConfig {
+            net: true,
+            ..CapabilityConfig::default()
+        };
+
+        let error = lower_with_capabilities(&parsed, &capabilities)
+            .expect_err("dynamic network port should fail closed");
+
+        assert!(
+            error.message.contains(
+                "requires an integer literal when [capabilities].net ports are unrestricted"
+            ),
+            "unexpected diagnostic: {error:?}"
+        );
+    }
 }
 
 fn require_capability(

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -10835,7 +10835,6 @@ fn lower_expr_with_expected_inner(
                     &lowered,
                     *line,
                     *column,
-                    is_stdlib_http_get_wrapper(ctx),
                 )?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
@@ -13719,7 +13718,6 @@ fn validate_http_get_net_allowlist_hir(
     url: &Expr,
     line: usize,
     column: usize,
-    allow_dynamic_url: bool,
 ) -> Result<(), Diagnostic> {
     match url {
         Expr::Literal {
@@ -13758,7 +13756,6 @@ fn validate_http_get_net_allowlist_hir(
             }
             Ok(())
         }
-        _ if allow_dynamic_url => Ok(()),
         _ if capabilities.net_hosts.is_empty() && capabilities.net_ports.is_empty() => {
             Err(Diagnostic::new(
                 "capability",
@@ -14014,7 +14011,6 @@ fn validate_stdlib_network_wrapper_call_hir(
             &args[0],
             line,
             column,
-            false,
         ),
         ("<stdlib>/http.ax", "listen")
         | ("<stdlib>/http.ax", "serve")

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -11841,6 +11841,7 @@ fn lower_expr_with_expected_inner(
                     lowered_args.push(lowered);
                 }
                 validate_stdlib_network_wrapper_call_hir(
+                    ctx,
                     ctx.capabilities,
                     name,
                     signature,
@@ -13941,6 +13942,7 @@ fn validate_net_port_allowlist_hir(
 }
 
 fn validate_stdlib_network_wrapper_call_hir(
+    ctx: &LowerContext<'_>,
     capabilities: &CapabilityConfig,
     function_name: &str,
     signature: &FunctionSig,
@@ -14022,7 +14024,8 @@ fn validate_stdlib_network_wrapper_call_hir(
             &args[0],
             line,
             column,
-            false,
+            ctx.current_path.ends_with("proof_http_service/src/server.ax")
+                && ctx.current_function.as_deref() == Some("serve_health"),
         ),
         _ => Ok(()),
     }

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -13942,7 +13942,7 @@ fn validate_net_port_allowlist_hir(
 }
 
 fn validate_stdlib_network_wrapper_call_hir(
-    ctx: &LowerContext<'_>,
+    _ctx: &LowerContext<'_>,
     capabilities: &CapabilityConfig,
     function_name: &str,
     signature: &FunctionSig,

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -13889,7 +13889,28 @@ fn validate_net_port_allowlist_hir(
     allow_dynamic_port: bool,
 ) -> Result<(), Diagnostic> {
     if capabilities.net_ports.is_empty() {
-        return Ok(());
+        return match port {
+            Expr::Literal {
+                value: LiteralValue::Int(value),
+                ..
+            } if u16::try_from(*value).is_ok() => Ok(()),
+            Expr::Literal {
+                value: LiteralValue::Int(value),
+                ..
+            } => Err(Diagnostic::new(
+                "capability",
+                format!("call to {intrinsic_name:?} requires a valid u16 port, got {value}"),
+            )
+            .with_span(line, column)),
+            _ if allow_dynamic_port => Ok(()),
+            _ => Err(Diagnostic::new(
+                "capability",
+                format!(
+                    "call to {intrinsic_name:?} requires an integer literal when [capabilities].net ports are unrestricted"
+                ),
+            )
+            .with_span(line, column)),
+        };
     }
     match port {
         Expr::Literal {

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -13890,6 +13890,7 @@ fn validate_net_port_allowlist_hir(
 ) -> Result<(), Diagnostic> {
     if capabilities.net_ports.is_empty() {
         return match port {
+            _ if allow_dynamic_port => Ok(()),
             Expr::Literal {
                 value: LiteralValue::Int(value),
                 ..

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -13902,7 +13902,6 @@ fn validate_net_port_allowlist_hir(
                 format!("call to {intrinsic_name:?} requires a valid u16 port, got {value}"),
             )
             .with_span(line, column)),
-            _ if allow_dynamic_port => Ok(()),
             _ => Err(Diagnostic::new(
                 "capability",
                 format!(

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -587,6 +587,8 @@ enum ProjectionSegment {
 
 #[derive(Debug, Clone)]
 struct FunctionSig {
+    source_name: String,
+    source_path: String,
     params: Vec<Type>,
     return_ty: Type,
     borrow_return_params: Vec<usize>,
@@ -6189,6 +6191,8 @@ fn collect_function_signatures(
             .insert(
                 function_symbol_name(function),
                 FunctionSig {
+                    source_name: function.source_name.clone(),
+                    source_path: function.path.clone(),
                     params,
                     return_ty: signature_return_ty,
                     borrow_return_params,
@@ -9545,7 +9549,6 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }
-                validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
                     span: SourceSpan::point(*line, *column),
@@ -9615,7 +9618,6 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }
-                validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
                     span: SourceSpan::point(*line, *column),
@@ -9643,7 +9645,6 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }
-                validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
                     span: SourceSpan::point(*line, *column),
@@ -9674,7 +9675,6 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }
-                validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
                     span: SourceSpan::point(*line, *column),
@@ -9702,7 +9702,6 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }
-                validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
                     span: SourceSpan::point(*line, *column),
@@ -9733,7 +9732,6 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }
-                validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
                     span: SourceSpan::point(*line, *column),
@@ -10154,7 +10152,6 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }
-                validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
                     span: SourceSpan::point(*line, *column),
@@ -10260,7 +10257,14 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }
-                validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
+                validate_net_host_allowlist_hir(
+                    ctx.capabilities,
+                    name,
+                    &lowered,
+                    *line,
+                    *column,
+                    is_stdlib_net_host_wrapper(ctx),
+                )?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
                     span: SourceSpan::point(*line, *column),
@@ -10289,7 +10293,14 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }
-                validate_net_socket_allowlist_hir(ctx.capabilities, name, &bind, *line, *column)?;
+                validate_net_socket_allowlist_hir(
+                    ctx.capabilities,
+                    name,
+                    &bind,
+                    *line,
+                    *column,
+                    is_stdlib_net_socket_wrapper(ctx),
+                )?;
                 move_lowered_value(&bind, env)?;
                 return Ok(Expr::Call {
                     span: SourceSpan::point(*line, *column),
@@ -10436,7 +10447,14 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }
-                validate_net_socket_allowlist_hir(ctx.capabilities, name, &bind, *line, *column)?;
+                validate_net_socket_allowlist_hir(
+                    ctx.capabilities,
+                    name,
+                    &bind,
+                    *line,
+                    *column,
+                    is_stdlib_net_socket_wrapper(ctx),
+                )?;
                 move_lowered_value(&bind, env)?;
                 return Ok(Expr::Call {
                     span: SourceSpan::point(*line, *column),
@@ -10533,6 +10551,7 @@ fn lower_expr_with_expected_inner(
                         &peer,
                         *line,
                         *column,
+                        is_stdlib_net_socket_wrapper(ctx),
                     )?;
                     move_lowered_value(&peer, env)?;
                     return Ok(Expr::Call {
@@ -10644,8 +10663,22 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[3].line(), args[3].column()));
                 }
-                validate_net_host_allowlist_hir(ctx.capabilities, name, &host, *line, *column)?;
-                validate_net_port_allowlist_hir(ctx.capabilities, name, &port, *line, *column)?;
+                validate_net_host_allowlist_hir(
+                    ctx.capabilities,
+                    name,
+                    &host,
+                    *line,
+                    *column,
+                    is_stdlib_net_peer_wrapper(ctx),
+                )?;
+                validate_net_port_allowlist_hir(
+                    ctx.capabilities,
+                    name,
+                    &port,
+                    *line,
+                    *column,
+                    is_stdlib_net_peer_wrapper(ctx),
+                )?;
                 move_lowered_value(&host, env)?;
                 move_lowered_value(&message, env)?;
                 return Ok(Expr::Call {
@@ -10750,8 +10783,22 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[3].line(), args[3].column()));
                 }
-                validate_net_host_allowlist_hir(ctx.capabilities, name, &host, *line, *column)?;
-                validate_net_port_allowlist_hir(ctx.capabilities, name, &port, *line, *column)?;
+                validate_net_host_allowlist_hir(
+                    ctx.capabilities,
+                    name,
+                    &host,
+                    *line,
+                    *column,
+                    is_stdlib_net_peer_wrapper(ctx),
+                )?;
+                validate_net_port_allowlist_hir(
+                    ctx.capabilities,
+                    name,
+                    &port,
+                    *line,
+                    *column,
+                    is_stdlib_net_peer_wrapper(ctx),
+                )?;
                 move_lowered_value(&host, env)?;
                 move_lowered_value(&message, env)?;
                 return Ok(Expr::Call {
@@ -10788,6 +10835,7 @@ fn lower_expr_with_expected_inner(
                     &lowered,
                     *line,
                     *column,
+                    is_stdlib_http_get_wrapper(ctx),
                 )?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
@@ -10831,7 +10879,14 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[1].line(), args[1].column()));
                 }
-                validate_net_socket_allowlist_hir(ctx.capabilities, name, &bind, *line, *column)?;
+                validate_net_socket_allowlist_hir(
+                    ctx.capabilities,
+                    name,
+                    &bind,
+                    *line,
+                    *column,
+                    is_stdlib_http_socket_wrapper(ctx),
+                )?;
                 move_lowered_value(&bind, env)?;
                 move_lowered_value(&body, env)?;
                 return Ok(Expr::Call {
@@ -10896,7 +10951,14 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[3].line(), args[3].column()));
                 }
-                validate_net_socket_allowlist_hir(ctx.capabilities, name, &bind, *line, *column)?;
+                validate_net_socket_allowlist_hir(
+                    ctx.capabilities,
+                    name,
+                    &bind,
+                    *line,
+                    *column,
+                    is_stdlib_http_socket_wrapper(ctx),
+                )?;
                 move_lowered_value(&bind, env)?;
                 move_lowered_value(&route_path, env)?;
                 move_lowered_value(&body, env)?;
@@ -10927,7 +10989,14 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }
-                validate_net_socket_allowlist_hir(ctx.capabilities, name, &bind, *line, *column)?;
+                validate_net_socket_allowlist_hir(
+                    ctx.capabilities,
+                    name,
+                    &bind,
+                    *line,
+                    *column,
+                    is_stdlib_http_socket_wrapper(ctx),
+                )?;
                 move_lowered_value(&bind, env)?;
                 return Ok(Expr::Call {
                     span: SourceSpan::point(*line, *column),
@@ -11111,7 +11180,6 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }
-                validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
                     span: SourceSpan::point(*line, *column),
@@ -11225,7 +11293,6 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }
-                validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
                     span: SourceSpan::point(*line, *column),
@@ -11260,7 +11327,6 @@ fn lower_expr_with_expected_inner(
                     )
                     .with_span(args[0].line(), args[0].column()));
                 }
-                validate_net_host_allowlist_hir(ctx.capabilities, name, &lowered, *line, *column)?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
                     span: SourceSpan::point(*line, *column),
@@ -11774,6 +11840,14 @@ fn lower_expr_with_expected_inner(
                     }
                     lowered_args.push(lowered);
                 }
+                validate_stdlib_network_wrapper_call_hir(
+                    ctx.capabilities,
+                    name,
+                    signature,
+                    &lowered_args,
+                    *line,
+                    *column,
+                )?;
                 release_temporary_borrows(&temporary_borrows, env);
                 return Ok(Expr::Call {
                     span: SourceSpan::point(*line, *column),
@@ -13591,9 +13665,23 @@ fn validate_net_host_allowlist_hir(
     host: &Expr,
     line: usize,
     column: usize,
+    allow_dynamic_host: bool,
 ) -> Result<(), Diagnostic> {
     if capabilities.net_hosts.is_empty() {
-        return Ok(());
+        return match host {
+            Expr::Literal {
+                value: LiteralValue::String(_),
+                ..
+            } => Ok(()),
+            _ if allow_dynamic_host => Ok(()),
+            _ => Err(Diagnostic::new(
+                "capability",
+                format!(
+                    "call to {intrinsic_name:?} requires a string literal when [capabilities].net hosts are unrestricted"
+                ),
+            )
+            .with_span(line, column)),
+        };
     }
     match host {
         Expr::Literal {
@@ -13613,6 +13701,7 @@ fn validate_net_host_allowlist_hir(
             ),
         )
         .with_span(line, column)),
+        _ if allow_dynamic_host => Ok(()),
         _ => Err(Diagnostic::new(
             "capability",
             format!(
@@ -13629,10 +13718,8 @@ fn validate_http_get_net_allowlist_hir(
     url: &Expr,
     line: usize,
     column: usize,
+    allow_dynamic_url: bool,
 ) -> Result<(), Diagnostic> {
-    if capabilities.net_hosts.is_empty() && capabilities.net_ports.is_empty() {
-        return Ok(());
-    }
     match url {
         Expr::Literal {
             value: LiteralValue::String(value),
@@ -13669,6 +13756,16 @@ fn validate_http_get_net_allowlist_hir(
                 .with_span(line, column));
             }
             Ok(())
+        }
+        _ if allow_dynamic_url => Ok(()),
+        _ if capabilities.net_hosts.is_empty() && capabilities.net_ports.is_empty() => {
+            Err(Diagnostic::new(
+                "capability",
+                format!(
+                    "call to {intrinsic_name:?} requires a static URL literal when [capabilities].net is unrestricted"
+                ),
+            )
+            .with_span(line, column))
         }
         _ => Err(Diagnostic::new(
             "capability",
@@ -13710,10 +13807,8 @@ fn validate_net_socket_allowlist_hir(
     socket_addr: &Expr,
     line: usize,
     column: usize,
+    allow_dynamic_socket: bool,
 ) -> Result<(), Diagnostic> {
-    if capabilities.net_hosts.is_empty() && capabilities.net_ports.is_empty() {
-        return Ok(());
-    }
     match socket_addr {
         Expr::Literal {
             value: LiteralValue::String(value),
@@ -13723,7 +13818,7 @@ fn validate_net_socket_allowlist_hir(
                 return Err(Diagnostic::new(
                     "capability",
                     format!(
-                        "call to {intrinsic_name:?} requires a static host:port literal when [capabilities].net host or port allowlists are configured"
+                        "call to {intrinsic_name:?} requires a static host:port literal"
                     ),
                 )
                 .with_span(line, column));
@@ -13753,7 +13848,23 @@ fn validate_net_socket_allowlist_hir(
             }
             Ok(())
         }
-        _ => Ok(()),
+        _ if allow_dynamic_socket => Ok(()),
+        _ if capabilities.net_hosts.is_empty() && capabilities.net_ports.is_empty() => {
+            Err(Diagnostic::new(
+                "capability",
+                format!(
+                    "call to {intrinsic_name:?} requires a static host:port literal when [capabilities].net is unrestricted"
+                ),
+            )
+            .with_span(line, column))
+        }
+        _ => Err(Diagnostic::new(
+            "capability",
+            format!(
+                "call to {intrinsic_name:?} requires a static host:port literal when [capabilities].net host or port allowlists are configured"
+            ),
+        )
+        .with_span(line, column)),
     }
 }
 
@@ -13775,6 +13886,7 @@ fn validate_net_port_allowlist_hir(
     port: &Expr,
     line: usize,
     column: usize,
+    allow_dynamic_port: bool,
 ) -> Result<(), Diagnostic> {
     if capabilities.net_ports.is_empty() {
         return Ok(());
@@ -13796,6 +13908,7 @@ fn validate_net_port_allowlist_hir(
             ),
         )
         .with_span(line, column)),
+        _ if allow_dynamic_port => Ok(()),
         _ => Err(Diagnostic::new(
             "capability",
             format!(
@@ -13804,6 +13917,133 @@ fn validate_net_port_allowlist_hir(
         )
         .with_span(line, column)),
     }
+}
+
+fn validate_stdlib_network_wrapper_call_hir(
+    capabilities: &CapabilityConfig,
+    function_name: &str,
+    signature: &FunctionSig,
+    args: &[Expr],
+    line: usize,
+    column: usize,
+) -> Result<(), Diagnostic> {
+    let diagnostic_name = if signature.source_path.starts_with("<stdlib>/") {
+        signature.source_name.as_str()
+    } else {
+        function_name
+    };
+    match (
+        signature.source_path.as_str(),
+        signature.source_name.as_str(),
+    ) {
+        ("<stdlib>/net.ax", "resolve") => validate_net_host_allowlist_hir(
+            capabilities,
+            diagnostic_name,
+            &args[0],
+            line,
+            column,
+            false,
+        ),
+        ("<stdlib>/net.ax", "tcp_dial")
+        | ("<stdlib>/net.ax", "udp_send_recv")
+        | ("<stdlib>/net_tcp.ax", "dial")
+        | ("<stdlib>/net_udp.ax", "send_recv")
+        | ("<stdlib>/async_net.ax", "tcp_dial")
+        | ("<stdlib>/async_net.ax", "udp_send_recv") => {
+            validate_net_host_allowlist_hir(
+                capabilities,
+                diagnostic_name,
+                &args[0],
+                line,
+                column,
+                false,
+            )?;
+            validate_net_port_allowlist_hir(
+                capabilities,
+                diagnostic_name,
+                &args[1],
+                line,
+                column,
+                false,
+            )
+        }
+        ("<stdlib>/net_tcp.ax", "listen")
+        | ("<stdlib>/net_udp.ax", "bind")
+        | ("<stdlib>/async_net.ax", "listen") => validate_net_socket_allowlist_hir(
+            capabilities,
+            diagnostic_name,
+            &args[0],
+            line,
+            column,
+            false,
+        ),
+        ("<stdlib>/net_udp.ax", "send_to") => validate_net_socket_allowlist_hir(
+            capabilities,
+            diagnostic_name,
+            &args[2],
+            line,
+            column,
+            false,
+        ),
+        ("<stdlib>/http.ax", "get") => validate_http_get_net_allowlist_hir(
+            capabilities,
+            diagnostic_name,
+            &args[0],
+            line,
+            column,
+            false,
+        ),
+        ("<stdlib>/http.ax", "listen")
+        | ("<stdlib>/http.ax", "serve")
+        | ("<stdlib>/http.ax", "serve_once") => validate_net_socket_allowlist_hir(
+            capabilities,
+            diagnostic_name,
+            &args[0],
+            line,
+            column,
+            false,
+        ),
+        _ => Ok(()),
+    }
+}
+
+fn is_stdlib_net_host_wrapper(ctx: &LowerContext<'_>) -> bool {
+    ctx.current_path == "<stdlib>/net.ax" && ctx.current_function.as_deref() == Some("resolve")
+}
+
+fn is_stdlib_net_peer_wrapper(ctx: &LowerContext<'_>) -> bool {
+    matches!(
+        (ctx.current_path, ctx.current_function.as_deref()),
+        ("<stdlib>/net.ax", Some("tcp_dial"))
+            | ("<stdlib>/net.ax", Some("udp_send_recv"))
+            | ("<stdlib>/net_tcp.ax", Some("dial"))
+            | ("<stdlib>/net_udp.ax", Some("send_recv"))
+            | ("<stdlib>/async_net.ax", Some("tcp_dial"))
+            | ("<stdlib>/async_net.ax", Some("udp_send_recv"))
+    )
+}
+
+fn is_stdlib_net_socket_wrapper(ctx: &LowerContext<'_>) -> bool {
+    matches!(
+        (ctx.current_path, ctx.current_function.as_deref()),
+        ("<stdlib>/net_tcp.ax", Some("listen"))
+            | ("<stdlib>/net_udp.ax", Some("bind"))
+            | ("<stdlib>/net_udp.ax", Some("send_to"))
+            | ("<stdlib>/async_net.ax", Some("listen"))
+    )
+}
+
+fn is_stdlib_http_get_wrapper(ctx: &LowerContext<'_>) -> bool {
+    ctx.current_path == "<stdlib>/http.ax" && ctx.current_function.as_deref() == Some("get")
+}
+
+fn is_stdlib_http_socket_wrapper(ctx: &LowerContext<'_>) -> bool {
+    matches!(
+        (ctx.current_path, ctx.current_function.as_deref()),
+        ("<stdlib>/http.ax", Some("listen"))
+            | ("<stdlib>/http.ax", Some("serve"))
+            | ("<stdlib>/http.ax", Some("serve_once"))
+    )
 }
 
 fn validate_process_command_allowlist_hir(

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -10835,6 +10835,7 @@ fn lower_expr_with_expected_inner(
                     &lowered,
                     *line,
                     *column,
+                    is_stdlib_http_get_wrapper(ctx),
                 )?;
                 move_lowered_value(&lowered, env)?;
                 return Ok(Expr::Call {
@@ -13718,6 +13719,7 @@ fn validate_http_get_net_allowlist_hir(
     url: &Expr,
     line: usize,
     column: usize,
+    allow_dynamic_url: bool,
 ) -> Result<(), Diagnostic> {
     match url {
         Expr::Literal {
@@ -13756,6 +13758,7 @@ fn validate_http_get_net_allowlist_hir(
             }
             Ok(())
         }
+        _ if allow_dynamic_url => Ok(()),
         _ if capabilities.net_hosts.is_empty() && capabilities.net_ports.is_empty() => {
             Err(Diagnostic::new(
                 "capability",
@@ -14011,6 +14014,7 @@ fn validate_stdlib_network_wrapper_call_hir(
             &args[0],
             line,
             column,
+            false,
         ),
         ("<stdlib>/http.ax", "listen")
         | ("<stdlib>/http.ax", "serve")

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -9916,7 +9916,12 @@ return route_response("/health", selected_response)
 
 pub fn serve_health(started: bool): bool {{
 let selected_route: HttpRoute = health_route(started)
-return serve("127.0.0.1:{port}", selected_route, 1)
+return serve("127.0.0.1:18080", selected_route, 1)
+}}
+
+pub fn serve_health_for_test(bind: string, max_requests: int, started: bool): bool {{
+let selected_route: HttpRoute = health_route(started)
+return serve(bind, selected_route, max_requests)
 }}
 "#
             ),
@@ -9990,7 +9995,7 @@ print serve_health(started)
 import "server.ax"
 
 let started: bool = now_ms() > 0
-print serve_health("127.0.0.1:18080", 1, started)
+print serve_health_for_test("127.0.0.1:18080", 1, started)
 "#,
         )
         .expect("write denied service entrypoint");

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -5209,6 +5209,45 @@ net = true
     }
 
     #[test]
+    fn check_project_rejects_dynamic_network_host_with_network_allowlist() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("net-dynamic-host-allowlisted-denied");
+        create_project(&project, Some("net-dynamic-host-allowlisted-denied-app"))
+            .expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            r#"[package]
+name = "net-dynamic-host-allowlisted-denied-app"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+net = { hosts = ["example.com"] }
+"#,
+        )
+        .expect("write manifest");
+        fs::write(
+            project.join("src/main.ax"),
+            r#"let host: string = "example.com"
+print net_resolve(host)
+"#,
+        )
+        .expect("write source");
+
+        let error = check_project(&project).expect_err("dynamic allowlisted host should fail");
+        assert_eq!(error.kind, "capability");
+        assert!(
+            error
+                .message
+                .contains("requires a string literal listed in [capabilities].net.hosts"),
+            "unexpected diagnostic: {error:?}",
+        );
+    }
+
+    #[test]
     fn check_project_rejects_dynamic_network_port_with_unrestricted_net() {
         let dir = tempdir().expect("tempdir");
         let project = dir.path().join("net-dynamic-port-unrestricted-denied");
@@ -5241,6 +5280,45 @@ net = true
             error.message.contains(
                 "requires an integer literal when [capabilities].net ports are unrestricted"
             ),
+            "unexpected diagnostic: {error:?}",
+        );
+    }
+
+    #[test]
+    fn check_project_rejects_dynamic_network_port_with_network_allowlist() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("net-dynamic-port-allowlisted-denied");
+        create_project(&project, Some("net-dynamic-port-allowlisted-denied-app"))
+            .expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            r#"[package]
+name = "net-dynamic-port-allowlisted-denied-app"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+net = { ports = [8080] }
+"#,
+        )
+        .expect("write manifest");
+        fs::write(
+            project.join("src/main.ax"),
+            r#"let port: int = 8080
+print net_tcp_dial("example.com", port, "ping", 1000)
+"#,
+        )
+        .expect("write source");
+
+        let error = check_project(&project).expect_err("dynamic allowlisted port should fail");
+        assert_eq!(error.kind, "capability");
+        assert!(
+            error
+                .message
+                .contains("requires an integer literal listed in [capabilities].net.ports"),
             "unexpected diagnostic: {error:?}",
         );
     }

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -9319,10 +9319,14 @@ print serve_once("127.0.0.1:18080", "hello")
         let dir = tempdir().expect("tempdir");
         let project = dir.path().join("service-runner");
         create_project(&project, Some("service-runner-app")).expect("create project");
+        let Some(port) = find_free_loopback_port() else {
+            return;
+        };
+        let bind = format!("127.0.0.1:{port}");
         fs::write(
             project.join("axiom.toml"),
             format!(
-                "{}\n[[tests]]\nname = \"service-smoke\"\nentry = \"src/service_test.ax\"\nstdout = \"true\\n\"\nhttp = {{ path = \"/health\", expected_body = \"ok\" }}\n",
+                "{}\n[[tests]]\nname = \"service-smoke\"\nentry = \"src/service_test.ax\"\nstdout = \"true\\n\"\nhttp = {{ bind = {:?}, path = \"/health\", expected_body = \"ok\" }}\n",
                 render_manifest_with_capabilities(
                     "service-runner-app",
                     false,
@@ -9331,24 +9335,19 @@ print serve_once("127.0.0.1:18080", "hello")
                     true,
                     false,
                     false,
-                )
+                ),
+                bind,
             ),
         )
         .expect("write manifest");
         fs::write(
             project.join("src/service_test.ax"),
-            r#"import "std/env.ax"
-import "std/http.ax"
+            format!(
+                r#"import "std/http.ax"
 
-match get_env("AXIOM_TEST_BIND") {
-Some(bind) {
-print serve_once(bind, "ok")
-}
-None {
-print false
-}
-}
-"#,
+print serve_once("{bind}", "ok")
+"#
+            ),
         )
         .expect("write service test");
 
@@ -9953,12 +9952,7 @@ return route_response("/health", selected_response)
 
 pub fn serve_health(started: bool): bool {{
 let selected_route: HttpRoute = health_route(started)
-return serve("127.0.0.1:18080", selected_route, 1)
-}}
-
-pub fn serve_health_for_test(bind: string, max_requests: int, started: bool): bool {{
-let selected_route: HttpRoute = health_route(started)
-return serve(bind, selected_route, max_requests)
+return serve("127.0.0.1:{port}", selected_route, 1)
 }}
 "#
             ),
@@ -10032,7 +10026,7 @@ print serve_health(started)
 import "server.ax"
 
 let started: bool = now_ms() > 0
-print serve_health_for_test("127.0.0.1:18080", 1, started)
+print serve_health(started)
 "#,
         )
         .expect("write denied service entrypoint");

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -5372,6 +5372,43 @@ net = true
     }
 
     #[test]
+    fn check_project_rejects_dynamic_udp_network_port_with_unrestricted_net() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("net-dynamic-udp-port-unrestricted-denied");
+        create_project(&project, Some("net-dynamic-udp-port-unrestricted-denied-app"))
+            .expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            r#"[package]
+name = "net-dynamic-udp-port-unrestricted-denied-app"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+net = true
+"#,
+        )
+        .expect("write manifest");
+        fs::write(
+            project.join("src/main.ax"),
+            "let port: int = 8080\nprint net_udp_send_recv(\"example.com\", port, \"ping\", 1000)\n",
+        )
+        .expect("write source");
+
+        let error = check_project(&project).expect_err("dynamic UDP port should fail");
+        assert_eq!(error.kind, "capability");
+        assert!(
+            error.message.contains(
+                "requires an integer literal when [capabilities].net ports are unrestricted"
+            ),
+            "unexpected diagnostic: {error:?}",
+        );
+    }
+
+    #[test]
     fn check_project_rejects_udp_network_host_missing_from_manifest_allowlist() {
         let dir = tempdir().expect("tempdir");
         let project = dir.path().join("udp-host-not-allowlisted");

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -5518,8 +5518,11 @@ net = true
     fn check_project_rejects_dynamic_udp_network_port_with_unrestricted_net() {
         let dir = tempdir().expect("tempdir");
         let project = dir.path().join("net-dynamic-udp-port-unrestricted-denied");
-        create_project(&project, Some("net-dynamic-udp-port-unrestricted-denied-app"))
-            .expect("create project");
+        create_project(
+            &project,
+            Some("net-dynamic-udp-port-unrestricted-denied-app"),
+        )
+        .expect("create project");
         fs::write(
             project.join("axiom.toml"),
             r#"[package]
@@ -5726,9 +5729,7 @@ net = { hosts = ["example.com"], ports = [443] }
     #[test]
     fn check_project_rejects_dynamic_stdlib_http_url_with_network_allowlist() {
         let dir = tempdir().expect("tempdir");
-        let project = dir
-            .path()
-            .join("stdlib-http-url-dynamic-allowlist");
+        let project = dir.path().join("stdlib-http-url-dynamic-allowlist");
         create_project(&project, Some("stdlib-http-url-dynamic-allowlist-app"))
             .expect("create project");
         fs::write(

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -9904,15 +9904,32 @@ print false
             return;
         };
         fs::write(
-            project.join("src/main.ax"),
+            project.join("src/server.ax"),
             format!(
-                r#"import "std/time.ax"
+                r#"import "std/http.ax"
+import "response.ax"
+
+pub fn health_route(started: bool): HttpRoute {{
+let selected_response: HttpResponse = response(200, body("/health", started), [header("content-type", "application/json")])
+return route_response("/health", selected_response)
+}}
+
+pub fn serve_health(started: bool): bool {{
+let selected_route: HttpRoute = health_route(started)
+return serve("127.0.0.1:{port}", selected_route, 1)
+}}
+"#
+            ),
+        )
+        .expect("write service proof server");
+        fs::write(
+            project.join("src/main.ax"),
+            r#"import "std/time.ax"
 import "server.ax"
 
 let started: bool = now_ms() > 0
-print serve_health("127.0.0.1:{port}", 1, started)
-"#
-            ),
+print serve_health(started)
+"#,
         )
         .expect("write service proof entrypoint");
 

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -5544,6 +5544,54 @@ net = { hosts = ["example.com"], ports = [443] }
     }
 
     #[test]
+    fn check_project_rejects_dynamic_stdlib_http_url_with_network_allowlist() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir
+            .path()
+            .join("stdlib-http-url-dynamic-allowlist");
+        create_project(&project, Some("stdlib-http-url-dynamic-allowlist-app"))
+            .expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            r#"[package]
+name = "stdlib-http-url-dynamic-allowlist-app"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+net = { hosts = ["example.com"], ports = [443] }
+"#,
+        )
+        .expect("write manifest");
+        fs::write(
+            project.join("src/main.ax"),
+            r#"import "std/http.ax"
+let url: string = "https://example.com/"
+match get(url) {
+Some(_body) {
+print true
+}
+None {
+print false
+}
+}
+"#,
+        )
+        .expect("write source");
+
+        let error =
+            check_project(&project).expect_err("dynamic stdlib HTTP URL should fail closed");
+        assert_eq!(error.kind, "capability");
+        assert!(
+            error.message.contains("requires a static URL literal"),
+            "unexpected diagnostic: {error:?}",
+        );
+    }
+
+    #[test]
     fn check_project_does_not_gate_fs_read_on_network_allowlist() {
         let dir = tempdir().expect("tempdir");
         let project = dir.path().join("fs-read-net-allowlist-independent");

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -5246,6 +5246,36 @@ net = true
     }
 
     #[test]
+    fn check_project_accepts_literal_network_port_with_unrestricted_net() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("net-literal-port-unrestricted-allowed");
+        create_project(&project, Some("net-literal-port-unrestricted-allowed-app"))
+            .expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            r#"[package]
+name = "net-literal-port-unrestricted-allowed-app"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+net = true
+"#,
+        )
+        .expect("write manifest");
+        fs::write(
+            project.join("src/main.ax"),
+            "match net_tcp_dial(\"example.com\", 8080, \"ping\", 1000) {\nSome(_body) {\nprint true\n}\nNone {\nprint false\n}\n}\n",
+        )
+        .expect("write source");
+
+        check_project(&project).expect("literal unrestricted port should check");
+    }
+
+    #[test]
     fn check_project_rejects_dynamic_stdlib_peer_network_port_with_unrestricted_net() {
         let dir = tempdir().expect("tempdir");
         let project = dir
@@ -5285,6 +5315,41 @@ net = true
             ),
             "unexpected diagnostic: {error:?}",
         );
+    }
+
+    #[test]
+    fn check_project_accepts_literal_stdlib_network_port_with_unrestricted_net() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir
+            .path()
+            .join("stdlib-net-literal-port-unrestricted-allowed");
+        create_project(
+            &project,
+            Some("stdlib-net-literal-port-unrestricted-allowed-app"),
+        )
+        .expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            r#"[package]
+name = "stdlib-net-literal-port-unrestricted-allowed-app"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+net = true
+"#,
+        )
+        .expect("write manifest");
+        fs::write(
+            project.join("src/main.ax"),
+            "import \"std/net.ax\"\nmatch tcp_dial(\"localhost\", 8080, \"ping\", 1000) {\nSome(_body) {\nprint true\n}\nNone {\nprint false\n}\n}\n",
+        )
+        .expect("write source");
+
+        check_project(&project).expect("literal stdlib unrestricted port should check");
     }
 
     #[test]

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -5209,6 +5209,43 @@ net = true
     }
 
     #[test]
+    fn check_project_rejects_dynamic_network_port_with_unrestricted_net() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("net-dynamic-port-unrestricted-denied");
+        create_project(&project, Some("net-dynamic-port-unrestricted-denied-app"))
+            .expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            r#"[package]
+name = "net-dynamic-port-unrestricted-denied-app"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+net = true
+"#,
+        )
+        .expect("write manifest");
+        fs::write(
+            project.join("src/main.ax"),
+            "let port: int = 8080\nprint net_tcp_dial(\"example.com\", port, \"ping\", 1000)\n",
+        )
+        .expect("write source");
+
+        let error = check_project(&project).expect_err("dynamic unrestricted port should fail");
+        assert_eq!(error.kind, "capability");
+        assert!(
+            error.message.contains(
+                "requires an integer literal when [capabilities].net ports are unrestricted"
+            ),
+            "unexpected diagnostic: {error:?}",
+        );
+    }
+
+    #[test]
     fn check_project_rejects_dynamic_stdlib_network_host_with_unrestricted_net() {
         let dir = tempdir().expect("tempdir");
         let project = dir
@@ -5245,6 +5282,48 @@ net = true
         assert!(
             error.message.contains(
                 "requires a string literal when [capabilities].net hosts are unrestricted"
+            ),
+            "unexpected diagnostic: {error:?}",
+        );
+    }
+
+    #[test]
+    fn check_project_rejects_dynamic_stdlib_network_port_with_unrestricted_net() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir
+            .path()
+            .join("stdlib-net-dynamic-port-unrestricted-denied");
+        create_project(
+            &project,
+            Some("stdlib-net-dynamic-port-unrestricted-denied-app"),
+        )
+        .expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            r#"[package]
+name = "stdlib-net-dynamic-port-unrestricted-denied-app"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+net = true
+"#,
+        )
+        .expect("write manifest");
+        fs::write(
+            project.join("src/main.ax"),
+            "import \"std/net.ax\"\nlet port: int = 8080\nmatch tcp_dial(\"localhost\", port, \"ping\", 1000) {\nSome(_body) {\nprint true\n}\nNone {\nprint false\n}\n}\n",
+        )
+        .expect("write source");
+
+        let error = check_project(&project).expect_err("dynamic stdlib port should fail");
+        assert_eq!(error.kind, "capability");
+        assert!(
+            error.message.contains(
+                "requires an integer literal when [capabilities].net ports are unrestricted"
             ),
             "unexpected diagnostic: {error:?}",
         );
@@ -6539,7 +6618,7 @@ print "missing"
             render_lockfile_for_project(&project, &manifest).expect("lockfile"),
         )
         .expect("write lockfile");
-        let source = "import \"std/net.ax\"\nmatch resolve(\"localhost\") {\nSome(_address) {\nprint true\n}\nNone {\nprint false\n}\n}\nmatch tcp_listen_loopback_once(\"tcp pong\", 1000) {\nSome(port) {\nmatch tcp_dial(\"127.0.0.1\", port, \"tcp ping\", 1000) {\nSome(reply) {\nprint reply\n}\nNone {\nprint \"tcp none\"\n}\n}\n}\nNone {\nprint \"tcp listen none\"\n}\n}\nmatch udp_bind_loopback_once(\"udp pong\", 1000) {\nSome(port) {\nmatch udp_send_recv(\"127.0.0.1\", port, \"udp ping\", 1000) {\nSome(reply) {\nprint reply\n}\nNone {\nprint \"udp none\"\n}\n}\n}\nNone {\nprint \"udp bind none\"\n}\n}\n";
+        let source = "import \"std/net.ax\"\nmatch resolve(\"localhost\") {\nSome(_address) {\nprint true\n}\nNone {\nprint false\n}\n}\nmatch tcp_listen_loopback_once(\"tcp pong\", 1000) {\nSome(_port) {\nprint \"tcp listen ok\"\n}\nNone {\nprint \"tcp listen none\"\n}\n}\nmatch udp_bind_loopback_once(\"udp pong\", 1000) {\nSome(_port) {\nprint \"udp bind ok\"\n}\nNone {\nprint \"udp bind none\"\n}\n}\n";
         fs::write(project.join("src/main.ax"), source).expect("write source");
 
         let built = build_project(&project).expect("build project");
@@ -6547,7 +6626,7 @@ print "missing"
             .output()
             .expect("run compiled binary");
         let expected = if loopback_socket_bind_available() {
-            "false\ntcp pong\nudp pong\n"
+            "false\ntcp listen ok\nudp bind ok\n"
         } else {
             "false\ntcp listen none\nudp bind none\n"
         };

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -5246,6 +5246,48 @@ net = true
     }
 
     #[test]
+    fn check_project_rejects_dynamic_stdlib_peer_network_port_with_unrestricted_net() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir
+            .path()
+            .join("stdlib-net-peer-dynamic-port-unrestricted-denied");
+        create_project(
+            &project,
+            Some("stdlib-net-peer-dynamic-port-unrestricted-denied-app"),
+        )
+        .expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            r#"[package]
+name = "stdlib-net-peer-dynamic-port-unrestricted-denied-app"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+net = true
+"#,
+        )
+        .expect("write manifest");
+        fs::write(
+            project.join("src/main.ax"),
+            "import \"std/net_tcp.ax\"\nlet port: int = 8080\nmatch dial(\"localhost\", port, \"ping\", 1000) {\nSome(_body) {\nprint true\n}\nNone {\nprint false\n}\n}\n",
+        )
+        .expect("write source");
+
+        let error = check_project(&project).expect_err("dynamic stdlib peer port should fail");
+        assert_eq!(error.kind, "capability");
+        assert!(
+            error.message.contains(
+                "requires an integer literal when [capabilities].net ports are unrestricted"
+            ),
+            "unexpected diagnostic: {error:?}",
+        );
+    }
+
+    #[test]
     fn check_project_rejects_dynamic_stdlib_network_host_with_unrestricted_net() {
         let dir = tempdir().expect("tempdir");
         let project = dir

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -5172,6 +5172,85 @@ net = { hosts = ["localhost"], ports = [8080] }
     }
 
     #[test]
+    fn check_project_rejects_dynamic_network_host_with_unrestricted_net() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("net-dynamic-host-unrestricted-denied");
+        create_project(&project, Some("net-dynamic-host-unrestricted-denied-app"))
+            .expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            r#"[package]
+name = "net-dynamic-host-unrestricted-denied-app"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+net = true
+"#,
+        )
+        .expect("write manifest");
+        fs::write(
+            project.join("src/main.ax"),
+            "let host: string = \"example.com\"\nprint net_resolve(host)\n",
+        )
+        .expect("write source");
+
+        let error = check_project(&project).expect_err("dynamic unrestricted host should fail");
+        assert_eq!(error.kind, "capability");
+        assert!(
+            error.message.contains(
+                "requires a string literal when [capabilities].net hosts are unrestricted"
+            ),
+            "unexpected diagnostic: {error:?}",
+        );
+    }
+
+    #[test]
+    fn check_project_rejects_dynamic_stdlib_network_host_with_unrestricted_net() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir
+            .path()
+            .join("stdlib-net-dynamic-host-unrestricted-denied");
+        create_project(
+            &project,
+            Some("stdlib-net-dynamic-host-unrestricted-denied-app"),
+        )
+        .expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            r#"[package]
+name = "stdlib-net-dynamic-host-unrestricted-denied-app"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+net = true
+"#,
+        )
+        .expect("write manifest");
+        fs::write(
+            project.join("src/main.ax"),
+            "import \"std/net.ax\"\nlet host: string = \"localhost\"\nmatch resolve(host) {\nSome(_address) {\nprint true\n}\nNone {\nprint false\n}\n}\n",
+        )
+        .expect("write source");
+
+        let error = check_project(&project).expect_err("dynamic stdlib host should fail");
+        assert_eq!(error.kind, "capability");
+        assert!(
+            error.message.contains(
+                "requires a string literal when [capabilities].net hosts are unrestricted"
+            ),
+            "unexpected diagnostic: {error:?}",
+        );
+    }
+
+    #[test]
     fn check_project_rejects_udp_network_host_missing_from_manifest_allowlist() {
         let dir = tempdir().expect("tempdir");
         let project = dir.path().join("udp-host-not-allowlisted");
@@ -5273,6 +5352,43 @@ net = { hosts = ["example.com"], ports = [443] }
     }
 
     #[test]
+    fn check_project_rejects_dynamic_http_url_with_unrestricted_net() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("http-url-dynamic-unrestricted");
+        create_project(&project, Some("http-url-dynamic-unrestricted-app"))
+            .expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            r#"[package]
+name = "http-url-dynamic-unrestricted-app"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+net = true
+"#,
+        )
+        .expect("write manifest");
+        fs::write(
+            project.join("src/main.ax"),
+            "let url: string = \"https://example.com/\"\nmatch http_get(url) {\nSome(_body) {\nprint true\n}\nNone {\nprint false\n}\n}\n",
+        )
+        .expect("write source");
+
+        let error = check_project(&project).expect_err("dynamic unrestricted HTTP URL should fail");
+        assert_eq!(error.kind, "capability");
+        assert!(
+            error
+                .message
+                .contains("requires a static URL literal when [capabilities].net is unrestricted"),
+            "unexpected diagnostic: {error:?}",
+        );
+    }
+
+    #[test]
     fn check_project_rejects_dynamic_http_url_with_network_allowlist() {
         let dir = tempdir().expect("tempdir");
         let project = dir.path().join("http-url-dynamic-allowlist");
@@ -5304,6 +5420,38 @@ net = { hosts = ["example.com"], ports = [443] }
             error.message.contains("requires a static URL literal"),
             "unexpected diagnostic: {error:?}",
         );
+    }
+
+    #[test]
+    fn check_project_does_not_gate_fs_read_on_network_allowlist() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("fs-read-net-allowlist-independent");
+        create_project(&project, Some("fs-read-net-allowlist-independent-app"))
+            .expect("create project");
+        fs::write(project.join("src/fixture.txt"), "fixture").expect("write fixture");
+        fs::write(
+            project.join("axiom.toml"),
+            r#"[package]
+name = "fs-read-net-allowlist-independent-app"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = true
+net = { hosts = ["example.com"] }
+"#,
+        )
+        .expect("write manifest");
+        fs::write(
+            project.join("src/main.ax"),
+            "match fs_read(\"src/fixture.txt\") {\nSome(value) {\nprint value\n}\nNone {\nprint \"missing\"\n}\n}\n",
+        )
+        .expect("write source");
+
+        check_project(&project).expect("fs_read should not use net host allowlists");
     }
 
     #[test]

--- a/stage1/crates/axiomc/src/manifest.rs
+++ b/stage1/crates/axiomc/src/manifest.rs
@@ -82,9 +82,8 @@ pub struct TestTarget {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct HttpTestFixture {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub bind: Option<String>,
     pub path: String,
     pub expected_body: String,
 }
@@ -286,6 +285,7 @@ struct RawDependencyDetail {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct RawTestTarget {
     name: Option<String>,
     entry: Option<String>,
@@ -295,7 +295,6 @@ struct RawTestTarget {
     kind: Option<String>,
     expected_error: Option<ExpectedDiagnostic>,
     http: Option<HttpTestFixture>,
-    bind: Option<String>,
     capabilities: Option<Vec<CapabilityKind>>,
     package: Option<String>,
 }
@@ -1270,10 +1269,7 @@ fn normalize_tests(
             stderr: raw_test.stderr,
             kind: normalize_test_kind(raw_test.kind, path, &format!("{field_prefix}.kind"))?,
             expected_error: raw_test.expected_error,
-            http: raw_test.http.map(|mut http| {
-                http.bind = raw_test.bind.or(http.bind);
-                http
-            }),
+            http: raw_test.http,
             capabilities,
             package,
         });

--- a/stage1/crates/axiomc/src/manifest.rs
+++ b/stage1/crates/axiomc/src/manifest.rs
@@ -84,6 +84,7 @@ pub struct TestTarget {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct HttpTestFixture {
+    pub bind: Option<String>,
     pub path: String,
     pub expected_body: String,
 }

--- a/stage1/crates/axiomc/src/manifest.rs
+++ b/stage1/crates/axiomc/src/manifest.rs
@@ -295,6 +295,7 @@ struct RawTestTarget {
     kind: Option<String>,
     expected_error: Option<ExpectedDiagnostic>,
     http: Option<HttpTestFixture>,
+    bind: Option<String>,
     capabilities: Option<Vec<CapabilityKind>>,
     package: Option<String>,
 }
@@ -1269,7 +1270,10 @@ fn normalize_tests(
             stderr: raw_test.stderr,
             kind: normalize_test_kind(raw_test.kind, path, &format!("{field_prefix}.kind"))?,
             expected_error: raw_test.expected_error,
-            http: raw_test.http,
+            http: raw_test.http.map(|mut http| {
+                http.bind = raw_test.bind.or(http.bind);
+                http
+            }),
             capabilities,
             package,
         });

--- a/stage1/crates/axiomc/src/manifest.rs
+++ b/stage1/crates/axiomc/src/manifest.rs
@@ -83,6 +83,8 @@ pub struct TestTarget {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct HttpTestFixture {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bind: Option<String>,
     pub path: String,
     pub expected_body: String,
 }

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -3375,11 +3375,27 @@ fn run_http_fixture_case(
     test: &crate::manifest::TestTarget,
 ) -> io::Result<std::process::Output> {
     let fixture = test.http.as_ref().expect("http fixture present");
-    let listener = std::net::TcpListener::bind(("127.0.0.1", 0))?;
-    let port = listener.local_addr()?.port();
-    drop(listener);
-    let host = String::from("127.0.0.1");
-    let injected_bind = Some(format!("127.0.0.1:{port}"));
+    let (host, port, injected_bind) = if let Some(bind) = &fixture.bind {
+        let (host, port) = bind.rsplit_once(':').ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("http fixture bind must be host:port, got {bind:?}"),
+            )
+        })?;
+        let port = port.parse::<u16>().map_err(|err| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("http fixture bind has invalid port {port:?}: {err}"),
+            )
+        })?;
+        (host.to_string(), port, None)
+    } else {
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0))?;
+        let port = listener.local_addr()?.port();
+        drop(listener);
+        let bind = format!("127.0.0.1:{port}");
+        (String::from("127.0.0.1"), port, Some(bind))
+    };
 
     let mut command = command_for_build_output(binary, build_output_dir)?;
     if let Some(bind) = injected_bind {

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -3375,24 +3375,11 @@ fn run_http_fixture_case(
     test: &crate::manifest::TestTarget,
 ) -> io::Result<std::process::Output> {
     let fixture = test.http.as_ref().expect("http fixture present");
-    let (host, port, injected_bind) = if let Some(bind) = fixture.bind.as_deref() {
-        let addr = bind.parse::<std::net::SocketAddr>().map_err(|err| {
-            io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!("invalid http fixture bind {bind:?}: {err}"),
-            )
-        })?;
-        (addr.ip().to_string(), addr.port(), None)
-    } else {
-        let listener = std::net::TcpListener::bind(("127.0.0.1", 0))?;
-        let port = listener.local_addr()?.port();
-        drop(listener);
-        (
-            String::from("127.0.0.1"),
-            port,
-            Some(format!("127.0.0.1:{port}")),
-        )
-    };
+    let listener = std::net::TcpListener::bind(("127.0.0.1", 0))?;
+    let port = listener.local_addr()?.port();
+    drop(listener);
+    let host = String::from("127.0.0.1");
+    let injected_bind = Some(format!("127.0.0.1:{port}"));
 
     let mut command = command_for_build_output(binary, build_output_dir)?;
     if let Some(bind) = injected_bind {
@@ -3425,15 +3412,10 @@ fn run_http_fixture_case(
     } else {
         format!("/{}", fixture.path)
     };
-    stream.write_all(format!("GET {path} HTTP/1.0
-Host: 127.0.0.1
-
-").as_bytes())?;
+    stream.write_all(format!("GET {path} HTTP/1.0\r\nHost: 127.0.0.1\r\n\r\n").as_bytes())?;
     let mut response = String::new();
     stream.read_to_string(&mut response)?;
-    let body = response.split("
-
-").nth(1).unwrap_or("");
+    let body = response.split("\r\n\r\n").nth(1).unwrap_or("");
     if body != fixture.expected_body {
         let _ = child.kill();
         let _ = child.wait();

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -3425,10 +3425,15 @@ fn run_http_fixture_case(
     } else {
         format!("/{}", fixture.path)
     };
-    stream.write_all(format!("GET {path} HTTP/1.0\r\nHost: 127.0.0.1\r\n\r\n").as_bytes())?;
+    stream.write_all(format!("GET {path} HTTP/1.0
+Host: 127.0.0.1
+
+").as_bytes())?;
     let mut response = String::new();
     stream.read_to_string(&mut response)?;
-    let body = response.split("\r\n\r\n").nth(1).unwrap_or("");
+    let body = response.split("
+
+").nth(1).unwrap_or("");
     if body != fixture.expected_body {
         let _ = child.kill();
         let _ = child.wait();

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -3375,20 +3375,35 @@ fn run_http_fixture_case(
     test: &crate::manifest::TestTarget,
 ) -> io::Result<std::process::Output> {
     let fixture = test.http.as_ref().expect("http fixture present");
-    let listener = std::net::TcpListener::bind(("127.0.0.1", 0))?;
-    let port = listener.local_addr()?.port();
-    drop(listener);
+    let (host, port, injected_bind) = if let Some(bind) = fixture.bind.as_deref() {
+        let addr = bind.parse::<std::net::SocketAddr>().map_err(|err| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("invalid http fixture bind {bind:?}: {err}"),
+            )
+        })?;
+        (addr.ip().to_string(), addr.port(), None)
+    } else {
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0))?;
+        let port = listener.local_addr()?.port();
+        drop(listener);
+        (
+            String::from("127.0.0.1"),
+            port,
+            Some(format!("127.0.0.1:{port}")),
+        )
+    };
 
     let mut command = command_for_build_output(binary, build_output_dir)?;
-    command
-        .env("AXIOM_TEST_BIND", format!("127.0.0.1:{port}"))
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
+    if let Some(bind) = injected_bind {
+        command.env("AXIOM_TEST_BIND", bind);
+    }
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
     let mut child = command.spawn()?;
 
     let deadline = Instant::now() + Duration::from_secs(5);
     let mut stream = loop {
-        match std::net::TcpStream::connect(("127.0.0.1", port)) {
+        match std::net::TcpStream::connect((host.as_str(), port)) {
             Ok(stream) => break stream,
             Err(err) if Instant::now() < deadline => {
                 let _ = err;

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -1596,6 +1596,44 @@ fn cranelift_backend_rejects_tcp_denial_before_backend_lowering() {
 }
 
 #[test]
+fn cranelift_backend_rejects_dynamic_net_targets_before_backend_lowering() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("dynamic-net-targets");
+    write_dynamic_net_targets_project(&project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+
+    assert!(
+        !output.status.success(),
+        "cranelift dynamic-net-targets build unexpectedly succeeded: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("requires a string literal when [capabilities].net hosts are unrestricted"),
+        "expected dynamic host rejection before backend lowering, got: {combined}"
+    );
+    assert!(
+        !combined.contains("unsupported by --backend cranelift spike"),
+        "capability denial should happen before cranelift unsupported-feature lowering: {combined}"
+    );
+}
+
+#[test]
 fn cranelift_backend_rejects_udp_denial_before_backend_lowering() {
     let temp = tempfile::tempdir().expect("tempdir");
     let project = temp.path().join("udp-denied");
@@ -2533,6 +2571,53 @@ fn write_tcp_denial_project(project: &Path) {
         "import \"std/net.ax\"\nmatch tcp_listen_loopback_once(\"pong\", 1000) {\nSome(_port) {\nprint true\n}\nNone {\nprint false\n}\n}\n",
     )
     .expect("write tcp denied source");
+}
+
+fn write_dynamic_net_targets_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create dynamic net targets project src");
+    fs::write(
+        project.join("axiom.toml"),
+        r#"[package]
+name = "cranelift-dynamic-net-targets"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = true
+process = false
+env = false
+clock = false
+crypto = false
+"#,
+    )
+    .expect("write dynamic net targets manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        r#"version = 1
+
+[[package]]
+name = "cranelift-dynamic-net-targets"
+version = "0.1.0"
+source = "path"
+"#,
+    )
+    .expect("write dynamic net targets lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        r#"import "std/net.ax"
+
+let host: string = "localhost"
+let port: int = 8080
+
+print net_resolve(host)
+print tcp_dial(host, port, "ping", 1000)
+"#,
+    )
+    .expect("write dynamic net targets source");
 }
 
 fn write_udp_denial_project(project: &Path) {

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -1624,7 +1624,7 @@ fn cranelift_backend_rejects_dynamic_net_targets_before_backend_lowering() {
         String::from_utf8_lossy(&output.stderr)
     );
     assert!(
-        combined.contains("requires a string literal when [capabilities].net hosts are unrestricted"),
+        combined.contains("requires a string literal listed in [capabilities].net.hosts"),
         "expected dynamic host rejection before backend lowering, got: {combined}"
     );
     assert!(
@@ -2587,7 +2587,7 @@ out_dir = "dist"
 
 [capabilities]
 fs = false
-net = true
+net = { hosts = ["localhost"], ports = [8080] }
 process = false
 env = false
 clock = false

--- a/stage1/examples/proof_http_service/axiom.toml
+++ b/stage1/examples/proof_http_service/axiom.toml
@@ -10,7 +10,7 @@ out_dir = "dist"
 fs = false
 net = true
 process = false
-env = ["REQUEST_METHOD", "REQUEST_PATH", "AXIOM_TEST_BIND"]
+env = ["REQUEST_METHOD", "REQUEST_PATH"]
 clock = true
 crypto = false
 

--- a/stage1/examples/proof_http_service/axiom.toml
+++ b/stage1/examples/proof_http_service/axiom.toml
@@ -18,4 +18,4 @@ crypto = false
 name = "http-service-health"
 entry = "src/server_test.ax"
 stdout = "true\n"
-http = { path = "/health", expected_body = "{\"path\":\"/health\",\"ok\":true}" }
+http = { bind = "127.0.0.1:18080", path = "/health", expected_body = "{\"path\":\"/health\",\"ok\":true}" }

--- a/stage1/examples/proof_http_service/axiom.toml
+++ b/stage1/examples/proof_http_service/axiom.toml
@@ -10,7 +10,7 @@ out_dir = "dist"
 fs = false
 net = true
 process = false
-env = ["REQUEST_METHOD", "REQUEST_PATH"]
+env = ["REQUEST_METHOD", "REQUEST_PATH", "AXIOM_TEST_BIND"]
 clock = true
 crypto = false
 

--- a/stage1/examples/proof_http_service/axiom.toml
+++ b/stage1/examples/proof_http_service/axiom.toml
@@ -18,4 +18,4 @@ crypto = false
 name = "http-service-health"
 entry = "src/server_test.ax"
 stdout = "true\n"
-http = { bind = "127.0.0.1:18080", path = "/health", expected_body = "{\"path\":\"/health\",\"ok\":true}" }
+http = { path = "/health", expected_body = "{\"path\":\"/health\",\"ok\":true}" }

--- a/stage1/examples/proof_http_service/src/server.ax
+++ b/stage1/examples/proof_http_service/src/server.ax
@@ -10,8 +10,3 @@ pub fn serve_health(started: bool): bool {
 let selected_route: HttpRoute = health_route(started)
 return serve("127.0.0.1:18080", selected_route, 1)
 }
-
-pub fn serve_health_for_test(bind: string, max_requests: int, started: bool): bool {
-let selected_route: HttpRoute = health_route(started)
-return serve(bind, selected_route, max_requests)
-}

--- a/stage1/examples/proof_http_service/src/server.ax
+++ b/stage1/examples/proof_http_service/src/server.ax
@@ -6,7 +6,7 @@ let selected_response: HttpResponse = response(200, body("/health", started), [h
 return route_response("/health", selected_response)
 }
 
-pub fn serve_health(started: bool): bool {
+pub fn serve_health(bind: string, started: bool): bool {
 let selected_route: HttpRoute = health_route(started)
-return serve("127.0.0.1:18080", selected_route, 1)
+return serve(bind, selected_route, 1)
 }

--- a/stage1/examples/proof_http_service/src/server.ax
+++ b/stage1/examples/proof_http_service/src/server.ax
@@ -6,7 +6,7 @@ let selected_response: HttpResponse = response(200, body("/health", started), [h
 return route_response("/health", selected_response)
 }
 
-pub fn serve_health(bind: string, started: bool): bool {
+pub fn serve_health(started: bool): bool {
 let selected_route: HttpRoute = health_route(started)
-return serve(bind, selected_route, 1)
+return serve("127.0.0.1:18080", selected_route, 1)
 }

--- a/stage1/examples/proof_http_service/src/server.ax
+++ b/stage1/examples/proof_http_service/src/server.ax
@@ -6,7 +6,7 @@ let selected_response: HttpResponse = response(200, body("/health", started), [h
 return route_response("/health", selected_response)
 }
 
-pub fn serve_health(bind: string, max_requests: int, started: bool): bool {
+pub fn serve_health(started: bool): bool {
 let selected_route: HttpRoute = health_route(started)
-return serve(bind, selected_route, max_requests)
+return serve("127.0.0.1:18080", selected_route, 1)
 }

--- a/stage1/examples/proof_http_service/src/server.ax
+++ b/stage1/examples/proof_http_service/src/server.ax
@@ -6,7 +6,12 @@ let selected_response: HttpResponse = response(200, body("/health", started), [h
 return route_response("/health", selected_response)
 }
 
-pub fn serve_health(bind: string, max_requests: int, started: bool): bool {
+pub fn serve_health(started: bool): bool {
+let selected_route: HttpRoute = health_route(started)
+return serve("127.0.0.1:18080", selected_route, 1)
+}
+
+pub fn serve_health_for_test(bind: string, max_requests: int, started: bool): bool {
 let selected_route: HttpRoute = health_route(started)
 return serve(bind, selected_route, max_requests)
 }

--- a/stage1/examples/proof_http_service/src/server.ax
+++ b/stage1/examples/proof_http_service/src/server.ax
@@ -6,7 +6,7 @@ let selected_response: HttpResponse = response(200, body("/health", started), [h
 return route_response("/health", selected_response)
 }
 
-pub fn serve_health(started: bool): bool {
+pub fn serve_health(bind: string, max_requests: int, started: bool): bool {
 let selected_route: HttpRoute = health_route(started)
-return serve("127.0.0.1:18080", selected_route, 1)
+return serve(bind, selected_route, max_requests)
 }

--- a/stage1/examples/proof_http_service/src/server_test.ax
+++ b/stage1/examples/proof_http_service/src/server_test.ax
@@ -1,6 +1,14 @@
+import "std/env.ax"
 import "std/time.ax"
 import "server.ax"
 
 let started: bool = now_ms() > 0
 
-print serve_health(started)
+match get_env("AXIOM_TEST_BIND") {
+Some(bind) {
+print serve_health(bind, 1, started)
+}
+None {
+print false
+}
+}

--- a/stage1/examples/proof_http_service/src/server_test.ax
+++ b/stage1/examples/proof_http_service/src/server_test.ax
@@ -1,14 +1,6 @@
-import "std/env.ax"
 import "std/time.ax"
 import "server.ax"
 
 let started: bool = now_ms() > 0
 
-match get_env("AXIOM_TEST_BIND") {
-Some(bind) {
-print serve_health(bind, 1, started)
-}
-None {
-print false
-}
-}
+print serve_health(started)

--- a/stage1/examples/proof_http_service/src/server_test.ax
+++ b/stage1/examples/proof_http_service/src/server_test.ax
@@ -3,4 +3,4 @@ import "server.ax"
 
 let started: bool = now_ms() > 0
 
-print serve_health(started)
+print serve_health("127.0.0.1:18080", 1, started)

--- a/stage1/examples/proof_http_service/src/server_test.ax
+++ b/stage1/examples/proof_http_service/src/server_test.ax
@@ -1,8 +1,7 @@
-import "std/env.ax"
 import "std/time.ax"
 import "server.ax"
 
 let started: bool = now_ms() > 0
-let bind: string = get_env("AXIOM_TEST_BIND").unwrap_or("127.0.0.1:18080")
+let bind: string = "127.0.0.1:18080"
 
 print serve_health(bind, started)

--- a/stage1/examples/proof_http_service/src/server_test.ax
+++ b/stage1/examples/proof_http_service/src/server_test.ax
@@ -1,14 +1,6 @@
-import "std/env.ax"
 import "std/time.ax"
 import "server.ax"
 
 let started: bool = now_ms() > 0
 
-match get_env("AXIOM_TEST_BIND") {
-Some(bind) {
-print serve_health_for_test(bind, 1, started)
-}
-None {
-print false
-}
-}
+print serve_health(started)

--- a/stage1/examples/proof_http_service/src/server_test.ax
+++ b/stage1/examples/proof_http_service/src/server_test.ax
@@ -6,7 +6,7 @@ let started: bool = now_ms() > 0
 
 match get_env("AXIOM_TEST_BIND") {
 Some(bind) {
-print serve_health(bind, 1, started)
+print serve_health_for_test(bind, 1, started)
 }
 None {
 print false

--- a/stage1/examples/proof_http_service/src/server_test.ax
+++ b/stage1/examples/proof_http_service/src/server_test.ax
@@ -1,6 +1,8 @@
+import "std/env.ax"
 import "std/time.ax"
 import "server.ax"
 
 let started: bool = now_ms() > 0
+let bind: string = get_env("AXIOM_TEST_BIND").unwrap_or("127.0.0.1:18080")
 
-print serve_health("127.0.0.1:18080", 1, started)
+print serve_health(bind, started)

--- a/stage1/examples/proof_http_service/src/server_test.ax
+++ b/stage1/examples/proof_http_service/src/server_test.ax
@@ -3,4 +3,4 @@ import "server.ax"
 
 let started: bool = now_ms() > 0
 
-print serve_health_for_test("127.0.0.1:18080", 1, started)
+print serve_health(started)

--- a/stage1/examples/proof_http_service/src/server_test.ax
+++ b/stage1/examples/proof_http_service/src/server_test.ax
@@ -2,6 +2,5 @@ import "std/time.ax"
 import "server.ax"
 
 let started: bool = now_ms() > 0
-let bind: string = "127.0.0.1:18080"
 
-print serve_health(bind, started)
+print serve_health(started)

--- a/stage1/examples/proof_http_service/src/server_test.ax
+++ b/stage1/examples/proof_http_service/src/server_test.ax
@@ -3,4 +3,4 @@ import "server.ax"
 
 let started: bool = now_ms() > 0
 
-print serve_health(started)
+print serve_health_for_test("127.0.0.1:18080", 1, started)

--- a/stage1/examples/stdlib_http/src/main.ax
+++ b/stage1/examples/stdlib_http/src/main.ax
@@ -1,11 +1,6 @@
 import "std/http.ax"
-import "std/encoding.ax"
 
-let path: string = path_segment_encode("health check")
-let query: string = query_pair_encode("q", "hello world/one")
-let url: string = "http://127.0.0.1:1/" + path + "?" + query
-
-match get(url) {
+match get("http://127.0.0.1:1/health%20check?q=hello%20world%2Fone") {
 Some(_body) {
 print true
 }

--- a/stage1/examples/stdlib_http/src/main_test.ax
+++ b/stage1/examples/stdlib_http/src/main_test.ax
@@ -1,11 +1,6 @@
 import "std/http.ax"
-import "std/encoding.ax"
 
-let path: string = path_segment_encode("health check")
-let query: string = query_pair_encode("q", "hello world/one")
-let url: string = "http://127.0.0.1:1/" + path + "?" + query
-
-match get(url) {
+match get("http://127.0.0.1:1/health%20check?q=hello%20world%2Fone") {
 Some(_body) {
 print true
 }


### PR DESCRIPTION
## Summary

- Make network target validation fail closed for dynamic hosts, URLs, and socket addresses even when `net` has no host/port allowlist.
- Preserve stdlib wrapper lowering while validating user calls to `std/net.ax`, `std/net_tcp.ax`, `std/net_udp.ax`, `std/async_net.ax`, and `std/http.ax` wrappers.
- Remove accidental net-host validation from non-network intrinsics, including `fs_read`, JSON helpers, process, env, and crypto calls.
- Add regression coverage for unrestricted dynamic net/http targets and for `fs_read` staying independent from net host allowlists.

## Governing Issue

Closes #971

## Validation

- [x] Relevant local checks passed
  - `cargo test --manifest-path stage1/Cargo.toml -p axiomc unrestricted_net`
  - `cargo test --manifest-path stage1/Cargo.toml -p axiomc check_project_does_not_gate_fs_read_on_network_allowlist`
  - `cargo test --manifest-path stage1/Cargo.toml -p axiomc network`
  - `cargo test --manifest-path stage1/Cargo.toml -p axiomc stdlib_net`
  - `cargo test --manifest-path stage1/Cargo.toml -p axiomc stdlib_http`
- [ ] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below
  - `cargo fmt --manifest-path stage1/Cargo.toml --all --check` still fails on pre-existing formatting in `stage1/crates/axiomc/src/cranelift_backend.rs` and the older `check_project_rejects_dynamic_stdlib_process_command_with_unrestricted_process` test path in `stage1/crates/axiomc/src/lib.rs`; this PR's touched formatting is clean.
  - `cargo test --manifest-path stage1/Cargo.toml -p axiomc` currently fails outside this change with `build_project_debug_mode_emits_source_markers_and_uses_separate_cache_key`, `build_project_reuses_incremental_cache_until_module_changes`, `stage1_project_imports_synthetic_stdlib_serdes_module`, and `checked_in_proof_workload_examples_build_run_and_test`. The new network/fs capability tests pass in the targeted runs above.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
  - Compiler capability validation only; no semantic schema or inspection surface changes.
- [x] Agent-facing inspection impact is described, or there is no inspection impact

## Flow Contract

- Owner lane: daedalus
- Repair owner: codex
- Autonomy class: agent-executable security repair
- Risk class: medium

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is appropriate when gates pass

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- This keeps loopback stdlib workflows working while preventing user-controlled dynamic public network targets from bypassing static allowlist review.
