### PR TITLE
Record direct-native crypto denial evidence

### DIFF
--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -126,6 +126,12 @@ without generated Rust. A package without the `crypto` capability fails before
 backend lowering. Runtime audit parity and broader crypto host-service coverage
 remain blocked under #928.
 
+The crypto random, signature, and AEAD rows remain blocked for positive
+direct-native runtime execution, but now have denial evidence: packages that
+call `std/crypto_rand.ax`, `std/crypto_sign.ax`, or `std/crypto_aead.ax`
+without the `crypto` capability must receive the public manifest-policy denial
+before any backend-specific lowering diagnostic.
+
 The HTTP client row remains blocked for positive direct-native runtime support:
 the Cranelift spike does not yet lower `std/http.ax` `get(...)` into a native
 host-service entrypoint. The current evidence proves only that denied `net`

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -1216,6 +1216,120 @@ fn cranelift_backend_rejects_crypto_mac_denial_before_backend_lowering() {
 }
 
 #[test]
+fn cranelift_backend_rejects_crypto_random_denial_before_backend_lowering() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("crypto-random-denied");
+    write_crypto_random_project(&project, false);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+
+    assert!(
+        !output.status.success(),
+        "cranelift crypto random denial build unexpectedly succeeded: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("requires [capabilities].crypto = true"),
+        "expected crypto capability denial before backend lowering, got: {combined}"
+    );
+    assert!(
+        !combined.contains("unsupported by --backend cranelift spike"),
+        "capability denial should happen before cranelift unsupported-feature lowering: {combined}"
+    );
+}
+
+#[test]
+fn cranelift_backend_rejects_crypto_signature_denial_before_backend_lowering() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("crypto-signature-denied");
+    write_crypto_signature_project(&project, false);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+
+    assert!(
+        !output.status.success(),
+        "cranelift crypto signature denial build unexpectedly succeeded: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("requires [capabilities].crypto = true"),
+        "expected crypto capability denial before backend lowering, got: {combined}"
+    );
+    assert!(
+        !combined.contains("unsupported by --backend cranelift spike"),
+        "capability denial should happen before cranelift unsupported-feature lowering: {combined}"
+    );
+}
+
+#[test]
+fn cranelift_backend_rejects_crypto_aead_denial_before_backend_lowering() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("crypto-aead-denied");
+    write_crypto_aead_project(&project, false);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+
+    assert!(
+        !output.status.success(),
+        "cranelift crypto AEAD denial build unexpectedly succeeded: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("requires [capabilities].crypto = true"),
+        "expected crypto capability denial before backend lowering, got: {combined}"
+    );
+    assert!(
+        !combined.contains("unsupported by --backend cranelift spike"),
+        "capability denial should happen before cranelift unsupported-feature lowering: {combined}"
+    );
+}
+
+#[test]
 fn cranelift_backend_rejects_process_denial_before_backend_lowering() {
     let temp = tempfile::tempdir().expect("tempdir");
     let project = temp.path().join("process-denied");
@@ -1919,6 +2033,69 @@ fn write_crypto_mac_project(project: &Path, crypto: bool) {
         "import \"std/crypto_mac.ax\"\nlet left: [u8] = [1u8, 2u8, 3u8]\nlet same: [u8] = [1u8, 2u8, 3u8]\nlet different: [u8] = [1u8, 2u8, 4u8]\nprint hmac_sha256(\"key\", \"The quick brown fox jumps over the lazy dog\")\nprint hmac_sha512(\"Jefe\", \"what do ya want for nothing?\")\nprint verify_sha256(\"f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8\", \"key\", \"The quick brown fox jumps over the lazy dog\")\nprint verify_sha512(\"164b7a7bfcf819e2e395fbe73b56e0a387bd64222e831fd610270cd7ea2505549758bf75c05a994a6d034f65f8f0e6fdcaeab1a34d4a6b4b636e070a38bce737\", \"Jefe\", \"what do ya want for nothing?\")\nprint constant_time_eq(hmac_sha256(\"key\", \"The quick brown fox jumps over the lazy dog\"), \"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad\")\nprint constant_time_eq(\"short\", \"shorter\")\nprint constant_time_eq_u8(left[:], same[:])\nprint constant_time_eq_u8(left[:], different[:])\n",
     )
     .expect("write crypto mac source");
+}
+
+fn write_crypto_random_project(project: &Path, crypto: bool) {
+    fs::create_dir_all(project.join("src")).expect("create crypto random project src");
+    fs::write(
+        project.join("axiom.toml"),
+        format!(
+            "[package]\nname = \"cranelift-crypto-random\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = {crypto}\n"
+        ),
+    )
+    .expect("write crypto random manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-crypto-random\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write crypto random lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "import \"std/crypto_rand.ax\"\nlet sample: u64 = random_u64()\nprint sample\n",
+    )
+    .expect("write crypto random source");
+}
+
+fn write_crypto_signature_project(project: &Path, crypto: bool) {
+    fs::create_dir_all(project.join("src")).expect("create crypto signature project src");
+    fs::write(
+        project.join("axiom.toml"),
+        format!(
+            "[package]\nname = \"cranelift-crypto-signature\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = {crypto}\n"
+        ),
+    )
+    .expect("write crypto signature manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-crypto-signature\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write crypto signature lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "import \"std/crypto_sign.ax\"\nlet message: [u8] = [104u8, 101u8, 108u8, 108u8, 111u8]\nlet keys: ([u8], [u8]) = ed25519_keygen()\nlet public_key: [u8] = keys.0\nlet secret_key: [u8] = keys.1\nlet signature: [u8] = ed25519_sign(secret_key[:], message[:])\nprint ed25519_verify(public_key[:], message[:], signature[:])\n",
+    )
+    .expect("write crypto signature source");
+}
+
+fn write_crypto_aead_project(project: &Path, crypto: bool) {
+    fs::create_dir_all(project.join("src")).expect("create crypto AEAD project src");
+    fs::write(
+        project.join("axiom.toml"),
+        format!(
+            "[package]\nname = \"cranelift-crypto-aead\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = {crypto}\n"
+        ),
+    )
+    .expect("write crypto AEAD manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-crypto-aead\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write crypto AEAD lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "import \"std/crypto_aead.ax\"\nlet key: [u8] = [0u8, 1u8, 2u8, 3u8, 4u8, 5u8, 6u8, 7u8, 8u8, 9u8, 10u8, 11u8, 12u8, 13u8, 14u8, 15u8, 16u8, 17u8, 18u8, 19u8, 20u8, 21u8, 22u8, 23u8, 24u8, 25u8, 26u8, 27u8, 28u8, 29u8, 30u8, 31u8]\nlet nonce: [u8] = [0u8, 1u8, 2u8, 3u8, 4u8, 5u8, 6u8, 7u8, 8u8, 9u8, 10u8, 11u8]\nlet aad: [u8] = [97u8, 97u8, 100u8]\nlet plaintext: [u8] = [104u8, 101u8, 108u8, 108u8, 111u8]\nlet ciphertext: [u8] = aead_seal(Aes256Gcm, key[:], nonce[:], aad[:], plaintext[:])\nmatch aead_open(Aes256Gcm, key[:], nonce[:], aad[:], ciphertext[:]) {\nSome(opened) {\nprint len(opened)\n}\nNone {\nprint 0\n}\n}\n",
+    )
+    .expect("write crypto AEAD source");
 }
 
 fn write_sync_primitives_project(project: &Path) {

--- a/stage1/runtime-abi/direct-native-v0.json
+++ b/stage1/runtime-abi/direct-native-v0.json
@@ -186,19 +186,25 @@
       "id": "crypto.random",
       "status": "blocked",
       "capability": "crypto",
-      "blockers": [928]
+      "blockers": [928],
+      "denial_evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
+      "notes": "The Cranelift spike still blocks positive random-byte and random-u64 execution, but packages without the crypto capability receive the public manifest-policy denial before backend lowering."
     },
     {
       "id": "crypto.signature",
       "status": "blocked",
       "capability": "crypto",
-      "blockers": [928]
+      "blockers": [928],
+      "denial_evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
+      "notes": "The Cranelift spike still blocks positive Ed25519 key generation, signing, and verification execution, but packages without the crypto capability receive the public manifest-policy denial before backend lowering."
     },
     {
       "id": "crypto.aead",
       "status": "blocked",
       "capability": "crypto",
-      "blockers": [928]
+      "blockers": [928],
+      "denial_evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
+      "notes": "The Cranelift spike still blocks positive AEAD seal/open execution, but packages without the crypto capability receive the public manifest-policy denial before backend lowering."
     },
     {
       "id": "ffi.call",


### PR DESCRIPTION
## Summary

- Adds Cranelift denial-before-backend-lowering tests for `std/crypto_rand.ax`, `std/crypto_sign.ax`, and `std/crypto_aead.ax` when `[capabilities].crypto` is disabled.
- Records denial evidence on the `crypto.random`, `crypto.signature`, and `crypto.aead` rows in `stage1/runtime-abi/direct-native-v0.json`.
- Updates `docs/direct-native-runtime-abi-v0.md` so agents can inspect the new evidence while the rows remain blocked for positive runtime support.

## Governing Issue

Part of #928

This is not full resolution for #928. Positive direct-native runtime support for random, signature, and AEAD crypto remains blocked; this PR only proves manifest-policy denial happens before Cranelift backend lowering for those surfaces.

## Validation

- [x] `cargo fmt --manifest-path stage1/Cargo.toml --all --check`
- [x] `make stage1-direct-native-runtime-abi` passed with `ready:false` and `errors: []`.
- [x] `git diff --check`
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend cranelift_backend_rejects_crypto_random_denial_before_backend_lowering -- --nocapture`
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend cranelift_backend_rejects_crypto_signature_denial_before_backend_lowering -- --nocapture`
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend cranelift_backend_rejects_crypto_aead_denial_before_backend_lowering -- --nocapture`
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend crypto_ -- --nocapture` passed: 7 passed.
- [ ] Required PR checks are expected to satisfy `CI Gate`.
- [ ] Skipped checks are explained below. None intentionally skipped.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue.
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable. Not applicable.
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies.
- [x] No real secrets, runtime auth, or machine-local env files are committed.

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior. No semantic node changes.
- [x] Schemas added/changed are listed, or this PR does not touch schemas. No schema changes.
- [x] Evidence added/changed is listed, or this PR does not touch evidence. Evidence added for `crypto.random`, `crypto.signature`, and `crypto.aead` denial-before-backend-lowering in `stage1/crates/axiomc/tests/cranelift_backend.rs` and `stage1/runtime-abi/direct-native-v0.json`.
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior. This is backend/runtime evidence only and leaves runtime semantics Axiom-neutral.
- [x] Agent-facing inspection impact is described, or there is no inspection impact. The runtime ABI ledger now exposes denial evidence for the three crypto rows while keeping them blocked for positive runtime support.

## Flow Contract

- Owner lane: daedalus
- Repair owner: codex
- Autonomy class: issue-backed implementation slice
- Risk class: medium

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action.
- [ ] No active blocking requested changes remain.
- [ ] Non-author approval is present when required.
- [ ] Auto-merge is appropriate when gates pass.

Current blockers: hosted checks need to run, and non-author review is required.

## Merge Automation

- [ ] Auto-merge is not enabled yet; this PR needs hosted checks and non-author review first.

## Notes

- The `crypto.random`, `crypto.signature`, and `crypto.aead` rows intentionally stay `blocked`. This PR narrows denial evidence only.
