### PR TITLE
Bound parser recursion depth

### DIFF
--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -37,8 +37,8 @@ mod tests {
         run_project_tests_with_options, run_project_with_options,
     };
     use crate::syntax::{
-        MacroStyle, ParseOptions, Stmt, TypeName, Visibility, parse_program,
-        parse_program_with_options, parse_program_with_recovery,
+        DEFAULT_PARSE_RECURSION_LIMIT, MacroStyle, ParseOptions, Stmt, TypeName, Visibility,
+        parse_program, parse_program_with_options, parse_program_with_recovery,
     };
     use serde::Serialize;
     use std::collections::HashMap;
@@ -843,6 +843,45 @@ spin!()
         )
         .expect_err("custom recursion limit should be enforced");
         assert!(error.message.contains("bounded depth of 3"));
+    }
+
+    #[test]
+    fn parser_bounds_deeply_nested_parenthesized_expressions() {
+        let nested = format!(
+            "print {}1{}\n",
+            "(".repeat(DEFAULT_PARSE_RECURSION_LIMIT + 8),
+            ")".repeat(DEFAULT_PARSE_RECURSION_LIMIT + 8)
+        );
+
+        let error = parse_program(&nested, Path::new("main.ax"))
+            .expect_err("deep expression nesting should be bounded");
+
+        assert_eq!(error.code.as_deref(), Some("parse_recursion_limit"));
+        assert!(
+            error.message.contains("parser recursion limit"),
+            "unexpected diagnostic: {error:?}",
+        );
+    }
+
+    #[test]
+    fn parser_bounds_deeply_nested_statement_blocks() {
+        let mut source = String::new();
+        for _ in 0..(DEFAULT_PARSE_RECURSION_LIMIT + 8) {
+            source.push_str("if true {\n");
+        }
+        source.push_str("print true\n");
+        for _ in 0..(DEFAULT_PARSE_RECURSION_LIMIT + 8) {
+            source.push_str("}\n");
+        }
+
+        let error = parse_program(&source, Path::new("main.ax"))
+            .expect_err("deep block nesting should be bounded");
+
+        assert_eq!(error.code.as_deref(), Some("parse_recursion_limit"));
+        assert!(
+            error.message.contains("parser recursion limit"),
+            "unexpected diagnostic: {error:?}",
+        );
     }
 
     #[test]

--- a/stage1/crates/axiomc/src/syntax.rs
+++ b/stage1/crates/axiomc/src/syntax.rs
@@ -1,5 +1,6 @@
 use crate::diagnostics::Diagnostic;
 use serde::Serialize;
+use std::cell::Cell;
 use std::path::Path;
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq, Hash)]
@@ -59,6 +60,44 @@ pub struct Program {
 pub const DEFAULT_MACRO_RECURSION_LIMIT: usize = 64;
 pub const DEFAULT_MACRO_EXPANSION_BYTE_LIMIT: usize = 16 * 1024 * 1024;
 pub const DEFAULT_MACRO_EXPANSION_INVOCATION_LIMIT: usize = 8192;
+pub const DEFAULT_PARSE_RECURSION_LIMIT: usize = 64;
+
+thread_local! {
+    static PARSE_RECURSION_DEPTH: Cell<usize> = const { Cell::new(0) };
+}
+
+struct ParseRecursionGuard;
+
+impl Drop for ParseRecursionGuard {
+    fn drop(&mut self) {
+        PARSE_RECURSION_DEPTH.with(|depth| {
+            depth.set(depth.get().saturating_sub(1));
+        });
+    }
+}
+
+fn enter_parse_recursion(
+    path: &Path,
+    line_no: usize,
+    column: usize,
+) -> Result<ParseRecursionGuard, Diagnostic> {
+    PARSE_RECURSION_DEPTH.with(|depth| {
+        let current = depth.get();
+        if current >= DEFAULT_PARSE_RECURSION_LIMIT {
+            return Err(Diagnostic::new(
+                "parse",
+                format!(
+                    "parser recursion limit of {DEFAULT_PARSE_RECURSION_LIMIT} nested constructs exceeded"
+                ),
+            )
+            .with_code("parse_recursion_limit")
+            .with_path(path.display().to_string())
+            .with_span(line_no, column));
+        }
+        depth.set(current + 1);
+        Ok(ParseRecursionGuard)
+    })
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ParseOptions {
@@ -2089,6 +2128,7 @@ fn parse_stmt_list(
     index: &mut usize,
     path: &Path,
 ) -> Result<Vec<Stmt>, Diagnostic> {
+    let _recursion_guard = enter_parse_recursion(path, (*index + 1).max(1), 1)?;
     let mut stmts = Vec::new();
     while *index < lines.len() {
         let line_no = *index + 1;
@@ -2193,6 +2233,9 @@ fn parse_stmt_list(
         match parse_stmt(lines, index, path, true) {
             Ok(stmt) => stmts.push(stmt),
             Err(error) => {
+                if error.code.as_deref() == Some("parse_recursion_limit") {
+                    return Err(error);
+                }
                 let mut diagnostics = vec![error];
                 let failed_index = *index;
                 synchronize_statement(lines, index);
@@ -2208,6 +2251,9 @@ fn parse_stmt_list(
                     match parse_stmt(lines, index, path, true) {
                         Ok(stmt) => stmts.push(stmt),
                         Err(error) => {
+                            if error.code.as_deref() == Some("parse_recursion_limit") {
+                                return Err(error);
+                            }
                             diagnostics.push(error);
                             let before = *index;
                             synchronize_statement(lines, index);
@@ -4006,6 +4052,7 @@ fn parse_type_name(
     line_no: usize,
     column: usize,
 ) -> Result<TypeName, Diagnostic> {
+    let _recursion_guard = enter_parse_recursion(path, line_no, column)?;
     if raw.starts_with("dyn ") {
         return Err(Diagnostic::new(
             "parse",
@@ -4323,6 +4370,7 @@ fn source_position_for_offset(
 }
 
 fn parse_expr(raw: &str, path: &Path, line_no: usize, column: usize) -> Result<Expr, Diagnostic> {
+    let _recursion_guard = enter_parse_recursion(path, line_no, column)?;
     let raw = raw.trim();
     if raw.starts_with('|') {
         return parse_term(raw, path, line_no, column);
@@ -4482,6 +4530,7 @@ fn parse_mul(raw: &str, path: &Path, line_no: usize, column: usize) -> Result<Ex
 }
 
 fn parse_term(raw: &str, path: &Path, line_no: usize, column: usize) -> Result<Expr, Diagnostic> {
+    let _recursion_guard = enter_parse_recursion(path, line_no, column)?;
     if let Some(closure) = parse_closure_expr(raw, path, line_no, column)? {
         return Ok(closure);
     }


### PR DESCRIPTION
## Summary

- Add a bounded parser recursion guard for expression, term, type-name, and statement-block parsing.
- Return a stable `parse_recursion_limit` diagnostic instead of allowing deeply nested source to overflow the compiler stack.
- Treat parser-recursion-limit diagnostics as fatal to block recovery so recovery does not re-enter malicious nested bodies.
- Add regressions for deeply nested parenthesized expressions and nested `if` blocks.

## Governing Issue

Closes #967

## Validation

- [x] Relevant local checks passed
  - `cargo test --manifest-path stage1/Cargo.toml -p axiomc parser_bounds_deeply_nested`
  - `cargo test --manifest-path stage1/Cargo.toml -p axiomc parser_`
- [ ] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below
  - `cargo fmt --manifest-path stage1/Cargo.toml --all --check` still fails on pre-existing formatting in `stage1/crates/axiomc/src/cranelift_backend.rs` and the older `check_project_rejects_dynamic_stdlib_process_command_with_unrestricted_process` test path in `stage1/crates/axiomc/src/lib.rs`; this PR's touched formatting is clean.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
  - Parser diagnostic hardening only; no semantic schema or inspection surface changes.
- [x] Agent-facing inspection impact is described, or there is no inspection impact

## Flow Contract

- Owner lane: daedalus
- Repair owner: codex
- Autonomy class: agent-executable security repair
- Risk class: high

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is appropriate when gates pass

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- The parser recursion budget is fixed at 64 nested constructs, matching the existing macro recursion default.
