### PR TITLE
Add Cranelift clock and stdio evidence

### DIFF
--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -886,6 +886,168 @@ message
 
 #[cfg(not(windows))]
 #[test]
+fn cranelift_backend_builds_logging_stdio_binary() {
+    if which::which("cc").is_err() {
+        eprintln!("skipping cranelift backend smoke test because cc is unavailable");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("logging-stdio");
+    write_logging_stdio_project(&project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+    assert!(
+        output.status.success(),
+        "cranelift logging stdio build failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
+    assert_eq!(payload["backend"], "cranelift");
+    let binary = payload["binary"].as_str().expect("binary path");
+    let run = Command::new(binary)
+        .output()
+        .expect("run cranelift logging stdio binary");
+    assert!(
+        run.status.success(),
+        "cranelift logging stdio binary failed: stderr={}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&run.stdout), "true\n");
+    assert_eq!(String::from_utf8_lossy(&run.stderr), "hello stderr\n");
+}
+
+#[cfg(not(windows))]
+#[test]
+fn cranelift_backend_builds_clock_binary() {
+    if which::which("cc").is_err() {
+        eprintln!("skipping cranelift backend smoke test because cc is unavailable");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("clock");
+    write_clock_project(&project, true, false);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+    assert!(
+        output.status.success(),
+        "cranelift clock build failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
+    assert_eq!(payload["backend"], "cranelift");
+    let binary = payload["binary"].as_str().expect("binary path");
+    let run = Command::new(binary)
+        .output()
+        .expect("run cranelift clock binary");
+    assert!(
+        run.status.success(),
+        "cranelift clock binary failed: stderr={}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "true\ntrue\ntrue\ntrue\n"
+    );
+}
+
+#[test]
+fn cranelift_backend_rejects_clock_denial_before_backend_lowering() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("clock-denied");
+    write_clock_project(&project, false, false);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+
+    assert!(
+        !output.status.success(),
+        "cranelift clock denied build unexpectedly succeeded: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("requires [capabilities].clock = true"),
+        "expected clock capability denial before backend lowering, got: {combined}"
+    );
+    assert!(
+        !combined.contains("unsupported by --backend cranelift spike"),
+        "clock capability denial should happen before cranelift unsupported-feature lowering: {combined}"
+    );
+}
+
+#[test]
+fn cranelift_backend_rejects_nonzero_clock_sleep() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("clock-nonzero-sleep");
+    write_clock_project(&project, true, true);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+
+    assert!(
+        !output.status.success(),
+        "cranelift nonzero clock sleep build unexpectedly succeeded: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("nonzero clock_sleep_ms is not supported by the cranelift spike"),
+        "expected nonzero sleep guard, got: {combined}"
+    );
+}
+
+#[cfg(not(windows))]
+#[test]
 fn cranelift_backend_builds_json_serdes_binary() {
     if which::which("cc").is_err() {
         eprintln!("skipping cranelift backend smoke test because cc is unavailable");
@@ -1820,6 +1982,60 @@ print direct > 0
 "#,
     )
     .expect("write logging stdio source");
+}
+
+fn write_clock_project(project: &Path, clock: bool, nonzero_sleep: bool) {
+    fs::create_dir_all(project.join("src")).expect("create clock project src");
+    fs::write(
+        project.join("axiom.toml"),
+        format!(
+            r#"[package]
+name = "cranelift-clock"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = {clock}
+crypto = false
+"#
+        ),
+    )
+    .expect("write clock manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        r#"version = 1
+
+[[package]]
+name = "cranelift-clock"
+version = "0.1.0"
+source = "path"
+"#,
+    )
+    .expect("write clock lockfile");
+    let pause_ms = if nonzero_sleep { 1 } else { 0 };
+    fs::write(
+        project.join("src/main.ax"),
+        format!(
+            r#"import "std/time.ax"
+
+let start: Instant = now()
+let pause: Duration = duration_ms({pause_ms})
+print start.ms > 0
+print now_ms() > 0
+print sleep(pause) == 0
+let elapsed: int = elapsed_ms(start)
+print elapsed == elapsed
+"#
+        ),
+    )
+    .expect("write clock source");
 }
 
 fn write_json_serdes_project(project: &Path) {


### PR DESCRIPTION
## Summary

- Add Cranelift backend evidence tests for `std/io.ax` stderr emission and `std/time.ax` clock helpers.
- Cover zero-duration `sleep`, clock capability denial before Cranelift lowering, and the nonzero-sleep fail-fast guard.
- Keep the direct-native runtime ABI status partial; this is evidence for #928, not full runtime ABI closure.

## Governing Issue

Refs #928

This PR does not close #928. The broader direct-native runtime ABI and capability-shim parity work remains open.

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Local checks:

- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend clock -- --nocapture` passed: 3 passed.
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend logging_stdio -- --nocapture` passed: 1 passed.
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend -- --nocapture` passed: 33 passed.
- `make stage1-direct-native-runtime-abi` passed with `ready:false` and `errors: []`, as expected for the partial ABI contract.
- `git diff --check` passed.

Known baseline caveats:

- `cargo fmt --manifest-path stage1/Cargo.toml --all --check` reports pre-existing formatting drift outside this PR in `stage1/crates/axiomc/src/lib.rs`.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Evidence added:

- `stage1/crates/axiomc/tests/cranelift_backend.rs` now has executable evidence for the `clock.now_sleep` and `io.logging_stdio` direct-native runtime ABI rows.

Agent-facing inspection impact:

- No schema or inspection API changes. The added tests make existing ABI row evidence reproducible.

## Flow Contract

- Owner lane: daedalus
- Repair owner: codex
- Autonomy class: bounded evidence/test slice
- Risk class: low

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [ ] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is appropriate when gates pass

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- Auto-merge should wait for PR checks and non-author review.
