### PR TITLE
Make cargo-vet setup idempotent

### DIFF
--- a/.github/workflows/toolchain-supply-chain.yml
+++ b/.github/workflows/toolchain-supply-chain.yml
@@ -45,8 +45,30 @@ jobs:
 
       - name: Ensure cargo-vet
         run: |
-          if ! command -v cargo-vet >/dev/null 2>&1; then
-            cargo install cargo-vet --locked
+          required_version="$(
+            awk '
+              /^\[cargo-vet\]$/ { in_cargo_vet = 1; next }
+              /^\[/ { in_cargo_vet = 0 }
+              in_cargo_vet && $1 == "version" {
+                gsub(/"/, "", $3)
+                print $3
+                exit
+              }
+            ' stage1/supply-chain/config.toml
+          )"
+          if [[ -z "$required_version" ]]; then
+            echo "unable to read cargo-vet version from stage1/supply-chain/config.toml" >&2
+            exit 1
+          fi
+
+          installed_version=""
+          if command -v cargo-vet >/dev/null 2>&1; then
+            installed_version="$(cargo-vet --version || true)"
+          fi
+
+          if [[ "$installed_version" != "cargo-vet ${required_version}" &&
+                "$installed_version" != "cargo-vet ${required_version}."* ]]; then
+            cargo install cargo-vet --version "$required_version" --locked --force
           fi
       - name: Run supply-chain checks
         env:

--- a/.github/workflows/toolchain-supply-chain.yml
+++ b/.github/workflows/toolchain-supply-chain.yml
@@ -43,8 +43,11 @@ jobs:
         with:
           node-version: 20
 
-      - name: Install cargo-vet
-        run: cargo install cargo-vet --locked
+      - name: Ensure cargo-vet
+        run: |
+          if ! command -v cargo-vet >/dev/null 2>&1; then
+            cargo install cargo-vet --locked
+          fi
       - name: Run supply-chain checks
         env:
           SOURCE_DATE_EPOCH: '1704067200'

--- a/scripts/ci/test-toolchain-supply-chain.sh
+++ b/scripts/ci/test-toolchain-supply-chain.sh
@@ -8,13 +8,18 @@ script="$repo_root/scripts/ci/run-toolchain-supply-chain.sh"
 [[ -f "$workflow" ]] || { echo "missing workflow: $workflow" >&2; exit 1; }
 [[ -x "$script" ]] || { echo "missing executable script: $script" >&2; exit 1; }
 
-grep -Fq 'command -v cargo-vet >/dev/null 2>&1' "$workflow" || {
-  echo "workflow must skip cargo-vet install when cargo-vet is already present" >&2
+grep -Fq 'stage1/supply-chain/config.toml' "$workflow" || {
+  echo "workflow must read the required cargo-vet version from the supply-chain config" >&2
   exit 1
 }
 
-grep -Fq 'cargo install cargo-vet --locked' "$workflow" || {
-  echo "workflow must install missing cargo-vet with a locked install" >&2
+grep -Fq 'cargo-vet --version' "$workflow" || {
+  echo "workflow must validate an existing cargo-vet binary before reusing it" >&2
+  exit 1
+}
+
+grep -Fq 'cargo install cargo-vet --version "$required_version" --locked --force' "$workflow" || {
+  echo "workflow must force-install the configured cargo-vet version on mismatch" >&2
   exit 1
 }
 

--- a/scripts/ci/test-toolchain-supply-chain.sh
+++ b/scripts/ci/test-toolchain-supply-chain.sh
@@ -8,8 +8,13 @@ script="$repo_root/scripts/ci/run-toolchain-supply-chain.sh"
 [[ -f "$workflow" ]] || { echo "missing workflow: $workflow" >&2; exit 1; }
 [[ -x "$script" ]] || { echo "missing executable script: $script" >&2; exit 1; }
 
+grep -Fq 'command -v cargo-vet >/dev/null 2>&1' "$workflow" || {
+  echo "workflow must skip cargo-vet install when cargo-vet is already present" >&2
+  exit 1
+}
+
 grep -Fq 'cargo install cargo-vet --locked' "$workflow" || {
-  echo "workflow must install cargo-vet with a locked install" >&2
+  echo "workflow must install missing cargo-vet with a locked install" >&2
   exit 1
 }
 


### PR DESCRIPTION
## Summary

- Make the Toolchain Supply Chain workflow reuse an existing `cargo-vet` binary on self-hosted runners.
- Preserve locked installation when `cargo-vet` is missing.
- Update the workflow regression test so the idempotent guard stays covered.

## Governing Issue

Closes #989

## Validation

- [x] Relevant local checks passed
  - `bash scripts/ci/test-toolchain-supply-chain.sh`
  - `git diff --check`
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

No checks were skipped.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

No contributor, PR guidance, or bootstrap policy changes are needed. Auto-merge is not enabled by this author; fallback merge-readiness applies after required checks and non-author review pass.

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Semantic node types: none.

Schemas: none.

Evidence: CI workflow setup evidence only; no semantic evidence model changes.

Rust capture risk: none. This is workflow setup behavior.

Agent-facing inspection impact: active PRs should no longer fail the supply-chain job just because a reusable self-hosted runner already has `cargo-vet` installed.

## Flow Contract

- Owner lane: pheidon / governance
- Repair owner: codex
- Autonomy class: issue-linked CI repair
- Risk class: low

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

Current blocker: non-author review approval is required before merge.

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

Auto-merge was not enabled by this author. A maintainer should enable it or merge manually after required checks and review pass.
