### PR TITLE
[codex] Allow aggregate assignment evidence

### DIFF
--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -8117,74 +8117,54 @@ fn is_assignment_target(expr: &Expr, ctx: &LowerContext<'_>) -> bool {
 }
 
 fn is_local_assignment_type(ty: &Type, ctx: &LowerContext<'_>) -> bool {
-    is_scalar_local_assignment_type(ty)
-        || is_scalar_option_assignment_type(ty)
-        || is_scalar_result_assignment_type(ty)
-        || is_scalar_enum_assignment_type(ty, ctx)
-        || is_scalar_projection_assignment_type(ty, ctx)
+    is_supported_local_assignment_type(ty, ctx)
 }
 
 fn is_scalar_local_assignment_type(ty: &Type) -> bool {
     matches!(ty, Type::Int | Type::Numeric(_) | Type::Bool)
 }
 
-fn is_scalar_option_assignment_type(ty: &Type) -> bool {
-    matches!(ty, Type::Option(inner) if is_scalar_option_assignment_payload_type(inner))
+fn is_supported_local_assignment_type(ty: &Type, ctx: &LowerContext<'_>) -> bool {
+    is_supported_local_assignment_type_inner(ty, ctx, 0)
 }
 
-fn is_scalar_option_assignment_payload_type(ty: &Type) -> bool {
-    is_scalar_local_assignment_type(ty)
-        || matches!(ty, Type::Tuple(elements) if elements.iter().all(is_scalar_local_assignment_type))
-}
-
-fn is_scalar_result_assignment_type(ty: &Type) -> bool {
-    matches!(ty, Type::Result(ok, err) if is_scalar_result_assignment_payload_type(ok) && is_scalar_result_assignment_payload_type(err))
-}
-
-fn is_scalar_result_assignment_payload_type(ty: &Type) -> bool {
-    is_scalar_local_assignment_type(ty)
-        || matches!(ty, Type::Tuple(elements) if elements.iter().all(is_scalar_local_assignment_type))
-}
-
-fn is_scalar_enum_assignment_type(ty: &Type, ctx: &LowerContext<'_>) -> bool {
-    let Type::Enum(name) = ty else {
+fn is_supported_local_assignment_type_inner(
+    ty: &Type,
+    ctx: &LowerContext<'_>,
+    depth: usize,
+) -> bool {
+    if depth > 8 {
         return false;
-    };
-    ctx.enums
-        .get(name)
-        .map(|enum_def| {
-            enum_def.variants.iter().all(|variant| {
-                variant
-                    .payload_tys
-                    .iter()
-                    .all(|ty| is_scalar_enum_assignment_payload_type(ty, ctx))
-            })
-        })
-        .unwrap_or(false)
-}
-
-fn is_scalar_enum_assignment_payload_type(ty: &Type, ctx: &LowerContext<'_>) -> bool {
-    is_scalar_result_assignment_payload_type(ty)
-        || matches!(ty, Type::Struct(name) if ctx.structs.get(name).map(|struct_def| {
-            struct_def
-                .fields
-                .iter()
-                .all(|field| is_scalar_local_assignment_type(&field.ty))
-        }).unwrap_or(false))
-}
-
-fn is_scalar_projection_assignment_type(ty: &Type, ctx: &LowerContext<'_>) -> bool {
+    }
     match ty {
-        Type::Tuple(elements) => elements.iter().all(is_scalar_local_assignment_type),
+        Type::Int | Type::Numeric(_) | Type::Bool => true,
+        Type::Option(inner) => is_supported_local_assignment_type_inner(inner, ctx, depth + 1),
+        Type::Result(ok, err) => {
+            is_supported_local_assignment_type_inner(ok, ctx, depth + 1)
+                && is_supported_local_assignment_type_inner(err, ctx, depth + 1)
+        }
+        Type::Tuple(elements) => elements
+            .iter()
+            .all(|element| is_supported_local_assignment_type_inner(element, ctx, depth + 1)),
         Type::Array(element, Some(_)) => is_scalar_local_assignment_type(element),
         Type::Struct(name) => ctx
             .structs
             .get(name)
             .map(|struct_def| {
-                struct_def
-                    .fields
-                    .iter()
-                    .all(|field| is_scalar_local_assignment_type(&field.ty))
+                struct_def.fields.iter().all(|field| {
+                    is_supported_local_assignment_type_inner(&field.ty, ctx, depth + 1)
+                })
+            })
+            .unwrap_or(false),
+        Type::Enum(name) => ctx
+            .enums
+            .get(name)
+            .map(|enum_def| {
+                enum_def.variants.iter().all(|variant| {
+                    variant.payload_tys.iter().all(|payload| {
+                        is_supported_local_assignment_type_inner(payload, ctx, depth + 1)
+                    })
+                })
             })
             .unwrap_or(false),
         _ => false,


### PR DESCRIPTION
## Summary

- Allow HIR local assignment targets whose types are recursively scalar-backed through Option, Result, tuple, fixed array, struct, and enum payloads.
- Unblock existing direct-native Cranelift evidence tests for nested aggregate matches and aggregate helper reassignment without widening assignment support to unsupported runtime shapes.
- Keep the Rust-exit ABI gate partial: this reduces evidence failures but does not claim full #1001 closure.

## Governing Issue

- Refs #1001

## Validation

- [x] cargo fmt --manifest-path stage1/crates/axiomc/Cargo.toml -- --check
- [x] cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend nested_ -- --nocapture --test-threads=1
- [x] cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend aggregate_helper_reassignment -- --nocapture --test-threads=1
- [x] bash scripts/ci/test-check-direct-native-runtime-abi.sh
- [x] make stage1-direct-native-runtime-abi
- [x] bash scripts/ci/test-check-rust-exit-readiness.sh
- [x] bash scripts/ci/check-rust-exit-readiness.sh --json exits 1 as expected while #1001 is open and reports 15 incomplete ABI rows with no checker errors
- [x] git diff --check

## Bootstrap Governance

- [x] Changes are scoped to the linked issue.
- [x] Contributor or PR guidance changes are not applicable.
- [x] Auto-merge is not enabled because this is a stacked follow-up on `codex/direct-native-next-abi-slice`; apply the fallback merge-readiness policy when the stack base is ready.
- [x] No real secrets, runtime auth, or machine-local env files are committed.

## Semantic Layer Checklist

- [x] Semantic node types added/changed: none.
- [x] Schemas added/changed: none.
- [x] Evidence added/changed: restores existing direct-native aggregate/nested evidence coverage by allowing the compiler to accept the assignment shapes those tests already exercise.
- [x] Rust capture check: targeted Cranelift backend evidence tests exercise native lowering paths; no generated Rust contract is added.
- [x] Agent-facing inspection impact: readiness remains `ready=false`, but native ABI evidence runs have fewer HIR validation blockers for aggregate value-feature rows.

## Flow Contract

- Owner lane: compiler/runtime
- Repair owner: codex
- Autonomy class: agent-executed
- Risk class: medium

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action.
- [ ] No active blocking requested changes remain.
- [ ] Non-author approval is present when required.
- [ ] Auto-merge is appropriate when gates pass.

## Merge Automation

- [ ] Auto-merge is not enabled while this PR is stacked on `codex/direct-native-next-abi-slice`.

## Notes

- Base: `codex/direct-native-next-abi-slice`.
- This branch intentionally does not modify #1089 or invalidate its queued check/review state.
- The full Rust-exit gate is still blocked by #1001 until the remaining ABI rows are implemented.
