### PR TITLE
[codex] Extend supply-chain CI timeout budget

### DIFF
--- a/.github/workflows/toolchain-supply-chain.yml
+++ b/.github/workflows/toolchain-supply-chain.yml
@@ -20,6 +20,10 @@ on:
     - cron: '17 6 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: toolchain-supply-chain-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -31,7 +35,7 @@ jobs:
   supply-chain:
     name: Lockfile Integrity, Vetting, and SBOM
     runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
-    timeout-minutes: 20
+    timeout-minutes: 90
     if: >-
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/scripts/ci/test-toolchain-supply-chain.sh
+++ b/scripts/ci/test-toolchain-supply-chain.sh
@@ -13,6 +13,16 @@ grep -Fq 'stage1/supply-chain/config.toml' "$workflow" || {
   exit 1
 }
 
+grep -Fq 'group: toolchain-supply-chain-${{ github.event.pull_request.number || github.ref }}' "$workflow" || {
+  echo "workflow must group supply-chain runs by PR or ref for cancellation" >&2
+  exit 1
+}
+
+grep -Fq 'cancel-in-progress: true' "$workflow" || {
+  echo "workflow must cancel superseded supply-chain runs" >&2
+  exit 1
+}
+
 grep -Fq 'cargo-vet --version' "$workflow" || {
   echo "workflow must validate an existing cargo-vet binary before reusing it" >&2
   exit 1
@@ -25,6 +35,11 @@ grep -Fq 'cargo install cargo-vet --version "$install_version" --locked --force'
 
 grep -Fq 'Ensure Rust linker availability' "$workflow" || {
   echo "workflow must provision a Rust linker before installing cargo-vet" >&2
+  exit 1
+}
+
+grep -Fq 'timeout-minutes: 90' "$workflow" || {
+  echo "workflow must leave enough budget for cold release builds and SBOM emission" >&2
   exit 1
 }
 


### PR DESCRIPTION
## Summary

- Increase the Toolchain Supply Chain job timeout from 20 to 90 minutes so cold self-hosted release builds and SBOM emission are not killed before producing a result.
- Add a workflow validation assertion that pins the timeout budget.
- Add a workflow concurrency group so superseded supply-chain runs are canceled instead of occupying self-hosted runner queue slots.
- Rebase the timeout-budget branch onto current `main`.

## Governing Issue

Refs #1001

## Validation

- [x] Relevant local checks passed
  - `bash scripts/ci/test-toolchain-supply-chain.sh`
  - `bash scripts/ci/test-pr-fast-ci-workflow.sh`
  - `git diff --check origin/main..HEAD`
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below
  - No local full supply-chain run was executed; this PR changes workflow budget and its static validation, not supply-chain script behavior.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Semantic node types added/changed: none.
Schemas added/changed: none.
Evidence added/changed: CI workflow validation for the Toolchain Supply Chain timeout budget.
Rust capture risk: none; this is CI governance for a Rust-hosted bootstrap gate, not a semantic contract change.
Agent-facing inspection impact: none.

## Flow Contract

- Owner lane: governance/docs
- Repair owner: Codex
- Autonomy class: bounded
- Risk class: low

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [ ] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is appropriate when gates pass

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- Recent direct-native runtime ABI evidence PRs are reaching the supply-chain release build on cold self-hosted runners and then failing or stalling around the prior 20-minute job budget.
- The earlier #1088 head with a 45-minute timeout was still in `Run supply-chain checks` after more than 50 minutes, so the budget is now 90 minutes to match observed cold-run behavior.
- Superseded supply-chain runs for older #1088 heads remained queued until manual cancellation, so the workflow now cancels in-progress or queued runs for the same PR/ref.
