### PR TITLE
Record direct-native FFI and async denial evidence

### DIFF
--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -155,6 +155,12 @@ package without the `env` capability fails before backend lowering. Full
 runtime-time lookup, manifest allowlist parity, and audit parity remain open
 under #928.
 
+The FFI call and async runtime rows remain blocked for positive direct-native
+runtime support, but now have denial evidence: a package with an `extern fn`
+declaration and no `ffi` capability, and a package importing `std/async.ax`
+with no `async` capability, must both receive their public manifest-policy
+denials before any Cranelift-specific lowering diagnostic.
+
 The sync-primitives row has partial direct-native evidence: the Cranelift spike
 now evaluates ownership-shaped `std/sync.ax` mutex, once, and channel wrappers
 and emits the expected native output. Concurrent execution, blocking behavior,

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -1406,6 +1406,82 @@ fn cranelift_backend_rejects_http_client_denial_before_backend_lowering() {
 }
 
 #[test]
+fn cranelift_backend_rejects_ffi_denial_before_backend_lowering() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("ffi-denied");
+    write_ffi_denial_project(&project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+
+    assert!(
+        !output.status.success(),
+        "cranelift ffi denial build unexpectedly succeeded: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("requires [capabilities].ffi = true"),
+        "expected ffi capability denial before backend lowering, got: {combined}"
+    );
+    assert!(
+        !combined.contains("unsupported by --backend cranelift spike"),
+        "capability denial should happen before cranelift unsupported-feature lowering: {combined}"
+    );
+}
+
+#[test]
+fn cranelift_backend_rejects_async_runtime_denial_before_backend_lowering() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("async-runtime-denied");
+    write_async_runtime_denial_project(&project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+
+    assert!(
+        !output.status.success(),
+        "cranelift async runtime denial build unexpectedly succeeded: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("requires [capabilities].async = true"),
+        "expected async capability denial before backend lowering, got: {combined}"
+    );
+    assert!(
+        !combined.contains("unsupported by --backend cranelift spike"),
+        "capability denial should happen before cranelift unsupported-feature lowering: {combined}"
+    );
+}
+
+#[test]
 fn cranelift_backend_rejects_capability_denial_before_backend_lowering() {
     let temp = tempfile::tempdir().expect("tempdir");
     let project = temp.path().join("fs-denied");
@@ -2499,6 +2575,93 @@ print get("https://example.com")
 "#,
     )
     .expect("write http client denied source");
+}
+
+fn write_ffi_denial_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create ffi denied project src");
+    fs::write(
+        project.join("axiom.toml"),
+        r#"[package]
+name = "cranelift-ffi-denied"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false
+ffi = false
+"#,
+    )
+    .expect("write ffi denied manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        r#"version = 1
+
+[[package]]
+name = "cranelift-ffi-denied"
+version = "0.1.0"
+source = "path"
+"#,
+    )
+    .expect("write ffi denied lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        r#"extern fn strlen(value: string): int from "c"
+print strlen("hello")
+"#,
+    )
+    .expect("write ffi denied source");
+}
+
+fn write_async_runtime_denial_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create async runtime denied project src");
+    fs::write(
+        project.join("axiom.toml"),
+        r#"[package]
+name = "cranelift-async-runtime-denied"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false
+async = false
+"#,
+    )
+    .expect("write async runtime denied manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        r#"version = 1
+
+[[package]]
+name = "cranelift-async-runtime-denied"
+version = "0.1.0"
+source = "path"
+"#,
+    )
+    .expect("write async runtime denied lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        r#"import "std/async.ax"
+let task: Task<int> = ready<int>(1)
+print await task
+"#,
+    )
+    .expect("write async runtime denied source");
 }
 
 fn write_env_denial_project(project: &Path) {

--- a/stage1/runtime-abi/direct-native-v0.json
+++ b/stage1/runtime-abi/direct-native-v0.json
@@ -210,13 +210,17 @@
       "id": "ffi.call",
       "status": "blocked",
       "capability": "ffi",
-      "blockers": [928]
+      "blockers": [928],
+      "denial_evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
+      "notes": "The Cranelift spike still blocks positive FFI call support, but packages without the ffi capability receive the public manifest-policy denial before backend lowering."
     },
     {
       "id": "async.runtime",
       "status": "blocked",
       "capability": "async",
-      "blockers": [928]
+      "blockers": [928],
+      "denial_evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
+      "notes": "The Cranelift spike still blocks positive async runtime support, but packages without the async capability receive the public manifest-policy denial before backend lowering."
     },
     {
       "id": "json.serdes",


### PR DESCRIPTION
## Summary

- Add direct-native Cranelift denial coverage for FFI calls when `[capabilities].ffi = false`.
- Add direct-native Cranelift denial coverage for async runtime use when `[capabilities].async = false`.
- Record both rows as blocked-but-covered denial evidence in the runtime ABI manifest and docs.

## Governing Issue

Part of #928

This is not full resolution for #928. The FFI call and async runtime rows remain blocked for positive direct-native runtime support; this PR only records manifest-policy denial evidence before backend lowering.

## Validation

- [x] Relevant local checks passed
- [ ] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Local checks:

- `cargo fmt --manifest-path stage1/Cargo.toml --all --check`
- `make stage1-direct-native-runtime-abi`
- `git diff --check`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend cranelift_backend_rejects_ffi_denial_before_backend_lowering -- --nocapture`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend cranelift_backend_rejects_async_runtime_denial_before_backend_lowering -- --nocapture`

Skipped checks:

- Full stage1 test suite not run; this is a focused evidence-only slice for two Cranelift denial fixtures.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Semantic layer details:

- Semantic node types added/changed: none.
- Schemas added/changed: none.
- Evidence added/changed: `ffi.call` and `async.runtime` now list denial evidence in `stage1/runtime-abi/direct-native-v0.json`.
- Rust capture risk: backend-specific denial fixtures only; positive direct-native support remains blocked.
- Agent-facing inspection impact: runtime ABI consumers can see denial evidence for the two blocked rows.

## Flow Contract

- Owner lane: daedalus
- Repair owner: codex
- Autonomy class: issue-backed implementation slice
- Risk class: medium

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [ ] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is appropriate when gates pass

Current blockers: hosted checks need to run, and non-author review is required.

## Merge Automation

- [ ] Auto-merge is not enabled yet; this PR needs hosted checks and non-author review first.

## Notes

- The `ffi.call` and `async.runtime` rows intentionally stay `blocked`. This PR narrows denial evidence only.
