### PR TITLE
Report direct-native ABI blockers

### DIFF
--- a/scripts/ci/check-direct-native-runtime-abi.py
+++ b/scripts/ci/check-direct-native-runtime-abi.py
@@ -63,13 +63,15 @@ def load_contract(path: Path) -> dict[str, Any]:
 
 def validate_rows(
     rows: object, required_ids: set[str], group_name: str, errors: list[str]
-) -> tuple[set[str], list[str]]:
+) -> tuple[set[str], list[str], dict[str, int], set[int]]:
     if not isinstance(rows, list):
         errors.append(f"{group_name} must be an array")
-        return set(), []
+        return set(), [], {status: 0 for status in sorted(VALID_STATUSES)}, set()
 
     seen: set[str] = set()
     blockers: list[str] = []
+    status_counts = {status: 0 for status in sorted(VALID_STATUSES)}
+    blocker_issues: set[int] = set()
     for index, row in enumerate(rows):
         if not isinstance(row, dict):
             errors.append(f"{group_name}[{index}] must be an object")
@@ -89,6 +91,7 @@ def validate_rows(
                 f"expected one of {sorted(VALID_STATUSES)}"
             )
             continue
+        status_counts[status] += 1
 
         row_blockers = row.get("blockers", [])
         if status != "implemented":
@@ -99,6 +102,8 @@ def validate_rows(
                 errors.append(
                     f"{group_name} row {row_id!r} blockers must be positive issue numbers"
                 )
+            else:
+                blocker_issues.update(row_blockers)
 
     missing = sorted(required_ids - seen)
     if missing:
@@ -106,7 +111,7 @@ def validate_rows(
     extra = sorted(seen - required_ids)
     if extra:
         errors.append(f"{group_name} has unknown rows: {', '.join(extra)}")
-    return seen, blockers
+    return seen, blockers, status_counts, blocker_issues
 
 
 def build_report(contract: dict[str, Any]) -> tuple[dict[str, Any], int]:
@@ -119,13 +124,18 @@ def build_report(contract: dict[str, Any]) -> tuple[dict[str, Any], int]:
     if contract.get("status") not in VALID_STATUSES:
         errors.append("status must be implemented, partial, or blocked")
 
-    _, value_blockers = validate_rows(
+    _, value_blockers, value_status_counts, value_blocker_issues = validate_rows(
         contract.get("value_features"),
         REQUIRED_VALUE_FEATURES,
         "value_features",
         errors,
     )
-    _, capability_blockers = validate_rows(
+    (
+        _,
+        capability_blockers,
+        capability_status_counts,
+        capability_blocker_issues,
+    ) = validate_rows(
         contract.get("capability_shims"),
         REQUIRED_CAPABILITY_SHIMS,
         "capability_shims",
@@ -133,12 +143,17 @@ def build_report(contract: dict[str, Any]) -> tuple[dict[str, Any], int]:
     )
 
     blocked_rows = sorted(value_blockers + capability_blockers)
+    blocker_issues = sorted(value_blocker_issues | capability_blocker_issues)
     ready = not errors and not blocked_rows and contract.get("status") == "implemented"
     report = {
         "schema": "axiom.direct_native.runtime_abi.check.v1",
         "ready": ready,
         "target_id": contract.get("target_id"),
         "contract_status": contract.get("status"),
+        "status_counts": {
+            "value_features": value_status_counts,
+            "capability_shims": capability_status_counts,
+        },
         "value_feature_count": len(contract.get("value_features", []))
         if isinstance(contract.get("value_features"), list)
         else 0,
@@ -146,6 +161,7 @@ def build_report(contract: dict[str, Any]) -> tuple[dict[str, Any], int]:
         if isinstance(contract.get("capability_shims"), list)
         else 0,
         "blocked_rows": blocked_rows,
+        "blocker_issues": blocker_issues,
         "errors": errors,
     }
     return report, 1 if errors else 0
@@ -172,9 +188,14 @@ def main() -> int:
             "ready": False,
             "target_id": None,
             "contract_status": None,
+            "status_counts": {
+                "value_features": {status: 0 for status in sorted(VALID_STATUSES)},
+                "capability_shims": {status: 0 for status in sorted(VALID_STATUSES)},
+            },
             "value_feature_count": 0,
             "capability_shim_count": 0,
             "blocked_rows": [],
+            "blocker_issues": [],
             "errors": [str(error)],
         }
         if args.json:
@@ -193,6 +214,11 @@ def main() -> int:
             "direct native runtime ABI: not ready "
             f"({len(report['blocked_rows'])} blocked rows, {len(report['errors'])} errors)"
         )
+        if report["blocked_rows"]:
+            print(f"blocked rows: {', '.join(report['blocked_rows'])}")
+        if report["blocker_issues"]:
+            issue_list = ", ".join(f"#{issue}" for issue in report["blocker_issues"])
+            print(f"blocker issues: {issue_list}")
 
     if validation_status:
         return validation_status

--- a/scripts/ci/test-check-direct-native-runtime-abi.sh
+++ b/scripts/ci/test-check-direct-native-runtime-abi.sh
@@ -20,8 +20,11 @@ assert report["ready"] is False
 assert report["target_id"] == "axiom://target/stage1-direct-native"
 assert report["value_feature_count"] == 12
 assert report["capability_shim_count"] == 22
+assert report["status_counts"]["value_features"]["partial"] == 12
+assert report["status_counts"]["capability_shims"]["blocked"] >= 1
 assert "fs.read" in report["blocked_rows"]
 assert "owned.move_state" in report["blocked_rows"]
+assert report["blocker_issues"] == [928]
 assert report["errors"] == []
 PY
 


### PR DESCRIPTION
## Summary

- Extend the direct-native runtime ABI checker report with derived status counts for value features and capability shims.
- Add `blocker_issues` extraction so automation can see which issue records own the remaining ABI gaps.
- Keep the current runtime contract state unchanged: this is traceability for the #928 gap, not a claim that additional runtime rows are implemented.

## Governing Issue

Part of #928.

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Validation run:

- `make stage1-direct-native-runtime-abi-test` passed.
- `make stage1-direct-native-runtime-abi` passed and now reports `status_counts` plus `blocker_issues: [928]`.
- `python3 -m py_compile scripts/ci/check-direct-native-runtime-abi.py` passed.
- `git diff --check` passed.

Skipped checks:

- Full stage1 test/conformance/smoke suites were not run because this is a narrow CI-reporting change to the runtime ABI checker.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Semantic details:

- Semantic node types: none.
- Schemas: no schema file changes; the existing checker report schema gains derived fields in the emitted JSON object.
- Evidence: checker output now includes status counts and blocker issue numbers derived from the checked-in ABI rows.
- Rust capture risk: none; this keeps the ABI report Axiom-neutral and does not introduce Rust implementation terms into the contract.
- Agent-facing inspection impact: agents can inspect `status_counts` and `blocker_issues` directly instead of inferring gap ownership from row text.

## Flow Contract

- Owner lane: daedalus
- Repair owner: codex
- Autonomy class: issue-scoped
- Risk class: low

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [ ] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

## Merge Automation

- [x] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

Auto-merge is enabled and should complete after required checks and non-author approval are present.

## Notes

- This PR intentionally does not update `stage1/runtime-abi/direct-native-v0.json`; it only makes the current partial/blocked state easier to audit.
