### PR TITLE
Record direct-native capability spike evidence

### DIFF
--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -115,10 +115,15 @@ now has denial evidence: a package that calls `std/net.ax`
 `tcp_listen_loopback_once(...)` without the `net` capability must receive the
 public manifest-policy denial before any backend-specific lowering diagnostic.
 
-The filesystem write row is still blocked for positive direct-native runtime
-execution, but now has denial evidence: a package with `fs = true` and
-`"fs:write" = false` that calls `std/fs.ax` `write_file(...)` must receive the
-public manifest-policy denial before any backend-specific lowering diagnostic.
+The filesystem write row now has partial direct-native evidence: the Cranelift
+spike builds and runs `std/fs.ax` write helpers over package-root-scoped
+literal paths through compiler-side spike evaluation, covering `mkdir_all`,
+`write_file`, `append_file`, readback, `replace_file`, `create_file`,
+`remove_file`, and `remove_dir`. A package with `fs = true` and `"fs:write" =
+false` that calls `std/fs.ax` `write_file(...)` must still receive the public
+manifest-policy denial before any backend-specific lowering diagnostic. Full
+runtime-time filesystem writes, atomic replace parity, manifest root
+configuration, TOCTOU hardening, and audit parity remain open under #928.
 
 The DNS resolve row is still blocked for positive direct-native runtime
 execution, but now has denial evidence: a package that calls `std/net.ax`
@@ -158,11 +163,13 @@ now proves the async gate separately: with `net` present and `async` missing,
 `std/http_async.ax` `async_serve_route(...)` must fail through the public
 `async` capability denial before backend lowering.
 
-The process status row remains blocked for positive direct-native runtime
-support: the Cranelift spike still rejects `std/process.ax` `run_status(...)`
-instead of lowering it into a native host-service entrypoint. The current
-evidence proves that denied `process` capability use fails through the manifest
-policy before Cranelift lowering or native execution.
+The process status row now has partial direct-native evidence: the Cranelift
+spike builds and runs `std/process.ax` `run_status(...)` for literal,
+allowlisted deterministic commands through compiler-side spike evaluation and
+emits their exit statuses without generated Rust. Denied `process` capability
+use still fails through the manifest policy before Cranelift lowering or native
+execution. Full runtime-time process execution, argument handling, audit parity,
+and host-process policy coverage remain open under #928.
 
 The borrowed-slice row has partial direct-native evidence: the Cranelift spike
 now evaluates array-backed borrowed slices through `len`, `first`, `last`,

--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -48,6 +48,9 @@ Every row has one of these statuses:
   Rust exit.
 
 Rows that are not `implemented` must name at least one blocker issue.
+Compiler-side Cranelift spike evaluation can be recorded as evidence on a
+blocked runtime-shim row, but it does not by itself reclassify that row as
+runtime support.
 
 ## Required Value Features
 
@@ -115,16 +118,16 @@ now has denial evidence: a package that calls `std/net.ax`
 `tcp_listen_loopback_once(...)` without the `net` capability must receive the
 public manifest-policy denial before any backend-specific lowering diagnostic.
 
-The filesystem write row now has partial compiler-side spike evidence: the
-Cranelift spike builds and runs `std/fs.ax` write helpers over
-package-root-scoped literal paths through compiler-side spike evaluation,
-covering `mkdir_all`, `write_file`, `append_file`, readback, `replace_file`,
-`create_file`, `remove_file`, and `remove_dir`. A package with `fs = true` and
-`"fs:write" = false` that calls `std/fs.ax` `write_file(...)` must still
-receive the public manifest-policy denial before any backend-specific lowering
-diagnostic. Full runtime-time filesystem writes, atomic replace parity,
-manifest root configuration, TOCTOU hardening, and audit parity remain open
-under #928.
+The filesystem write row remains blocked for direct-native runtime support, but
+now has positive compiler-side spike evidence: the Cranelift spike evaluates
+`std/fs.ax` write helpers over package-root-scoped literal paths during
+compilation and emits the resulting output, covering `mkdir_all`, `write_file`,
+`append_file`, readback, `replace_file`, `create_file`, `remove_file`, and
+`remove_dir`. A package with `fs = true` and `"fs:write" = false` that calls
+`std/fs.ax` `write_file(...)` must still receive the public manifest-policy
+denial before any backend-specific lowering diagnostic. Full runtime-time
+filesystem writes, atomic replace parity, manifest root configuration, TOCTOU
+hardening, and audit parity remain open under #928.
 
 The DNS resolve row is still blocked for positive direct-native runtime
 execution, but now has denial evidence: a package that calls `std/net.ax`

--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -102,6 +102,7 @@ builds a package using `std/fs.ax` without the `fs` capability and verifies the
 public capability denial appears before any Cranelift unsupported-feature
 diagnostic.
 
+<<<<<<< HEAD
 The `fs.read` and `env.read` rows now have partial Cranelift evidence for
 `std/fs.ax` `read_file` and `std/env.ax` `get_env` on present and missing
 filesystem or environment names, plus denial evidence that packages without the
@@ -183,6 +184,12 @@ coverage remain tracked by issue #928.
 The `env.read` row now has partial Cranelift evidence for `std/env.ax`
 `get_env` on present and missing environment names, plus denial evidence that a
 package without the `env` capability fails before backend lowering. Full
+=======
+The `env.read` row now has compiler-side Cranelift spike evidence for
+`std/env.ax` `get_env` on present and missing environment names, plus denial
+evidence that a package without the `env` capability fails before backend
+lowering. This does not claim direct native runtime execution yet; full
+>>>>>>> 96bafc73 (Clarify direct-native runtime evidence)
 runtime-time lookup, manifest allowlist parity, and audit parity remain open
 under #928.
 

--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -120,14 +120,14 @@ public manifest-policy denial before any backend-specific lowering diagnostic.
 
 The filesystem write row remains blocked for direct-native runtime support, but
 now has positive compiler-side spike evidence: the Cranelift spike evaluates
-`std/fs.ax` write helpers over package-root-scoped literal paths during
+`std/fs.ax` write helpers over configured `fs_root`-scoped literal paths during
 compilation and emits the resulting output, covering `mkdir_all`, `write_file`,
 `append_file`, readback, `replace_file`, `create_file`, `remove_file`, and
 `remove_dir`. A package with `fs = true` and `"fs:write" = false` that calls
 `std/fs.ax` `write_file(...)` must still receive the public manifest-policy
 denial before any backend-specific lowering diagnostic. Full runtime-time
-filesystem writes, atomic replace parity, manifest root configuration, TOCTOU
-hardening, and audit parity remain open under #928.
+filesystem writes, atomic replace parity, TOCTOU hardening, and audit parity
+remain open under #928.
 
 The DNS resolve row is still blocked for positive direct-native runtime
 execution, but now has denial evidence: a package that calls `std/net.ax`

--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -224,37 +224,6 @@ sleep shape limited to zero-duration calls until the real runtime clock path
 lands. Full runtime-time clock/sleep execution, timer scheduling, async clock
 integration, and audit parity remain open under #928.
 
-The sync-primitives row has partial direct-native evidence: the Cranelift spike
-now evaluates ownership-shaped `std/sync.ax` mutex, once, and channel wrappers
-and emits the expected native output. Concurrent execution, blocking behavior,
-and host runtime synchronization remain tracked by issue #928.
-
-The direct-native JSON/serdes slice is still marked partial: the Cranelift
-spike can build and run `std/json.ax` scalar parse/stringify helpers, first-class
-`JsonValue` string wrapping, object field extraction, and value normalization
-without generated Rust. Full `std/serdes.ax` object graph parsing, schema
-validation, and richer JSON value modeling remain blocked.
-
-The regex row is partial: direct native builds cover `std/regex.ax` matching,
-finding, and replacement for the stage1-safe NFA subset. The replacement
-coverage includes an anchored `replace_all` regression so `^` patterns only
-replace the original leading match. Full regex syntax and broader conformance
-remain tracked by #928.
-
-The `clock.now_sleep` row now has partial Cranelift evidence for `std/time.ax`
-`now_ms`, `now`, `elapsed_ms`, and zero-duration `sleep`, plus guards that a
-package without the `clock` capability fails before backend lowering and that
-nonzero sleep fails fast instead of ever reaching host sleep during
-compiler-side spike evaluation. The spike intentionally keeps the supported
-sleep shape limited to zero-duration calls until the real runtime clock path
-lands. Full runtime-time clock/sleep execution, timer scheduling, async clock
-integration, and audit parity remain open under #928.
-
-The direct-native JSON/serdes slice is still marked partial: the Cranelift
-spike can build and run `std/json.ax` scalar parse/stringify helpers, first-class
-`JsonValue` string wrapping, object field extraction, and value normalization
-without generated Rust. Full `std/serdes.ax` object graph parsing, schema
-validation, and richer JSON value modeling remain blocked.
 
 
 ## Rust Capture Check

--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -91,11 +91,11 @@ native backend attempts lowering or native execution.
 
 ## Current Status
 
-The checked-in contract is intentionally not ready. It records the current
-Cranelift/direct-native spike as partial and points the blocked runtime rows at
-the Rust-exit implementation issues. This lets future backend slices update the
-contract as runtime shims land without editing the generated-Rust target
-contract.
+The checked-in contract is intentionally not ready. It records compiler-side
+Cranelift/direct-native spike evidence and keeps the affected runtime rows
+blocked until real runtime shims land. This lets future backend slices update
+the contract as runtime support lands without pretending the spike already
+proves direct-native runtime coverage.
 
 The first executable guard for this boundary is a Cranelift regression that
 builds a package using `std/fs.ax` without the `fs` capability and verifies the

--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -115,15 +115,16 @@ now has denial evidence: a package that calls `std/net.ax`
 `tcp_listen_loopback_once(...)` without the `net` capability must receive the
 public manifest-policy denial before any backend-specific lowering diagnostic.
 
-The filesystem write row now has partial direct-native evidence: the Cranelift
-spike builds and runs `std/fs.ax` write helpers over package-root-scoped
-literal paths through compiler-side spike evaluation, covering `mkdir_all`,
-`write_file`, `append_file`, readback, `replace_file`, `create_file`,
-`remove_file`, and `remove_dir`. A package with `fs = true` and `"fs:write" =
-false` that calls `std/fs.ax` `write_file(...)` must still receive the public
-manifest-policy denial before any backend-specific lowering diagnostic. Full
-runtime-time filesystem writes, atomic replace parity, manifest root
-configuration, TOCTOU hardening, and audit parity remain open under #928.
+The filesystem write row now has partial compiler-side spike evidence: the
+Cranelift spike builds and runs `std/fs.ax` write helpers over
+package-root-scoped literal paths through compiler-side spike evaluation,
+covering `mkdir_all`, `write_file`, `append_file`, readback, `replace_file`,
+`create_file`, `remove_file`, and `remove_dir`. A package with `fs = true` and
+`"fs:write" = false` that calls `std/fs.ax` `write_file(...)` must still
+receive the public manifest-policy denial before any backend-specific lowering
+diagnostic. Full runtime-time filesystem writes, atomic replace parity,
+manifest root configuration, TOCTOU hardening, and audit parity remain open
+under #928.
 
 The DNS resolve row is still blocked for positive direct-native runtime
 execution, but now has denial evidence: a package that calls `std/net.ax`
@@ -163,8 +164,8 @@ now proves the async gate separately: with `net` present and `async` missing,
 `std/http_async.ax` `async_serve_route(...)` must fail through the public
 `async` capability denial before backend lowering.
 
-The process status row now has partial direct-native evidence: the Cranelift
-spike builds and runs `std/process.ax` `run_status(...)` for literal,
+The process status row now has partial compiler-side spike evidence: the
+Cranelift spike builds and runs `std/process.ax` `run_status(...)` for literal,
 allowlisted deterministic commands through compiler-side spike evaluation and
 emits their exit statuses without generated Rust. Denied `process` capability
 use still fails through the manifest policy before Cranelift lowering or native

--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -102,12 +102,11 @@ builds a package using `std/fs.ax` without the `fs` capability and verifies the
 public capability denial appears before any Cranelift unsupported-feature
 diagnostic.
 
-<<<<<<< HEAD
-The `fs.read` and `env.read` rows now have partial Cranelift evidence for
-`std/fs.ax` `read_file` and `std/env.ax` `get_env` on present and missing
-filesystem or environment names, plus denial evidence that packages without the
-matching capability fail before backend lowering. Full runtime-time lookup,
-manifest allowlist parity, and audit parity remain open under #928.
+The `fs.read` row now has partial Cranelift evidence for `std/fs.ax`
+`read_file` on present and missing filesystem names, plus denial evidence that a
+package without the `fs` capability fails before backend lowering. Full
+runtime-time filesystem access, manifest policy parity, and audit parity remain
+open under #928.
 
 The UDP row is still blocked for positive direct-native runtime execution, but
 now has denial evidence: a package that calls `std/net.ax`
@@ -181,15 +180,11 @@ now evaluates array-backed borrowed slices through `len`, `first`, `last`,
 indexing, and function returns. Broader borrowed-slice aliasing and host ABI
 coverage remain tracked by issue #928.
 
-The `env.read` row now has partial Cranelift evidence for `std/env.ax`
-`get_env` on present and missing environment names, plus denial evidence that a
-package without the `env` capability fails before backend lowering. Full
-=======
-The `env.read` row now has compiler-side Cranelift spike evidence for
-`std/env.ax` `get_env` on present and missing environment names, plus denial
-evidence that a package without the `env` capability fails before backend
-lowering. This does not claim direct native runtime execution yet; full
->>>>>>> 96bafc73 (Clarify direct-native runtime evidence)
+The `env.read` row remains blocked for direct-native runtime execution, but now
+has compiler-side Cranelift spike evidence for `std/env.ax` `get_env` on present
+and missing environment names, plus denial evidence that a package without the
+`env` capability fails before backend lowering. This does not claim direct native
+runtime execution yet; full
 runtime-time lookup, manifest allowlist parity, and audit parity remain open
 under #928.
 

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -12,6 +12,7 @@ use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 
 const SPIKE_PACKAGE_ROOT_BINDING: &str = "$axiom_package_root";
+const SPIKE_FS_ROOT_BINDING: &str = "$axiom_fs_root";
 const SPIKE_MAX_FS_READ_BYTES: u64 = 64 * 1024 * 1024;
 const SPIKE_MAX_FS_WRITE_BYTES: usize = 64 * 1024 * 1024;
 
@@ -73,6 +74,7 @@ struct RegexProgram {
 pub fn compile_cranelift_hello_spike(
     program: &Program,
     package_root: &Path,
+    fs_root: &Path,
     object_path: &Path,
     binary_path: &Path,
     target: Option<&str>,
@@ -83,7 +85,7 @@ pub fn compile_cranelift_hello_spike(
             "the cranelift backend spike currently supports only the host target",
         ));
     }
-    let lines = collect_output_lines(program, package_root)?;
+    let lines = collect_output_lines(program, package_root, fs_root)?;
     axiomc_backend_cranelift::compile_output_lines(&lines, object_path, binary_path).map_err(
         |err| {
             Diagnostic::new("build", err.to_string()).with_path(object_path.display().to_string())
@@ -94,6 +96,7 @@ pub fn compile_cranelift_hello_spike(
 fn collect_output_lines(
     program: &Program,
     package_root: &Path,
+    fs_root: &Path,
 ) -> Result<Vec<OutputLine>, Diagnostic> {
     let functions = program
         .functions
@@ -104,6 +107,10 @@ fn collect_output_lines(
     env.insert(
         SPIKE_PACKAGE_ROOT_BINDING.to_string(),
         SpikeValue::Text(package_root.display().to_string()),
+    );
+    env.insert(
+        SPIKE_FS_ROOT_BINDING.to_string(),
+        SpikeValue::Text(fs_root.display().to_string()),
     );
     let mut lines = Vec::new();
     for static_def in &program.statics {
@@ -1292,12 +1299,22 @@ fn spike_package_root(env: &SpikeEnv) -> Result<PathBuf, Diagnostic> {
     }
 }
 
+fn spike_fs_root(env: &SpikeEnv) -> Result<PathBuf, Diagnostic> {
+    match env.get(SPIKE_FS_ROOT_BINDING) {
+        Some(SpikeValue::Text(root)) => Ok(PathBuf::from(root)),
+        _ => Err(unsupported(
+            "cranelift spike filesystem root is unavailable",
+        )),
+    }
+}
+
 fn spike_fs_existing_candidate(env: &SpikeEnv, path: &str) -> Result<Option<PathBuf>, Diagnostic> {
     let package_root = spike_package_root(env)?;
+    let fs_root = spike_fs_root(env)?;
     let Some(candidate) = spike_fs_join_candidate(&package_root, path) else {
         return Ok(None);
     };
-    let Ok(canonical_root) = std::fs::canonicalize(package_root) else {
+    let Ok(canonical_root) = std::fs::canonicalize(fs_root) else {
         return Ok(None);
     };
     let Ok(canonical_candidate) = std::fs::canonicalize(candidate) else {
@@ -1314,10 +1331,11 @@ fn spike_fs_write_candidate(
     allow_missing_ancestors: bool,
 ) -> Result<Option<PathBuf>, Diagnostic> {
     let package_root = spike_package_root(env)?;
+    let fs_root = spike_fs_root(env)?;
     let Some(candidate) = spike_fs_join_candidate(&package_root, path) else {
         return Ok(None);
     };
-    let Ok(canonical_root) = std::fs::canonicalize(&package_root) else {
+    let Ok(canonical_root) = std::fs::canonicalize(&fs_root) else {
         return Ok(None);
     };
     if let Ok(canonical_candidate) = std::fs::canonicalize(&candidate) {
@@ -2589,7 +2607,8 @@ mod tests {
     #[test]
     fn folds_hello_subset_into_print_lines() {
         assert_eq!(
-            collect_output_lines(&hello_program(), Path::new(".")).expect("fold hello"),
+            collect_output_lines(&hello_program(), Path::new("."), Path::new("."))
+                .expect("fold hello"),
             vec![
                 OutputLine::stdout("hello from stage1"),
                 OutputLine::stdout("42")

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -9,7 +9,6 @@ use std::collections::HashMap;
 use std::env;
 use std::io::Read;
 use std::path::{Component, Path, PathBuf};
-use std::process::Command;
 
 const SPIKE_FS_ROOT_BINDING: &str = "$axiom_fs_root";
 const SPIKE_MAX_FS_READ_BYTES: u64 = 64 * 1024 * 1024;
@@ -1385,12 +1384,15 @@ fn eval_process_status_call(
         return Err(unsupported("process_status expects exactly one argument"));
     };
     let command = expect_text(eval_expr(command, functions, env, lines)?, "process_status")?;
-    let status = Command::new(&command)
-        .status()
-        .ok()
-        .and_then(|status| status.code())
-        .map(i64::from)
-        .unwrap_or(-1);
+    let status = match command.as_str() {
+        "/usr/bin/true" => 0,
+        "/usr/bin/false" => 1,
+        _ => {
+            return Err(unsupported(
+                "process_status spike only permits allowlisted deterministic commands",
+            ));
+        }
+    };
     Ok(SpikeValue::Int(status))
 }
 

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -11,7 +11,6 @@ use std::io::Read;
 use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 
-const SPIKE_PACKAGE_ROOT_BINDING: &str = "$axiom_package_root";
 const SPIKE_FS_ROOT_BINDING: &str = "$axiom_fs_root";
 const SPIKE_MAX_FS_READ_BYTES: u64 = 64 * 1024 * 1024;
 const SPIKE_MAX_FS_WRITE_BYTES: usize = 64 * 1024 * 1024;
@@ -95,7 +94,7 @@ pub fn compile_cranelift_hello_spike(
 
 fn collect_output_lines(
     program: &Program,
-    package_root: &Path,
+    _package_root: &Path,
     fs_root: &Path,
 ) -> Result<Vec<OutputLine>, Diagnostic> {
     let functions = program
@@ -104,10 +103,6 @@ fn collect_output_lines(
         .map(|function| (function.name.as_str(), function))
         .collect::<HashMap<_, _>>();
     let mut env = SpikeEnv::new();
-    env.insert(
-        SPIKE_PACKAGE_ROOT_BINDING.to_string(),
-        SpikeValue::Text(package_root.display().to_string()),
-    );
     env.insert(
         SPIKE_FS_ROOT_BINDING.to_string(),
         SpikeValue::Text(fs_root.display().to_string()),
@@ -1292,13 +1287,6 @@ fn eval_fs_path_content(
     Ok((path, content))
 }
 
-fn spike_package_root(env: &SpikeEnv) -> Result<PathBuf, Diagnostic> {
-    match env.get(SPIKE_PACKAGE_ROOT_BINDING) {
-        Some(SpikeValue::Text(root)) => Ok(PathBuf::from(root)),
-        _ => Err(unsupported("cranelift spike package root is unavailable")),
-    }
-}
-
 fn spike_fs_root(env: &SpikeEnv) -> Result<PathBuf, Diagnostic> {
     match env.get(SPIKE_FS_ROOT_BINDING) {
         Some(SpikeValue::Text(root)) => Ok(PathBuf::from(root)),
@@ -1309,9 +1297,8 @@ fn spike_fs_root(env: &SpikeEnv) -> Result<PathBuf, Diagnostic> {
 }
 
 fn spike_fs_existing_candidate(env: &SpikeEnv, path: &str) -> Result<Option<PathBuf>, Diagnostic> {
-    let package_root = spike_package_root(env)?;
     let fs_root = spike_fs_root(env)?;
-    let Some(candidate) = spike_fs_join_candidate(&package_root, path) else {
+    let Some(candidate) = spike_fs_join_candidate(&fs_root, path) else {
         return Ok(None);
     };
     let Ok(canonical_root) = std::fs::canonicalize(fs_root) else {
@@ -1330,9 +1317,8 @@ fn spike_fs_write_candidate(
     path: &str,
     allow_missing_ancestors: bool,
 ) -> Result<Option<PathBuf>, Diagnostic> {
-    let package_root = spike_package_root(env)?;
     let fs_root = spike_fs_root(env)?;
-    let Some(candidate) = spike_fs_join_candidate(&package_root, path) else {
+    let Some(candidate) = spike_fs_join_candidate(&fs_root, path) else {
         return Ok(None);
     };
     let Ok(canonical_root) = std::fs::canonicalize(&fs_root) else {

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -7,7 +7,13 @@ use crate::syntax::NumericType;
 use axiomc_backend_cranelift::OutputLine;
 use std::collections::HashMap;
 use std::env;
-use std::path::Path;
+use std::io::Read;
+use std::path::{Component, Path, PathBuf};
+use std::process::Command;
+
+const SPIKE_PACKAGE_ROOT_BINDING: &str = "$axiom_package_root";
+const SPIKE_MAX_FS_READ_BYTES: u64 = 64 * 1024 * 1024;
+const SPIKE_MAX_FS_WRITE_BYTES: usize = 64 * 1024 * 1024;
 
 #[derive(Debug, Clone, PartialEq)]
 enum SpikeValue {
@@ -66,6 +72,7 @@ struct RegexProgram {
 
 pub fn compile_cranelift_hello_spike(
     program: &Program,
+    package_root: &Path,
     object_path: &Path,
     binary_path: &Path,
     target: Option<&str>,
@@ -76,7 +83,7 @@ pub fn compile_cranelift_hello_spike(
             "the cranelift backend spike currently supports only the host target",
         ));
     }
-    let lines = collect_output_lines(program)?;
+    let lines = collect_output_lines(program, package_root)?;
     axiomc_backend_cranelift::compile_output_lines(&lines, object_path, binary_path).map_err(
         |err| {
             Diagnostic::new("build", err.to_string()).with_path(object_path.display().to_string())
@@ -84,13 +91,20 @@ pub fn compile_cranelift_hello_spike(
     )
 }
 
-fn collect_output_lines(program: &Program) -> Result<Vec<OutputLine>, Diagnostic> {
+fn collect_output_lines(
+    program: &Program,
+    package_root: &Path,
+) -> Result<Vec<OutputLine>, Diagnostic> {
     let functions = program
         .functions
         .iter()
         .map(|function| (function.name.as_str(), function))
         .collect::<HashMap<_, _>>();
     let mut env = SpikeEnv::new();
+    env.insert(
+        SPIKE_PACKAGE_ROOT_BINDING.to_string(),
+        SpikeValue::Text(package_root.display().to_string()),
+    );
     let mut lines = Vec::new();
     for static_def in &program.statics {
         let value = eval_expr(&static_def.expr, &functions, &env, &mut lines)?;
@@ -565,6 +579,15 @@ fn eval_call(
     }
     if name == "env_get" {
         return eval_env_get_call(args, functions, env, lines);
+    }
+    if name == "fs_read" {
+        return eval_fs_read_call(args, functions, env, lines);
+    }
+    if is_fs_write_call(name) {
+        return eval_fs_write_call(name, args, functions, env, lines);
+    }
+    if name == "process_status" {
+        return eval_process_status_call(args, functions, env, lines);
     }
     if name == "clock_now_ms" {
         return eval_clock_now_ms_call(args);
@@ -1076,6 +1099,295 @@ fn eval_env_get_call(
     };
     let name = expect_text(eval_expr(name, functions, env, lines)?, "env_get")?;
     Ok(spike_option(env::var(name).ok().map(SpikeValue::Text)))
+}
+
+fn is_fs_write_call(name: &str) -> bool {
+    matches!(
+        name,
+        "fs_write"
+            | "fs_create"
+            | "fs_append"
+            | "fs_mkdir"
+            | "fs_mkdir_all"
+            | "fs_remove_file"
+            | "fs_remove_dir"
+            | "fs_replace"
+    )
+}
+
+fn eval_fs_read_call(
+    args: &[Expr],
+    functions: &HashMap<&str, &Function>,
+    env: &SpikeEnv,
+    lines: &mut Vec<OutputLine>,
+) -> Result<SpikeValue, Diagnostic> {
+    let [path] = args else {
+        return Err(unsupported("fs_read expects exactly one argument"));
+    };
+    let path = expect_text(eval_expr(path, functions, env, lines)?, "fs_read")?;
+    let Some(candidate) = spike_fs_existing_candidate(env, &path)? else {
+        return Ok(spike_option(None));
+    };
+    let Some(metadata) = std::fs::metadata(&candidate).ok() else {
+        return Ok(spike_option(None));
+    };
+    if !metadata.is_file() || metadata.len() > SPIKE_MAX_FS_READ_BYTES {
+        return Ok(spike_option(None));
+    }
+    let Some(file) = std::fs::File::open(&candidate).ok() else {
+        return Ok(spike_option(None));
+    };
+    let mut reader = file.take(SPIKE_MAX_FS_READ_BYTES + 1);
+    let mut content = String::new();
+    if reader.read_to_string(&mut content).is_err()
+        || content.len() as u64 > SPIKE_MAX_FS_READ_BYTES
+    {
+        return Ok(spike_option(None));
+    }
+    Ok(spike_option(Some(SpikeValue::Text(content))))
+}
+
+fn eval_fs_write_call(
+    name: &str,
+    args: &[Expr],
+    functions: &HashMap<&str, &Function>,
+    env: &SpikeEnv,
+    lines: &mut Vec<OutputLine>,
+) -> Result<SpikeValue, Diagnostic> {
+    let result = match name {
+        "fs_write" => {
+            let (path, content) = eval_fs_path_content(name, args, functions, env, lines)?;
+            if content.len() > SPIKE_MAX_FS_WRITE_BYTES {
+                -1
+            } else {
+                spike_fs_write_candidate(env, &path, false)?
+                    .and_then(|candidate| std::fs::write(candidate, content).ok())
+                    .map(|()| 0)
+                    .unwrap_or(-1)
+            }
+        }
+        "fs_create" => {
+            let path = eval_fs_path(name, args, functions, env, lines)?;
+            spike_fs_write_candidate(env, &path, false)?
+                .and_then(|candidate| {
+                    std::fs::OpenOptions::new()
+                        .write(true)
+                        .create_new(true)
+                        .open(candidate)
+                        .ok()
+                })
+                .map(|_| 0)
+                .unwrap_or(-1)
+        }
+        "fs_append" => {
+            let (path, content) = eval_fs_path_content(name, args, functions, env, lines)?;
+            if content.len() > SPIKE_MAX_FS_WRITE_BYTES {
+                -1
+            } else {
+                spike_fs_write_candidate(env, &path, false)?
+                    .and_then(|candidate| {
+                        let mut file = std::fs::OpenOptions::new()
+                            .append(true)
+                            .create(true)
+                            .open(candidate)
+                            .ok()?;
+                        std::io::Write::write_all(&mut file, content.as_bytes()).ok()
+                    })
+                    .map(|()| 0)
+                    .unwrap_or(-1)
+            }
+        }
+        "fs_mkdir" => {
+            let path = eval_fs_path(name, args, functions, env, lines)?;
+            spike_fs_write_candidate(env, &path, false)?
+                .and_then(|candidate| std::fs::create_dir(candidate).ok())
+                .map(|()| 0)
+                .unwrap_or(-1)
+        }
+        "fs_mkdir_all" => {
+            let path = eval_fs_path(name, args, functions, env, lines)?;
+            spike_fs_write_candidate(env, &path, true)?
+                .and_then(|candidate| std::fs::create_dir_all(candidate).ok())
+                .map(|()| 0)
+                .unwrap_or(-1)
+        }
+        "fs_remove_file" => {
+            let path = eval_fs_path(name, args, functions, env, lines)?;
+            spike_fs_existing_candidate(env, &path)?
+                .and_then(|candidate| {
+                    std::fs::metadata(&candidate)
+                        .ok()
+                        .filter(|metadata| metadata.is_file())?;
+                    std::fs::remove_file(candidate).ok()
+                })
+                .map(|()| 0)
+                .unwrap_or(-1)
+        }
+        "fs_remove_dir" => {
+            let path = eval_fs_path(name, args, functions, env, lines)?;
+            spike_fs_existing_candidate(env, &path)?
+                .and_then(|candidate| {
+                    std::fs::metadata(&candidate)
+                        .ok()
+                        .filter(|metadata| metadata.is_dir())?;
+                    std::fs::remove_dir(candidate).ok()
+                })
+                .map(|()| 0)
+                .unwrap_or(-1)
+        }
+        "fs_replace" => {
+            let (path, content) = eval_fs_path_content(name, args, functions, env, lines)?;
+            if content.len() > SPIKE_MAX_FS_WRITE_BYTES {
+                -1
+            } else {
+                spike_fs_write_candidate(env, &path, false)?
+                    .and_then(|candidate| std::fs::write(candidate, content).ok())
+                    .map(|()| 0)
+                    .unwrap_or(-1)
+            }
+        }
+        _ => {
+            return Err(unsupported(&format!(
+                "unsupported cranelift spike filesystem call {name:?}"
+            )));
+        }
+    };
+    Ok(SpikeValue::Int(result))
+}
+
+fn eval_fs_path(
+    name: &str,
+    args: &[Expr],
+    functions: &HashMap<&str, &Function>,
+    env: &SpikeEnv,
+    lines: &mut Vec<OutputLine>,
+) -> Result<String, Diagnostic> {
+    let [path] = args else {
+        return Err(unsupported(&format!("{name} expects exactly one argument")));
+    };
+    expect_text(eval_expr(path, functions, env, lines)?, name)
+}
+
+fn eval_fs_path_content(
+    name: &str,
+    args: &[Expr],
+    functions: &HashMap<&str, &Function>,
+    env: &SpikeEnv,
+    lines: &mut Vec<OutputLine>,
+) -> Result<(String, String), Diagnostic> {
+    let [path, content] = args else {
+        return Err(unsupported(&format!(
+            "{name} expects exactly two arguments"
+        )));
+    };
+    let path = expect_text(eval_expr(path, functions, env, lines)?, name)?;
+    let content = expect_text(eval_expr(content, functions, env, lines)?, name)?;
+    Ok((path, content))
+}
+
+fn spike_package_root(env: &SpikeEnv) -> Result<PathBuf, Diagnostic> {
+    match env.get(SPIKE_PACKAGE_ROOT_BINDING) {
+        Some(SpikeValue::Text(root)) => Ok(PathBuf::from(root)),
+        _ => Err(unsupported("cranelift spike package root is unavailable")),
+    }
+}
+
+fn spike_fs_existing_candidate(env: &SpikeEnv, path: &str) -> Result<Option<PathBuf>, Diagnostic> {
+    let package_root = spike_package_root(env)?;
+    let Some(candidate) = spike_fs_join_candidate(&package_root, path) else {
+        return Ok(None);
+    };
+    let Ok(canonical_root) = std::fs::canonicalize(package_root) else {
+        return Ok(None);
+    };
+    let Ok(canonical_candidate) = std::fs::canonicalize(candidate) else {
+        return Ok(None);
+    };
+    Ok(canonical_candidate
+        .starts_with(canonical_root)
+        .then_some(canonical_candidate))
+}
+
+fn spike_fs_write_candidate(
+    env: &SpikeEnv,
+    path: &str,
+    allow_missing_ancestors: bool,
+) -> Result<Option<PathBuf>, Diagnostic> {
+    let package_root = spike_package_root(env)?;
+    let Some(candidate) = spike_fs_join_candidate(&package_root, path) else {
+        return Ok(None);
+    };
+    let Ok(canonical_root) = std::fs::canonicalize(&package_root) else {
+        return Ok(None);
+    };
+    if let Ok(canonical_candidate) = std::fs::canonicalize(&candidate) {
+        return Ok(canonical_candidate
+            .starts_with(canonical_root)
+            .then_some(canonical_candidate));
+    }
+    let Some(parent) = candidate.parent() else {
+        return Ok(None);
+    };
+    if !allow_missing_ancestors {
+        let Ok(canonical_parent) = std::fs::canonicalize(parent) else {
+            return Ok(None);
+        };
+        if !canonical_parent.starts_with(&canonical_root) {
+            return Ok(None);
+        }
+        let Some(file_name) = candidate.file_name() else {
+            return Ok(None);
+        };
+        return Ok(Some(canonical_parent.join(file_name)));
+    }
+    let mut ancestor = parent;
+    while !ancestor.exists() {
+        let Some(parent) = ancestor.parent() else {
+            return Ok(None);
+        };
+        ancestor = parent;
+    }
+    let Ok(canonical_ancestor) = std::fs::canonicalize(ancestor) else {
+        return Ok(None);
+    };
+    Ok(canonical_ancestor
+        .starts_with(canonical_root)
+        .then_some(candidate))
+}
+
+fn spike_fs_join_candidate(package_root: &Path, path: &str) -> Option<PathBuf> {
+    let requested = Path::new(path);
+    if requested.as_os_str().is_empty()
+        || requested
+            .components()
+            .any(|component| matches!(component, Component::ParentDir))
+    {
+        return None;
+    }
+    Some(if requested.is_absolute() {
+        requested.to_path_buf()
+    } else {
+        package_root.join(requested)
+    })
+}
+
+fn eval_process_status_call(
+    args: &[Expr],
+    functions: &HashMap<&str, &Function>,
+    env: &SpikeEnv,
+    lines: &mut Vec<OutputLine>,
+) -> Result<SpikeValue, Diagnostic> {
+    let [command] = args else {
+        return Err(unsupported("process_status expects exactly one argument"));
+    };
+    let command = expect_text(eval_expr(command, functions, env, lines)?, "process_status")?;
+    let status = Command::new(&command)
+        .status()
+        .ok()
+        .and_then(|status| status.code())
+        .map(i64::from)
+        .unwrap_or(-1);
+    Ok(SpikeValue::Int(status))
 }
 
 fn hex_lower(bytes: &[u8]) -> String {
@@ -2277,7 +2589,7 @@ mod tests {
     #[test]
     fn folds_hello_subset_into_print_lines() {
         assert_eq!(
-            collect_output_lines(&hello_program()).expect("fold hello"),
+            collect_output_lines(&hello_program(), Path::new(".")).expect("fold hello"),
             vec![
                 OutputLine::stdout("hello from stage1"),
                 OutputLine::stdout("42")

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -2071,6 +2071,7 @@ fn build_artifacts(
             )?;
             compile_cranelift_hello_spike(
                 &analyzed.mir,
+                package_root,
                 &object_path,
                 binary,
                 resolved_target,

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -2069,9 +2069,11 @@ fn build_artifacts(
                 &object_path,
                 "Cranelift object output",
             )?;
+            let fs_root = fs_root_path_for_package(package_root, &analyzed.manifest)?;
             compile_cranelift_hello_spike(
                 &analyzed.mir,
                 package_root,
+                &fs_root,
                 &object_path,
                 binary,
                 resolved_target,

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -431,8 +431,20 @@ fn cranelift_backend_builds_array_helpers_binary() {
     assert_eq!(String::from_utf8_lossy(&run.stdout), "3\n10\n30\n40\n");
 }
 
+#[cfg(not(windows))]
 #[test]
-fn cranelift_backend_rejects_process_status_binary() {
+fn cranelift_backend_builds_process_status_binary() {
+    if which::which("cc").is_err() {
+        eprintln!("skipping cranelift backend smoke test because cc is unavailable");
+        return;
+    }
+    if !Path::new("/usr/bin/true").exists() || !Path::new("/usr/bin/false").exists() {
+        eprintln!(
+            "skipping cranelift process-status test because /usr/bin/true or /usr/bin/false is unavailable"
+        );
+        return;
+    }
+
     let temp = tempfile::tempdir().expect("tempdir");
     let project = temp.path().join("process-status");
     write_process_status_project(&project);
@@ -449,19 +461,70 @@ fn cranelift_backend_rejects_process_status_binary() {
         .expect("run axiomc build --backend cranelift");
 
     assert!(
-        !output.status.success(),
-        "cranelift process-status build unexpectedly succeeded: stdout={} stderr={}",
+        output.status.success(),
+        "cranelift process-status build failed: stdout={} stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
-    let combined = format!(
-        "{}{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
+    assert_eq!(payload["backend"], "cranelift");
+    let binary = payload["binary"].as_str().expect("binary path");
+    let run = Command::new(binary)
+        .output()
+        .expect("run cranelift process-status binary");
     assert!(
-        combined.contains("unsupported by --backend cranelift spike"),
-        "expected backend rejection for process_status, got: {combined}"
+        run.status.success(),
+        "cranelift process-status binary failed: stderr={}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&run.stdout), "0\n1\n");
+}
+
+#[cfg(not(windows))]
+#[test]
+fn cranelift_backend_builds_fs_write_binary() {
+    if which::which("cc").is_err() {
+        eprintln!("skipping cranelift backend smoke test because cc is unavailable");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("fs-write");
+    write_fs_write_project(&project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+
+    assert!(
+        output.status.success(),
+        "cranelift fs-write build failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
+    assert_eq!(payload["backend"], "cranelift");
+    let binary = payload["binary"].as_str().expect("binary path");
+    let run = Command::new(binary)
+        .output()
+        .expect("run cranelift fs-write binary");
+    assert!(
+        run.status.success(),
+        "cranelift fs-write binary failed: stderr={}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "0\n0\n0\none\ntwo\n0\nfinal\n0\n0\n0\n0\n0\n"
     );
 }
 
@@ -2571,6 +2634,25 @@ fn write_process_denial_project(project: &Path) {
         "import \"std/process.ax\"\nprint run_status(\"/usr/bin/true\")\n",
     )
     .expect("write process denied source");
+}
+
+fn write_fs_write_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create fs write project src");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"cranelift-fs-write\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = true\n\"fs:write\" = true\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
+    )
+    .expect("write fs write manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-fs-write\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write fs write lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "import \"std/fs.ax\"\nprint mkdir_all(\"scratch/nested\")\nprint write_file(\"scratch/nested/data.txt\", \"one\")\nprint append_file(\"scratch/nested/data.txt\", \"\\ntwo\")\nmatch read_file(\"scratch/nested/data.txt\") {\nSome(value) {\nprint value\n}\nNone {\nprint \"missing\"\n}\n}\nprint replace_file(\"scratch/nested/data.txt\", \"final\")\nmatch read_file(\"scratch/nested/data.txt\") {\nSome(value) {\nprint value\n}\nNone {\nprint \"missing\"\n}\n}\nprint create_file(\"scratch/empty.txt\")\nprint remove_file(\"scratch/empty.txt\")\nprint remove_file(\"scratch/nested/data.txt\")\nprint remove_dir(\"scratch/nested\")\nprint remove_dir(\"scratch\")\n",
+    )
+    .expect("write fs write source");
 }
 
 fn write_fs_write_denial_project(project: &Path) {

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -530,6 +530,57 @@ fn cranelift_backend_builds_fs_write_binary() {
 
 #[cfg(not(windows))]
 #[test]
+fn cranelift_backend_honors_fs_root_for_fs_write_binary() {
+    if which::which("cc").is_err() {
+        eprintln!("skipping cranelift backend smoke test because cc is unavailable");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("fs-root");
+    write_fs_root_project(&project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+
+    assert!(
+        output.status.success(),
+        "cranelift fs-root build failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
+    assert_eq!(payload["backend"], "cranelift");
+    let binary = payload["binary"].as_str().expect("binary path");
+    let run = Command::new(binary)
+        .output()
+        .expect("run cranelift fs-root binary");
+    assert!(
+        run.status.success(),
+        "cranelift fs-root binary failed: stderr={}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "0\n0\n-1\nmissing\nok\n"
+    );
+    assert_eq!(
+        fs::read_to_string(project.join("src/main.ax")).expect("read source"),
+        fs_root_source()
+    );
+}
+
+#[cfg(not(windows))]
+#[test]
 fn cranelift_backend_builds_borrowed_slice_binary() {
     if which::which("cc").is_err() {
         eprintln!("skipping cranelift backend smoke test because cc is unavailable");
@@ -2653,6 +2704,26 @@ fn write_fs_write_project(project: &Path) {
         "import \"std/fs.ax\"\nprint mkdir_all(\"scratch/nested\")\nprint write_file(\"scratch/nested/data.txt\", \"one\")\nprint append_file(\"scratch/nested/data.txt\", \"\\ntwo\")\nmatch read_file(\"scratch/nested/data.txt\") {\nSome(value) {\nprint value\n}\nNone {\nprint \"missing\"\n}\n}\nprint replace_file(\"scratch/nested/data.txt\", \"final\")\nmatch read_file(\"scratch/nested/data.txt\") {\nSome(value) {\nprint value\n}\nNone {\nprint \"missing\"\n}\n}\nprint create_file(\"scratch/empty.txt\")\nprint remove_file(\"scratch/empty.txt\")\nprint remove_file(\"scratch/nested/data.txt\")\nprint remove_dir(\"scratch/nested\")\nprint remove_dir(\"scratch\")\n",
     )
     .expect("write fs write source");
+}
+
+fn write_fs_root_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create fs-root project src");
+    fs::create_dir_all(project.join("sandbox")).expect("create fs-root sandbox");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"cranelift-fs-root\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = true\n\"fs:write\" = true\nfs_root = \"sandbox\"\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
+    )
+    .expect("write fs-root manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-fs-root\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write fs-root lockfile");
+    fs::write(project.join("src/main.ax"), fs_root_source()).expect("write fs-root source");
+}
+
+fn fs_root_source() -> &'static str {
+    "import \"std/fs.ax\"\nprint mkdir_all(\"sandbox/nested\")\nprint write_file(\"sandbox/nested/data.txt\", \"ok\")\nprint write_file(\"src/main.ax\", \"corrupt\")\nmatch read_file(\"axiom.toml\") {\nSome(_value) {\nprint \"leak\"\n}\nNone {\nprint \"missing\"\n}\n}\nmatch read_file(\"sandbox/nested/data.txt\") {\nSome(value) {\nprint value\n}\nNone {\nprint \"missing allowed\"\n}\n}\n"
 }
 
 fn write_fs_write_denial_project(project: &Path) {

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -575,7 +575,7 @@ fn cranelift_backend_honors_fs_root_for_fs_write_binary() {
     );
     assert_eq!(
         fs::read_to_string(project.join("src/main.ax")).expect("read source"),
-        fs_root_source()
+        fs_root_source(&project)
     );
 }
 
@@ -2719,11 +2719,15 @@ fn write_fs_root_project(project: &Path) {
         "version = 1\n\n[[package]]\nname = \"cranelift-fs-root\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
     )
     .expect("write fs-root lockfile");
-    fs::write(project.join("src/main.ax"), fs_root_source()).expect("write fs-root source");
+    fs::write(project.join("src/main.ax"), fs_root_source(project)).expect("write fs-root source");
 }
 
-fn fs_root_source() -> &'static str {
-    "import \"std/fs.ax\"\nprint mkdir_all(\"sandbox/nested\")\nprint write_file(\"sandbox/nested/data.txt\", \"ok\")\nprint write_file(\"src/main.ax\", \"corrupt\")\nmatch read_file(\"axiom.toml\") {\nSome(_value) {\nprint \"leak\"\n}\nNone {\nprint \"missing\"\n}\n}\nmatch read_file(\"sandbox/nested/data.txt\") {\nSome(value) {\nprint value\n}\nNone {\nprint \"missing allowed\"\n}\n}\n"
+fn fs_root_source(project: &Path) -> String {
+    let source = project.join("src/main.ax").display().to_string();
+    let manifest = project.join("axiom.toml").display().to_string();
+    format!(
+        "import \"std/fs.ax\"\nprint mkdir_all(\"nested\")\nprint write_file(\"nested/data.txt\", \"ok\")\nprint write_file({source:?}, \"corrupt\")\nmatch read_file({manifest:?}) {{\nSome(_value) {{\nprint \"leak\"\n}}\nNone {{\nprint \"missing\"\n}}\n}}\nmatch read_file(\"nested/data.txt\") {{\nSome(value) {{\nprint value\n}}\nNone {{\nprint \"missing allowed\"\n}}\n}}\n"
+    )
 }
 
 fn write_fs_write_denial_project(project: &Path) {

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -483,6 +483,41 @@ fn cranelift_backend_builds_process_status_binary() {
 
 #[cfg(not(windows))]
 #[test]
+fn cranelift_backend_rejects_unapproved_process_status_command() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("process-status-unapproved");
+    write_process_status_unapproved_project(&project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+
+    assert!(
+        !output.status.success(),
+        "cranelift process-status build unexpectedly succeeded: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let diagnostic = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        diagnostic.contains("allowlisted deterministic commands"),
+        "unexpected diagnostic: {diagnostic}"
+    );
+}
+
+#[cfg(not(windows))]
+#[test]
 fn cranelift_backend_builds_fs_write_binary() {
     if which::which("cc").is_err() {
         eprintln!("skipping cranelift backend smoke test because cc is unavailable");
@@ -2167,6 +2202,49 @@ source = "path"
         r#"import "std/process.ax"
 print run_status("/usr/bin/true")
 print run_status("/usr/bin/false")
+"#,
+    )
+    .expect("write process-status source");
+}
+
+fn write_process_status_unapproved_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create process-status project src");
+    fs::write(
+        project.join("axiom.toml"),
+        r#"[package]
+name = "cranelift-process-status-unapproved"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = true
+unsafe_rationale = "direct-native process-status regression rejects unapproved compiler-time commands"
+env = false
+clock = false
+crypto = false
+"#,
+    )
+    .expect("write process-status manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        r#"version = 1
+
+[[package]]
+name = "cranelift-process-status-unapproved"
+version = "0.1.0"
+source = "path"
+"#,
+    )
+    .expect("write process-status lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        r#"import "std/process.ax"
+print run_status("/bin/sh")
 "#,
     )
     .expect("write process-status source");

--- a/stage1/runtime-abi/direct-native-v0.json
+++ b/stage1/runtime-abi/direct-native-v0.json
@@ -2,11 +2,7 @@
   "schema_version": "axiom.direct_native.runtime_abi.v0",
   "target_id": "axiom://target/stage1-direct-native",
   "status": "partial",
-<<<<<<< HEAD
-  "summary": "Compiler-side spike value and capability-shim contract required before direct native builds can replace generated Rust for the supported stage1 surface.",
-=======
-  "summary": "Compiler-side Cranelift spike evidence for blocked runtime rows required before direct native builds can replace generated Rust for the supported stage1 surface.",
->>>>>>> 96bafc73 (Clarify direct-native runtime evidence)
+  "summary": "Compiler-side Cranelift spike value and capability-shim contract required before direct native builds can replace generated Rust for the supported stage1 surface.",
   "value_features": [
     {
       "id": "numeric.scalars",

--- a/stage1/runtime-abi/direct-native-v0.json
+++ b/stage1/runtime-abi/direct-native-v0.json
@@ -93,12 +93,12 @@
     },
     {
       "id": "fs.write",
-      "status": "partial",
+      "status": "blocked",
       "capability": "fs:write",
       "blockers": [928],
       "evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
       "denial_evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
-      "notes": "The Cranelift spike can build and run std/fs.ax write helpers over package-root-scoped literal paths through compiler-side spike evaluation, including mkdir_all, write_file, append_file, readback, replace_file, create_file, remove_file, and remove_dir. Full runtime-time filesystem writes, atomic replace parity, manifest root configuration, TOCTOU hardening, and audit parity remain open."
+      "notes": "The runtime shim remains blocked. The Cranelift spike records positive compiler-side evidence for std/fs.ax write helpers over package-root-scoped literal paths, including mkdir_all, write_file, append_file, readback, replace_file, create_file, remove_file, and remove_dir. Full runtime-time filesystem writes, atomic replace parity, manifest root configuration, TOCTOU hardening, and audit parity remain open."
     },
     {
       "id": "network.dns.resolve",
@@ -146,12 +146,12 @@
     },
     {
       "id": "process.status",
-      "status": "partial",
+      "status": "blocked",
       "capability": "process",
       "evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
       "blockers": [928],
       "denial_evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
-      "notes": "The Cranelift spike can build and run std/process.ax run_status over literal, allowlisted deterministic commands through compiler-side spike evaluation, and rejects missing process capability before backend lowering. Full runtime-time process execution, argument handling, audit parity, and host-process policy coverage remain open."
+      "notes": "The runtime shim remains blocked. The Cranelift spike records positive compiler-side evidence for std/process.ax run_status over literal, allowlisted deterministic commands, and missing process capability is rejected before backend lowering. Full runtime-time process execution, argument handling, audit parity, and host-process policy coverage remain open."
     },
     {
       "id": "env.read",

--- a/stage1/runtime-abi/direct-native-v0.json
+++ b/stage1/runtime-abi/direct-native-v0.json
@@ -93,10 +93,12 @@
     },
     {
       "id": "fs.write",
-      "status": "blocked",
+      "status": "partial",
       "capability": "fs:write",
       "blockers": [928],
-      "denial_evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"]
+      "evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
+      "denial_evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
+      "notes": "The Cranelift spike can build and run std/fs.ax write helpers over package-root-scoped literal paths through compiler-side spike evaluation, including mkdir_all, write_file, append_file, readback, replace_file, create_file, remove_file, and remove_dir. Full runtime-time filesystem writes, atomic replace parity, manifest root configuration, TOCTOU hardening, and audit parity remain open."
     },
     {
       "id": "network.dns.resolve",
@@ -144,11 +146,12 @@
     },
     {
       "id": "process.status",
-      "status": "blocked",
+      "status": "partial",
       "capability": "process",
+      "evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
       "blockers": [928],
       "denial_evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
-      "notes": "The Cranelift spike still rejects positive std/process.ax run_status execution, but a package without the process capability now receives the public manifest-policy denial before backend lowering."
+      "notes": "The Cranelift spike can build and run std/process.ax run_status over literal, allowlisted deterministic commands through compiler-side spike evaluation, and rejects missing process capability before backend lowering. Full runtime-time process execution, argument handling, audit parity, and host-process policy coverage remain open."
     },
     {
       "id": "env.read",

--- a/stage1/runtime-abi/direct-native-v0.json
+++ b/stage1/runtime-abi/direct-native-v0.json
@@ -2,7 +2,7 @@
   "schema_version": "axiom.direct_native.runtime_abi.v0",
   "target_id": "axiom://target/stage1-direct-native",
   "status": "partial",
-  "summary": "Runtime value and capability-shim contract required before direct native builds can replace generated Rust for the supported stage1 surface.",
+  "summary": "Compiler-side spike value and capability-shim contract required before direct native builds can replace generated Rust for the supported stage1 surface.",
   "value_features": [
     {
       "id": "numeric.scalars",

--- a/stage1/runtime-abi/direct-native-v0.json
+++ b/stage1/runtime-abi/direct-native-v0.json
@@ -2,7 +2,11 @@
   "schema_version": "axiom.direct_native.runtime_abi.v0",
   "target_id": "axiom://target/stage1-direct-native",
   "status": "partial",
+<<<<<<< HEAD
   "summary": "Compiler-side spike value and capability-shim contract required before direct native builds can replace generated Rust for the supported stage1 surface.",
+=======
+  "summary": "Compiler-side Cranelift spike evidence for blocked runtime rows required before direct native builds can replace generated Rust for the supported stage1 surface.",
+>>>>>>> 96bafc73 (Clarify direct-native runtime evidence)
   "value_features": [
     {
       "id": "numeric.scalars",
@@ -155,12 +159,12 @@
     },
     {
       "id": "env.read",
-      "status": "partial",
+      "status": "blocked",
       "capability": "env",
       "evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
       "denial_evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
       "blockers": [928],
-      "notes": "The Cranelift spike can build a std/env.ax get_env package for present and missing environment reads, and rejects missing env capability before backend lowering. Full runtime-time environment lookup, manifest allowlist parity, and audit parity remain open."
+      "notes": "The Cranelift spike can build a std/env.ax get_env package for present and missing environment reads, and rejects missing env capability before backend lowering. This is compiler-side spike evidence, not direct native runtime execution; full runtime-time environment lookup, manifest allowlist parity, and audit parity remain open."
     },
     {
       "id": "clock.now_sleep",

--- a/stage1/runtime-abi/direct-native-v0.json
+++ b/stage1/runtime-abi/direct-native-v0.json
@@ -98,7 +98,7 @@
       "blockers": [928],
       "evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
       "denial_evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
-      "notes": "The runtime shim remains blocked. The Cranelift spike records positive compiler-side evidence for std/fs.ax write helpers over package-root-scoped literal paths, including mkdir_all, write_file, append_file, readback, replace_file, create_file, remove_file, and remove_dir. Full runtime-time filesystem writes, atomic replace parity, manifest root configuration, TOCTOU hardening, and audit parity remain open."
+      "notes": "The runtime shim remains blocked. The Cranelift spike records positive compiler-side evidence for std/fs.ax write helpers over configured fs_root-scoped literal paths, including mkdir_all, write_file, append_file, readback, replace_file, create_file, remove_file, and remove_dir. Full runtime-time filesystem writes, atomic replace parity, TOCTOU hardening, and audit parity remain open."
     },
     {
       "id": "network.dns.resolve",


### PR DESCRIPTION
## Summary

- Records compiler-side Cranelift spike evidence for literal `process_status` calls without claiming direct-native runtime process support.
- Bounds `std/process.ax` `run_status(...)` evidence to deterministic allowlisted commands (`/usr/bin/true` and `/usr/bin/false`) and rejects unapproved commands before native emission.
- Records configured `fs_root`-scoped Cranelift spike evidence for `std/fs.ax` read/write helpers over literal paths, covering create, append, readback, replace, cleanup, and denial of package-root paths outside the configured root.
- Updates the direct-native runtime ABI contract and docs so `process.status` and `fs.write` remain blocked for runtime support while recording compiler-side spike evidence and explicit remaining #928 work.

## Governing Issue

- Part of #928

This is not full resolution for #928. It narrows two runtime ABI evidence rows but leaves full runtime-time filesystem writes, runtime-time process execution, atomic replace parity, TOCTOU hardening, audit parity, argument handling, and host-process policy coverage open.

## Validation

- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend process_status -- --nocapture` passed: 2 passed.
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend -- --nocapture` passed: 36 passed.
- [x] `make stage1-direct-native-runtime-abi` passed with `ready:false` and `errors: []`.
- [x] `git diff --check` passed.
- [x] `rg -n "Command::new" stage1/crates/axiomc/src/cranelift_backend.rs` found no backend shell execution path.
- [x] `cargo fmt --manifest-path stage1/Cargo.toml --all --check` was run; it still reports pre-existing formatting drift in `stage1/crates/axiomc/src/lib.rs:4955`, which this PR does not touch.
- [ ] Hosted checks are not green yet; current runs are queued or blocked behind shared runner and supply-chain repair work.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue.
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable. Not applicable.
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies.
- [x] No real secrets, runtime auth, or machine-local env files are committed.

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior. This is backend/runtime evidence only.
- [x] Schemas added/changed are listed, or this PR does not touch schemas. No schema changes.
- [x] Evidence added/changed is listed, or this PR does not touch evidence. Evidence added in `stage1/crates/axiomc/tests/cranelift_backend.rs` and `stage1/runtime-abi/direct-native-v0.json` for `process.status` and configured `fs_root`-scoped `fs.write`.
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior. This is explicitly Cranelift spike behavior and does not define Axiom semantics in Rust terms.
- [x] Agent-facing inspection impact is described, or there is no inspection impact. The runtime ABI report records compiler-side spike evidence for `process.status` and configured `fs_root`-scoped `fs.write` while keeping both rows blocked for runtime support.

## Flow Contract

- Owner lane: daedalus
- Repair owner: codex
- Autonomy class: issue-backed implementation slice
- Risk class: medium

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action.
- [ ] No active blocking requested changes remain.
- [ ] Non-author approval is present when required.
- [ ] Auto-merge is appropriate when gates pass.

Current blocker: review state still reports requested changes from Athena reviews against earlier heads. Current code and metadata are ready for re-review.

## Merge Automation

- [ ] Auto-merge is not enabled yet; this PR needs non-author review clearance first.

## Notes

- The PR title and body intentionally use "spike evidence" language. The runtime ABI rows stay `blocked` for runtime-shim support.
