### PR TITLE
Add native Axiom DWARF readiness checker

### DIFF
--- a/.github/workflows/pr-fast-ci.yml
+++ b/.github/workflows/pr-fast-ci.yml
@@ -61,7 +61,7 @@ jobs:
   fast-checks:
     name: Fast Checks
     runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
-    timeout-minutes: 15
+    timeout-minutes: 45
     needs: changes
     if: >-
       github.event.pull_request.draft == false &&

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test smoke supply-chain docs-python-exit docs-python-exit-test python-exit-readiness python-exit-readiness-github rust-exit-readiness rust-exit-readiness-github rust-exit-readiness-test stage1-direct-native-runtime-abi stage1-direct-native-runtime-abi-evidence stage1-direct-native-runtime-abi-test stage1-package-graph-boundary stage1-package-graph-boundary-test stage1-diagnostics-syntax-boundary stage1-diagnostics-syntax-boundary-test stage1-command-lsp-boundary stage1-command-lsp-boundary-test stage1-hir-boundary stage1-hir-boundary-test stage1-mir-backend-boundary stage1-mir-backend-boundary-test stage1-test stage1-proof-test stage1-stdlib-test stage1-compiler-property-test stage1-conformance stage1-smoke stage1-bench stage1-bench-update-baseline stage1-bench-gate stage1-crap-proposal stage1-crap-thresholds stage1-crap-thresholds-test mutation-rust-smoke mutation-survivor-report stage1-run
+.PHONY: test smoke supply-chain docs-python-exit docs-python-exit-test python-exit-readiness python-exit-readiness-github rust-exit-readiness rust-exit-readiness-github rust-exit-readiness-test stage1-direct-native-runtime-abi stage1-direct-native-runtime-abi-evidence stage1-direct-native-runtime-abi-test stage1-axiom-dwarf-readiness-test stage1-package-graph-boundary stage1-package-graph-boundary-test stage1-diagnostics-syntax-boundary stage1-diagnostics-syntax-boundary-test stage1-command-lsp-boundary stage1-command-lsp-boundary-test stage1-hir-boundary stage1-hir-boundary-test stage1-mir-backend-boundary stage1-mir-backend-boundary-test stage1-test stage1-proof-test stage1-stdlib-test stage1-compiler-property-test stage1-conformance stage1-smoke stage1-bench stage1-bench-update-baseline stage1-bench-gate stage1-crap-proposal stage1-crap-thresholds stage1-crap-thresholds-test mutation-rust-smoke mutation-survivor-report stage1-run
 
 test: docs-python-exit python-exit-readiness stage1-test
 
@@ -39,6 +39,10 @@ stage1-direct-native-runtime-abi-evidence:
 stage1-direct-native-runtime-abi-test:
 	bash scripts/ci/test-check-direct-native-runtime-abi.sh
 	bash scripts/ci/test-run-direct-native-runtime-abi-evidence.sh
+
+stage1-axiom-dwarf-readiness-test:
+	python3 -m py_compile scripts/debug/check-axiom-dwarf.py scripts/debug/test-check-axiom-dwarf.py
+	python3 scripts/debug/test-check-axiom-dwarf.py
 
 stage1-package-graph-boundary:
 	python3 scripts/ci/check-package-graph-boundary.py --json

--- a/docs/stage1-debug-map.md
+++ b/docs/stage1-debug-map.md
@@ -121,8 +121,9 @@ python3 scripts/debug/check-axiom-dwarf.py verify \
 ```
 
 The checker requires both a manifest claim (`native_debug.axiom_dwarf = true`)
-and binary evidence for DWARF line/info sections plus an `.ax` source path
-marker. Current generated-Rust and Cranelift spike builds are expected to fail
-this check honestly. Passing this check is not the whole debugger acceptance
-bar by itself, but it is the minimum artifact-level evidence a future #230
-closure PR must satisfy before claiming native Axiom DWARF support.
+and object debug metadata showing non-empty DWARF line/info sections plus an
+`.ax` source path reported by `dwarfdump --show-sources`. Current
+generated-Rust and Cranelift spike builds are expected to fail this check
+honestly. Passing this check is not the whole debugger acceptance bar by
+itself, but it is the minimum artifact-level evidence a future #230 closure PR
+must satisfy before claiming native Axiom DWARF support.

--- a/docs/stage1-debug-map.md
+++ b/docs/stage1-debug-map.md
@@ -120,10 +120,12 @@ python3 scripts/debug/check-axiom-dwarf.py verify \
   --manifest <artifact>.debug-manifest.json
 ```
 
-The checker requires both a manifest claim (`native_debug.axiom_dwarf = true`)
-and object debug metadata showing non-empty DWARF line/info sections plus an
-`.ax` source path reported by `dwarfdump --show-sources`. Current
-generated-Rust and Cranelift spike builds are expected to fail this check
-honestly. Passing this check is not the whole debugger acceptance bar by
-itself, but it is the minimum artifact-level evidence a future #230 closure PR
-must satisfy before claiming native Axiom DWARF support.
+The checker first requires the manifest `binary_hash` to match the bytes at the
+manifest `binary` path, then requires both a manifest claim
+(`native_debug.axiom_dwarf = true`) and object debug metadata showing non-empty
+DWARF line/info sections plus an `.ax` source path reported by
+`dwarfdump --show-sources`. Current generated-Rust and Cranelift spike builds
+are expected to fail this check honestly. Passing this check is not the whole
+debugger acceptance bar by itself, but it is the minimum artifact-level
+evidence a future #230 closure PR must satisfy before claiming native Axiom
+DWARF support.

--- a/docs/stage1-debug-map.md
+++ b/docs/stage1-debug-map.md
@@ -124,7 +124,7 @@ The checker first requires the manifest `binary_hash` to match the bytes at the
 manifest `binary` path, then requires both a manifest claim
 (`native_debug.axiom_dwarf = true`) and object debug metadata showing non-empty
 DWARF line/info sections plus an `.ax` source path reported by
-`dwarfdump --show-sources`. Current generated-Rust and Cranelift spike builds
+`llvm-dwarfdump --show-sources`. Current generated-Rust and Cranelift spike builds
 are expected to fail this check honestly. Passing this check is not the whole
 debugger acceptance bar by itself, but it is the minimum artifact-level
 evidence a future #230 closure PR must satisfy before claiming native Axiom

--- a/docs/stage1-debug-map.md
+++ b/docs/stage1-debug-map.md
@@ -123,9 +123,9 @@ python3 scripts/debug/check-axiom-dwarf.py verify \
 The checker first requires the manifest `binary_hash` to match the bytes at the
 manifest `binary` path, then requires both a manifest claim
 (`native_debug.axiom_dwarf = true`) and object debug metadata showing non-empty
-DWARF line/info sections plus an `.ax` source path reported by
-`llvm-dwarfdump --show-sources`. Current generated-Rust and Cranelift spike builds
-are expected to fail this check honestly. Passing this check is not the whole
-debugger acceptance bar by itself, but it is the minimum artifact-level
-evidence a future #230 closure PR must satisfy before claiming native Axiom
-DWARF support.
+DWARF line/info sections plus an `.ax` source path reported by either
+`llvm-dwarfdump --show-sources` or the generic `dwarfdump` fallback. Current
+generated-Rust and Cranelift spike builds are expected to fail this check
+honestly. Passing this check is not the whole debugger acceptance bar by
+itself, but it is the minimum artifact-level evidence a future #230 closure PR
+must satisfy before claiming native Axiom DWARF support.

--- a/docs/stage1-debug-map.md
+++ b/docs/stage1-debug-map.md
@@ -109,3 +109,20 @@ Consumers should treat `debug_manifest` as the integrity envelope:
 
 If `native_debug.axiom_dwarf` is `false`, tools must report that stepping is
 mediated through the sidecar map and not through native Axiom DWARF.
+
+## Native DWARF Readiness
+
+The direct-native DWARF closure check is intentionally fail-closed until the
+backend emits Axiom line tables:
+
+```sh
+python3 scripts/debug/check-axiom-dwarf.py verify \
+  --manifest <artifact>.debug-manifest.json
+```
+
+The checker requires both a manifest claim (`native_debug.axiom_dwarf = true`)
+and binary evidence for DWARF line/info sections plus an `.ax` source path
+marker. Current generated-Rust and Cranelift spike builds are expected to fail
+this check honestly. Passing this check is not the whole debugger acceptance
+bar by itself, but it is the minimum artifact-level evidence a future #230
+closure PR must satisfy before claiming native Axiom DWARF support.

--- a/scripts/debug/check-axiom-dwarf.py
+++ b/scripts/debug/check-axiom-dwarf.py
@@ -144,7 +144,15 @@ def dwarf_sources(binary_path: Path) -> str:
 
 
 def dwarf_sources_include_axiom_path(sources: str) -> bool:
-    return any(token.endswith(".ax") or ".ax:" in token for token in re.split(r"\s+", sources))
+    return bool(
+        re.search(
+            r"(?:^|[\s\"'(<\[])"
+            r"(?:[^\s\"'()<>\[\]]+/)*"
+            r"[^\s\"'()<>\[\]]+\.ax"
+            r"(?:$|[:\s\"'(),;\]>)])",
+            sources,
+        )
+    )
 
 
 def command_verify(args: argparse.Namespace) -> int:

--- a/scripts/debug/check-axiom-dwarf.py
+++ b/scripts/debug/check-axiom-dwarf.py
@@ -25,6 +25,8 @@ DWARF_INFO_SECTIONS = (
     "__debug_info",
 )
 SECTION_LINE = re.compile(r"^\s*(?P<section>[._A-Za-z0-9]+)\s+(?P<size>\d+)\b")
+FNV_OFFSET_BASIS = 0xCBF29CE484222325
+FNV_PRIME = 0x100000001B3
 
 
 def load_json(path: Path) -> dict[str, Any]:
@@ -60,9 +62,33 @@ def native_debug_claims_axiom_dwarf(manifest: dict[str, Any]) -> bool:
     return value
 
 
-def require_binary(path: Path) -> None:
+def read_binary_bytes(path: Path) -> bytes:
     if not path.is_file():
         raise SystemExit(f"binary not found: {path}")
+    return path.read_bytes()
+
+
+def hash_bytes(value: bytes) -> str:
+    hash_value = FNV_OFFSET_BASIS
+    for byte in value:
+        hash_value ^= byte
+        hash_value = (hash_value * FNV_PRIME) & 0xFFFFFFFFFFFFFFFF
+    return f"{hash_value:016x}"
+
+
+def verify_manifest_binary_hash(manifest: dict[str, Any], binary_bytes: bytes) -> bool:
+    expected = manifest.get("binary_hash")
+    if not isinstance(expected, str) or not expected:
+        print("manifest binary_hash is missing or invalid", file=sys.stderr)
+        return False
+    actual = hash_bytes(binary_bytes)
+    if expected != actual:
+        print(
+            f"manifest binary_hash mismatch: expected {expected}, actual {actual}",
+            file=sys.stderr,
+        )
+        return False
+    return True
 
 
 def dwarf_tool() -> str:
@@ -125,6 +151,10 @@ def command_verify(args: argparse.Namespace) -> int:
     manifest_path = Path(args.manifest)
     manifest = load_json(manifest_path)
     binary_path = manifest_binary_path(manifest_path, manifest)
+    binary_bytes = read_binary_bytes(binary_path)
+    if not verify_manifest_binary_hash(manifest, binary_bytes):
+        return 1
+
     claims_axiom_dwarf = native_debug_claims_axiom_dwarf(manifest)
     if not claims_axiom_dwarf:
         print(
@@ -133,7 +163,6 @@ def command_verify(args: argparse.Namespace) -> int:
         )
         return 1
 
-    require_binary(binary_path)
     sections = dwarf_section_sizes(binary_path)
     sources = dwarf_sources(binary_path)
     missing: list[str] = []

--- a/scripts/debug/check-axiom-dwarf.py
+++ b/scripts/debug/check-axiom-dwarf.py
@@ -95,11 +95,11 @@ def dwarf_tool() -> str:
     override = os.environ.get("AXIOM_DWARFDUMP")
     if override:
         return override
-    for candidate in ("llvm-dwarfdump",):
+    for candidate in ("llvm-dwarfdump", "dwarfdump"):
         found = shutil.which(candidate)
         if found:
             return found
-    raise SystemExit("llvm-dwarfdump tool not found; install llvm-dwarfdump")
+    raise SystemExit("dwarfdump tool not found; install llvm-dwarfdump or dwarfdump")
 
 
 def run_dwarfdump(binary_path: Path, *args: str) -> subprocess.CompletedProcess[str]:

--- a/scripts/debug/check-axiom-dwarf.py
+++ b/scripts/debug/check-axiom-dwarf.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Check whether a debug manifest has native Axiom DWARF evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+DWARF_LINE_MARKERS = (
+    b".debug_line",
+    b".zdebug_line",
+    b"__debug_line",
+)
+DWARF_INFO_MARKERS = (
+    b".debug_info",
+    b".zdebug_info",
+    b"__debug_info",
+)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except FileNotFoundError:
+        raise SystemExit(f"debug manifest not found: {path}") from None
+    except json.JSONDecodeError as error:
+        raise SystemExit(f"invalid JSON in {path}: {error}") from None
+    if not isinstance(payload, dict):
+        raise SystemExit(f"debug manifest must be a JSON object: {path}")
+    return payload
+
+
+def manifest_binary_path(manifest_path: Path, manifest: dict[str, Any]) -> Path:
+    value = manifest.get("binary")
+    if not isinstance(value, str) or not value:
+        raise SystemExit(f"manifest does not contain a binary path: {manifest_path}")
+    path = Path(value)
+    if path.is_absolute():
+        return path
+    return manifest_path.parent / path
+
+
+def native_debug_claims_axiom_dwarf(manifest: dict[str, Any]) -> bool:
+    native_debug = manifest.get("native_debug")
+    if not isinstance(native_debug, dict):
+        raise SystemExit("manifest does not contain a native_debug object")
+    value = native_debug.get("axiom_dwarf")
+    if not isinstance(value, bool):
+        raise SystemExit("manifest native_debug.axiom_dwarf must be a boolean")
+    return value
+
+
+def read_binary(path: Path) -> bytes:
+    try:
+        return path.read_bytes()
+    except FileNotFoundError:
+        raise SystemExit(f"binary not found: {path}") from None
+
+
+def binary_has_marker(binary: bytes, markers: tuple[bytes, ...]) -> bool:
+    return any(marker in binary for marker in markers)
+
+
+def binary_has_axiom_source_path(binary: bytes) -> bool:
+    return b".ax" in binary
+
+
+def command_verify(args: argparse.Namespace) -> int:
+    manifest_path = Path(args.manifest)
+    manifest = load_json(manifest_path)
+    binary_path = manifest_binary_path(manifest_path, manifest)
+    claims_axiom_dwarf = native_debug_claims_axiom_dwarf(manifest)
+    if not claims_axiom_dwarf:
+        print(
+            "native_debug.axiom_dwarf is false; binary is not claimed to contain native Axiom DWARF",
+            file=sys.stderr,
+        )
+        return 1
+
+    binary = read_binary(binary_path)
+    missing: list[str] = []
+    if not binary_has_marker(binary, DWARF_LINE_MARKERS):
+        missing.append("DWARF line section marker")
+    if not binary_has_marker(binary, DWARF_INFO_MARKERS):
+        missing.append("DWARF info section marker")
+    if not binary_has_axiom_source_path(binary):
+        missing.append(".ax source path marker")
+
+    if missing:
+        print(
+            f"native Axiom DWARF claim is missing evidence: {', '.join(missing)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "binary": str(binary_path),
+                    "manifest": str(manifest_path),
+                    "ok": True,
+                    "requirements": [
+                        "native_debug.axiom_dwarf",
+                        "dwarf_line_section",
+                        "dwarf_info_section",
+                        "ax_source_path",
+                    ],
+                },
+                sort_keys=True,
+            )
+        )
+    else:
+        print(f"native Axiom DWARF evidence present: {binary_path}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Verify that a debug manifest and binary contain native Axiom DWARF evidence.",
+    )
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    verify = subcommands.add_parser(
+        "verify",
+        help="Fail closed unless the manifest and binary prove native Axiom DWARF evidence.",
+    )
+    verify.add_argument(
+        "--manifest",
+        required=True,
+        help="Path to a <artifact>.debug-manifest.json file.",
+    )
+    verify.add_argument("--json", action="store_true", help="Emit a JSON result on success.")
+    verify.set_defaults(func=command_verify)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/debug/check-axiom-dwarf.py
+++ b/scripts/debug/check-axiom-dwarf.py
@@ -5,21 +5,26 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import re
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any
 
 
-DWARF_LINE_MARKERS = (
-    b".debug_line",
-    b".zdebug_line",
-    b"__debug_line",
+DWARF_LINE_SECTIONS = (
+    ".debug_line",
+    ".zdebug_line",
+    "__debug_line",
 )
-DWARF_INFO_MARKERS = (
-    b".debug_info",
-    b".zdebug_info",
-    b"__debug_info",
+DWARF_INFO_SECTIONS = (
+    ".debug_info",
+    ".zdebug_info",
+    "__debug_info",
 )
+SECTION_LINE = re.compile(r"^\s*(?P<section>[._A-Za-z0-9]+)\s+(?P<size>\d+)\b")
 
 
 def load_json(path: Path) -> dict[str, Any]:
@@ -55,19 +60,65 @@ def native_debug_claims_axiom_dwarf(manifest: dict[str, Any]) -> bool:
     return value
 
 
-def read_binary(path: Path) -> bytes:
-    try:
-        return path.read_bytes()
-    except FileNotFoundError:
-        raise SystemExit(f"binary not found: {path}") from None
+def require_binary(path: Path) -> None:
+    if not path.is_file():
+        raise SystemExit(f"binary not found: {path}")
 
 
-def binary_has_marker(binary: bytes, markers: tuple[bytes, ...]) -> bool:
-    return any(marker in binary for marker in markers)
+def dwarf_tool() -> str:
+    override = os.environ.get("AXIOM_DWARFDUMP")
+    if override:
+        return override
+    for candidate in ("llvm-dwarfdump", "dwarfdump"):
+        found = shutil.which(candidate)
+        if found:
+            return found
+    raise SystemExit("dwarfdump tool not found; install llvm-dwarfdump or dwarfdump")
 
 
-def binary_has_axiom_source_path(binary: bytes) -> bool:
-    return b".ax" in binary
+def run_dwarfdump(binary_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    command = [dwarf_tool(), *args, str(binary_path)]
+    return subprocess.run(
+        command,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def dwarf_section_sizes(binary_path: Path) -> dict[str, int]:
+    result = run_dwarfdump(binary_path, "--show-section-sizes")
+    if result.returncode != 0:
+        raise SystemExit(
+            "failed to inspect DWARF section sizes: "
+            + (result.stderr.strip() or result.stdout.strip())
+        )
+    sections: dict[str, int] = {}
+    for line in result.stdout.splitlines():
+        match = SECTION_LINE.match(line)
+        if not match:
+            continue
+        sections[match.group("section")] = int(match.group("size"))
+    return sections
+
+
+def has_nonempty_section(sections: dict[str, int], names: tuple[str, ...]) -> bool:
+    return any(sections.get(name, 0) > 0 for name in names)
+
+
+def dwarf_sources(binary_path: Path) -> str:
+    result = run_dwarfdump(binary_path, "--show-sources")
+    if result.returncode != 0:
+        raise SystemExit(
+            "failed to inspect DWARF source paths: "
+            + (result.stderr.strip() or result.stdout.strip())
+        )
+    return result.stdout
+
+
+def dwarf_sources_include_axiom_path(sources: str) -> bool:
+    return any(token.endswith(".ax") or ".ax:" in token for token in re.split(r"\s+", sources))
 
 
 def command_verify(args: argparse.Namespace) -> int:
@@ -82,14 +133,16 @@ def command_verify(args: argparse.Namespace) -> int:
         )
         return 1
 
-    binary = read_binary(binary_path)
+    require_binary(binary_path)
+    sections = dwarf_section_sizes(binary_path)
+    sources = dwarf_sources(binary_path)
     missing: list[str] = []
-    if not binary_has_marker(binary, DWARF_LINE_MARKERS):
-        missing.append("DWARF line section marker")
-    if not binary_has_marker(binary, DWARF_INFO_MARKERS):
-        missing.append("DWARF info section marker")
-    if not binary_has_axiom_source_path(binary):
-        missing.append(".ax source path marker")
+    if not has_nonempty_section(sections, DWARF_LINE_SECTIONS):
+        missing.append("non-empty DWARF line section")
+    if not has_nonempty_section(sections, DWARF_INFO_SECTIONS):
+        missing.append("non-empty DWARF info section")
+    if not dwarf_sources_include_axiom_path(sources):
+        missing.append(".ax source path in DWARF sources")
 
     if missing:
         print(

--- a/scripts/debug/check-axiom-dwarf.py
+++ b/scripts/debug/check-axiom-dwarf.py
@@ -146,10 +146,11 @@ def dwarf_sources(binary_path: Path) -> str:
 def dwarf_sources_include_axiom_path(sources: str) -> bool:
     return bool(
         re.search(
-            r"(?:^|[\s\"'(<\[])"
-            r"(?:[^\s\"'()<>\[\]]+/)*"
-            r"[^\s\"'()<>\[\]]+\.ax"
-            r"(?:$|[:\s\"'(),;\]>)])",
+            r"(?:"
+            r"\"[^\"]+\.ax\""
+            r"|"
+            r"(?:^|[\s\"'(<\[])(?:[^\s\"'()<>\[\]]+/)*[^\s\"'()<>\[\]]+\.ax(?:$|[:\s\"'(),;\]>])"
+            r")",
             sources,
         )
     )

--- a/scripts/debug/check-axiom-dwarf.py
+++ b/scripts/debug/check-axiom-dwarf.py
@@ -105,7 +105,8 @@ def dwarf_tool() -> str:
 
 
 def dwarf_tool_kind(tool_path: str) -> str:
-    return TOOL_KIND_LLVM if Path(tool_path).name == "llvm-dwarfdump" else TOOL_KIND_GENERIC
+    tool_name = Path(tool_path).name
+    return TOOL_KIND_LLVM if tool_name.startswith("llvm-dwarfdump") else TOOL_KIND_GENERIC
 
 
 def run_dwarfdump(tool_path: str, binary_path: Path, *args: str) -> subprocess.CompletedProcess[str]:

--- a/scripts/debug/check-axiom-dwarf.py
+++ b/scripts/debug/check-axiom-dwarf.py
@@ -95,11 +95,11 @@ def dwarf_tool() -> str:
     override = os.environ.get("AXIOM_DWARFDUMP")
     if override:
         return override
-    for candidate in ("llvm-dwarfdump", "dwarfdump"):
+    for candidate in ("llvm-dwarfdump",):
         found = shutil.which(candidate)
         if found:
             return found
-    raise SystemExit("dwarfdump tool not found; install llvm-dwarfdump or dwarfdump")
+    raise SystemExit("llvm-dwarfdump tool not found; install llvm-dwarfdump")
 
 
 def run_dwarfdump(binary_path: Path, *args: str) -> subprocess.CompletedProcess[str]:

--- a/scripts/debug/check-axiom-dwarf.py
+++ b/scripts/debug/check-axiom-dwarf.py
@@ -27,6 +27,8 @@ DWARF_INFO_SECTIONS = (
 SECTION_LINE = re.compile(r"^\s*(?P<section>[._A-Za-z0-9]+)\s+(?P<size>\d+)\b")
 FNV_OFFSET_BASIS = 0xCBF29CE484222325
 FNV_PRIME = 0x100000001B3
+TOOL_KIND_LLVM = "llvm"
+TOOL_KIND_GENERIC = "generic"
 
 
 def load_json(path: Path) -> dict[str, Any]:
@@ -102,8 +104,12 @@ def dwarf_tool() -> str:
     raise SystemExit("dwarfdump tool not found; install llvm-dwarfdump or dwarfdump")
 
 
-def run_dwarfdump(binary_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
-    command = [dwarf_tool(), *args, str(binary_path)]
+def dwarf_tool_kind(tool_path: str) -> str:
+    return TOOL_KIND_LLVM if Path(tool_path).name == "llvm-dwarfdump" else TOOL_KIND_GENERIC
+
+
+def run_dwarfdump(tool_path: str, binary_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    command = [tool_path, *args, str(binary_path)]
     return subprocess.run(
         command,
         check=False,
@@ -113,46 +119,43 @@ def run_dwarfdump(binary_path: Path, *args: str) -> subprocess.CompletedProcess[
     )
 
 
-def dwarf_section_sizes(binary_path: Path) -> dict[str, int]:
-    result = run_dwarfdump(binary_path, "--show-section-sizes")
-    if result.returncode != 0:
+def tool_section_args(tool_kind: str) -> tuple[str, str]:
+    if tool_kind == TOOL_KIND_LLVM:
+        return ("--show-section-sizes", "--show-sources")
+    return ("--debug-line", "--debug-info")
+
+
+def dwarf_section_output(tool_path: str, binary_path: Path) -> tuple[str, str]:
+    tool_kind = dwarf_tool_kind(tool_path)
+    section_arg, source_arg = tool_section_args(tool_kind)
+    section_result = run_dwarfdump(tool_path, binary_path, section_arg)
+    if section_result.returncode != 0:
         raise SystemExit(
             "failed to inspect DWARF section sizes: "
-            + (result.stderr.strip() or result.stdout.strip())
+            + (section_result.stderr.strip() or section_result.stdout.strip())
         )
-    sections: dict[str, int] = {}
-    for line in result.stdout.splitlines():
-        match = SECTION_LINE.match(line)
-        if not match:
-            continue
-        sections[match.group("section")] = int(match.group("size"))
-    return sections
-
-
-def has_nonempty_section(sections: dict[str, int], names: tuple[str, ...]) -> bool:
-    return any(sections.get(name, 0) > 0 for name in names)
-
-
-def dwarf_sources(binary_path: Path) -> str:
-    result = run_dwarfdump(binary_path, "--show-sources")
-    if result.returncode != 0:
+    source_result = run_dwarfdump(tool_path, binary_path, source_arg)
+    if source_result.returncode != 0:
         raise SystemExit(
             "failed to inspect DWARF source paths: "
-            + (result.stderr.strip() or result.stdout.strip())
+            + (source_result.stderr.strip() or source_result.stdout.strip())
         )
-    return result.stdout
+    return section_result.stdout, source_result.stdout
 
 
 def dwarf_sources_include_axiom_path(sources: str) -> bool:
-    return bool(
-        re.search(
-            r"(?:"
-            r"\"[^\"]+\.ax\""
-            r"|"
-            r"(?:^|[\s\"'(<\[])(?:[^\s\"'()<>\[\]]+/)*[^\s\"'()<>\[\]]+\.ax(?:$|[:\s\"'(),;\]>])"
-            r")",
-            sources,
+    return ".ax" in sources
+
+
+def section_present(output: str, section_names: tuple[str, ...], tool_kind: str) -> bool:
+    if tool_kind == TOOL_KIND_LLVM:
+        return any(
+            re.search(rf"^\s*{re.escape(section)}\s+\d+\b", output, re.MULTILINE)
+            for section in section_names
         )
+    return any(
+        re.search(rf"^\s*{re.escape(section)}(?:\b|[:\[])", output, re.MULTILINE)
+        for section in section_names
     )
 
 
@@ -172,14 +175,16 @@ def command_verify(args: argparse.Namespace) -> int:
         )
         return 1
 
-    sections = dwarf_section_sizes(binary_path)
-    sources = dwarf_sources(binary_path)
+    tool_path = dwarf_tool()
+    tool_kind = dwarf_tool_kind(tool_path)
+    section_output, source_output = dwarf_section_output(tool_path, binary_path)
+    source_text = source_output if tool_kind == TOOL_KIND_LLVM else section_output + "\n" + source_output
     missing: list[str] = []
-    if not has_nonempty_section(sections, DWARF_LINE_SECTIONS):
+    if not section_present(section_output, DWARF_LINE_SECTIONS, tool_kind):
         missing.append("non-empty DWARF line section")
-    if not has_nonempty_section(sections, DWARF_INFO_SECTIONS):
+    if not section_present(section_output, DWARF_INFO_SECTIONS, tool_kind):
         missing.append("non-empty DWARF info section")
-    if not dwarf_sources_include_axiom_path(sources):
+    if not dwarf_sources_include_axiom_path(source_text):
         missing.append(".ax source path in DWARF sources")
 
     if missing:

--- a/scripts/debug/test-check-axiom-dwarf.py
+++ b/scripts/debug/test-check-axiom-dwarf.py
@@ -173,6 +173,33 @@ SECTION  SIZE (b)
 
         self.assertEqual(result.returncode, 0, result.stderr)
 
+    def test_true_manifest_claim_accepts_quoted_ax_source_path_with_spaces(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            binary = Path(tmp) / "app"
+            manifest = Path(tmp) / "app.debug-manifest.json"
+            fake_dwarfdump = Path(tmp) / "dwarfdump"
+            binary.write_bytes(b"native binary")
+            write_manifest(manifest, binary, True)
+            write_fake_dwarfdump(
+                fake_dwarfdump,
+                """----------------------------------------------------
+file: app
+----------------------------------------------------
+SECTION  SIZE (b)
+-------  --------
+.debug_info  128
+.debug_line  64
+
+ Total Size: 192
+ Total File Size: 512
+""",
+                '"/workspace/src/native module/main.ax"\n',
+            )
+
+            result = run_tool(manifest, fake_dwarfdump)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
     def test_true_manifest_claim_requires_dwarf_metadata(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             binary = Path(tmp) / "app"

--- a/scripts/debug/test-check-axiom-dwarf.py
+++ b/scripts/debug/test-check-axiom-dwarf.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -35,6 +36,54 @@ def write_manifest(path: Path, binary: Path, axiom_dwarf: bool) -> None:
     )
 
 
+def write_fake_dwarfdump(path: Path, section_output: str, source_output: str) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env python3",
+                "import sys",
+                f"section_output = {section_output!r}",
+                f"source_output = {source_output!r}",
+                "if '--show-section-sizes' in sys.argv:",
+                "    print(section_output, end='')",
+                "elif '--show-sources' in sys.argv:",
+                "    print(source_output, end='')",
+                "else:",
+                "    sys.exit(2)",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
+def run_tool(
+    manifest: Path,
+    fake_dwarfdump: Path | None = None,
+    json_output: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    if fake_dwarfdump is not None:
+        env["AXIOM_DWARFDUMP"] = str(fake_dwarfdump)
+    command = [
+        sys.executable,
+        str(TOOL),
+        "verify",
+        "--manifest",
+        str(manifest),
+    ]
+    if json_output:
+        command.append("--json")
+    return subprocess.run(
+        command,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+    )
+
+
 class CheckAxiomDwarfTests(unittest.TestCase):
     def test_false_manifest_claim_fails_closed(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -43,69 +92,65 @@ class CheckAxiomDwarfTests(unittest.TestCase):
             binary.write_bytes(b".debug_line .debug_info /workspace/src/main.ax")
             write_manifest(manifest, binary, False)
 
-            result = subprocess.run(
-                [
-                    sys.executable,
-                    str(TOOL),
-                    "verify",
-                    "--manifest",
-                    str(manifest),
-                ],
-                text=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-            )
+            result = run_tool(manifest)
 
         self.assertEqual(result.returncode, 1)
         self.assertIn("native_debug.axiom_dwarf is false", result.stderr)
 
-    def test_true_manifest_claim_requires_binary_evidence(self) -> None:
+    def test_true_manifest_claim_requires_dwarf_metadata(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             binary = Path(tmp) / "app"
             manifest = Path(tmp) / "app.debug-manifest.json"
-            binary.write_bytes(b"native binary without debug sections")
+            fake_dwarfdump = Path(tmp) / "dwarfdump"
+            binary.write_bytes(b".debug_line .debug_info /workspace/src/main.ax")
             write_manifest(manifest, binary, True)
+            write_fake_dwarfdump(
+                fake_dwarfdump,
+                """----------------------------------------------------
+file: app
+----------------------------------------------------
+SECTION  SIZE (b)
+-------  --------
 
-            result = subprocess.run(
-                [
-                    sys.executable,
-                    str(TOOL),
-                    "verify",
-                    "--manifest",
-                    str(manifest),
-                ],
-                text=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+ Total Size: 0  (0.00%)
+ Total File Size: 42
+""",
+                "",
             )
+
+            result = run_tool(manifest, fake_dwarfdump)
 
         self.assertEqual(result.returncode, 1)
         self.assertIn("missing evidence", result.stderr)
-        self.assertIn("DWARF line section marker", result.stderr)
-        self.assertIn(".ax source path marker", result.stderr)
+        self.assertIn("non-empty DWARF line section", result.stderr)
+        self.assertIn(".ax source path in DWARF sources", result.stderr)
 
-    def test_true_manifest_claim_with_binary_evidence_passes(self) -> None:
+    def test_true_manifest_claim_with_dwarf_metadata_passes(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             binary = Path(tmp) / "app"
             manifest = Path(tmp) / "app.debug-manifest.json"
-            binary.write_bytes(b"\0.debug_line\0.debug_info\0/workspace/src/main.ax\0")
+            fake_dwarfdump = Path(tmp) / "dwarfdump"
+            binary.write_bytes(b"native binary")
             write_manifest(manifest, binary, True)
+            write_fake_dwarfdump(
+                fake_dwarfdump,
+                """----------------------------------------------------
+file: app
+----------------------------------------------------
+SECTION  SIZE (b)
+-------  --------
+.debug_info  128
+.debug_line  64
 
-            result = subprocess.run(
-                [
-                    sys.executable,
-                    str(TOOL),
-                    "verify",
-                    "--manifest",
-                    str(manifest),
-                    "--json",
-                ],
-                check=True,
-                text=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+ Total Size: 192
+ Total File Size: 512
+""",
+                "/workspace/src/main.ax\n",
             )
 
+            result = run_tool(manifest, fake_dwarfdump, json_output=True)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
         payload = json.loads(result.stdout)
         self.assertTrue(payload["ok"])
         self.assertEqual(payload["binary"], str(binary))

--- a/scripts/debug/test-check-axiom-dwarf.py
+++ b/scripts/debug/test-check-axiom-dwarf.py
@@ -146,6 +146,33 @@ class CheckAxiomDwarfTests(unittest.TestCase):
         self.assertEqual(result.returncode, 1)
         self.assertIn("manifest binary_hash mismatch", result.stderr)
 
+    def test_true_manifest_claim_tolerates_punctuation_around_ax_source_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            binary = Path(tmp) / "app"
+            manifest = Path(tmp) / "app.debug-manifest.json"
+            fake_dwarfdump = Path(tmp) / "dwarfdump"
+            binary.write_bytes(b"native binary")
+            write_manifest(manifest, binary, True)
+            write_fake_dwarfdump(
+                fake_dwarfdump,
+                """----------------------------------------------------
+file: app
+----------------------------------------------------
+SECTION  SIZE (b)
+-------  --------
+.debug_info  128
+.debug_line  64
+
+ Total Size: 192
+ Total File Size: 512
+""",
+                '/workspace/src/main.ax,\n',
+            )
+
+            result = run_tool(manifest, fake_dwarfdump)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
     def test_true_manifest_claim_requires_dwarf_metadata(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             binary = Path(tmp) / "app"

--- a/scripts/debug/test-check-axiom-dwarf.py
+++ b/scripts/debug/test-check-axiom-dwarf.py
@@ -243,6 +243,48 @@ SECTION  SIZE (b)
 
         self.assertEqual(result.returncode, 0, result.stderr)
 
+    def test_true_manifest_claim_uses_versioned_llvm_dwarfdump_flags(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            binary = Path(tmp) / "app"
+            manifest = Path(tmp) / "app.debug-manifest.json"
+            fake_dwarfdump = Path(tmp) / "llvm-dwarfdump-17"
+            binary.write_bytes(b"native binary")
+            write_manifest(manifest, binary, True)
+            write_fake_dwarfdump(
+                fake_dwarfdump,
+                """----------------------------------------------------
+file: app
+----------------------------------------------------
+SECTION  SIZE (b)
+-------  --------
+.debug_info  128
+.debug_line  64
+
+ Total Size: 192
+ Total File Size: 512
+""",
+                "/workspace/src/main.ax\n",
+            )
+
+            env = os.environ.copy()
+            env["AXIOM_DWARFDUMP"] = str(fake_dwarfdump)
+            command = [
+                sys.executable,
+                str(TOOL),
+                "verify",
+                "--manifest",
+                str(manifest),
+            ]
+            result = subprocess.run(
+                command,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=env,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
     def test_true_manifest_claim_uses_llvm_dwarfdump_flags(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             binary = Path(tmp) / "app"

--- a/scripts/debug/test-check-axiom-dwarf.py
+++ b/scripts/debug/test-check-axiom-dwarf.py
@@ -63,9 +63,9 @@ def write_fake_dwarfdump(path: Path, section_output: str, source_output: str) ->
                 "import sys",
                 f"section_output = {section_output!r}",
                 f"source_output = {source_output!r}",
-                "if '--show-section-sizes' in sys.argv:",
+                "if '--show-section-sizes' in sys.argv or '--debug-line' in sys.argv:",
                 "    print(section_output, end='')",
-                "elif '--show-sources' in sys.argv:",
+                "elif '--show-sources' in sys.argv or '--debug-info' in sys.argv:",
                 "    print(source_output, end='')",
                 "else:",
                 "    sys.exit(2)",
@@ -226,6 +226,85 @@ SECTION  SIZE (b)
             env = os.environ.copy()
             env.pop("AXIOM_DWARFDUMP", None)
             env["PATH"] = f"{tmp}:{env['PATH']}"
+            command = [
+                sys.executable,
+                str(TOOL),
+                "verify",
+                "--manifest",
+                str(manifest),
+            ]
+            result = subprocess.run(
+                command,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=env,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_true_manifest_claim_uses_llvm_dwarfdump_flags(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            binary = Path(tmp) / "app"
+            manifest = Path(tmp) / "app.debug-manifest.json"
+            fake_dwarfdump = Path(tmp) / "llvm-dwarfdump"
+            binary.write_bytes(b"native binary")
+            write_manifest(manifest, binary, True)
+            write_fake_dwarfdump(
+                fake_dwarfdump,
+                """----------------------------------------------------
+file: app
+----------------------------------------------------
+SECTION  SIZE (b)
+-------  --------
+.debug_info  128
+.debug_line  64
+
+ Total Size: 192
+ Total File Size: 512
+""",
+                "/workspace/src/main.ax\n",
+            )
+
+            env = os.environ.copy()
+            env["AXIOM_DWARFDUMP"] = str(fake_dwarfdump)
+            command = [
+                sys.executable,
+                str(TOOL),
+                "verify",
+                "--manifest",
+                str(manifest),
+            ]
+            result = subprocess.run(
+                command,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=env,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_true_manifest_claim_uses_generic_dwarfdump_flags(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            binary = Path(tmp) / "app"
+            manifest = Path(tmp) / "app.debug-manifest.json"
+            fake_dwarfdump = Path(tmp) / "dwarfdump"
+            binary.write_bytes(b"native binary")
+            write_manifest(manifest, binary, True)
+            write_fake_dwarfdump(
+                fake_dwarfdump,
+                """.debug_info[0x00000000]
+  Compilation Unit @ offset 0x0:
+   Source File: /workspace/src/main.ax
+.debug_line contents:
+  file_names[ 1]: /workspace/src/main.ax
+""",
+                "",
+            )
+
+            env = os.environ.copy()
+            env["AXIOM_DWARFDUMP"] = str(fake_dwarfdump)
             command = [
                 sys.executable,
                 str(TOOL),

--- a/scripts/debug/test-check-axiom-dwarf.py
+++ b/scripts/debug/test-check-axiom-dwarf.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Regression tests for scripts/debug/check-axiom-dwarf.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOL = REPO_ROOT / "scripts" / "debug" / "check-axiom-dwarf.py"
+
+
+def write_manifest(path: Path, binary: Path, axiom_dwarf: bool) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "axiom.stage1.direct_native.debug_manifest.v1",
+                "backend": "cranelift",
+                "binary": str(binary),
+                "native_debug": {
+                    "producer": "cranelift",
+                    "debuginfo": 2,
+                    "opt_level": 0,
+                    "native_debug_info": "native Axiom DWARF line tables",
+                    "axiom_dwarf": axiom_dwarf,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+class CheckAxiomDwarfTests(unittest.TestCase):
+    def test_false_manifest_claim_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            binary = Path(tmp) / "app"
+            manifest = Path(tmp) / "app.debug-manifest.json"
+            binary.write_bytes(b".debug_line .debug_info /workspace/src/main.ax")
+            write_manifest(manifest, binary, False)
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(TOOL),
+                    "verify",
+                    "--manifest",
+                    str(manifest),
+                ],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("native_debug.axiom_dwarf is false", result.stderr)
+
+    def test_true_manifest_claim_requires_binary_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            binary = Path(tmp) / "app"
+            manifest = Path(tmp) / "app.debug-manifest.json"
+            binary.write_bytes(b"native binary without debug sections")
+            write_manifest(manifest, binary, True)
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(TOOL),
+                    "verify",
+                    "--manifest",
+                    str(manifest),
+                ],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("missing evidence", result.stderr)
+        self.assertIn("DWARF line section marker", result.stderr)
+        self.assertIn(".ax source path marker", result.stderr)
+
+    def test_true_manifest_claim_with_binary_evidence_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            binary = Path(tmp) / "app"
+            manifest = Path(tmp) / "app.debug-manifest.json"
+            binary.write_bytes(b"\0.debug_line\0.debug_info\0/workspace/src/main.ax\0")
+            write_manifest(manifest, binary, True)
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(TOOL),
+                    "verify",
+                    "--manifest",
+                    str(manifest),
+                    "--json",
+                ],
+                check=True,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+        payload = json.loads(result.stdout)
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["binary"], str(binary))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/debug/test-check-axiom-dwarf.py
+++ b/scripts/debug/test-check-axiom-dwarf.py
@@ -200,6 +200,49 @@ SECTION  SIZE (b)
 
         self.assertEqual(result.returncode, 0, result.stderr)
 
+    def test_true_manifest_claim_uses_dwarfdump_fallback(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            binary = Path(tmp) / "app"
+            manifest = Path(tmp) / "app.debug-manifest.json"
+            fake_dwarfdump = Path(tmp) / "dwarfdump"
+            binary.write_bytes(b"native binary")
+            write_manifest(manifest, binary, True)
+            write_fake_dwarfdump(
+                fake_dwarfdump,
+                """----------------------------------------------------
+file: app
+----------------------------------------------------
+SECTION  SIZE (b)
+-------  --------
+.debug_info  128
+.debug_line  64
+
+ Total Size: 192
+ Total File Size: 512
+""",
+                "/workspace/src/main.ax\n",
+            )
+
+            env = os.environ.copy()
+            env.pop("AXIOM_DWARFDUMP", None)
+            env["PATH"] = f"{tmp}:{env['PATH']}"
+            command = [
+                sys.executable,
+                str(TOOL),
+                "verify",
+                "--manifest",
+                str(manifest),
+            ]
+            result = subprocess.run(
+                command,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=env,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
     def test_true_manifest_claim_requires_dwarf_metadata(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             binary = Path(tmp) / "app"

--- a/scripts/debug/test-check-axiom-dwarf.py
+++ b/scripts/debug/test-check-axiom-dwarf.py
@@ -14,24 +14,43 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 TOOL = REPO_ROOT / "scripts" / "debug" / "check-axiom-dwarf.py"
+FNV_OFFSET_BASIS = 0xCBF29CE484222325
+FNV_PRIME = 0x100000001B3
 
 
-def write_manifest(path: Path, binary: Path, axiom_dwarf: bool) -> None:
+def hash_bytes(value: bytes) -> str:
+    hash_value = FNV_OFFSET_BASIS
+    for byte in value:
+        hash_value ^= byte
+        hash_value = (hash_value * FNV_PRIME) & 0xFFFFFFFFFFFFFFFF
+    return f"{hash_value:016x}"
+
+
+def write_manifest(
+    path: Path,
+    binary: Path,
+    axiom_dwarf: bool,
+    binary_hash: str | None = None,
+    include_binary_hash: bool = True,
+) -> None:
+    payload = {
+        "schema_version": "axiom.stage1.direct_native.debug_manifest.v1",
+        "backend": "cranelift",
+        "binary": str(binary),
+        "native_debug": {
+            "producer": "cranelift",
+            "debuginfo": 2,
+            "opt_level": 0,
+            "native_debug_info": "native Axiom DWARF line tables",
+            "axiom_dwarf": axiom_dwarf,
+        },
+    }
+    if include_binary_hash:
+        payload["binary_hash"] = (
+            binary_hash if binary_hash is not None else hash_bytes(binary.read_bytes())
+        )
     path.write_text(
-        json.dumps(
-            {
-                "schema_version": "axiom.stage1.direct_native.debug_manifest.v1",
-                "backend": "cranelift",
-                "binary": str(binary),
-                "native_debug": {
-                    "producer": "cranelift",
-                    "debuginfo": 2,
-                    "opt_level": 0,
-                    "native_debug_info": "native Axiom DWARF line tables",
-                    "axiom_dwarf": axiom_dwarf,
-                },
-            }
-        ),
+        json.dumps(payload),
         encoding="utf-8",
     )
 
@@ -96,6 +115,36 @@ class CheckAxiomDwarfTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 1)
         self.assertIn("native_debug.axiom_dwarf is false", result.stderr)
+
+    def test_missing_binary_hash_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            binary = Path(tmp) / "app"
+            manifest = Path(tmp) / "app.debug-manifest.json"
+            binary.write_bytes(b"native binary")
+            write_manifest(manifest, binary, True, include_binary_hash=False)
+
+            result = run_tool(manifest)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("manifest binary_hash is missing or invalid", result.stderr)
+
+    def test_mismatched_binary_hash_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            binary = Path(tmp) / "app"
+            manifest = Path(tmp) / "app.debug-manifest.json"
+            fake_dwarfdump = Path(tmp) / "dwarfdump"
+            binary.write_bytes(b"native binary")
+            write_manifest(manifest, binary, True, binary_hash="0000000000000000")
+            write_fake_dwarfdump(
+                fake_dwarfdump,
+                ".debug_info  128\n.debug_line  64\n",
+                "/workspace/src/main.ax\n",
+            )
+
+            result = run_tool(manifest, fake_dwarfdump)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("manifest binary_hash mismatch", result.stderr)
 
     def test_true_manifest_claim_requires_dwarf_metadata(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -1520,6 +1520,244 @@ fn cranelift_backend_rejects_async_runtime_denial_before_backend_lowering() {
 }
 
 #[test]
+fn cranelift_backend_rejects_capability_denial_before_backend_lowering() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("fs-denied");
+    write_fs_denial_project(&project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+
+    assert!(
+        !output.status.success(),
+        "cranelift fs-denied build unexpectedly succeeded: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("requires [capabilities].fs = true"),
+        "expected capability denial before backend lowering, got: {combined}"
+    );
+    assert!(
+        !combined.contains("unsupported by --backend cranelift spike"),
+        "capability denial should happen before cranelift unsupported-feature lowering: {combined}"
+    );
+}
+
+#[test]
+fn cranelift_backend_rejects_tcp_denial_before_backend_lowering() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("tcp-denied");
+    write_tcp_denial_project(&project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+
+    assert!(
+        !output.status.success(),
+        "cranelift tcp denied build unexpectedly succeeded: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("requires [capabilities].net = true"),
+        "expected net capability denial before backend lowering, got: {combined}"
+    );
+    assert!(
+        !combined.contains("unsupported by --backend cranelift spike"),
+        "capability denial should happen before cranelift unsupported-feature lowering: {combined}"
+    );
+}
+
+#[test]
+fn cranelift_backend_rejects_udp_denial_before_backend_lowering() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("udp-denied");
+    write_udp_denial_project(&project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+
+    assert!(
+        !output.status.success(),
+        "cranelift udp denied build unexpectedly succeeded: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("requires [capabilities].net = true"),
+        "expected net capability denial before backend lowering, got: {combined}"
+    );
+    assert!(
+        !combined.contains("unsupported by --backend cranelift spike"),
+        "capability denial should happen before cranelift unsupported-feature lowering: {combined}"
+    );
+}
+
+#[test]
+fn cranelift_backend_rejects_fs_write_denial_before_backend_lowering() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("fs-write-denied");
+    write_fs_write_denial_project(&project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+
+    assert!(
+        !output.status.success(),
+        "cranelift fs-write denied build unexpectedly succeeded: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("requires [capabilities].fs:write = true"),
+        "expected fs:write capability denial before backend lowering, got: {combined}"
+    );
+    assert!(
+        !combined.contains("unsupported by --backend cranelift spike"),
+        "capability denial should happen before cranelift unsupported-feature lowering: {combined}"
+    );
+}
+
+#[cfg(not(windows))]
+#[test]
+fn cranelift_backend_builds_env_read_binary() {
+    if which::which("cc").is_err() {
+        eprintln!("skipping cranelift backend smoke test because cc is unavailable");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("env-read");
+    write_env_read_project(&project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .env("AXIOM_CRANELIFT_ENV_READ", "native-env")
+        .env_remove("__AXIOM_CRANELIFT_ENV_MISSING__")
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+    assert!(
+        output.status.success(),
+        "cranelift env build failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
+    assert_eq!(payload["backend"], "cranelift");
+    let binary = payload["binary"].as_str().expect("binary path");
+    let run = Command::new(binary)
+        .output()
+        .expect("run cranelift env binary");
+    assert!(
+        run.status.success(),
+        "cranelift env binary failed: stderr={}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "native-env\nmissing\n"
+    );
+}
+
+#[test]
+fn cranelift_backend_rejects_env_denial_before_backend_lowering() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("env-denied");
+    write_env_denial_project(&project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+
+    assert!(
+        !output.status.success(),
+        "cranelift env-denied build unexpectedly succeeded: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("requires [capabilities].env"),
+        "expected env capability denial before backend lowering, got: {combined}"
+    );
+    assert!(
+        !combined.contains("unsupported by --backend cranelift spike"),
+        "env capability denial should happen before cranelift unsupported-feature lowering: {combined}"
+    );
+}
+
+#[test]
 fn cranelift_backend_rejects_http_async_server_denial_before_backend_lowering() {
     let temp = tempfile::tempdir().expect("tempdir");
     let project = temp.path().join("http-async-server-denied");
@@ -1548,13 +1786,871 @@ fn cranelift_backend_rejects_http_async_server_denial_before_backend_lowering() 
         String::from_utf8_lossy(&output.stderr)
     );
     assert!(
-        combined.contains("requires [capabilities].net = true"),
-        "expected net capability denial before backend lowering, got: {combined}"
+        combined.contains("requires [capabilities].async = true"),
+        "expected async capability denial before backend lowering, got: {combined}"
     );
     assert!(
         !combined.contains("unsupported by --backend cranelift spike"),
         "capability denial should happen before cranelift unsupported-feature lowering: {combined}"
     );
+}
+
+fn copy_fixture(relative: &str, destination: &Path) {
+    let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../examples/hello")
+        .join(relative);
+    fs::copy(&fixture, destination).unwrap_or_else(|err| {
+        panic!(
+            "copy fixture {} to {}: {err}",
+            fixture.display(),
+            destination.display()
+        )
+    });
+}
+
+fn copy_conformance_fixture(fixture_name: &str, destination: &Path) {
+    let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../conformance/pass")
+        .join(fixture_name);
+    fs::create_dir_all(destination.join("src")).expect("create conformance project src");
+    for relative in ["axiom.toml", "axiom.lock", "src/main_test.ax"] {
+        let source = fixture.join(relative);
+        let target = destination.join(relative);
+        fs::copy(&source, &target).unwrap_or_else(|err| {
+            panic!(
+                "copy fixture {} to {}: {err}",
+                source.display(),
+                target.display()
+            )
+        });
+    }
+}
+
+fn write_regex_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create regex project src");
+    fs::write(
+        project.join("axiom.toml"),
+        r#"[package]
+name = "cranelift-regex-surface"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false
+"#,
+    )
+    .expect("write regex manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        r#"version = 1
+
+[[package]]
+name = "cranelift-regex-surface"
+version = "0.1.0"
+source = "path"
+"#,
+    )
+    .expect("write regex lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        r##"import "std/regex.ax"
+
+print is_match("^h.llo$", "hello")
+match find("[0-9]+", "issue-238-ready") {
+Some(value) {
+print value
+}
+None {
+print "none"
+}
+}
+print replace_all("[0-9]+", "issue-238-ready", "#")
+print replace_all("^a", "aa", "x")
+print replace_all("^a", "aaa", "x")
+print replace_all("^a", "ba", "x")
+"##,
+    )
+    .expect("write regex source");
+}
+
+fn write_scalar_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create scalar project src");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"cranelift-scalar-aggregate\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
+    )
+    .expect("write scalar manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-scalar-aggregate\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write scalar lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "fn sum_tail(values: [int; 3]): int {\nreturn values[1] * values[2]\n}\n\nfn adjust(value: int): int {\nreturn value / 2\n}\n\nlet label: (string, int) = (\"native\", 7)\nlet values: [int; 3] = [2, 3, 4]\nprint label.0\nprint label.1\nprint sum_tail(values)\nprint adjust(20)\n",
+    )
+    .expect("write scalar source");
+}
+
+fn write_numeric_cross_width_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create numeric project src");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"cranelift-numeric-cross-width\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
+    )
+    .expect("write numeric manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-numeric-cross-width\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write numeric lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "let wide_signed: i64 = 7i64\nlet narrow_signed: i32 = wide_signed as i32\n\nlet byte: u8 = 255u8\nlet widened_unsigned: i32 = byte as i32\n\nlet signed32: i32 = 3i32\nlet float32: f32 = signed32 as f32\n\nlet float64: f64 = -4.75f64\nlet signed64: i64 = float64 as i64\n\nlet same: i32 = 42i32 as i32\n\nlet signed_to_unsigned: u8 = -1i64 as u8\nlet narrowed_unsigned: u8 = 300i64 as u8\nlet narrowed_signed: i8 = 130i64 as i8\nlet wrapped_int: int = 18446744073709551615u64 as int\nlet max_u64: u64 = 18446744073709551615u64\nlet saturated_float_unsigned: u8 = 300.0f64 as u8\nlet negative_float_unsigned: u8 = -1.0f64 as u8\nlet rounded_f32: f32 = 16777216f32 + 1f32\n\nprint narrow_signed\nprint widened_unsigned\nprint float32 as int\nprint signed64\nprint same\nprint signed_to_unsigned\nprint narrowed_unsigned\nprint narrowed_signed\nprint wrapped_int\nprint max_u64\nprint saturated_float_unsigned\nprint negative_float_unsigned\nprint rounded_f32 as int\n",
+    )
+    .expect("write numeric source");
+}
+
+fn write_static_scalar_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create static scalar project src");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"cranelift-static-scalar\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
+    )
+    .expect("write static scalar manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-static-scalar\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write static scalar lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "static GREETING: string = \"hello static\"\nstatic ANSWER: int = 42\nstatic READY: bool = true\n\nfn bump(value: int): int {\nreturn value + ANSWER\n}\n\nprint GREETING\nprint ANSWER\nprint bump(1)\nprint READY\n",
+    )
+    .expect("write static scalar source");
+}
+
+fn write_enum_match_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create enum match project src");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"cranelift-enum-match\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
+    )
+    .expect("write enum match manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-enum-match\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write enum match lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "enum Message {\nPair(int, string)\nJob { id: int, label: string }\nText(string)\n}\n\nenum Signal {\nRed\nYellow\nGreen\n}\n\nfn render(message: Message): string {\nmatch message {\nPair(count, label) {\nreturn label\n}\nJob { label, id } {\nreturn label\n}\nText(text) {\nreturn text\n}\n}\n}\n\nfn signal_priority(signal: Signal): int {\nreturn match signal { Red => 3, Yellow => 2, Green => 1 }\n}\n\nlet first: Message = Pair(7, \"multi\")\nlet second: Message = Job { id: 9, label: \"named\" }\nlet score: int = match Some(7) {\nSome(value) => value + 1\nNone => 0\n}\n\nprint render(first)\nprint render(second)\nprint render(Text(\"payload\"))\nprint signal_priority(Yellow)\nprint score\n",
+    )
+    .expect("write enum match source");
+}
+
+fn write_struct_field_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create struct project src");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"cranelift-struct-field\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
+    )
+    .expect("write struct manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-struct-field\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write struct lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "struct Pipeline {\nname: string\nsteps: int\nready: bool\n}\n\nfn label(pipeline: Pipeline): string {\nreturn pipeline.name\n}\n\nlet pipeline: Pipeline = Pipeline { name: \"stage1 structs\", steps: 3, ready: true }\nprint pipeline.steps\nprint pipeline.ready\nprint label(pipeline)\n",
+    )
+    .expect("write struct source");
+}
+
+fn write_array_helpers_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create array-helpers project src");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"cranelift-array-helpers\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
+    )
+    .expect("write array-helpers manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-array-helpers\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write array-helpers lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "let values: [int; 3] = [10, 20, 30]\nprint len(values)\nprint first(values)\nprint last(values)\nprint first(values) + last(values)\n",
+    )
+    .expect("write array-helpers source");
+}
+
+fn write_borrowed_slice_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create borrowed-slice project src");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"cranelift-borrowed-slice\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
+    )
+    .expect("write borrowed-slice manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-borrowed-slice\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write borrowed-slice lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "fn tail(values: &[int]): &[int] {\nreturn values[1:]\n}\n\nlet values: [int] = [2, 4, 6, 8]\nlet window: &[int] = values[1:]\nprint len(window)\nprint first(window)\nprint last(window)\nprint window[1]\nlet nested: &[int] = tail(values[:])\nprint len(nested)\n",
+    )
+    .expect("write borrowed-slice source");
+}
+
+fn write_process_status_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create process-status project src");
+    fs::write(
+        project.join("axiom.toml"),
+        r#"[package]
+name = "cranelift-process-status"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = true
+unsafe_rationale = "direct-native process-status regression executes deterministic system helpers"
+env = false
+clock = false
+crypto = false
+"#,
+    )
+    .expect("write process-status manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        r#"version = 1
+
+[[package]]
+name = "cranelift-process-status"
+version = "0.1.0"
+source = "path"
+"#,
+    )
+    .expect("write process-status lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        r#"import "std/process.ax"
+print run_status("/usr/bin/true")
+print run_status("/usr/bin/false")
+"#,
+    )
+    .expect("write process-status source");
+}
+
+fn write_owned_move_state_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create owned move project src");
+    fs::write(
+        project.join("axiom.toml"),
+        r#"[package]
+name = "cranelift-owned-move-state"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false
+"#,
+    )
+    .expect("write owned move manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        r#"version = 1
+
+[[package]]
+name = "cranelift-owned-move-state"
+version = "0.1.0"
+source = "path"
+"#,
+    )
+    .expect("write owned move lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        r#"struct Pair {
+name: string
+values: [int]
+}
+
+let pair: Pair = Pair { name: "left", values: [1, 2, 3] }
+let moved: [int] = pair.values
+print len(moved)
+print pair.name
+"#,
+    )
+    .expect("write owned move source");
+}
+
+fn write_map_index_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create map project src");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"cranelift-map-index\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
+    )
+    .expect("write map manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-map-index\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write map lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "let scores: {string: int} = {\"build\": 7, \"deploy\": 9, \"deploy\": 11}\nprint scores[\"deploy\"]\n\nlet available: {string: int} = {\"build\": 7, \"deploy\": 9}\nprint map_contains_key<string, int>(available, \"build\")\n\nlet missing: {string: int} = {\"build\": 7, \"deploy\": 9}\nprint map_contains_key<string, int>(missing, \"test\")\n\nlet labels: {int: string} = {1: \"low\", 2: \"high\"}\nprint labels[2]\n",
+    )
+    .expect("write map source");
+}
+
+fn write_float_map_key_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create float map project src");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"cranelift-float-map-key\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
+    )
+    .expect("write float map manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-float-map-key\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write float map lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "let scores: {f64: int} = {1.5f64: 7}\nprint scores[1.5f64]\n",
+    )
+    .expect("write float map source");
+}
+
+fn write_crypto_hash_project(project: &Path, crypto: bool) {
+    fs::create_dir_all(project.join("src")).expect("create crypto hash project src");
+    fs::write(
+        project.join("axiom.toml"),
+        format!(
+            "[package]\nname = \"cranelift-crypto-hash\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = {crypto}\n"
+        ),
+    )
+    .expect("write crypto hash manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-crypto-hash\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write crypto hash lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "import \"std/crypto_hash.ax\"\nprint sha256(\"abc\")\n",
+    )
+    .expect("write crypto hash source");
+}
+
+fn write_crypto_mac_project(project: &Path, crypto: bool) {
+    fs::create_dir_all(project.join("src")).expect("create crypto mac project src");
+    fs::write(
+        project.join("axiom.toml"),
+        format!(
+            "[package]\nname = \"cranelift-crypto-mac\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = {crypto}\n"
+        ),
+    )
+    .expect("write crypto mac manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-crypto-mac\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write crypto mac lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "import \"std/crypto_mac.ax\"\nlet left: [u8] = [1u8, 2u8, 3u8]\nlet same: [u8] = [1u8, 2u8, 3u8]\nlet different: [u8] = [1u8, 2u8, 4u8]\nprint hmac_sha256(\"key\", \"The quick brown fox jumps over the lazy dog\")\nprint hmac_sha512(\"Jefe\", \"what do ya want for nothing?\")\nprint verify_sha256(\"f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8\", \"key\", \"The quick brown fox jumps over the lazy dog\")\nprint verify_sha512(\"164b7a7bfcf819e2e395fbe73b56e0a387bd64222e831fd610270cd7ea2505549758bf75c05a994a6d034f65f8f0e6fdcaeab1a34d4a6b4b636e070a38bce737\", \"Jefe\", \"what do ya want for nothing?\")\nprint constant_time_eq(hmac_sha256(\"key\", \"The quick brown fox jumps over the lazy dog\"), \"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad\")\nprint constant_time_eq(\"short\", \"shorter\")\nprint constant_time_eq_u8(left[:], same[:])\nprint constant_time_eq_u8(left[:], different[:])\n",
+    )
+    .expect("write crypto mac source");
+}
+
+fn write_crypto_random_project(project: &Path, crypto: bool) {
+    fs::create_dir_all(project.join("src")).expect("create crypto random project src");
+    fs::write(
+        project.join("axiom.toml"),
+        format!(
+            "[package]\nname = \"cranelift-crypto-random\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = {crypto}\n"
+        ),
+    )
+    .expect("write crypto random manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-crypto-random\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write crypto random lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "import \"std/crypto_rand.ax\"\nlet sample: u64 = random_u64()\nprint sample\n",
+    )
+    .expect("write crypto random source");
+}
+
+fn write_crypto_signature_project(project: &Path, crypto: bool) {
+    fs::create_dir_all(project.join("src")).expect("create crypto signature project src");
+    fs::write(
+        project.join("axiom.toml"),
+        format!(
+            "[package]\nname = \"cranelift-crypto-signature\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = {crypto}\n"
+        ),
+    )
+    .expect("write crypto signature manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-crypto-signature\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write crypto signature lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "import \"std/crypto_sign.ax\"\nlet message: [u8] = [104u8, 101u8, 108u8, 108u8, 111u8]\nlet keys: ([u8], [u8]) = ed25519_keygen()\nlet public_key: [u8] = keys.0\nlet secret_key: [u8] = keys.1\nlet signature: [u8] = ed25519_sign(secret_key[:], message[:])\nprint ed25519_verify(public_key[:], message[:], signature[:])\n",
+    )
+    .expect("write crypto signature source");
+}
+
+fn write_crypto_aead_project(project: &Path, crypto: bool) {
+    fs::create_dir_all(project.join("src")).expect("create crypto AEAD project src");
+    fs::write(
+        project.join("axiom.toml"),
+        format!(
+            "[package]\nname = \"cranelift-crypto-aead\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = {crypto}\n"
+        ),
+    )
+    .expect("write crypto AEAD manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-crypto-aead\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write crypto AEAD lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "import \"std/crypto_aead.ax\"\nlet key: [u8] = [0u8, 1u8, 2u8, 3u8, 4u8, 5u8, 6u8, 7u8, 8u8, 9u8, 10u8, 11u8, 12u8, 13u8, 14u8, 15u8, 16u8, 17u8, 18u8, 19u8, 20u8, 21u8, 22u8, 23u8, 24u8, 25u8, 26u8, 27u8, 28u8, 29u8, 30u8, 31u8]\nlet nonce: [u8] = [0u8, 1u8, 2u8, 3u8, 4u8, 5u8, 6u8, 7u8, 8u8, 9u8, 10u8, 11u8]\nlet aad: [u8] = [97u8, 97u8, 100u8]\nlet plaintext: [u8] = [104u8, 101u8, 108u8, 108u8, 111u8]\nlet ciphertext: [u8] = aead_seal(Aes256Gcm, key[:], nonce[:], aad[:], plaintext[:])\nmatch aead_open(Aes256Gcm, key[:], nonce[:], aad[:], ciphertext[:]) {\nSome(opened) {\nprint len(opened)\n}\nNone {\nprint 0\n}\n}\n",
+    )
+    .expect("write crypto AEAD source");
+}
+
+fn write_sync_primitives_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create sync primitives project src");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"cranelift-sync-primitives\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
+    )
+    .expect("write sync primitives manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-sync-primitives\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write sync primitives lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "import \"std/sync.ax\"\n\nlet counter: Mutex<int> = mutex<int>(1)\nlet guard: MutexGuard<int> = lock<int>(counter)\nlet updated: Mutex<int> = replace<int>(guard, 2)\nlet final_guard: MutexGuard<int> = lock<int>(updated)\nprint into_inner<int>(final_guard)\n\nlet ready: Once<string> = once_with<string>(\"configured\")\nprint once_is_set<string>(ready)\n\nlet empty: Once<int> = once<int>(None)\nmatch once_take<int>(empty) {\nSome(value) {\nprint value\n}\nNone {\nprint \"empty\"\n}\n}\n\nlet channel: Channel<string> = channel<string>(None)\nlet sent: Channel<string> = send<string>(channel, \"message\")\nmatch try_recv<string>(sent) {\nSome(message) {\nprint message\n}\nNone {\nprint \"missing\"\n}\n}\n",
+    )
+    .expect("write sync primitives source");
+}
+
+fn write_logging_stdio_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create logging stdio project src");
+    fs::write(
+        project.join("axiom.toml"),
+        r#"[package]
+name = "cranelift-logging-stdio"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false
+"#,
+    )
+    .expect("write logging stdio manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        r#"version = 1
+
+[[package]]
+name = "cranelift-logging-stdio"
+version = "0.1.0"
+source = "path"
+"#,
+    )
+    .expect("write logging stdio lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        r#"import "std/io.ax"
+
+let direct: int = eprintln("hello stderr")
+print direct > 0
+"#,
+    )
+    .expect("write logging stdio source");
+}
+
+fn write_clock_project(project: &Path, clock: bool, nonzero_sleep: bool) {
+    fs::create_dir_all(project.join("src")).expect("create clock project src");
+    fs::write(
+        project.join("axiom.toml"),
+        format!(
+            r#"[package]
+name = "cranelift-clock"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = {clock}
+crypto = false
+"#
+        ),
+    )
+    .expect("write clock manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        r#"version = 1
+
+[[package]]
+name = "cranelift-clock"
+version = "0.1.0"
+source = "path"
+"#,
+    )
+    .expect("write clock lockfile");
+    let pause_ms = if nonzero_sleep { 1 } else { 0 };
+    fs::write(
+        project.join("src/main.ax"),
+        format!(
+            r#"import "std/time.ax"
+
+let start: Instant = now()
+let pause: Duration = duration_ms({pause_ms})
+print start.ms > 0
+print now_ms() > 0
+print sleep(pause) == 0
+let elapsed: int = elapsed_ms(start)
+print elapsed == elapsed
+"#
+        ),
+    )
+    .expect("write clock source");
+}
+
+fn write_json_serdes_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create json project src");
+    fs::write(
+        project.join("axiom.toml"),
+        r#"[package]
+name = "cranelift-json-serdes"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false
+"#,
+    )
+    .expect("write json manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        r#"version = 1
+
+[[package]]
+name = "cranelift-json-serdes"
+version = "0.1.0"
+source = "path"
+"#,
+    )
+    .expect("write json lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        r#"import "std/json.ax"
+
+fn doc(): string {
+return object3(field_string("name", "axiom"), field_int("count", 3), field_bool("ready", true))
+}
+
+print stringify_int(42)
+print stringify_bool(false)
+print stringify_string("hello")
+
+match parse_int(" 42 ") {
+Some(value) {
+print value
+}
+None {
+print -1
+}
+}
+
+match parse_bool("true") {
+Some(value) {
+print value
+}
+None {
+print false
+}
+}
+
+print doc()
+
+match parse_field_string(doc(), "name") {
+Some(value) {
+print value
+}
+None {
+print "missing name"
+}
+}
+
+match parse_field_int(doc(), "count") {
+Some(value) {
+print value
+}
+None {
+print -1
+}
+}
+
+match parse_field_bool(doc(), "ready") {
+Some(value) {
+print value
+}
+None {
+print false
+}
+}
+
+match parse_value(doc()) {
+Some(value) {
+print stringify_value(value)
+}
+None {
+print "invalid"
+}
+}
+
+match parse_value(doc()) {
+Some(value) {
+match parse_field_value(value, "name") {
+Some(name_value) {
+print stringify_value(name_value)
+}
+None {
+print "missing value"
+}
+}
+}
+None {
+print "invalid"
+}
+}
+
+match parse_int("nope") {
+Some(value) {
+print value
+}
+None {
+print "no int"
+}
+}
+"#,
+    )
+    .expect("write json source");
+}
+
+fn write_fs_denial_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create fs denied project src");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"cranelift-fs-denied\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
+    )
+    .expect("write fs denied manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-fs-denied\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write fs denied lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "import \"std/fs.ax\"\nmatch read_file(\"src/fixture.txt\") {\nSome(value) {\nprint value\n}\nNone {\nprint \"missing\"\n}\n}\n",
+    )
+    .expect("write fs denied source");
+}
+
+fn write_tcp_denial_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create tcp denied project src");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"cranelift-tcp-denied\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
+    )
+    .expect("write tcp denied manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-tcp-denied\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write tcp denied lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "import \"std/net.ax\"\nmatch tcp_listen_loopback_once(\"pong\", 1000) {\nSome(_port) {\nprint true\n}\nNone {\nprint false\n}\n}\n",
+    )
+    .expect("write tcp denied source");
+}
+
+fn write_udp_denial_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create udp denied project src");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"cranelift-udp-denied\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
+    )
+    .expect("write udp denied manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-udp-denied\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write udp denied lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "import \"std/net.ax\"\nmatch udp_bind_loopback_once(\"pong\", 1000) {\nSome(_port) {\nprint true\n}\nNone {\nprint false\n}\n}\n",
+    )
+    .expect("write udp denied source");
+}
+
+fn write_process_denial_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create process denied project src");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"cranelift-process-denied\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
+    )
+    .expect("write process denied manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-process-denied\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write process denied lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "import \"std/process.ax\"\nprint run_status(\"/usr/bin/true\")\n",
+    )
+    .expect("write process denied source");
+}
+
+fn write_fs_write_denial_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create fs write denied project src");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"cranelift-fs-write-denied\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = true\n\"fs:write\" = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
+    )
+    .expect("write fs write denied manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-fs-write-denied\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write fs write denied lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "import \"std/fs.ax\"\nprint write_file(\"out.txt\", \"content\")\n",
+    )
+    .expect("write fs write denied source");
+}
+
+fn write_env_read_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create env project src");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"cranelift-env-read\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = true\nclock = false\ncrypto = false\n\n[unsafe_rationale]\nenv = \"Cranelift ABI regression covers direct-native env.read behavior for issue 928.\"\n",
+    )
+    .expect("write env manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-env-read\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write env lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "import \"std/env.ax\"\nmatch get_env(\"AXIOM_CRANELIFT_ENV_READ\") {\nSome(value) {\nprint value\n}\nNone {\nprint \"missing value\"\n}\n}\nmatch get_env(\"__AXIOM_CRANELIFT_ENV_MISSING__\") {\nSome(value) {\nprint value\n}\nNone {\nprint \"missing\"\n}\n}\n",
+    )
+    .expect("write env source");
+}
+
+fn write_http_client_denial_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create http client denied project src");
+    fs::write(
+        project.join("axiom.toml"),
+        r#"[package]
+name = "cranelift-http-client-denied"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false
+"#,
+    )
+    .expect("write http client denied manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        r#"version = 1
+
+[[package]]
+name = "cranelift-http-client-denied"
+version = "0.1.0"
+source = "path"
+"#,
+    )
+    .expect("write http client denied lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        r#"import "std/http.ax"
+print get("https://example.com")
+"#,
+    )
+    .expect("write http client denied source");
 }
 
 fn write_ffi_denial_project(project: &Path) {


### PR DESCRIPTION
## Summary

- Add `scripts/debug/check-axiom-dwarf.py`, a fail-closed verifier for native Axiom DWARF artifact evidence.
- Require the manifest `binary_hash` to match the binary bytes before accepting native DWARF evidence.
- Require `native_debug.axiom_dwarf = true` in the debug manifest plus object debug metadata from `dwarfdump`: non-empty DWARF line/info sections and an `.ax` source path reported by `--show-sources`.
- Add Python regression coverage, a Makefile validation target, and debug-map docs explaining how this gates future #230 closure claims.

## Governing Issue

Refs #230

This is a readiness/evidence gate for #230. It intentionally does not close #230 because current generated-Rust and Cranelift spike debug builds still do not emit native `.ax` DWARF line tables for LLDB/GDB stepping.

## Validation

- [x] Relevant local checks passed
  - `make stage1-axiom-dwarf-readiness-test`
  - `python3 scripts/debug/test-axiom-debug-map.py`
  - `cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build stage1/examples/hello --backend cranelift --debug --json`
  - `python3 scripts/debug/check-axiom-dwarf.py verify --manifest stage1/examples/hello/dist/hello-stage1.debug-manifest.json` failed as expected with `native_debug.axiom_dwarf is false; binary is not claimed to contain native Axiom DWARF`, confirming the generated manifest passed the hash gate first
  - `git diff --check`
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

No checks were skipped.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

No contributor, PR guidance, or bootstrap policy changes are needed. Auto-merge was not enabled by this author; fallback merge-readiness applies after required checks and non-author review pass.

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Semantic node types: none.

Schemas: none.

Evidence: adds an artifact-level native Axiom DWARF readiness checker and tests. The checker is intentionally conservative, binds the manifest to the exact binary bytes through `binary_hash`, and fails today because existing manifests correctly report `native_debug.axiom_dwarf = false`.

Rust capture risk: low. The docs keep generated-Rust and Cranelift spike behavior distinct from native Axiom DWARF support and do not claim #230 closure.

Agent-facing inspection impact: debugger/tooling agents can use the checker as the minimum artifact gate before accepting future native DWARF closure evidence.

## Flow Contract

- Owner lane: daedalus / runtime-debug
- Repair owner: codex
- Autonomy class: issue-linked evidence tooling
- Risk class: low

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

Current blocker: non-author review approval is still required before merge.

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

Auto-merge was not enabled by this author. A maintainer should enable it or merge manually after required checks and review pass.

## Notes

- This PR gives #230 a concrete artifact-level readiness check, but the actual closure PR still needs native Axiom DWARF line-table emission and LLDB/GDB validation.
