### PR TITLE
Lower terminal panics natively

### DIFF
--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -747,8 +747,11 @@ and stderr streams from the native binary. The direct-native i64 path now also
 lowers deterministic public `std/log.ax` formatting wrappers for field
 construction, field-list joining, and event rendering into known string facts
 that can feed comparisons, length projections, and native process exit status
-without generated Rust. Stdin reads, runtime stderr emission, and broader
-streaming/runtime buffering remain tracked by issue #1001.
+without generated Rust. Terminal source-level `panic(...)` statements with
+known string messages, including terminal branch arms, also lower into native
+stderr JSON panic reports and exit status `1` without generated Rust. Stdin
+reads, runtime stderr emission, and broader streaming/runtime buffering remain
+tracked by issue #1001.
 
 The `clock.now_sleep` row now has partial Cranelift evidence for `std/time.ax`
 `now_ms`, `now`, `elapsed_ms`, and zero-duration `sleep`, plus guards that a

--- a/stage1/crates/axiomc-backend-cranelift/src/lib.rs
+++ b/stage1/crates/axiomc-backend-cranelift/src/lib.rs
@@ -155,6 +155,10 @@ pub struct I64Assign {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum I64Stmt {
     Assign(I64Assign),
+    WriteLine {
+        stream: OutputStream,
+        text: String,
+    },
     CallAssign {
         locals: Vec<usize>,
         function: usize,
@@ -367,10 +371,29 @@ fn emit_i64_exit_object(
             CraneliftBackendError::new(format!("cranelift object setup: {message}"))
         })?;
     let mut module = ObjectModule::new(builder);
+    let mut write_sig = module.make_signature();
+    write_sig.params.push(AbiParam::new(types::I32));
+    let pointer_type = module.target_config().pointer_type();
+    write_sig.params.push(AbiParam::new(pointer_type));
+    write_sig.params.push(AbiParam::new(pointer_type));
+    write_sig.returns.push(AbiParam::new(pointer_type));
+    let write_id = module
+        .declare_function("write", Linkage::Import, &write_sig)
+        .map_err(|message| {
+            CraneliftBackendError::new(format!("declare write import: {message}"))
+        })?;
+    let output_data_ids = declare_i64_output_data(&mut module, &program)?;
     let function_ids = declare_i64_functions(&mut module, &program.functions)?;
 
     for (index, function) in program.functions.iter().enumerate() {
-        define_i64_function(&mut module, &function_ids, index, function)?;
+        define_i64_function(
+            &mut module,
+            &function_ids,
+            write_id,
+            &output_data_ids,
+            index,
+            function,
+        )?;
     }
 
     let mut context = module.make_context();
@@ -389,6 +412,7 @@ fn emit_i64_exit_object(
         builder.switch_to_block(block);
         builder.seal_block(block);
         let function_refs = i64_function_refs(&mut module, &mut builder, &function_ids);
+        let write_ref = module.declare_func_in_func(write_id, builder.func);
         let mut locals = Vec::new();
         for local_expr in &program.locals {
             let local = builder.declare_var(types::I64);
@@ -396,8 +420,24 @@ fn emit_i64_exit_object(
             builder.def_var(local, value);
             locals.push(local);
         }
-        emit_i64_stmts(&mut builder, &locals, &function_refs, &program.stmts)?;
-        emit_i64_exit_body(&mut builder, &locals, &function_refs, &program.body)?;
+        emit_i64_stmts(
+            &mut module,
+            &mut builder,
+            &locals,
+            &function_refs,
+            write_ref,
+            &output_data_ids,
+            &program.stmts,
+        )?;
+        emit_i64_exit_body(
+            &mut module,
+            &mut builder,
+            &locals,
+            &function_refs,
+            write_ref,
+            &output_data_ids,
+            &program.body,
+        )?;
         builder.finalize();
     }
     module
@@ -411,6 +451,95 @@ fn emit_i64_exit_object(
     fs::write(object_path, bytes).map_err(|err| {
         CraneliftBackendError::new(format!("failed to write {}: {err}", object_path.display()))
     })
+}
+
+fn declare_i64_output_data(
+    module: &mut ObjectModule,
+    program: &I64ExitProgram,
+) -> Result<Vec<(OutputStream, String, cranelift_module::DataId, usize)>, CraneliftBackendError> {
+    let mut lines = Vec::new();
+    collect_i64_output_lines(&program.stmts, &mut lines);
+    collect_i64_exit_body_output_lines(&program.body, &mut lines);
+    for function in &program.functions {
+        collect_i64_output_lines(&function.stmts, &mut lines);
+        collect_i64_value_body_output_lines(&function.body, &mut lines);
+    }
+    lines
+        .into_iter()
+        .enumerate()
+        .map(|(index, (stream, text))| {
+            let data_id = module
+                .declare_data(
+                    &format!("__axiom_i64_line_{index}"),
+                    Linkage::Local,
+                    false,
+                    false,
+                )
+                .map_err(|message| {
+                    CraneliftBackendError::new(format!("declare i64 output data: {message}"))
+                })?;
+            let mut description = DataDescription::new();
+            let mut bytes = text.as_bytes().to_vec();
+            bytes.push(b'\n');
+            let byte_len = bytes.len();
+            description.define(bytes.into_boxed_slice());
+            module.define_data(data_id, &description).map_err(|message| {
+                CraneliftBackendError::new(format!("define i64 output data: {message}"))
+            })?;
+            Ok((stream, text, data_id, byte_len))
+        })
+        .collect()
+}
+
+fn collect_i64_output_lines(stmts: &[I64Stmt], lines: &mut Vec<(OutputStream, String)>) {
+    for stmt in stmts {
+        match stmt {
+            I64Stmt::WriteLine { stream, text } => lines.push((*stream, text.clone())),
+            I64Stmt::If {
+                then_body,
+                else_body,
+                ..
+            } => {
+                collect_i64_output_lines(then_body, lines);
+                collect_i64_output_lines(else_body, lines);
+            }
+            I64Stmt::While { body, .. } => collect_i64_output_lines(body, lines),
+            I64Stmt::Assign(_) | I64Stmt::CallAssign { .. } => {}
+        }
+    }
+}
+
+fn collect_i64_exit_body_output_lines(body: &I64ExitBody, lines: &mut Vec<(OutputStream, String)>) {
+    match body {
+        I64ExitBody::BlockReturn(block) => collect_i64_output_lines(&block.stmts, lines),
+        I64ExitBody::IfBlockReturn {
+            then_block,
+            else_block,
+            ..
+        } => {
+            collect_i64_output_lines(&then_block.stmts, lines);
+            collect_i64_output_lines(&else_block.stmts, lines);
+        }
+        I64ExitBody::Return(_) | I64ExitBody::IfReturn { .. } => {}
+    }
+}
+
+fn collect_i64_value_body_output_lines(
+    body: &I64ValueBody,
+    lines: &mut Vec<(OutputStream, String)>,
+) {
+    match body {
+        I64ValueBody::BlockReturn(block) => collect_i64_output_lines(&block.stmts, lines),
+        I64ValueBody::IfBlockReturn {
+            then_block,
+            else_block,
+            ..
+        } => {
+            collect_i64_output_lines(&then_block.stmts, lines);
+            collect_i64_output_lines(&else_block.stmts, lines);
+        }
+        I64ValueBody::Return(_) | I64ValueBody::IfReturn { .. } => {}
+    }
 }
 
 fn declare_i64_functions(
@@ -444,6 +573,8 @@ fn declare_i64_functions(
 fn define_i64_function(
     module: &mut ObjectModule,
     function_ids: &[FuncId],
+    write_id: FuncId,
+    output_data_ids: &[(OutputStream, String, cranelift_module::DataId, usize)],
     index: usize,
     function: &I64Function,
 ) -> Result<(), CraneliftBackendError> {
@@ -473,6 +604,7 @@ fn define_i64_function(
         builder.switch_to_block(block);
         builder.seal_block(block);
         let function_refs = i64_function_refs(module, &mut builder, function_ids);
+        let write_ref = module.declare_func_in_func(write_id, builder.func);
         let mut locals = Vec::new();
         for param in builder.block_params(block).to_vec() {
             let local = builder.declare_var(types::I64);
@@ -485,11 +617,22 @@ fn define_i64_function(
             builder.def_var(local, value);
             locals.push(local);
         }
-        emit_i64_stmts(&mut builder, &locals, &function_refs, &function.stmts)?;
-        emit_i64_value_body(
+        emit_i64_stmts(
+            module,
             &mut builder,
             &locals,
             &function_refs,
+            write_ref,
+            output_data_ids,
+            &function.stmts,
+        )?;
+        emit_i64_value_body(
+            module,
+            &mut builder,
+            &locals,
+            &function_refs,
+            write_ref,
+            output_data_ids,
             function.returns,
             &function.body,
         )?;
@@ -514,25 +657,42 @@ fn i64_function_refs(
 }
 
 fn emit_i64_stmts(
+    module: &mut ObjectModule,
     builder: &mut FunctionBuilder<'_>,
     locals: &[Variable],
     function_refs: &[FuncRef],
+    write_ref: FuncRef,
+    output_data_ids: &[(OutputStream, String, cranelift_module::DataId, usize)],
     stmts: &[I64Stmt],
 ) -> Result<(), CraneliftBackendError> {
     for stmt in stmts {
-        emit_i64_stmt(builder, locals, function_refs, stmt)?;
+        emit_i64_stmt(
+            module,
+            builder,
+            locals,
+            function_refs,
+            write_ref,
+            output_data_ids,
+            stmt,
+        )?;
     }
     Ok(())
 }
 
 fn emit_i64_stmt(
+    module: &mut ObjectModule,
     builder: &mut FunctionBuilder<'_>,
     locals: &[Variable],
     function_refs: &[FuncRef],
+    write_ref: FuncRef,
+    output_data_ids: &[(OutputStream, String, cranelift_module::DataId, usize)],
     stmt: &I64Stmt,
 ) -> Result<(), CraneliftBackendError> {
     match stmt {
         I64Stmt::Assign(assign) => emit_i64_assign(builder, locals, function_refs, assign),
+        I64Stmt::WriteLine { stream, text } => {
+            emit_i64_write_line(module, builder, write_ref, output_data_ids, *stream, text)
+        }
         I64Stmt::CallAssign {
             locals: assign_locals,
             function,
@@ -560,12 +720,28 @@ fn emit_i64_stmt(
 
             builder.switch_to_block(then_block);
             builder.seal_block(then_block);
-            emit_i64_stmts(builder, locals, function_refs, then_body)?;
+            emit_i64_stmts(
+                module,
+                builder,
+                locals,
+                function_refs,
+                write_ref,
+                output_data_ids,
+                then_body,
+            )?;
             builder.ins().jump(after_if, &[]);
 
             builder.switch_to_block(else_block);
             builder.seal_block(else_block);
-            emit_i64_stmts(builder, locals, function_refs, else_body)?;
+            emit_i64_stmts(
+                module,
+                builder,
+                locals,
+                function_refs,
+                write_ref,
+                output_data_ids,
+                else_body,
+            )?;
             builder.ins().jump(after_if, &[]);
 
             builder.switch_to_block(after_if);
@@ -586,7 +762,15 @@ fn emit_i64_stmt(
 
             builder.switch_to_block(loop_body);
             builder.seal_block(loop_body);
-            emit_i64_stmts(builder, locals, function_refs, body)?;
+            emit_i64_stmts(
+                module,
+                builder,
+                locals,
+                function_refs,
+                write_ref,
+                output_data_ids,
+                body,
+            )?;
             builder.ins().jump(loop_header, &[]);
             builder.seal_block(loop_header);
 
@@ -595,6 +779,35 @@ fn emit_i64_stmt(
             Ok(())
         }
     }
+}
+
+fn emit_i64_write_line(
+    module: &mut ObjectModule,
+    builder: &mut FunctionBuilder<'_>,
+    write_ref: FuncRef,
+    output_data_ids: &[(OutputStream, String, cranelift_module::DataId, usize)],
+    stream: OutputStream,
+    text: &str,
+) -> Result<(), CraneliftBackendError> {
+    let (data_id, byte_len) = output_data_ids
+        .iter()
+        .find_map(|(candidate_stream, candidate_text, data_id, byte_len)| {
+            (*candidate_stream == stream && candidate_text == text).then_some((data_id, byte_len))
+        })
+        .ok_or_else(|| CraneliftBackendError::new("missing i64 output line data"))?;
+    let data_ref = module.declare_data_in_func(*data_id, builder.func);
+    let pointer_type = module.target_config().pointer_type();
+    let pointer = builder.ins().global_value(pointer_type, data_ref);
+    let fd = builder.ins().iconst(
+        types::I32,
+        match stream {
+            OutputStream::Stdout => 1,
+            OutputStream::Stderr => 2,
+        },
+    );
+    let len = builder.ins().iconst(pointer_type, *byte_len as i64);
+    builder.ins().call(write_ref, &[fd, pointer, len]);
+    Ok(())
 }
 
 fn emit_i64_assign(
@@ -650,15 +863,26 @@ fn emit_i64_call_assign(
 }
 
 fn emit_i64_exit_body(
+    module: &mut ObjectModule,
     builder: &mut FunctionBuilder<'_>,
     locals: &[Variable],
     function_refs: &[FuncRef],
+    write_ref: FuncRef,
+    output_data_ids: &[(OutputStream, String, cranelift_module::DataId, usize)],
     body: &I64ExitBody,
 ) -> Result<(), CraneliftBackendError> {
     match body {
         I64ExitBody::Return(result) => emit_i64_return(builder, locals, function_refs, result),
         I64ExitBody::BlockReturn(block) => {
-            emit_i64_stmts(builder, locals, function_refs, &block.stmts)?;
+            emit_i64_stmts(
+                module,
+                builder,
+                locals,
+                function_refs,
+                write_ref,
+                output_data_ids,
+                &block.stmts,
+            )?;
             emit_i64_return(builder, locals, function_refs, &block.result)
         }
         I64ExitBody::IfReturn {
@@ -699,21 +923,40 @@ fn emit_i64_exit_body(
 
             builder.switch_to_block(then_cranelift_block);
             builder.seal_block(then_cranelift_block);
-            emit_i64_stmts(builder, locals, function_refs, &then_block.stmts)?;
+            emit_i64_stmts(
+                module,
+                builder,
+                locals,
+                function_refs,
+                write_ref,
+                output_data_ids,
+                &then_block.stmts,
+            )?;
             emit_i64_return(builder, locals, function_refs, &then_block.result)?;
 
             builder.switch_to_block(else_cranelift_block);
             builder.seal_block(else_cranelift_block);
-            emit_i64_stmts(builder, locals, function_refs, &else_block.stmts)?;
+            emit_i64_stmts(
+                module,
+                builder,
+                locals,
+                function_refs,
+                write_ref,
+                output_data_ids,
+                &else_block.stmts,
+            )?;
             emit_i64_return(builder, locals, function_refs, &else_block.result)
         }
     }
 }
 
 fn emit_i64_value_body(
+    module: &mut ObjectModule,
     builder: &mut FunctionBuilder<'_>,
     locals: &[Variable],
     function_refs: &[FuncRef],
+    write_ref: FuncRef,
+    output_data_ids: &[(OutputStream, String, cranelift_module::DataId, usize)],
     returns: usize,
     body: &I64ValueBody,
 ) -> Result<(), CraneliftBackendError> {
@@ -722,7 +965,15 @@ fn emit_i64_value_body(
             emit_i64_value_return(builder, locals, function_refs, returns, results)
         }
         I64ValueBody::BlockReturn(block) => {
-            emit_i64_stmts(builder, locals, function_refs, &block.stmts)?;
+            emit_i64_stmts(
+                module,
+                builder,
+                locals,
+                function_refs,
+                write_ref,
+                output_data_ids,
+                &block.stmts,
+            )?;
             emit_i64_value_return(builder, locals, function_refs, returns, &block.results)
         }
         I64ValueBody::IfReturn {
@@ -763,12 +1014,28 @@ fn emit_i64_value_body(
 
             builder.switch_to_block(then_cranelift_block);
             builder.seal_block(then_cranelift_block);
-            emit_i64_stmts(builder, locals, function_refs, &then_block.stmts)?;
+            emit_i64_stmts(
+                module,
+                builder,
+                locals,
+                function_refs,
+                write_ref,
+                output_data_ids,
+                &then_block.stmts,
+            )?;
             emit_i64_value_return(builder, locals, function_refs, returns, &then_block.results)?;
 
             builder.switch_to_block(else_cranelift_block);
             builder.seal_block(else_cranelift_block);
-            emit_i64_stmts(builder, locals, function_refs, &else_block.stmts)?;
+            emit_i64_stmts(
+                module,
+                builder,
+                locals,
+                function_refs,
+                write_ref,
+                output_data_ids,
+                &else_block.stmts,
+            )?;
             emit_i64_value_return(builder, locals, function_refs, returns, &else_block.results)
         }
     }

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -11,7 +11,7 @@ use axiomc_backend_cranelift::{
     I64Expr as CraneliftI64Expr, I64Function as CraneliftI64Function,
     I64ReturnBlock as CraneliftI64ReturnBlock, I64Stmt as CraneliftI64Stmt,
     I64ValueBody as CraneliftI64ValueBody, I64ValueReturnBlock as CraneliftI64ValueReturnBlock,
-    OutputLine,
+    OutputLine, OutputStream,
 };
 use std::collections::{HashMap, HashSet};
 use std::env;
@@ -872,6 +872,7 @@ fn lower_i64_exit_program(program: &Program, fs_root: &Path) -> Option<I64ExitPr
         &helper_signatures,
         &static_bindings,
         &struct_defs,
+        true,
     )?;
     Some(I64ExitProgram {
         functions,
@@ -966,6 +967,7 @@ fn lower_i64_function(
         helper_signatures,
         static_bindings,
         struct_defs,
+        false,
     )?;
     Some(CraneliftI64Function {
         params: i64_abi_param_count(&function.params, struct_defs, static_bindings)?,
@@ -2251,6 +2253,7 @@ fn lower_i64_body(
     helper_signatures: &HashMap<&str, I64HelperSignature>,
     static_bindings: &I64StaticBindings,
     struct_defs: &I64StructDefs<'_>,
+    allow_terminal_panic: bool,
 ) -> Option<(Vec<CraneliftI64Expr>, Vec<CraneliftI64Stmt>, I64ExitBody)> {
     let (return_stmt, body_stmts) = stmts.split_last()?;
     let mut locals = Vec::new();
@@ -2841,6 +2844,13 @@ fn lower_i64_body(
                 else_block,
             }
         }
+        Stmt::Panic { message, .. } if allow_terminal_panic => lower_i64_panic_exit_body(
+            message,
+            &local_indexes,
+            &local_conditions,
+            helper_signatures,
+            static_bindings,
+        )?,
         _ => return None,
     };
     Some((locals, lowered_stmts, body))
@@ -4643,39 +4653,52 @@ fn lower_i64_return_block(
     helper_signatures: &HashMap<&str, I64HelperSignature>,
     static_bindings: &I64StaticBindings,
 ) -> Option<CraneliftI64ReturnBlock> {
-    let (return_stmt, body_stmts) = stmts.split_last()?;
-    let Stmt::Return { expr, .. } = return_stmt else {
-        return None;
-    };
+    let (terminal_stmt, body_stmts) = stmts.split_last()?;
     let mut stmts = Vec::new();
     for stmt in body_stmts {
-        if matches!(stmt, Stmt::Let { .. }) {
-            stmts.extend(lower_i64_runtime_let_stmts(
-                stmt,
-                locals,
-                &mut local_indexes,
-                &mut local_conditions,
-                helper_signatures,
-                static_bindings,
-            )?);
-        } else {
-            stmts.extend(lower_i64_runtime_stmt_stmts(
-                stmt,
-                locals,
-                local_indexes.clone(),
-                local_conditions.clone(),
-                helper_signatures,
-                static_bindings,
-            )?);
+        match stmt {
+            Stmt::Let { .. } => {
+                stmts.extend(lower_i64_runtime_let_stmts(
+                    stmt,
+                    locals,
+                    &mut local_indexes,
+                    &mut local_conditions,
+                    helper_signatures,
+                    static_bindings,
+                )?);
+            }
+            _ => {
+                stmts.extend(lower_i64_runtime_stmt_stmts(
+                    stmt,
+                    locals,
+                    local_indexes.clone(),
+                    local_conditions.clone(),
+                    helper_signatures,
+                    static_bindings,
+                )?);
+            }
         }
     }
-    let result = lower_i64_return_value_expr(
-        expr,
-        &local_indexes,
-        &local_conditions,
-        helper_signatures,
-        static_bindings,
-    )?;
+    let result = match terminal_stmt {
+        Stmt::Return { expr, .. } => lower_i64_return_value_expr(
+            expr,
+            &local_indexes,
+            &local_conditions,
+            helper_signatures,
+            static_bindings,
+        )?,
+        Stmt::Panic { message, .. } => {
+            stmts.extend(lower_i64_panic_report_stmts(
+                message,
+                &local_indexes,
+                &local_conditions,
+                helper_signatures,
+                static_bindings,
+            )?);
+            CraneliftI64Expr::Literal(1)
+        }
+        _ => return None,
+    };
     Some(CraneliftI64ReturnBlock { stmts, result })
 }
 
@@ -4725,6 +4748,43 @@ fn lower_i64_exit_return(
         )?)),
         _ => None,
     }
+}
+
+fn lower_i64_panic_exit_body(
+    message: &Expr,
+    local_indexes: &HashMap<String, usize>,
+    local_conditions: &HashMap<String, CraneliftI64Condition>,
+    helper_signatures: &HashMap<&str, I64HelperSignature>,
+    static_bindings: &I64StaticBindings,
+) -> Option<I64ExitBody> {
+    let stmts = lower_i64_panic_report_stmts(
+        message,
+        local_indexes,
+        local_conditions,
+        helper_signatures,
+        static_bindings,
+    )?;
+    Some(I64ExitBody::BlockReturn(CraneliftI64ReturnBlock {
+        stmts,
+        result: CraneliftI64Expr::Literal(1),
+    }))
+}
+
+fn lower_i64_panic_report_stmts(
+    message: &Expr,
+    _local_indexes: &HashMap<String, usize>,
+    _local_conditions: &HashMap<String, CraneliftI64Condition>,
+    _helper_signatures: &HashMap<&str, I64HelperSignature>,
+    static_bindings: &I64StaticBindings,
+) -> Option<Vec<CraneliftI64Stmt>> {
+    let message = i64_string_text(message, static_bindings)?;
+    Some(vec![CraneliftI64Stmt::WriteLine {
+        stream: OutputStream::Stderr,
+        text: format!(
+            "{{\"kind\":\"panic\",\"message\":{}}}",
+            json_escape_string(&message)
+        ),
+    }])
 }
 
 fn lower_i64_option_match_exit_return(

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -100,6 +100,118 @@ fn cranelift_backend_lowers_i64_main_to_runtime_exit_code() {
 
 #[cfg(not(windows))]
 #[test]
+fn cranelift_backend_lowers_terminal_panic_to_native_report() {
+    if which::which("cc").is_err() {
+        eprintln!("skipping cranelift backend smoke test because cc is unavailable");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let known_project = temp.path().join("terminal-panic-known");
+    write_terminal_panic_project(
+        &known_project,
+        r#"fn main(): int {
+panic("boom")
+}
+"#,
+    );
+    assert_terminal_panic_report(
+        &known_project,
+        "{\"kind\":\"panic\",\"message\":\"boom\"}\n",
+    );
+
+    let then_branch_project = temp.path().join("terminal-panic-then-branch");
+    write_terminal_panic_project(
+        &then_branch_project,
+        r#"fn should_panic(): bool {
+return true
+}
+
+fn main(): int {
+if should_panic() {
+panic("then boom")
+} else {
+return 0
+}
+}
+"#,
+    );
+    assert_terminal_panic_report(
+        &then_branch_project,
+        "{\"kind\":\"panic\",\"message\":\"then boom\"}\n",
+    );
+
+    let else_branch_project = temp.path().join("terminal-panic-else-branch");
+    write_terminal_panic_project(
+        &else_branch_project,
+        r#"fn should_panic(): bool {
+return false
+}
+
+fn main(): int {
+if should_panic() {
+return 0
+} else {
+panic("else boom")
+}
+}
+"#,
+    );
+    assert_terminal_panic_report(
+        &else_branch_project,
+        "{\"kind\":\"panic\",\"message\":\"else boom\"}\n",
+    );
+}
+
+#[cfg(not(windows))]
+#[test]
+fn cranelift_backend_rejects_helper_terminal_panic_as_native_value_return() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("terminal-panic-helper");
+    write_terminal_panic_project(
+        &project,
+        r#"fn fail(): int {
+panic("helper boom")
+}
+
+fn main(): int {
+let ignored: int = fail()
+return 0
+}
+"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+    assert!(
+        !output.status.success(),
+        "cranelift helper panic build unexpectedly succeeded: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
+    assert_eq!(payload["ok"], Value::Bool(false));
+    assert!(
+        payload["error"]["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("main function is outside the direct-native i64 ABI subset"),
+        "unexpected helper panic rejection: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[cfg(not(windows))]
+#[test]
 fn cranelift_backend_lowers_i64_returning_main_to_runtime_exit_code() {
     if which::which("cc").is_err() {
         eprintln!("skipping cranelift backend smoke test because cc is unavailable");
@@ -5670,6 +5782,52 @@ fn write_i64_returning_main_exit_project(project: &Path) {
         "fn main(): i64 {\nreturn 48i64\n}\n",
     )
     .expect("write i64 returning main exit source");
+}
+
+fn write_terminal_panic_project(project: &Path, source: &str) {
+    fs::create_dir_all(project.join("src")).expect("create terminal panic project src");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"cranelift-terminal-panic\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = false\nclock = false\ncrypto = false\n",
+    )
+    .expect("write terminal panic manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-terminal-panic\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write terminal panic lockfile");
+    fs::write(project.join("src/main.ax"), source).expect("write terminal panic source");
+}
+
+fn assert_terminal_panic_report(project: &Path, expected_stderr: &str) {
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+    assert!(
+        output.status.success(),
+        "cranelift terminal panic build failed for {}: stdout={} stderr={}",
+        project.display(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
+    assert_eq!(payload["backend"], "cranelift");
+    assert_eq!(payload["generated_rust"], Value::Null);
+    let binary = payload["binary"].as_str().expect("binary path");
+    let run = Command::new(binary)
+        .output()
+        .expect("run cranelift terminal panic binary");
+    assert_eq!(run.status.code(), Some(1));
+    assert_eq!(String::from_utf8_lossy(&run.stdout), "");
+    assert_eq!(String::from_utf8_lossy(&run.stderr), expected_stderr);
 }
 
 fn write_typed_numeric_returning_main_exit_project(

--- a/stage1/runtime-abi/direct-native-v0.json
+++ b/stage1/runtime-abi/direct-native-v0.json
@@ -293,7 +293,7 @@
       "capability": null,
       "evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
       "blockers": [1001],
-      "notes": "The Cranelift spike now builds and runs std/io eprintln with stdout and stderr output from the native binary, and std/log.ax event formatting plus info_attrs stderr emission without generated Rust. The direct-native i64 path now also lowers deterministic public std/log.ax formatting wrappers for field construction, field-list joining, and event rendering into known string facts that can feed comparisons, length projections, and native process exit status without generated Rust. Stdin reads, runtime stderr emission, and broader streaming/runtime buffering remain open."
+      "notes": "The Cranelift spike now builds and runs std/io eprintln with stdout and stderr output from the native binary, and std/log.ax event formatting plus info_attrs stderr emission without generated Rust. The direct-native i64 path now also lowers deterministic public std/log.ax formatting wrappers for field construction, field-list joining, and event rendering into known string facts that can feed comparisons, length projections, and native process exit status without generated Rust. Terminal source-level panic(...) statements with known string messages, including terminal branch arms, also lower into native stderr JSON panic reports and exit status 1 without generated Rust. Stdin reads, runtime stderr emission, and broader streaming/runtime buffering remain open."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add direct-native i64 write-line support in the Cranelift backend so native exit programs can emit stdout/stderr lines without generated Rust.
- Lower known-message terminal `panic(...)` paths, including terminal branch arms, into native JSON stderr reports with exit status 1.
- Update the direct-native runtime ABI evidence for the logging/stdio row while keeping the overall Rust-exit gate partial under #1001.

## Governing Issue
- Refs #1001

## Validation
- [x] `cargo test --manifest-path stage1/crates/axiomc/Cargo.toml --test cranelift_backend cranelift_backend_lowers_terminal_panic_to_native_report -- --nocapture`
- [x] `cargo test --manifest-path stage1/crates/axiomc-backend-cranelift/Cargo.toml`
- [x] `cargo fmt --manifest-path stage1/crates/axiomc/Cargo.toml -- --check`
- [x] `python3 -m json.tool stage1/runtime-abi/direct-native-v0.json`
- [x] `git diff --check`
- [x] `bash scripts/ci/test-check-direct-native-runtime-abi.sh`
- [x] `make stage1-direct-native-runtime-abi`
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

## Bootstrap Governance
- [x] Changes are scoped to the linked issue.
- [x] Contributor or PR guidance changes are not applicable.
- [ ] Auto-merge is not enabled yet; wait for required checks and non-author approval before enabling or merging.
- [x] No real secrets, runtime auth, or machine-local env files are committed.

## Semantic Layer Checklist
- [x] Semantic node types added/changed: none.
- [x] Schemas added/changed: none.
- [x] Evidence added/changed: `docs/direct-native-runtime-abi-v0.md`, `stage1/runtime-abi/direct-native-v0.json`, and Cranelift regression coverage.
- [x] Rust capture check: backend-specific direct-native lowering only; no new Rust semantic contract.
- [x] Agent-facing inspection impact: none.

## Flow Contract
- Owner lane: compiler/runtime
- Repair owner: branch author
- Autonomy class: PR-gated backend slice
- Risk class: medium

## Flow Merge Readiness
- [x] Every blocker has a next actor and next action: CI/review must run on this PR; remaining ABI rows stay under #1001.
- [x] No active blocking requested changes remain at PR creation.
- [ ] Non-author approval is present when required.
- [ ] Auto-merge is appropriate when gates pass.

## Merge Automation
- [ ] Auto-merge is not enabled yet; enable only after checks and approval are clear.

## Notes
- Current stage1 control-flow validation rejects statements after `panic(...)` as unreachable, so this PR intentionally covers terminal panic paths only.
- `make stage1-direct-native-runtime-abi` still reports `ready:false`, `errors:[]`, blocker `#1001`.
