### PR TITLE
[codex] Prove signature helper evidence

### DIFF
--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -540,9 +540,12 @@ The direct-native crypto signature slice is now marked partial: the Cranelift
 spike builds and runs `std/crypto_sign.ax` Ed25519 key generation, signing, and
 verification while the public smoke asserts `generated_rust` is null by
 dynamically loading the host libcrypto EVP provider for real cryptographic
-operations. Packages without the `crypto` capability still fail before backend
-lowering. Runtime-integrated crypto provider selection, deterministic test
-hooks, audit parity, and non-Unix support remain open under #1001.
+operations. The smoke now also sends Ed25519 verification, signature length, and
+public-key length projections through helper functions before native binary
+stdout, proving those crypto byte-array values can cross helper boundaries in
+the spike path. Packages without the `crypto` capability still fail before
+backend lowering. Runtime-integrated crypto provider selection, deterministic
+test hooks, audit parity, and non-Unix support remain open under #1001.
 
 The direct-native crypto AEAD slice is now marked partial: the Cranelift spike
 builds and runs `std/crypto_aead.ax` AES-256-GCM seal/open while the public

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -6390,7 +6390,7 @@ fn cranelift_backend_builds_crypto_signature_binary() {
         "cranelift crypto signature binary failed: stderr={}",
         String::from_utf8_lossy(&run.stderr)
     );
-    assert_eq!(String::from_utf8_lossy(&run.stdout), "true\n");
+    assert_eq!(String::from_utf8_lossy(&run.stdout), "true\ntrue\n64\n32\n");
 }
 
 #[test]
@@ -10825,7 +10825,7 @@ fn write_crypto_signature_project(project: &Path, crypto: bool) {
     .expect("write crypto signature lockfile");
     fs::write(
         project.join("src/main.ax"),
-        "import \"std/crypto_sign.ax\"\nlet message: [u8] = [104u8, 101u8, 108u8, 108u8, 111u8]\nlet keys: ([u8], [u8]) = ed25519_keygen()\nlet public_key: [u8] = keys.0\nlet secret_key: [u8] = keys.1\nlet signature: [u8] = ed25519_sign(secret_key[:], message[:])\nprint ed25519_verify(public_key[:], message[:], signature[:])\n",
+        "import \"std/crypto_sign.ax\"\n\nfn signature_ok(public_key: &[u8], message: &[u8], signature: &[u8]): bool {\nreturn ed25519_verify(public_key, message, signature)\n}\n\nfn signature_len(secret_key: &[u8], message: &[u8]): int {\nreturn len(ed25519_sign(secret_key, message))\n}\n\nfn public_key_len(public_key: &[u8]): int {\nreturn len(public_key)\n}\n\nlet message: [u8] = [104u8, 101u8, 108u8, 108u8, 111u8]\nlet keys: ([u8], [u8]) = ed25519_keygen()\nlet public_key: [u8] = keys.0\nlet secret_key: [u8] = keys.1\nlet signature: [u8] = ed25519_sign(secret_key[:], message[:])\nprint ed25519_verify(public_key[:], message[:], signature[:])\nprint signature_ok(public_key[:], message[:], signature[:])\nprint signature_len(secret_key[:], message[:])\nprint public_key_len(public_key[:])\n",
     )
     .expect("write crypto signature source");
 }

--- a/stage1/runtime-abi/direct-native-v0.json
+++ b/stage1/runtime-abi/direct-native-v0.json
@@ -310,7 +310,7 @@
       ],
       "blockers": [1001],
       "denial_evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
-      "notes": "The Cranelift spike builds and runs std/crypto_sign.ax Ed25519 key generation, signing, and verification while the public smoke asserts generated_rust is null by dynamically loading the host libcrypto EVP provider for real cryptographic operations. Packages without the crypto capability receive the public manifest-policy denial before backend lowering. Runtime-integrated crypto provider selection, deterministic test hooks, audit parity, and non-Unix support remain blocked."
+      "notes": "The Cranelift spike builds and runs std/crypto_sign.ax Ed25519 key generation, signing, and verification while the public smoke asserts generated_rust is null by dynamically loading the host libcrypto EVP provider for real cryptographic operations. The smoke also sends Ed25519 verification, signature length, and public-key length projections through helper functions before native binary stdout, proving those crypto byte-array values can cross helper boundaries in the spike path. Packages without the crypto capability receive the public manifest-policy denial before backend lowering. Runtime-integrated crypto provider selection, deterministic test hooks, audit parity, and non-Unix support remain blocked."
     },
     {
       "id": "crypto.aead",


### PR DESCRIPTION
## Summary

- Add direct-native runtime smoke coverage for Ed25519 signature verification and byte-length projections returned through helper functions.
- Document the `crypto.signature` runtime ABI evidence without claiming runtime-integrated provider selection is complete.
- Keep direct-native runtime ABI readiness partial under #1001.

## Governing Issue

Refs #1001

## Validation

- [x] Relevant local checks passed
  - `cargo test --manifest-path stage1/Cargo.toml -p axiomc cranelift_backend_builds_crypto_signature_binary -- --nocapture`
  - `cargo test --manifest-path stage1/Cargo.toml -p axiomc cranelift_backend_rejects_crypto_signature_denial_before_backend_lowering -- --nocapture`
  - `bash scripts/ci/test-check-direct-native-runtime-abi.sh`
  - `python3 scripts/ci/check-direct-native-runtime-abi.py --contract stage1/runtime-abi/direct-native-v0.json --json`
  - `bash scripts/ci/test-check-rust-exit-readiness.sh`
  - `cargo fmt --manifest-path stage1/crates/axiomc/Cargo.toml -- --check`
  - `git diff --check`
  - `SSL_CERT_FILE=/Users/johnteneyckjr./Library/Python/3.10/lib/python/site-packages/certifi/cacert.pem bash scripts/ci/run-fast-checks.sh`
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
  - None.
- [x] Schemas added/changed are listed, or this PR does not touch schemas
  - None.
- [x] Evidence added/changed is listed, or this PR does not touch evidence
  - `crypto.signature` direct-native runtime ABI evidence now names Ed25519 verification, signature length, and public-key length projections crossing helper boundaries before native binary stdout.
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
  - Low risk: this is direct-native Cranelift evidence and runtime ABI metadata, not generated-Rust semantics.
- [x] Agent-facing inspection impact is described, or there is no inspection impact
  - Agents auditing #1001 can see Ed25519 signature values crossing direct-native helper boundaries; the row remains partial.

## Flow Contract

- Owner lane: compiler/runtime
- Repair owner: Codex
- Autonomy class: supervised
- Risk class: low

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [ ] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is appropriate when gates pass

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- Merge readiness waits on reviewer action; I did not approve my own PR.
- The ABI checker still reports `ready: false` because the direct-native runtime ABI contract remains partial under #1001.
