### PR TITLE
Add Cranelift crypto MAC evidence

### DIFF
--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -116,8 +116,15 @@ manifest-policy denial before any backend-specific lowering diagnostic.
 
 The direct-native crypto hash slice is still marked partial: the Cranelift
 spike can build and run `std/crypto_hash.ax` `sha256(...)` without generated
-Rust, and crypto capability denials still happen before backend lowering. MAC,
-random, signature, AEAD, and broader crypto audit parity remain blocked.
+Rust, and crypto capability denials still happen before backend lowering.
+Random, signature, AEAD, and broader crypto audit parity remain blocked.
+
+The direct-native crypto MAC slice is now marked partial: the Cranelift spike
+can build and run `std/crypto_mac.ax` HMAC-SHA256, HMAC-SHA512, verification
+helpers, string constant-time equality, and byte-slice constant-time equality
+without generated Rust. A package without the `crypto` capability fails before
+backend lowering. Runtime audit parity and broader crypto host-service coverage
+remain blocked under #928.
 
 The HTTP client row remains blocked for positive direct-native runtime support:
 the Cranelift spike does not yet lower `std/http.ax` `get(...)` into a native

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -560,8 +560,8 @@ fn eval_call(
     if is_json_call(name) {
         return eval_json_call(name, args, functions, env, lines);
     }
-    if name == "crypto_sha256" {
-        return eval_crypto_sha256_call(args, functions, env, lines);
+    if is_crypto_call(name) {
+        return eval_crypto_call(name, args, functions, env, lines);
     }
     if name == "env_get" {
         return eval_env_get_call(args, functions, env, lines);
@@ -995,20 +995,74 @@ fn json_escape_string(value: &str) -> String {
     out
 }
 
-fn eval_crypto_sha256_call(
+fn is_crypto_call(name: &str) -> bool {
+    matches!(
+        name,
+        "crypto_sha256"
+            | "crypto_hmac_sha256"
+            | "crypto_hmac_sha512"
+            | "crypto_constant_time_eq"
+            | "crypto_constant_time_eq_u8"
+    )
+}
+
+fn eval_crypto_call(
+    name: &str,
     args: &[Expr],
     functions: &HashMap<&str, &Function>,
     env: &SpikeEnv,
     lines: &mut Vec<OutputLine>,
 ) -> Result<SpikeValue, Diagnostic> {
-    let [arg] = args else {
-        return Err(unsupported("crypto_sha256 expects exactly one argument"));
-    };
-    let input = match eval_expr(arg, functions, env, lines)? {
-        SpikeValue::Text(value) => value,
-        _ => return Err(unsupported("crypto_sha256 expects a string argument")),
-    };
-    Ok(SpikeValue::Text(sha256_hex(&input)))
+    match name {
+        "crypto_sha256" => {
+            let [arg] = args else {
+                return Err(unsupported("crypto_sha256 expects exactly one argument"));
+            };
+            let input = expect_text(eval_expr(arg, functions, env, lines)?, name)?;
+            Ok(SpikeValue::Text(sha256_hex(input.as_bytes())))
+        }
+        "crypto_hmac_sha256" | "crypto_hmac_sha512" => {
+            let [key, message] = args else {
+                return Err(unsupported(&format!(
+                    "{name} expects exactly two arguments"
+                )));
+            };
+            let key = expect_text(eval_expr(key, functions, env, lines)?, name)?;
+            let message = expect_text(eval_expr(message, functions, env, lines)?, name)?;
+            let tag = if name == "crypto_hmac_sha256" {
+                hmac_hex(key.as_bytes(), message.as_bytes(), 64, sha256_bytes)
+            } else {
+                hmac_hex(key.as_bytes(), message.as_bytes(), 128, sha512_bytes)
+            };
+            Ok(SpikeValue::Text(tag))
+        }
+        "crypto_constant_time_eq" => {
+            let [left, right] = args else {
+                return Err(unsupported(
+                    "crypto_constant_time_eq expects exactly two arguments",
+                ));
+            };
+            let left = expect_text(eval_expr(left, functions, env, lines)?, name)?;
+            let right = expect_text(eval_expr(right, functions, env, lines)?, name)?;
+            Ok(SpikeValue::Bool(constant_time_eq_bytes(
+                left.as_bytes(),
+                right.as_bytes(),
+            )))
+        }
+        "crypto_constant_time_eq_u8" => {
+            let [left, right] = args else {
+                return Err(unsupported(
+                    "crypto_constant_time_eq_u8 expects exactly two arguments",
+                ));
+            };
+            let left = expect_u8_array(eval_expr(left, functions, env, lines)?, name)?;
+            let right = expect_u8_array(eval_expr(right, functions, env, lines)?, name)?;
+            Ok(SpikeValue::Bool(constant_time_eq_bytes(&left, &right)))
+        }
+        _ => Err(unsupported(&format!(
+            "unsupported cranelift spike crypto call {name:?}"
+        ))),
+    }
 }
 
 fn eval_env_get_call(
@@ -1024,7 +1078,49 @@ fn eval_env_get_call(
     Ok(spike_option(env::var(name).ok().map(SpikeValue::Text)))
 }
 
-fn sha256_hex(input: &str) -> String {
+fn hex_lower(bytes: &[u8]) -> String {
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push_str(&format!("{byte:02x}"));
+    }
+    output
+}
+
+fn hmac_hex(key: &[u8], message: &[u8], block_len: usize, digest: fn(&[u8]) -> Vec<u8>) -> String {
+    let mut key_bytes = key.to_vec();
+    if key_bytes.len() > block_len {
+        key_bytes = digest(&key_bytes);
+    }
+    key_bytes.resize(block_len, 0);
+
+    let mut inner = Vec::with_capacity(block_len + message.len());
+    let mut outer = Vec::with_capacity(block_len + block_len);
+    for byte in key_bytes {
+        inner.push(byte ^ 0x36);
+        outer.push(byte ^ 0x5c);
+    }
+    inner.extend_from_slice(message);
+    let inner_digest = digest(&inner);
+    outer.extend_from_slice(&inner_digest);
+    hex_lower(&digest(&outer))
+}
+
+fn constant_time_eq_bytes(left: &[u8], right: &[u8]) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (&left_byte, &right_byte) in left.iter().zip(right.iter()) {
+        diff |= left_byte ^ right_byte;
+    }
+    diff == 0
+}
+
+fn sha256_hex(input: &[u8]) -> String {
+    hex_lower(&sha256_bytes(input))
+}
+
+fn sha256_bytes(input: &[u8]) -> Vec<u8> {
     const K: [u32; 64] = [
         0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4,
         0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe,
@@ -1041,7 +1137,7 @@ fn sha256_hex(input: &str) -> String {
         0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab,
         0x5be0cd19,
     ];
-    let mut data = input.as_bytes().to_vec();
+    let mut data = input.to_vec();
     let bit_len = (data.len() as u64) * 8;
     data.push(0x80);
     while data.len() % 64 != 56 {
@@ -1108,9 +1204,180 @@ fn sha256_hex(input: &str) -> String {
         state[6] = state[6].wrapping_add(g);
         state[7] = state[7].wrapping_add(h);
     }
-    let mut output = String::with_capacity(64);
+    let mut output = Vec::with_capacity(32);
     for value in state {
-        output.push_str(&format!("{value:08x}"));
+        output.extend_from_slice(&value.to_be_bytes());
+    }
+    output
+}
+
+fn sha512_bytes(input: &[u8]) -> Vec<u8> {
+    const K: [u64; 80] = [
+        0x428a2f98d728ae22,
+        0x7137449123ef65cd,
+        0xb5c0fbcfec4d3b2f,
+        0xe9b5dba58189dbbc,
+        0x3956c25bf348b538,
+        0x59f111f1b605d019,
+        0x923f82a4af194f9b,
+        0xab1c5ed5da6d8118,
+        0xd807aa98a3030242,
+        0x12835b0145706fbe,
+        0x243185be4ee4b28c,
+        0x550c7dc3d5ffb4e2,
+        0x72be5d74f27b896f,
+        0x80deb1fe3b1696b1,
+        0x9bdc06a725c71235,
+        0xc19bf174cf692694,
+        0xe49b69c19ef14ad2,
+        0xefbe4786384f25e3,
+        0x0fc19dc68b8cd5b5,
+        0x240ca1cc77ac9c65,
+        0x2de92c6f592b0275,
+        0x4a7484aa6ea6e483,
+        0x5cb0a9dcbd41fbd4,
+        0x76f988da831153b5,
+        0x983e5152ee66dfab,
+        0xa831c66d2db43210,
+        0xb00327c898fb213f,
+        0xbf597fc7beef0ee4,
+        0xc6e00bf33da88fc2,
+        0xd5a79147930aa725,
+        0x06ca6351e003826f,
+        0x142929670a0e6e70,
+        0x27b70a8546d22ffc,
+        0x2e1b21385c26c926,
+        0x4d2c6dfc5ac42aed,
+        0x53380d139d95b3df,
+        0x650a73548baf63de,
+        0x766a0abb3c77b2a8,
+        0x81c2c92e47edaee6,
+        0x92722c851482353b,
+        0xa2bfe8a14cf10364,
+        0xa81a664bbc423001,
+        0xc24b8b70d0f89791,
+        0xc76c51a30654be30,
+        0xd192e819d6ef5218,
+        0xd69906245565a910,
+        0xf40e35855771202a,
+        0x106aa07032bbd1b8,
+        0x19a4c116b8d2d0c8,
+        0x1e376c085141ab53,
+        0x2748774cdf8eeb99,
+        0x34b0bcb5e19b48a8,
+        0x391c0cb3c5c95a63,
+        0x4ed8aa4ae3418acb,
+        0x5b9cca4f7763e373,
+        0x682e6ff3d6b2b8a3,
+        0x748f82ee5defb2fc,
+        0x78a5636f43172f60,
+        0x84c87814a1f0ab72,
+        0x8cc702081a6439ec,
+        0x90befffa23631e28,
+        0xa4506cebde82bde9,
+        0xbef9a3f7b2c67915,
+        0xc67178f2e372532b,
+        0xca273eceea26619c,
+        0xd186b8c721c0c207,
+        0xeada7dd6cde0eb1e,
+        0xf57d4f7fee6ed178,
+        0x06f067aa72176fba,
+        0x0a637dc5a2c898a6,
+        0x113f9804bef90dae,
+        0x1b710b35131c471b,
+        0x28db77f523047d84,
+        0x32caab7b40c72493,
+        0x3c9ebe0a15c9bebc,
+        0x431d67c49c100d4c,
+        0x4cc5d4becb3e42b6,
+        0x597f299cfc657e2a,
+        0x5fcb6fab3ad6faec,
+        0x6c44198c4a475817,
+    ];
+    let mut state: [u64; 8] = [
+        0x6a09e667f3bcc908,
+        0xbb67ae8584caa73b,
+        0x3c6ef372fe94f82b,
+        0xa54ff53a5f1d36f1,
+        0x510e527fade682d1,
+        0x9b05688c2b3e6c1f,
+        0x1f83d9abfb41bd6b,
+        0x5be0cd19137e2179,
+    ];
+    let mut data = input.to_vec();
+    let bit_len = (data.len() as u128) * 8;
+    data.push(0x80);
+    while data.len() % 128 != 112 {
+        data.push(0);
+    }
+    data.extend_from_slice(&bit_len.to_be_bytes());
+    for chunk in data.chunks(128) {
+        let mut schedule = [0u64; 80];
+        for (index, word) in schedule.iter_mut().take(16).enumerate() {
+            let start = index * 8;
+            *word = u64::from_be_bytes([
+                chunk[start],
+                chunk[start + 1],
+                chunk[start + 2],
+                chunk[start + 3],
+                chunk[start + 4],
+                chunk[start + 5],
+                chunk[start + 6],
+                chunk[start + 7],
+            ]);
+        }
+        for index in 16..80 {
+            let s0 = schedule[index - 15].rotate_right(1)
+                ^ schedule[index - 15].rotate_right(8)
+                ^ (schedule[index - 15] >> 7);
+            let s1 = schedule[index - 2].rotate_right(19)
+                ^ schedule[index - 2].rotate_right(61)
+                ^ (schedule[index - 2] >> 6);
+            schedule[index] = schedule[index - 16]
+                .wrapping_add(s0)
+                .wrapping_add(schedule[index - 7])
+                .wrapping_add(s1);
+        }
+        let mut a = state[0];
+        let mut b = state[1];
+        let mut c = state[2];
+        let mut d = state[3];
+        let mut e = state[4];
+        let mut f = state[5];
+        let mut g = state[6];
+        let mut h = state[7];
+        for index in 0..80 {
+            let sigma1 = e.rotate_right(14) ^ e.rotate_right(18) ^ e.rotate_right(41);
+            let choice = (e & f) ^ ((!e) & g);
+            let temp1 = h
+                .wrapping_add(sigma1)
+                .wrapping_add(choice)
+                .wrapping_add(K[index])
+                .wrapping_add(schedule[index]);
+            let sigma0 = a.rotate_right(28) ^ a.rotate_right(34) ^ a.rotate_right(39);
+            let majority = (a & b) ^ (a & c) ^ (b & c);
+            let temp2 = sigma0.wrapping_add(majority);
+            h = g;
+            g = f;
+            f = e;
+            e = d.wrapping_add(temp1);
+            d = c;
+            c = b;
+            b = a;
+            a = temp1.wrapping_add(temp2);
+        }
+        state[0] = state[0].wrapping_add(a);
+        state[1] = state[1].wrapping_add(b);
+        state[2] = state[2].wrapping_add(c);
+        state[3] = state[3].wrapping_add(d);
+        state[4] = state[4].wrapping_add(e);
+        state[5] = state[5].wrapping_add(f);
+        state[6] = state[6].wrapping_add(g);
+        state[7] = state[7].wrapping_add(h);
+    }
+    let mut output = Vec::with_capacity(64);
+    for value in state {
+        output.extend_from_slice(&value.to_be_bytes());
     }
     output
 }
@@ -1154,10 +1421,15 @@ fn eval_regex_call(
                     "regex_replace_all expects exactly three arguments",
                 ));
             };
-            let pattern = expect_text(eval_expr(pattern, functions, env, lines)?, "regex_replace_all")?;
+            let pattern = expect_text(
+                eval_expr(pattern, functions, env, lines)?,
+                "regex_replace_all",
+            )?;
             let text = expect_text(eval_expr(text, functions, env, lines)?, "regex_replace_all")?;
-            let replacement =
-                expect_text(eval_expr(replacement, functions, env, lines)?, "regex_replace_all")?;
+            let replacement = expect_text(
+                eval_expr(replacement, functions, env, lines)?,
+                "regex_replace_all",
+            )?;
             Ok(SpikeValue::Text(regex_replace_all(
                 &pattern,
                 &text,
@@ -1259,6 +1531,20 @@ fn expect_text(value: SpikeValue, name: &str) -> Result<String, Diagnostic> {
         SpikeValue::Text(value) => Ok(value),
         _ => Err(unsupported(&format!("{name} expects string arguments"))),
     }
+}
+
+fn expect_u8_array(value: SpikeValue, name: &str) -> Result<Vec<u8>, Diagnostic> {
+    let SpikeValue::Array(values) = value else {
+        return Err(unsupported(&format!("{name} expects byte-slice arguments")));
+    };
+    values
+        .into_iter()
+        .map(|value| match value {
+            SpikeValue::UInt(value) if value <= u8::MAX as u64 => Ok(value as u8),
+            SpikeValue::Int(value) if (0..=u8::MAX as i64).contains(&value) => Ok(value as u8),
+            _ => Err(unsupported(&format!("{name} expects byte-slice arguments"))),
+        })
+        .collect()
 }
 
 fn regex_escape_char(ch: char) -> char {

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -39,14 +39,10 @@ fn cranelift_backend_builds_hello_binary() {
     assert_eq!(payload["backend"], "cranelift");
     assert_eq!(payload["packages"][0]["backend"], "cranelift");
     let binary = payload["binary"].as_str().expect("binary path");
-    let generated_rust = payload["generated_rust"]
-        .as_str()
-        .expect("generated Rust path");
+    assert_eq!(payload["generated_rust"], Value::Null);
     assert!(Path::new(binary).exists(), "cranelift binary exists");
     assert!(
-        Path::new(generated_rust)
-            .with_extension("cranelift.o")
-            .exists(),
+        Path::new(binary).with_extension("cranelift.o").exists(),
         "cranelift object exists"
     );
 
@@ -592,18 +588,14 @@ fn cranelift_backend_debug_build_emits_sidecars_without_axiom_dwarf() {
     assert_eq!(payload["backend"], "cranelift");
     assert_eq!(payload["debug"], true);
     let binary = payload["binary"].as_str().expect("binary path");
-    let generated_rust = payload["generated_rust"]
-        .as_str()
-        .expect("generated Rust path");
+    assert_eq!(payload["generated_rust"], Value::Null);
     let debug_map = payload["debug_map"].as_str().expect("debug map path");
     let debug_manifest = payload["debug_manifest"]
         .as_str()
         .expect("debug manifest path");
     assert!(Path::new(binary).exists(), "cranelift binary exists");
     assert!(
-        Path::new(generated_rust)
-            .with_extension("cranelift.o")
-            .exists(),
+        Path::new(binary).with_extension("cranelift.o").exists(),
         "cranelift object exists"
     );
     assert!(Path::new(debug_map).exists(), "debug map exists");
@@ -618,12 +610,18 @@ fn cranelift_backend_debug_build_emits_sidecars_without_axiom_dwarf() {
     let map: Value =
         serde_json::from_str(&fs::read_to_string(debug_map).expect("read cranelift debug map"))
             .expect("parse cranelift debug map");
+    assert_eq!(
+        map["schema_version"],
+        "axiom.stage1.direct_native.debug_map.v1"
+    );
+    assert_eq!(map["backend"], "cranelift");
+    assert_eq!(map["binary"], binary);
     assert!(
-        map["mappings"]
+        map["source_spans"]
             .as_array()
-            .expect("debug mappings")
+            .expect("debug source spans")
             .iter()
-            .any(|mapping| mapping["source"] == source),
+            .any(|span| span["source"] == source),
         "debug map should retain Axiom source spans for cranelift builds"
     );
 
@@ -631,15 +629,18 @@ fn cranelift_backend_debug_build_emits_sidecars_without_axiom_dwarf() {
         &fs::read_to_string(debug_manifest).expect("read cranelift debug manifest"),
     )
     .expect("parse cranelift debug manifest");
-    assert_eq!(manifest["schema_version"], "axiom.stage1.debug_manifest.v1");
+    assert_eq!(
+        manifest["schema_version"],
+        "axiom.stage1.direct_native.debug_manifest.v1"
+    );
     assert_eq!(manifest["backend"], "cranelift");
+    assert_eq!(manifest["artifact_class"], "native_binary");
     assert_eq!(manifest["binary"], binary);
-    assert_eq!(manifest["generated_rust"], generated_rust);
     assert!(
-        manifest["generated_rust_hash"]
+        manifest["binary_hash"]
             .as_str()
             .is_some_and(|hash| !hash.is_empty()),
-        "debug manifest v1 should keep generated_rust_hash in the integrity envelope"
+        "direct-native debug manifest should keep the binary hash in the integrity envelope"
     );
     assert_eq!(manifest["debug_map"], debug_map);
     assert_eq!(manifest["native_debug"]["producer"], "cranelift");
@@ -776,6 +777,60 @@ fn cranelift_backend_builds_crypto_hash_binary() {
     assert_eq!(
         String::from_utf8_lossy(&run.stdout),
         "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad\n"
+    );
+}
+
+#[cfg(not(windows))]
+#[test]
+fn cranelift_backend_builds_crypto_mac_binary() {
+    if which::which("cc").is_err() {
+        eprintln!("skipping cranelift backend smoke test because cc is unavailable");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("crypto-mac");
+    write_crypto_mac_project(&project, true);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+    assert!(
+        output.status.success(),
+        "cranelift crypto mac build failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
+    assert_eq!(payload["backend"], "cranelift");
+    let binary = payload["binary"].as_str().expect("binary path");
+    let run = Command::new(binary)
+        .output()
+        .expect("run cranelift crypto mac binary");
+    assert!(
+        run.status.success(),
+        "cranelift crypto mac binary failed: stderr={}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8
+164b7a7bfcf819e2e395fbe73b56e0a387bd64222e831fd610270cd7ea2505549758bf75c05a994a6d034f65f8f0e6fdcaeab1a34d4a6b4b636e070a38bce737
+true
+true
+false
+false
+true
+false
+"
     );
 }
 
@@ -942,6 +997,44 @@ fn cranelift_backend_rejects_crypto_hash_denial_before_backend_lowering() {
     assert!(
         !output.status.success(),
         "cranelift crypto hash denial build unexpectedly succeeded: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("requires [capabilities].crypto = true"),
+        "expected crypto capability denial before backend lowering, got: {combined}"
+    );
+    assert!(
+        !combined.contains("unsupported by --backend cranelift spike"),
+        "capability denial should happen before cranelift unsupported-feature lowering: {combined}"
+    );
+}
+
+#[test]
+fn cranelift_backend_rejects_crypto_mac_denial_before_backend_lowering() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("crypto-mac-denied");
+    write_crypto_mac_project(&project, false);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+
+    assert!(
+        !output.status.success(),
+        "cranelift crypto mac denial build unexpectedly succeeded: stdout={} stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
@@ -1643,6 +1736,27 @@ fn write_crypto_hash_project(project: &Path, crypto: bool) {
         "import \"std/crypto_hash.ax\"\nprint sha256(\"abc\")\n",
     )
     .expect("write crypto hash source");
+}
+
+fn write_crypto_mac_project(project: &Path, crypto: bool) {
+    fs::create_dir_all(project.join("src")).expect("create crypto mac project src");
+    fs::write(
+        project.join("axiom.toml"),
+        format!(
+            "[package]\nname = \"cranelift-crypto-mac\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = {crypto}\n"
+        ),
+    )
+    .expect("write crypto mac manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-crypto-mac\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write crypto mac lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "import \"std/crypto_mac.ax\"\nlet left: [u8] = [1u8, 2u8, 3u8]\nlet same: [u8] = [1u8, 2u8, 3u8]\nlet different: [u8] = [1u8, 2u8, 4u8]\nprint hmac_sha256(\"key\", \"The quick brown fox jumps over the lazy dog\")\nprint hmac_sha512(\"Jefe\", \"what do ya want for nothing?\")\nprint verify_sha256(\"f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8\", \"key\", \"The quick brown fox jumps over the lazy dog\")\nprint verify_sha512(\"164b7a7bfcf819e2e395fbe73b56e0a387bd64222e831fd610270cd7ea2505549758bf75c05a994a6d034f65f8f0e6fdcaeab1a34d4a6b4b636e070a38bce737\", \"Jefe\", \"what do ya want for nothing?\")\nprint constant_time_eq(hmac_sha256(\"key\", \"The quick brown fox jumps over the lazy dog\"), \"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad\")\nprint constant_time_eq(\"short\", \"shorter\")\nprint constant_time_eq_u8(left[:], same[:])\nprint constant_time_eq_u8(left[:], different[:])\n",
+    )
+    .expect("write crypto mac source");
 }
 
 fn write_sync_primitives_project(project: &Path) {

--- a/stage1/runtime-abi/direct-native-v0.json
+++ b/stage1/runtime-abi/direct-native-v0.json
@@ -171,13 +171,16 @@
       "evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
       "denial_evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
       "blockers": [928],
-      "notes": "The Cranelift spike covers std/crypto_hash.ax sha256 over strings without using generated Rust. MAC, random, signature, AEAD, and broader crypto audit parity remain blocked."
+      "notes": "The Cranelift spike covers std/crypto_hash.ax sha256 over strings without using generated Rust. Random, signature, AEAD, and broader crypto audit parity remain blocked."
     },
     {
       "id": "crypto.mac",
-      "status": "blocked",
+      "status": "partial",
       "capability": "crypto",
-      "blockers": [928]
+      "evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
+      "denial_evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
+      "blockers": [928],
+      "notes": "The Cranelift spike covers std/crypto_mac.ax HMAC-SHA256, HMAC-SHA512, verification helpers, string constant-time equality, and byte-slice constant-time equality without generated Rust. Runtime audit parity and broader crypto host-service coverage remain blocked."
     },
     {
       "id": "crypto.random",


### PR DESCRIPTION
## Summary

- Adds Cranelift spike support for `std/crypto_mac.ax` HMAC-SHA256, HMAC-SHA512, verification helpers, string constant-time equality, and byte-slice constant-time equality.
- Updates the direct-native runtime ABI contract so `crypto.mac` moves from blocked to partial with compiler-side evidence while keeping runtime audit parity and broader crypto host-service coverage open.
- Refreshes stale Cranelift debug sidecar tests to assert the direct-native JSON map/manifest schema and `generated_rust: null`.

## Governing Issue

Part of #928

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Commands run:

- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend crypto_mac -- --nocapture` passed
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend crypto_hash -- --nocapture` passed
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend -- --nocapture` passed
- `make stage1-direct-native-runtime-abi` passed with `ready:false` and `errors: []`, as expected while #928 still has blocked rows
- `make stage1-direct-native-runtime-abi-test` passed
- `git diff --check` passed
- `cargo fmt --manifest-path stage1/Cargo.toml --all --check` was run; it still reports pre-existing unrelated formatting drift in `stage1/crates/axiomc/src/lib.rs:4955`, which this PR does not touch. The files touched by this PR were formatted.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable. Not applicable.
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior. No semantic node types changed.
- [x] Schemas added/changed are listed, or this PR does not touch schemas. No schemas changed.
- [x] Evidence added/changed is listed, or this PR does not touch evidence. Evidence added in `stage1/crates/axiomc/tests/cranelift_backend.rs` and `stage1/runtime-abi/direct-native-v0.json` for `crypto.mac`.
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior. This is Cranelift spike evidence and does not define Axiom semantics in Rust terms.
- [x] Agent-facing inspection impact is described, or there is no inspection impact. The runtime ABI report now records compiler-side `crypto.mac` evidence while keeping the row partial and blocked on #928.

## Flow Contract

- Owner lane: daedalus
- Repair owner: codex
- Autonomy class: issue-backed implementation slice
- Risk class: medium

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [ ] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is appropriate when gates pass

## Merge Automation

- [ ] Auto-merge is not enabled yet; this PR needs full ready-PR checks and non-author review first.

## Notes

- This does not close #928. It narrows the direct-native runtime ABI gap by adding positive compiler-side `crypto.mac` evidence while leaving random, signature, AEAD, runtime audit parity, and broader host-service coverage open under #928.
