### PR TITLE
Lower static clock sleep durations in direct-native ABI

### DIFF
--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -424,8 +424,11 @@ spike can build and run `std/crypto_rand.ax` `random_bytes(...)` and
 preserving the generated-Rust helper's `0..=65536` byte length cap. The
 direct-native i64 path now also lowers public `std/crypto_rand.ax`
 `random_u64()` into native process exit status through the same Unix OS-random
-source. A package without the `crypto` capability still fails before backend
-lowering. Direct-native `random_bytes(...)`, portable entropy source parity,
+source. It also lowers `len(random_bytes(n))` for literal and static scalar
+nonnegative lengths up to the stage1 65,536 byte cap into native process exit
+status without materializing a general byte-array value. A package without the
+`crypto` capability still fails before backend lowering. Direct-native
+`random_bytes(...)` byte storage and contents, portable entropy source parity,
 deterministic test hooks, and runtime audit parity remain open under #1001.
 
 The direct-native crypto signature slice is now marked partial: the Cranelift

--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -730,9 +730,10 @@ The `clock.now_sleep` row now has partial Cranelift evidence for `std/time.ax`
 package without the `clock` capability fails before backend lowering and that
 nonzero sleep fails fast instead of ever reaching host sleep during
 compiler-side spike evaluation. The direct-native i64 path now also lowers
-literal `clock_sleep_ms(0)` through entrypoint and helper functions to a native
-process exit status without generated Rust. Imported public `std/time.ax`
-`sleep(duration_ms(...))` wrappers now alias that same deterministic path for
+literal and static scalar `clock_sleep_ms(...)` nonpositive durations through
+entrypoint and helper functions to a native process exit status without
+generated Rust. Imported public `std/time.ax` `sleep(duration_ms(...))`
+wrappers now alias that same deterministic path for literal and static scalar
 zero-duration and negative-duration calls in runtime-exit programs. The
 supported sleep shape remains limited to compile-time-known nonpositive
 durations until the real runtime clock path lands. Full runtime-time

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -97,6 +97,7 @@ struct I64StaticBindings {
     crypto_constant_time_eq_u8_wrappers: HashSet<String>,
     crypto_verify_sha256_wrappers: HashSet<String>,
     crypto_verify_sha512_wrappers: HashSet<String>,
+    crypto_random_bytes_wrappers: HashSet<String>,
     crypto_random_u64_wrappers: HashSet<String>,
     ffi_strlen_symbols: HashSet<String>,
     sync_once_wrappers: HashSet<String>,
@@ -636,6 +637,7 @@ fn lower_i64_exit_program(program: &Program, fs_root: &Path) -> Option<I64ExitPr
                 || is_i64_std_crypto_wrapper(function, "constant_time_eq_u8")
                 || is_i64_std_crypto_wrapper(function, "verify_sha256")
                 || is_i64_std_crypto_wrapper(function, "verify_sha512")
+                || is_i64_std_crypto_wrapper(function, "random_bytes")
                 || is_i64_std_crypto_wrapper(function, "random_u64")
                 || function.path == "<stdlib>/crypto_rand.ax"
         })
@@ -681,6 +683,12 @@ fn lower_i64_exit_program(program: &Program, fs_root: &Path) -> Option<I64ExitPr
         .functions
         .iter()
         .filter(|function| is_i64_std_crypto_wrapper(function, "verify_sha512"))
+        .flat_map(|function| [function.name.clone(), function.source_name.clone()])
+        .collect();
+    static_bindings.crypto_random_bytes_wrappers = program
+        .functions
+        .iter()
+        .filter(|function| is_i64_std_crypto_wrapper(function, "random_bytes"))
         .flat_map(|function| [function.name.clone(), function.source_name.clone()])
         .collect();
     static_bindings.crypto_random_u64_wrappers = program
@@ -9173,6 +9181,26 @@ fn lower_i64_crypto_random_intrinsic_expr(
     Some(CraneliftI64Expr::Literal(i64::from_ne_bytes(bytes)))
 }
 
+fn lower_i64_crypto_random_bytes_len_expr(
+    expr: &Expr,
+    static_bindings: &I64StaticBindings,
+) -> Option<CraneliftI64Expr> {
+    let Expr::Call { name, args, .. } = expr else {
+        return None;
+    };
+    if !is_i64_crypto_random_bytes_name(name, static_bindings) {
+        return None;
+    }
+    let [length] = args.as_slice() else {
+        return None;
+    };
+    let length = i64_static_scalar_value(length, static_bindings)?;
+    if !(0..=65_536).contains(&length) {
+        return None;
+    }
+    Some(CraneliftI64Expr::Literal(length))
+}
+
 fn lower_i64_ffi_intrinsic_expr(
     name: &str,
     args: &[Expr],
@@ -9702,6 +9730,10 @@ fn is_i64_crypto_verify_sha512_name(name: &str, static_bindings: &I64StaticBindi
     static_bindings.crypto_verify_sha512_wrappers.contains(name)
 }
 
+fn is_i64_crypto_random_bytes_name(name: &str, static_bindings: &I64StaticBindings) -> bool {
+    name == "crypto_rand_bytes" || static_bindings.crypto_random_bytes_wrappers.contains(name)
+}
+
 fn is_i64_crypto_random_u64_name(name: &str, static_bindings: &I64StaticBindings) -> bool {
     name == "crypto_rand_u64" || static_bindings.crypto_random_u64_wrappers.contains(name)
 }
@@ -9773,6 +9805,9 @@ fn lower_i64_fixed_array_intrinsic_expr(
             helper_signatures,
             static_bindings,
         ) {
+            return Some(length);
+        }
+        if let Some(length) = lower_i64_crypto_random_bytes_len_expr(arg, static_bindings) {
             return Some(length);
         }
         if let Some(length) = lower_i64_map_keys_len_expr(arg, static_bindings) {

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -9104,7 +9104,7 @@ fn lower_i64_clock_intrinsic_expr(
             let [milliseconds] = args else {
                 return None;
             };
-            lower_i64_literal_value(milliseconds)?
+            i64_static_scalar_value(milliseconds, static_bindings)?
         }
         name if is_i64_time_sleep_name(name, static_bindings) => {
             let [duration] = args else {
@@ -9127,12 +9127,12 @@ fn lower_i64_duration_ms_value(expr: &Expr, static_bindings: &I64StaticBindings)
             let [milliseconds] = args.as_slice() else {
                 return None;
             };
-            lower_i64_literal_value(milliseconds)
+            i64_static_scalar_value(milliseconds, static_bindings)
         }
         Expr::StructLiteral { fields, .. } => fields
             .iter()
             .find(|field| field.name == "ms")
-            .and_then(|field| lower_i64_literal_value(&field.expr)),
+            .and_then(|field| i64_static_scalar_value(&field.expr, static_bindings)),
         _ => None,
     }
 }

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -3598,15 +3598,15 @@ true
 
 #[cfg(not(windows))]
 #[test]
-fn cranelift_backend_lowers_crypto_random_u64_to_runtime_exit_code() {
+fn cranelift_backend_lowers_crypto_random_to_runtime_exit_code() {
     if which::which("cc").is_err() {
         eprintln!("skipping cranelift backend smoke test because cc is unavailable");
         return;
     }
 
     let temp = tempfile::tempdir().expect("tempdir");
-    let project = temp.path().join("crypto-random-u64-main-exit");
-    write_crypto_random_u64_main_exit_project(&project);
+    let project = temp.path().join("crypto-random-main-exit");
+    write_crypto_random_main_exit_project(&project);
 
     let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
         .args([
@@ -3620,7 +3620,7 @@ fn cranelift_backend_lowers_crypto_random_u64_to_runtime_exit_code() {
         .expect("run axiomc build --backend cranelift");
     assert!(
         output.status.success(),
-        "cranelift crypto random u64 main build failed: stdout={} stderr={}",
+        "cranelift crypto random main build failed: stdout={} stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
@@ -3631,7 +3631,7 @@ fn cranelift_backend_lowers_crypto_random_u64_to_runtime_exit_code() {
     let binary = payload["binary"].as_str().expect("binary path");
     let run = Command::new(binary)
         .output()
-        .expect("run cranelift crypto random u64 main binary");
+        .expect("run cranelift crypto random main binary");
     assert_eq!(run.status.code(), Some(48));
     assert_eq!(String::from_utf8_lossy(&run.stdout), "");
 }
@@ -5402,7 +5402,7 @@ clock = false
 crypto = false
 
 [unsafe_rationale]
-env = \"Cranelift ABI regression needs a runtime-only projected key index source.\"
+env = "Cranelift ABI regression needs a runtime-only projected key index source."
 "#,
     )
     .expect("write regex manifest");
@@ -6863,7 +6863,7 @@ clock = false
 crypto = false
 
 [unsafe_rationale]
-env = \"Cranelift ABI regression needs a runtime-only projected key index source.\"
+env = "Cranelift ABI regression needs a runtime-only projected key index source."
 "#,
     )
     .expect("write owned move manifest");
@@ -6997,7 +6997,7 @@ fn write_std_collection_wrapper_main_exit_project(project: &Path) {
         .expect("create std collection wrapper main project src");
     fs::write(
         project.join("axiom.toml"),
-        "[package]\nname = \"cranelift-std-collection-wrapper-main-exit\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = true\nclock = false\ncrypto = false\n\n[unsafe_rationale]\nenv = \"Cranelift ABI regression needs a runtime-only projected key index source.\"\n",
+        "[package]\nname = \"cranelift-std-collection-wrapper-main-exit\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
     )
     .expect("write std collection wrapper main manifest");
     fs::write(
@@ -7008,11 +7008,9 @@ fn write_std_collection_wrapper_main_exit_project(project: &Path) {
     fs::write(
         project.join("src/main.ax"),
         r#"import "std/collections.ax"
-import "std/env.ax"
-
-fn choose_key_index(length: int): int {
-if length > 0 {
-return length - 1
+fn choose_key_index(found: bool): int {
+if found {
+return 1
 } else {
 return 0
 }
@@ -7040,7 +7038,7 @@ let second_key_names: [string] = keys<string, int>(second_key_scores)
 let second_key_len: int = len(second_key_names[1])
 let dynamic_key_scores: {string: int} = {"build": 7, "deploy": 9}
 let dynamic_key_names: [string] = keys<string, int>(dynamic_key_scores)
-let dynamic_key_index: int = choose_key_index(match get_env("AXIOM_CRANELIFT_DYNAMIC_KEY_INDEX") { Some(value) => len(value), None => 0 })
+let dynamic_key_index: int = choose_key_index(contains_hit)
 let dynamic_key_len: int = len(dynamic_key_names[dynamic_key_index])
 let dynamic_key_eq_scores: {string: int} = {"build": 7, "deploy": 9}
 let dynamic_key_eq_names: [string] = keys<string, int>(dynamic_key_eq_scores)
@@ -7818,23 +7816,23 @@ fn write_crypto_random_project(project: &Path, crypto: bool) {
     .expect("write crypto random source");
 }
 
-fn write_crypto_random_u64_main_exit_project(project: &Path) {
-    fs::create_dir_all(project.join("src")).expect("create crypto random u64 project src");
+fn write_crypto_random_main_exit_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create crypto random project src");
     fs::write(
         project.join("axiom.toml"),
-        "[package]\nname = \"cranelift-crypto-random-u64-main-exit\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = true\n\n[unsafe_rationale]\ncrypto = \"Direct-native random_u64 regression covers std/crypto_rand.ax for issue 928.\"\n",
+        "[package]\nname = \"cranelift-crypto-random-main-exit\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = true\n\n[unsafe_rationale]\ncrypto = \"Direct-native random_bytes length and random_u64 regression covers std/crypto_rand.ax for issue 1001.\"\n",
     )
-    .expect("write crypto random u64 main manifest");
+    .expect("write crypto random main manifest");
     fs::write(
         project.join("axiom.lock"),
-        "version = 1\n\n[[package]]\nname = \"cranelift-crypto-random-u64-main-exit\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+        "version = 1\n\n[[package]]\nname = \"cranelift-crypto-random-main-exit\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
     )
-    .expect("write crypto random u64 main lockfile");
+    .expect("write crypto random main lockfile");
     fs::write(
         project.join("src/main.ax"),
-        "import \"std/crypto_rand.ax\"\n\nfn main(): int {\nlet value: int = random_u64() as int\nif value == value {\nreturn 48\n} else {\nreturn 1\n}\n}\n",
+        "import \"std/crypto_rand.ax\"\n\nstatic RANDOM_LEN: int = 16\n\nfn main(): int {\nlet sample_len: int = len(random_bytes(RANDOM_LEN))\nlet empty_len: int = len(random_bytes(0))\nlet value: int = random_u64() as int\nif sample_len == RANDOM_LEN && empty_len == 0 && value == value {\nreturn 48\n} else {\nreturn 1\n}\n}\n",
     )
-    .expect("write crypto random u64 main source");
+    .expect("write crypto random main source");
 }
 
 fn write_crypto_signature_project(project: &Path, crypto: bool) {

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -8384,7 +8384,7 @@ source = "path"
     .expect("write clock sleep zero lockfile");
     fs::write(
         project.join("src/main.ax"),
-        "fn pause_zero(): int {\nreturn clock_sleep_ms(0)\n}\n\nfn main(): int {\nlet direct: int = clock_sleep_ms(0)\nlet helper: int = pause_zero()\nif direct == 0 && helper == 0 {\nreturn 48\n} else {\nreturn 1\n}\n}\n",
+        "static ZERO_MS: int = 0\n\nfn pause_zero(): int {\nreturn clock_sleep_ms(ZERO_MS)\n}\n\nfn main(): int {\nlet direct: int = clock_sleep_ms(ZERO_MS)\nlet helper: int = pause_zero()\nif direct == 0 && helper == 0 {\nreturn 48\n} else {\nreturn 1\n}\n}\n",
     )
     .expect("write clock sleep zero source");
 }
@@ -8426,16 +8426,19 @@ source = "path"
         project.join("src/main.ax"),
         r#"import "std/time.ax"
 
+static ZERO_MS: int = 0
+static NEGATIVE_MS: int = -1
+
 fn pause_zero(): int {
-return sleep(duration_ms(0))
+return sleep(duration_ms(ZERO_MS))
 }
 
 fn pause_negative(): int {
-return sleep(duration_ms(-1))
+return sleep(duration_ms(NEGATIVE_MS))
 }
 
 fn main(): int {
-let direct: int = sleep(duration_ms(0))
+let direct: int = sleep(duration_ms(ZERO_MS))
 let helper: int = pause_zero()
 let negative: int = pause_negative()
 if direct == 0 && helper == 0 && negative == -1 {

--- a/stage1/runtime-abi/direct-native-v0.json
+++ b/stage1/runtime-abi/direct-native-v0.json
@@ -195,7 +195,7 @@
       "evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
       "denial_evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
       "blockers": [1001],
-      "notes": "The Cranelift spike can build a std/time.ax package covering now_ms, now, elapsed_ms, and zero-duration sleep, rejects missing clock capability before backend lowering, and fails fast for nonzero sleep before any host sleep or backend lowering. The direct-native i64 path now also lowers literal clock_sleep_ms(0) through entrypoint and helper functions to a native process exit status without generated Rust. Imported public std/time.ax sleep(duration_ms(...)) wrappers now alias that same deterministic path for zero-duration and negative-duration calls in runtime-exit programs. Full runtime-time clock/sleep execution, timer scheduling, async clock integration, nonzero sleep, and audit parity remain open."
+      "notes": "The Cranelift spike can build a std/time.ax package covering now_ms, now, elapsed_ms, and zero-duration sleep, rejects missing clock capability before backend lowering, and fails fast for nonzero sleep before any host sleep or backend lowering. The direct-native i64 path now also lowers literal and static scalar clock_sleep_ms(...) nonpositive durations through entrypoint and helper functions to a native process exit status without generated Rust. Imported public std/time.ax sleep(duration_ms(...)) wrappers now alias that same deterministic path for literal and static scalar zero-duration and negative-duration calls in runtime-exit programs. Full runtime-time clock/sleep execution, timer scheduling, async clock integration, nonzero sleep, and audit parity remain open."
     },
     {
       "id": "crypto.hash",

--- a/stage1/runtime-abi/direct-native-v0.json
+++ b/stage1/runtime-abi/direct-native-v0.json
@@ -222,7 +222,7 @@
       "evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
       "blockers": [1001],
       "denial_evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
-      "notes": "The Cranelift spike builds and runs std/crypto_rand.ax random_bytes and random_u64 through a Unix OS-random source without generated Rust, preserving the existing 0..=65536 byte length cap. The direct-native i64 path now also lowers public std/crypto_rand.ax random_u64 into native process exit status through the same Unix OS-random source. Packages without the crypto capability receive the public manifest-policy denial before backend lowering. Direct-native random_bytes, portable entropy source parity, deterministic test hooks, and runtime audit parity remain blocked."
+      "notes": "The Cranelift spike builds and runs std/crypto_rand.ax random_bytes and random_u64 through a Unix OS-random source without generated Rust, preserving the existing 0..=65536 byte length cap. The direct-native i64 path now also lowers public std/crypto_rand.ax random_u64 into native process exit status through the same Unix OS-random source, and lowers len(random_bytes(n)) for literal and static scalar nonnegative lengths up to that cap into native process exit status without materializing a general byte-array value. Packages without the crypto capability receive the public manifest-policy denial before backend lowering. Direct-native random_bytes byte storage and contents, portable entropy source parity, deterministic test hooks, and runtime audit parity remain blocked."
     },
     {
       "id": "crypto.signature",


### PR DESCRIPTION
## Summary

- Lower static scalar nonpositive `clock_sleep_ms(...)` arguments through the direct-native i64 exit path without generated Rust.
- Lower static scalar nonpositive `sleep(duration_ms(...))` wrappers through the same direct-native clock/sleep path.
- Update the runtime ABI evidence docs and fixture so `clock.now_sleep` records literal and static scalar coverage while leaving runtime-time sleep semantics under #1001.

## Governing Issue

Refs #1001

## Validation

- [x] `cargo fmt --manifest-path stage1/crates/axiomc/Cargo.toml -- --check`
- [x] `git diff --check`
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc cranelift_backend_lowers_zero_clock_sleep_to_runtime_exit_code -- --nocapture`
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc cranelift_backend_lowers_std_time_sleep_wrappers_to_runtime_exit_code -- --nocapture`
- [x] `bash scripts/ci/test-check-direct-native-runtime-abi.sh`
- [x] `make stage1-direct-native-runtime-abi`

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

## Flow Contract

- Owner lane: backend
- Repair owner: codex
- Autonomy class: worker
- Risk class: medium

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [ ] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is appropriate when gates pass

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- This is stacked on #1003, which is stacked on #1002, so each direct-native ABI slice stays reviewable. Retarget this PR after #1002 and #1003 land.
- This does not claim `clock.now_sleep` is complete. Runtime-time clock reads, positive/nonzero sleep scheduling, timer integration, async wakeups, and portable runtime parity remain under #1001.
