### PR TITLE
Accept rust backend fallback alias

### DIFF
--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -335,10 +335,12 @@ still far from the stated 1.0 target for service and agent workloads.
 
 - `axiomc build` now defaults to the direct-native Cranelift backend for native
   builds, with `--backend generated-rust` retained as an explicit compatibility
-  fallback. Targeted builds such as `--target wasm32` continue to default to
-  generated Rust until direct-native target support lands. The direct-native
-  path folds the supported MIR subset into print lines, emits a Cranelift
-  object, and links it with the host linker.
+  fallback. `--backend rust` is accepted as a transition alias for the same
+  generated-Rust backend so existing fallback workflows can keep their current
+  spelling for one release. Targeted builds such as `--target wasm32` continue
+  to default to generated Rust until direct-native target support lands. The
+  direct-native path folds the supported MIR subset into print lines, emits a
+  Cranelift object, and links it with the host linker.
 - The backend-selection surface remains preparatory backend plumbing for later
   native-backend expansion. `generated-rust` remains the broad compatibility
   backend; `cranelift` is intentionally limited to scalar print-line programs,

--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -56,10 +56,10 @@ impl FromStr for NativeBackendKind {
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         match value {
-            "generated-rust" => Ok(Self::GeneratedRust),
+            "generated-rust" | "rust" => Ok(Self::GeneratedRust),
             "cranelift" => Ok(Self::Cranelift),
             other => Err(format!(
-                "unsupported backend {other:?}; supported backends: generated-rust, cranelift"
+                "unsupported backend {other:?}; supported backends: generated-rust, rust, cranelift"
             )),
         }
     }
@@ -86,6 +86,14 @@ mod tests {
     }
 
     #[test]
+    fn parses_rust_backend_alias() {
+        assert_eq!(
+            NativeBackendKind::from_str("rust").expect("parse rust alias"),
+            NativeBackendKind::GeneratedRust
+        );
+    }
+
+    #[test]
     fn parses_cranelift_backend() {
         assert_eq!(
             NativeBackendKind::from_str("cranelift").expect("parse cranelift"),
@@ -97,7 +105,7 @@ mod tests {
     fn rejects_unsupported_backend_value() {
         let error = NativeBackendKind::from_str("direct-native")
             .expect_err("unsupported backend values should be rejected");
-        assert!(error.contains("supported backends: generated-rust, cranelift"));
+        assert!(error.contains("supported backends: generated-rust, rust, cranelift"));
     }
 
     #[test]

--- a/stage1/crates/axiomc/src/main.rs
+++ b/stage1/crates/axiomc/src/main.rs
@@ -81,7 +81,7 @@ enum Command {
         path: PathBuf,
         #[arg(long)]
         json: bool,
-        /// Select the build backend. When omitted, native builds default to `cranelift` while targeted builds keep `generated-rust` for compatibility.
+        /// Select the build backend. When omitted, native builds default to `cranelift` while targeted builds keep `generated-rust` for compatibility. `rust` is accepted as a transition alias for `generated-rust`.
         #[arg(long)]
         backend: Option<NativeBackendKind>,
         #[arg(long)]
@@ -7549,6 +7549,7 @@ mod tests {
             .to_string();
         assert!(build_help.contains("native builds default to `cranelift`"));
         assert!(build_help.contains("targeted builds keep `generated-rust` for compatibility"));
+        assert!(build_help.contains("`rust` is accepted as a transition alias"));
         assert!(
             build_help.contains("Build a stage1 package through the default direct-native backend")
         );
@@ -8034,6 +8035,17 @@ return "ok"
     }
 
     #[test]
+    fn build_accepts_rust_backend_alias() {
+        let cli = Cli::parse_from(["axiomc", "build", ".", "--backend", "rust"]);
+        match cli.command {
+            Command::Build { backend, .. } => {
+                assert_eq!(backend, Some(NativeBackendKind::GeneratedRust));
+            }
+            other => panic!("expected build command, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn build_target_accepts_explicit_cranelift_backend() {
         let cli = Cli::parse_from([
             "axiomc",
@@ -8097,7 +8109,7 @@ return "ok"
             );
         let rendered = error.to_string();
         assert!(rendered.contains("unsupported backend \"direct-native\""));
-        assert!(rendered.contains("supported backends: generated-rust, cranelift"));
+        assert!(rendered.contains("supported backends: generated-rust, rust, cranelift"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Accept `--backend rust` as a transition alias for the generated-Rust fallback.
- Keep output canonical as `generated-rust`, including JSON payloads and backend-specific cache metadata.
- Document the alias in the Stage 1 backend/tooling gap notes.

## Governing Issue

Related to #693. This is a stacked follow-up to #1025 and does not close the issue by itself.

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Local checks:

- `cargo test --manifest-path stage1/Cargo.toml -p axiomc parses_rust_backend_alias -- --nocapture`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc build_accepts_rust_backend_alias -- --nocapture`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc help_describes_supported_stage1_workflows -- --nocapture`
- `cargo fmt --manifest-path stage1/crates/axiomc/Cargo.toml -- --check`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --bin axiomc`
- `git diff --check`
- `cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build stage1/examples/hello --backend rust --json`

Skipped checks:

- No full `make stage1-test stage1-smoke`; this branch only changes CLI backend parsing, help text, and docs. The focused CLI suite and smoke command cover the changed behavior.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

Auto-merge note:

- Not enabled at creation because this PR is stacked on #1025.

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Semantic impact:

- Semantic node types: none.
- Schemas: none.
- Evidence: CLI parser tests and one build smoke command for the alias.
- Rust capture risk: intentionally backend-specific; the alias preserves the generated-Rust fallback spelling while native builds move to Cranelift by default.
- Agent-facing inspection impact: `--backend rust` parses to the canonical `generated-rust` backend, so JSON and cache metadata remain stable for agents.

## Flow Contract

- Owner lane: Daedalus / runtime
- Repair owner: codex
- Autonomy class: scoped implementation
- Risk class: low

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [ ] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is appropriate when gates pass

Blockers:

- Next actor: reviewer. Next action: review after #1025 is ready, because this PR is stacked on that branch.

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

Auto-merge note:

- Unsafe at creation because the PR is stacked on #1025.

## Notes

- This branch intentionally does not modify #1025, preserving the current reviewed head for the default Cranelift backend switch.
