### PR TITLE
Reject unsupported direct-native main functions

### DIFF
--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -524,14 +524,15 @@ representation remain tracked by issue #1001.
 The borrowed-slice row has partial direct-native evidence: the Cranelift spike
 evaluates array-backed borrowed slices through `len`, `first`, `last`, indexing,
 and function returns. The direct-native runtime path now also lowers narrow
-static-range fixed-array slices such as `values[1:]` and `values[:2]` through
-`len`, `first`, and `last` for scalar and bool elements by projecting the
-underlying fixed-array slots, including helper-parameter arrays feeding a
-direct-native process exit status. Static-range fixed-array slices also support
-narrow literal and dynamic indexing over the sliced window through the same
-projection slots, including pre-runtime slice locals that alias the projected
-fixed-array slots. Broader borrowed-slice aliasing, dynamic slice bounds, slice
-returns, and host ABI coverage remain tracked by issue #1001.
+static-range fixed-array slices using literal or static scalar bounds such as
+`values[1:]`, `values[START:]`, `values[:2]`, and `values[:END]` through `len`,
+`first`, and `last` for scalar and bool elements by projecting the underlying
+fixed-array slots, including helper-parameter arrays feeding a direct-native
+process exit status. Static-range fixed-array slices also support narrow literal
+and dynamic indexing over the sliced window through the same projection slots,
+including pre-runtime slice locals that alias the projected fixed-array slots.
+Broader borrowed-slice aliasing, dynamic slice bounds, slice returns, and host
+ABI coverage remain tracked by issue #1001.
 
 The map lookup row has partial direct-native evidence: the Cranelift spike now
 builds and runs direct map indexing, `get`, `get_or_default`,

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -1355,6 +1355,7 @@ fn lower_i64_aggregate_return_body(
                     &mut locals,
                     &mut local_indexes,
                     &mut local_conditions,
+                    static_bindings,
                     false,
                 )?;
             }
@@ -2546,6 +2547,7 @@ fn lower_i64_body(
                     &mut locals,
                     &mut local_indexes,
                     &mut local_conditions,
+                    static_bindings,
                     false,
                 )?;
             }
@@ -3242,6 +3244,7 @@ fn lower_i64_runtime_let_stmts(
             locals,
             local_indexes,
             local_conditions,
+            static_bindings,
             true,
         );
     }
@@ -6698,10 +6701,10 @@ fn lower_i64_byte_slice_eq_condition(
         return None;
     };
     if !matches!(
-        i64_fixed_array_or_slice_element(left)?,
+        i64_fixed_array_or_slice_element(left, static_bindings)?,
         Type::Numeric(NumericType::U8)
     ) || !matches!(
-        i64_fixed_array_or_slice_element(right)?,
+        i64_fixed_array_or_slice_element(right, static_bindings)?,
         Type::Numeric(NumericType::U8)
     ) {
         return None;
@@ -7854,6 +7857,7 @@ fn lower_i64_slice_projection_aliases(
     locals: &mut Vec<CraneliftI64Expr>,
     local_indexes: &mut HashMap<String, usize>,
     local_conditions: &mut HashMap<String, CraneliftI64Condition>,
+    static_bindings: &I64StaticBindings,
     runtime: bool,
 ) -> Option<Vec<CraneliftI64Stmt>> {
     let Expr::Slice {
@@ -7869,7 +7873,12 @@ fn lower_i64_slice_projection_aliases(
     else {
         return None;
     };
-    let (start, end) = i64_static_slice_range(*base_size, start.as_deref(), end.as_deref())?;
+    let (start, end) = i64_static_slice_range(
+        *base_size,
+        start.as_deref(),
+        end.as_deref(),
+        static_bindings,
+    )?;
     let mut assigns = Vec::new();
     for (slice_index, base_index) in (start..end).enumerate() {
         let base_key = i64_array_projection_key(base_name, base_index);
@@ -8964,7 +8973,7 @@ fn lower_i64_slice_projection_index_expr(
         }
         return Some(result);
     }
-    let (name, start, size) = i64_static_slice_base_range(base)?;
+    let (name, start, size) = i64_static_slice_base_range(base, static_bindings)?;
     if size == 0 {
         return None;
     }
@@ -9814,7 +9823,7 @@ fn lower_i64_fixed_array_intrinsic_expr(
             return Some(length);
         }
     }
-    let element = i64_fixed_array_or_slice_element(arg)?;
+    let element = i64_fixed_array_or_slice_element(arg, static_bindings)?;
     if !is_i64_array_param_element_type(&element) {
         return None;
     }
@@ -10326,7 +10335,7 @@ fn lower_i64_fixed_array_bool_intrinsic_expr(
     let [arg] = args else {
         return None;
     };
-    let element = i64_fixed_array_or_slice_element(arg)?;
+    let element = i64_fixed_array_or_slice_element(arg, static_bindings)?;
     if !matches!(element, Type::Bool) {
         return None;
     }
@@ -10348,10 +10357,13 @@ fn lower_i64_fixed_array_bool_intrinsic_expr(
     elements.get(index).cloned()
 }
 
-fn i64_fixed_array_or_slice_element(arg: &Expr) -> Option<Type> {
+fn i64_fixed_array_or_slice_element(
+    arg: &Expr,
+    static_bindings: &I64StaticBindings,
+) -> Option<Type> {
     match arg {
         Expr::Slice { base, .. } => {
-            let (_, _, _) = i64_static_slice_base_range(arg)?;
+            let (_, _, _) = i64_static_slice_base_range(arg, static_bindings)?;
             let Expr::VarRef {
                 ty: Type::Array(element, Some(_)),
                 ..
@@ -10381,7 +10393,10 @@ fn i64_fixed_array_or_slice_element(arg: &Expr) -> Option<Type> {
     }
 }
 
-fn i64_static_slice_base_range(arg: &Expr) -> Option<(&str, usize, usize)> {
+fn i64_static_slice_base_range<'a>(
+    arg: &'a Expr,
+    static_bindings: &I64StaticBindings,
+) -> Option<(&'a str, usize, usize)> {
     let Expr::Slice {
         base, start, end, ..
     } = arg
@@ -10395,7 +10410,12 @@ fn i64_static_slice_base_range(arg: &Expr) -> Option<(&str, usize, usize)> {
     else {
         return None;
     };
-    let (start, end) = i64_static_slice_range(*base_size, start.as_deref(), end.as_deref())?;
+    let (start, end) = i64_static_slice_range(
+        *base_size,
+        start.as_deref(),
+        end.as_deref(),
+        static_bindings,
+    )?;
     Some((name.as_str(), start, end - start))
 }
 
@@ -10403,16 +10423,22 @@ fn i64_static_slice_range(
     base_size: usize,
     start: Option<&Expr>,
     end: Option<&Expr>,
+    static_bindings: &I64StaticBindings,
 ) -> Option<(usize, usize)> {
     let start = match start {
-        Some(expr) => lower_i64_literal_index(expr)?,
+        Some(expr) => lower_i64_static_index(expr, static_bindings)?,
         None => 0,
     };
     let end = match end {
-        Some(expr) => lower_i64_literal_index(expr)?,
+        Some(expr) => lower_i64_static_index(expr, static_bindings)?,
         None => base_size,
     };
     (start <= end && end <= base_size).then_some((start, end))
+}
+
+fn lower_i64_static_index(expr: &Expr, static_bindings: &I64StaticBindings) -> Option<usize> {
+    let value = i64_static_scalar_value(expr, static_bindings)?;
+    usize::try_from(value).ok()
 }
 
 fn lower_i64_literal_index(expr: &Expr) -> Option<usize> {
@@ -10910,7 +10936,12 @@ fn lower_i64_array_or_slice_call_arg_exprs(
     if !is_i64_array_param_element_type(element) {
         return None;
     }
-    let (start, end) = i64_static_slice_range(*base_size, start.as_deref(), end.as_deref())?;
+    let (start, end) = i64_static_slice_range(
+        *base_size,
+        start.as_deref(),
+        end.as_deref(),
+        static_bindings,
+    )?;
     (start..end)
         .map(|index| {
             local_indexes

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -288,6 +288,16 @@ pub fn compile_cranelift_hello_spike(
             Diagnostic::new("build", err.to_string()).with_path(object_path.display().to_string())
         });
     }
+    if program.stmts.is_empty()
+        && program
+            .functions
+            .iter()
+            .any(|function| function.source_name == "main" && function.params.is_empty())
+    {
+        return Err(unsupported(
+            "main function is outside the direct-native i64 ABI subset",
+        ));
+    }
     let lines = collect_output_lines(program, package_root, fs_root)?;
     axiomc_backend_cranelift::compile_output_lines(&lines, object_path, binary_path).map_err(
         |err| {

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -1328,6 +1328,38 @@ fn cranelift_backend_lowers_string_literal_len_to_runtime_exit_code() {
     assert_eq!(String::from_utf8_lossy(&run.stdout), "");
 }
 
+#[test]
+fn cranelift_backend_rejects_unsupported_string_helper_main() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("unsupported-string-helper-main");
+    write_unsupported_string_helper_main_project(&project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+    assert!(
+        !output.status.success(),
+        "cranelift unsupported string helper main unexpectedly built: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
+    assert_eq!(payload["ok"], Value::Bool(false));
+    let message = payload["error"]["message"].as_str().expect("error message");
+    assert!(
+        message.contains("main function is outside the direct-native i64 ABI subset"),
+        "unexpected cranelift unsupported string helper error: {message}"
+    );
+}
+
 #[cfg(not(windows))]
 #[test]
 fn cranelift_backend_lowers_std_encoding_wrappers_to_runtime_exit_code() {
@@ -6308,19 +6340,154 @@ fn write_string_literal_len_main_exit_project(project: &Path) {
         .expect("create string literal len main exit project src");
     fs::write(
         project.join("axiom.toml"),
-        "[package]\nname = \"cranelift-string-literal-len-main-exit\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
+        r#"[package]
+name = "cranelift-string-literal-len-main-exit"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false
+"#,
     )
     .expect("write string literal len main exit manifest");
     fs::write(
         project.join("axiom.lock"),
-        "version = 1\n\n[[package]]\nname = \"cranelift-string-literal-len-main-exit\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+        r#"version = 1
+
+[[package]]
+name = "cranelift-string-literal-len-main-exit"
+version = "0.1.0"
+source = "path"
+"#,
     )
     .expect("write string literal len main exit lockfile");
     fs::write(
         project.join("src/main.ax"),
-        "static BANNER: string = \"direct-native\"\nstatic PADDED: string = \"  direct-native  \"\nstatic SECOND_LINE_INDEX: int = 1\nstatic MISSING_LINE_INDEX: int = -1\n\nfn local_len(): int {\nlet text: string = \"native\"\nreturn len(text)\n}\n\nfn add_base(value: int): int {\nreturn value + 19\n}\n\nfn native_prefix(): bool {\nlet value: string = string_clone(BANNER)\nreturn string_starts_with(value, \"direct\")\n}\n\nfn static_prefix(): bool {\nlet trimmed: string = string_trim(PADDED)\nreturn string_starts_with(trimmed, \"direct\")\n}\n\nfn main(): int {\nlet owned: string = \"direct-native\"\nlet short: string = \"abi\"\nlet prefix_text: string = string_clone(BANNER)\nlet miss_text: string = string_trim(PADDED)\nlet compare_text: string = string_trim_start(\"  direct-native\")\nlet literal_len: int = len(\"runtime\")\nlet local_len_value: int = len(owned)\nlet static_len_value: int = len(BANNER)\nlet clone_len_value: int = len(string_clone(BANNER))\nlet trim_len_value: int = len(string_trim(PADDED))\nlet trim_start_len_value: int = len(string_trim_start(\"  abi\"))\nlet concat_len_value: int = len(string_clone(BANNER) + string_trim_start(\"  abi\"))\nlet encoded_len: int = len(encoding_url_component_encode(\"hello world/one\"))\nlet segment_len: int = len(encoding_path_segment_encode(\"a/b c\"))\nlet pair_len: int = len(encoding_url_query_pair_encode(\"q\", \"agent path/one\"))\nlet joined_len: int = len(encoding_path_join_segment(\"/docs\", \"stage 1/encoding\"))\nlet strip_prefix_len: int = match string_strip_prefix(BANNER, \"direct-\") { Some(rest) => len(rest), None => 1 }\nlet strip_suffix_gate: bool = match string_strip_suffix(BANNER, \"-native\") { Some(rest) => string_starts_with(rest, \"direct\"), None => false }\nlet line_len: int = match string_line_at(\"first\\nsecond\\nthird\", SECOND_LINE_INDEX) { Some(line) => len(line), None => 1 }\nlet line_missing: int = match string_line_at(\"first\\nsecond\", MISSING_LINE_INDEX) { Some(line) => len(line), None => 4 }\nlet decoded_len: int = match encoding_url_component_decode(\"hello%20axiom\") { Some(value) => len(value), None => 1 }\nlet decode_missing: int = match encoding_url_component_decode(\"bad%2\") { Some(value) => len(value), None => 4 }\nlet short_len: int = len(short)\nlet helper_len: int = local_len()\nlet helper_arg_len: int = add_base(len(short))\nlet prefix_gate: bool = string_starts_with(prefix_text, \"direct\")\nlet miss_gate: bool = string_starts_with(miss_text, \"rust\") == false\nlet helper_gate: bool = native_prefix()\nlet static_gate: bool = static_prefix()\nlet compare_gate: bool = compare_text == BANNER\nif prefix_gate && miss_gate && helper_gate && static_gate && compare_gate && strip_suffix_gate && literal_len == 7 && local_len_value == 13 && static_len_value == 13 && clone_len_value == 13 && trim_len_value == 13 && trim_start_len_value == 3 && concat_len_value == 16 && encoded_len == 19 && segment_len == 9 && pair_len == 20 && joined_len == 26 && strip_prefix_len == 6 && line_len == 6 && line_missing == 4 && decoded_len == 11 && decode_missing == 4 && short_len == 3 && helper_len == 6 && helper_arg_len == 22 {\nreturn literal_len + local_len_value + helper_len + helper_arg_len\n} else {\nreturn 1\n}\n}\n",
+        r#"static BANNER: string = "direct-native"
+static PADDED: string = "  direct-native  "
+static SECOND_LINE_INDEX: int = 1
+static MISSING_LINE_INDEX: int = -1
+
+fn local_len(): int {
+let text: string = "native"
+return len(text)
+}
+
+fn add_base(value: int): int {
+return value + 19
+}
+
+fn native_prefix(): bool {
+let value: string = string_clone(BANNER)
+return string_starts_with(value, "direct")
+}
+
+fn static_prefix(): bool {
+let trimmed: string = string_trim(PADDED)
+return string_starts_with(trimmed, "direct")
+}
+
+fn main(): int {
+let owned: string = "direct-native"
+let short: string = "abi"
+let prefix_text: string = string_clone(BANNER)
+let miss_text: string = string_trim(PADDED)
+let compare_text: string = string_trim_start("  direct-native")
+let literal_len: int = len("runtime")
+let local_len_value: int = len(owned)
+let static_len_value: int = len(BANNER)
+let clone_len_value: int = len(string_clone(BANNER))
+let trim_len_value: int = len(string_trim(PADDED))
+let trim_start_len_value: int = len(string_trim_start("  abi"))
+let concat_len_value: int = len(string_clone(BANNER) + string_trim_start("  abi"))
+let encoded_len: int = len(encoding_url_component_encode("hello world/one"))
+let segment_len: int = len(encoding_path_segment_encode("a/b c"))
+let pair_len: int = len(encoding_url_query_pair_encode("q", "agent path/one"))
+let joined_len: int = len(encoding_path_join_segment("/docs", "stage 1/encoding"))
+let strip_prefix_len: int = match string_strip_prefix(BANNER, "direct-") { Some(rest) => len(rest), None => 1 }
+let strip_suffix_gate: bool = match string_strip_suffix(BANNER, "-native") { Some(rest) => string_starts_with(rest, "direct"), None => false }
+let line_len: int = match string_line_at("first\nsecond\nthird", SECOND_LINE_INDEX) { Some(line) => len(line), None => 1 }
+let line_missing: int = match string_line_at("first\nsecond", MISSING_LINE_INDEX) { Some(line) => len(line), None => 4 }
+let decoded_len: int = match encoding_url_component_decode("hello%20axiom") { Some(value) => len(value), None => 1 }
+let decode_missing: int = match encoding_url_component_decode("bad%2") { Some(value) => len(value), None => 4 }
+let short_len: int = len(short)
+let helper_len: int = local_len()
+let helper_arg_len: int = add_base(len(short))
+let prefix_gate: bool = string_starts_with(prefix_text, "direct")
+let miss_gate: bool = string_starts_with(miss_text, "rust") == false
+let helper_gate: bool = native_prefix()
+let static_gate: bool = static_prefix()
+let compare_gate: bool = compare_text == BANNER
+if prefix_gate && miss_gate && helper_gate && static_gate && compare_gate && strip_suffix_gate && literal_len == 7 && local_len_value == 13 && static_len_value == 13 && clone_len_value == 13 && trim_len_value == 13 && trim_start_len_value == 3 && concat_len_value == 16 && encoded_len == 19 && segment_len == 9 && pair_len == 20 && joined_len == 26 && strip_prefix_len == 6 && line_len == 6 && line_missing == 4 && decoded_len == 11 && decode_missing == 4 && short_len == 3 && helper_len == 6 && helper_arg_len == 22 {
+return literal_len + local_len_value + helper_len + helper_arg_len
+} else {
+return 1
+}
+}
+"#,
     )
     .expect("write string literal len main exit source");
+}
+
+fn write_unsupported_string_helper_main_project(project: &Path) {
+    fs::create_dir_all(project.join("src"))
+        .expect("create unsupported string helper main project src");
+    fs::write(
+        project.join("axiom.toml"),
+        r#"[package]
+name = "cranelift-unsupported-string-helper-main"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false
+"#,
+    )
+    .expect("write unsupported string helper main manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        r#"version = 1
+
+[[package]]
+name = "cranelift-unsupported-string-helper-main"
+version = "0.1.0"
+source = "path"
+"#,
+    )
+    .expect("write unsupported string helper main lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        r#"fn score(text: string): int {
+return len(text)
+}
+
+fn main(): int {
+let direct: int = score("direct-native")
+if direct == 13 {
+return 48
+} else {
+return 1
+}
+}
+"#,
+    )
+    .expect("write unsupported string helper main source");
 }
 
 fn write_std_encoding_wrapper_main_exit_project(project: &Path) {

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -1250,6 +1250,46 @@ fn cranelift_backend_lowers_fixed_array_intrinsics_to_runtime_exit_code() {
 
 #[cfg(not(windows))]
 #[test]
+fn cranelift_backend_lowers_static_slice_bounds_to_runtime_exit_code() {
+    if which::which("cc").is_err() {
+        eprintln!("skipping cranelift backend smoke test because cc is unavailable");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("static-slice-bounds-main-exit");
+    write_static_slice_bounds_main_exit_project(&project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+    assert!(
+        output.status.success(),
+        "cranelift static slice bounds main build failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
+    assert_eq!(payload["backend"], "cranelift");
+    assert_eq!(payload["generated_rust"], Value::Null);
+    let binary = payload["binary"].as_str().expect("binary path");
+    let run = Command::new(binary)
+        .output()
+        .expect("run cranelift static slice bounds main binary");
+    assert_eq!(run.status.code(), Some(48));
+    assert_eq!(String::from_utf8_lossy(&run.stdout), "");
+}
+
+#[cfg(not(windows))]
+#[test]
 fn cranelift_backend_lowers_string_literal_len_to_runtime_exit_code() {
     if which::which("cc").is_err() {
         eprintln!("skipping cranelift backend smoke test because cc is unavailable");
@@ -6241,6 +6281,26 @@ fn write_fixed_array_intrinsics_main_exit_project(project: &Path) {
         "fn score(values: [int; 3]): int {\nreturn len(values) + first(values) + last(values)\n}\n\nfn gate(flags: [bool; 2]): bool {\nreturn first(flags) && last(flags) == false\n}\n\nfn slice_score(len_values: [int; 3], first_values: [int; 3], last_values: [int; 3]): int {\nreturn len(len_values[1:]) + first(first_values[1:]) + last(last_values[1:])\n}\n\nfn prefix_score(len_values: [int; 3], first_values: [int; 3], last_values: [int; 3]): int {\nreturn len(len_values[:2]) + first(first_values[:2]) + last(last_values[:2])\n}\n\nfn slice_pick(values: [int; 3], index: int): int {\nreturn values[1:][index]\n}\n\nfn slice_gate(first_flags: [bool; 3], last_flags: [bool; 3]): bool {\nreturn first(first_flags[1:]) == false && last(last_flags[1:])\n}\n\nfn slice_index_gate(flags: [bool; 3], index: int): bool {\nreturn flags[1:][index]\n}\n\nfn make_values(): [int; 3] {\nreturn [20, 3, 25]\n}\n\nfn make_flags(): [bool; 2] {\nreturn [true, false]\n}\n\nfn main(): int {\nlet values: [int; 3] = [20, 3, 25]\nlet returned: [int; 3] = make_values()\nlet slice_len_values: [int; 3] = [1, 20, 26]\nlet slice_first_values: [int; 3] = [1, 20, 26]\nlet slice_last_values: [int; 3] = [1, 20, 26]\nlet prefix_len_values: [int; 3] = [20, 26, 1]\nlet prefix_first_values: [int; 3] = [20, 26, 1]\nlet prefix_last_values: [int; 3] = [20, 26, 1]\nlet slice_index_literal_values: [int; 3] = [1, 20, 26]\nlet slice_index_dynamic_values: [int; 3] = [1, 20, 26]\nlet slice_local_values: [int; 3] = [1, 20, 26]\nlet slice_local_index_values: [int; 3] = [1, 20, 26]\nlet helper_slice_index_values: [int; 3] = [1, 20, 26]\nlet helper_slice_len_values: [int; 3] = [1, 20, 26]\nlet helper_slice_first_values: [int; 3] = [1, 20, 26]\nlet helper_slice_last_values: [int; 3] = [1, 20, 26]\nlet helper_prefix_len_values: [int; 3] = [20, 26, 1]\nlet helper_prefix_first_values: [int; 3] = [20, 26, 1]\nlet helper_prefix_last_values: [int; 3] = [20, 26, 1]\nlet flags: [bool; 2] = [true, false]\nlet returned_flags: [bool; 2] = make_flags()\nlet slice_gate_first_flags: [bool; 3] = [false, false, true]\nlet slice_gate_last_flags: [bool; 3] = [false, false, true]\nlet slice_index_flags: [bool; 3] = [false, false, true]\nlet slice_local_flags: [bool; 3] = [false, false, true]\nlet helper_slice_gate_first_flags: [bool; 3] = [false, false, true]\nlet helper_slice_gate_last_flags: [bool; 3] = [false, false, true]\nlet helper_slice_index_flags: [bool; 3] = [false, false, true]\nlet dynamic_slice_index: int = 1\nlet local_code: int = len(values) + first(values) + last(values)\nlet literal_code: int = len([20, 3, 25]) + first([20, 3, 25]) + last([20, 3, 25])\nlet helper_code: int = score(values)\nlet returned_code: int = len(returned) + first(returned) + last(returned)\nlet slice_code: int = len(slice_len_values[1:]) + first(slice_first_values[1:]) + last(slice_last_values[1:])\nlet prefix_code: int = len(prefix_len_values[:2]) + first(prefix_first_values[:2]) + last(prefix_last_values[:2])\nlet slice_index_code: int = slice_index_literal_values[1:][0] + slice_index_dynamic_values[1:][dynamic_slice_index] + 2\nlet literal_dynamic_code: int = [20, 26][dynamic_slice_index] + 22\nlet slice_window: &[int] = slice_local_values[1:]\nlet slice_index_window: &[int] = slice_local_index_values[1:]\nlet slice_local_code: int = len(slice_window) + first(slice_window) + last(slice_window)\nlet slice_local_index_code: int = slice_index_window[0] + slice_index_window[dynamic_slice_index] + 2\nlet helper_slice_index_code: int = slice_pick(helper_slice_index_values, dynamic_slice_index) + 22\nlet helper_slice_code: int = slice_score(helper_slice_len_values, helper_slice_first_values, helper_slice_last_values)\nlet helper_prefix_code: int = prefix_score(helper_prefix_len_values, helper_prefix_first_values, helper_prefix_last_values)\nlet bool_len: int = len(flags)\nlet local_gate: bool = first(flags) && last(flags) == false\nlet literal_gate: bool = first([true, false]) && last([true, false]) == false\nlet helper_gate: bool = gate(flags)\nlet returned_gate: bool = first(returned_flags) && last(returned_flags) == false\nlet slice_gate_local: bool = first(slice_gate_first_flags[1:]) == false && last(slice_gate_last_flags[1:])\nlet slice_index_gate_local: bool = slice_index_flags[1:][dynamic_slice_index]\nlet flag_window: &[bool] = slice_local_flags[1:]\nlet slice_local_gate: bool = first(flag_window) == false && last(flag_window) && flag_window[dynamic_slice_index]\nlet literal_dynamic_gate: bool = [false, true][dynamic_slice_index]\nlet helper_slice_gate: bool = slice_gate(helper_slice_gate_first_flags, helper_slice_gate_last_flags)\nlet helper_slice_index_gate: bool = slice_index_gate(helper_slice_index_flags, dynamic_slice_index)\nif local_gate && literal_gate && helper_gate && returned_gate && slice_gate_local && slice_index_gate_local && slice_local_gate && literal_dynamic_gate && helper_slice_gate && helper_slice_index_gate && bool_len == 2 && local_code == 48 && literal_code == 48 && helper_code == 48 && returned_code == 48 && slice_code == 48 && prefix_code == 48 && slice_index_code == 48 && literal_dynamic_code == 48 && slice_local_code == 48 && slice_local_index_code == 48 && helper_slice_index_code == 48 && helper_slice_code == 48 && helper_prefix_code == 48 {\nreturn local_code\n} else {\nreturn 1\n}\n}\n",
     )
     .expect("write fixed array intrinsics main exit source");
+}
+
+fn write_static_slice_bounds_main_exit_project(project: &Path) {
+    fs::create_dir_all(project.join("src"))
+        .expect("create static slice bounds main exit project src");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"cranelift-static-slice-bounds-main-exit\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
+    )
+    .expect("write static slice bounds main exit manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-static-slice-bounds-main-exit\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write static slice bounds main exit lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "static TAIL_START: int = 1\nstatic PREFIX_END: int = 2\n\nfn tail_score(values: [int; 3]): int {\nreturn len(values[TAIL_START:]) + first(values[TAIL_START:]) + last(values[TAIL_START:])\n}\n\nfn prefix_score(values: [int; 3]): int {\nreturn len(values[:PREFIX_END]) + first(values[:PREFIX_END]) + last(values[:PREFIX_END])\n}\n\nfn main(): int {\nlet tail_values: [int; 3] = [1, 20, 26]\nlet prefix_values: [int; 3] = [20, 26, 1]\nlet helper_tail_values: [int; 3] = [1, 20, 26]\nlet helper_prefix_values: [int; 3] = [20, 26, 1]\nlet tail_window: &[int] = tail_values[TAIL_START:]\nlet prefix_window: &[int] = prefix_values[:PREFIX_END]\nlet tail_code: int = len(tail_window) + first(tail_window) + last(tail_window)\nlet prefix_code: int = len(prefix_window) + first(prefix_window) + last(prefix_window)\nlet helper_tail: int = tail_score(helper_tail_values)\nlet helper_prefix: int = prefix_score(helper_prefix_values)\nif tail_code == 48 && prefix_code == 48 && helper_tail == 48 && helper_prefix == 48 {\nreturn 48\n} else {\nreturn 1\n}\n}\n",
+    )
+    .expect("write static slice bounds main exit source");
 }
 
 fn write_string_literal_len_main_exit_project(project: &Path) {

--- a/stage1/runtime-abi/direct-native-v0.json
+++ b/stage1/runtime-abi/direct-native-v0.json
@@ -39,7 +39,7 @@
       "status": "partial",
       "evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
       "blockers": [1001],
-      "notes": "The Cranelift spike evaluates borrowed array slices for len, first, last, indexing, and function returns. The direct-native runtime path now also lowers narrow static-range fixed-array slices such as values[1:] and values[:2] through len, first, and last for scalar and bool elements by projecting the underlying fixed-array slots, including helper-parameter arrays feeding a direct-native process exit status. Static-range fixed-array slices also support narrow literal and dynamic indexing over the sliced window through the same projection slots, including pre-runtime slice locals that alias the projected fixed-array slots. Broader borrowed-slice aliasing, dynamic slice bounds, slice returns, and host ABI coverage remain open."
+      "notes": "The Cranelift spike evaluates borrowed array slices for len, first, last, indexing, and function returns. The direct-native runtime path now also lowers narrow static-range fixed-array slices using literal or static scalar bounds such as values[1:], values[START:], values[:2], and values[:END] through len, first, and last for scalar and bool elements by projecting the underlying fixed-array slots, including helper-parameter arrays feeding a direct-native process exit status. Static-range fixed-array slices also support narrow literal and dynamic indexing over the sliced window through the same projection slots, including pre-runtime slice locals that alias the projected fixed-array slots. Broader borrowed-slice aliasing, dynamic slice bounds, slice returns, and host ABI coverage remain open."
     },
     {
       "id": "map.lookup",


### PR DESCRIPTION
## Summary
- Reject `main()` function programs that cannot lower through the direct-native i64 exit ABI instead of falling through to the print-only Cranelift spike.
- Add regression coverage for unsupported string helper parameters in a `main(): int` program so the backend fails cleanly rather than emitting an empty native binary.
- Keep the supported known-string runtime-exit fixture passing without generated Rust.

## Governing Issue
- Refs #1001
- This is a direct-native ABI safety slice and does not close #1001.

## Validation
- [x] `cargo fmt --manifest-path stage1/crates/axiomc/Cargo.toml -- --check`
- [x] `git diff --check`
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc cranelift_backend_lowers_string_literal_len_to_runtime_exit_code -- --nocapture`
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc cranelift_backend_rejects_unsupported_string_helper_main -- --nocapture`
- [x] `bash scripts/ci/test-check-direct-native-runtime-abi.sh`
- [x] `make stage1-direct-native-runtime-abi`

## Bootstrap Governance
- [x] Changes are scoped to #1001 direct-native runtime ABI correctness.
- [x] Contributor or PR guidance changes are not applicable.
- [x] Auto-merge should wait for the stack below this PR and required checks.
- [x] No real secrets, runtime auth, or machine-local env files are committed.

## Semantic Layer Checklist
- [x] Semantic node types added/changed: none; this is backend eligibility behavior.
- [x] Schemas added/changed: none.
- [x] Evidence added/changed: Cranelift backend regression test for unsupported string helper ABI rejection.
- [x] Rust capture check: supported known-string fixture still asserts `generated_rust` is null; unsupported string helper ABI now rejects instead of producing an incorrect native binary.
- [x] Agent-facing inspection impact: no inspection API impact.

## Flow Contract

- Owner lane: compiler/runtime
- Repair owner: Codex
- Autonomy class: bounded backend ABI safety slice
- Risk class: low; unsupported direct-native programs fail earlier instead of compiling wrong native output

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action.
- [x] No active blocking requested changes are known locally.
- [ ] Non-author approval is present when required.
- [ ] Auto-merge is appropriate when gates pass.

## Merge Automation

- [ ] Auto-merge is not enabled yet; this PR is stacked on #1008 and should merge after lower stack PRs are green and approved.

## Notes
- Stacked on #1008 (`codex/direct-native-static-slice-bounds`).
- Retarget to the next lower branch or `main` as stack PRs merge.
- General string helper parameters and returns remain tracked by #1001 until the direct-native ABI has a real string representation.
