### PR TITLE
[codex] Allow async TCP listener port evidence

### DIFF
--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -565,6 +565,7 @@ struct Binding {
     moved_projections: HashSet<ProjectionPath>,
     borrow_kind: Option<BorrowKind>,
     borrow_origin: Option<BorrowOrigin>,
+    net_origin: Option<NetBindingOrigin>,
     borrowed_owners: HashSet<BorrowedOwner>,
     active_borrow_count: usize,
     active_mut_borrow_count: usize,
@@ -612,6 +613,12 @@ enum BorrowOrigin {
 }
 
 type BorrowKind = borrowck::BorrowKind;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum NetBindingOrigin {
+    LoopbackTcpListener,
+    LoopbackTcpListenerPort,
+}
 
 struct LowerContext<'a> {
     current_path: &'a str,
@@ -6777,6 +6784,7 @@ fn lower_function(
                 moved_projections: HashSet::new(),
                 borrow_kind: borrow_kind_for_type(&ty, structs, enums),
                 borrow_origin: binding_borrow_origin(&ty, Some("self"), structs, enums),
+                net_origin: None,
                 borrowed_owners: HashSet::new(),
                 active_borrow_count: 0,
                 active_mut_borrow_count: 0,
@@ -6822,6 +6830,7 @@ fn lower_function(
                 moved_projections: HashSet::new(),
                 borrow_kind: borrow_kind_for_type(&ty, structs, enums),
                 borrow_origin: binding_borrow_origin(&ty, Some(&param.name), structs, enums),
+                net_origin: None,
                 borrowed_owners: HashSet::new(),
                 active_borrow_count: 0,
                 active_mut_borrow_count: 0,
@@ -7131,6 +7140,7 @@ fn insert_type_error_binding_for_failed_stmt(
             moved_projections: HashSet::new(),
             borrow_kind: None,
             borrow_origin: None,
+            net_origin: None,
             borrowed_owners: HashSet::new(),
             active_borrow_count: 0,
             active_mut_borrow_count: 0,
@@ -7682,6 +7692,7 @@ fn lower_match_stmt(
                         &before,
                         ctx,
                     ),
+                    net_origin: None,
                     borrowed_owners,
                     active_borrow_count: 0,
                     active_mut_borrow_count: 0,
@@ -7913,6 +7924,7 @@ fn lower_match_expr(
                         &before,
                         ctx,
                     ),
+                    net_origin: None,
                     borrowed_owners: match_binding_borrowed_owners(
                         &lowered_expr,
                         &arm.variant,
@@ -8248,6 +8260,7 @@ fn lower_stmt(
             if !actual.is_copy() {
                 move_lowered_value(&lowered_expr, env)?;
             }
+            let net_origin = net_binding_origin_from_expr(&lowered_expr, env, ctx);
             env.insert(
                 name.clone(),
                 Binding {
@@ -8261,6 +8274,7 @@ fn lower_stmt(
                         env,
                         ctx,
                     ),
+                    net_origin,
                     borrowed_owners,
                     active_borrow_count: 0,
                     active_mut_borrow_count: 0,
@@ -8716,6 +8730,7 @@ fn merge_branch_state(
                 ),
                 borrow_kind: binding.borrow_kind,
                 borrow_origin: binding.borrow_origin.clone(),
+                net_origin: binding.net_origin.clone(),
                 borrowed_owners: binding.borrowed_owners.clone(),
                 active_borrow_count: merge_borrow_count(
                     binding.active_borrow_count,
@@ -8785,6 +8800,7 @@ fn merge_loop_state(
                 moved_projections: binding.moved_projections.clone(),
                 borrow_kind: binding.borrow_kind,
                 borrow_origin: binding.borrow_origin.clone(),
+                net_origin: binding.net_origin.clone(),
                 borrowed_owners: binding.borrowed_owners.clone(),
                 active_borrow_count: if body_returns {
                     binding.active_borrow_count
@@ -8835,6 +8851,7 @@ fn merge_match_state(
                 moved_projections: merge_match_projection_sets(binding, name, arm_states),
                 borrow_kind: binding.borrow_kind,
                 borrow_origin: binding.borrow_origin.clone(),
+                net_origin: binding.net_origin.clone(),
                 borrowed_owners: binding.borrowed_owners.clone(),
                 active_borrow_count: arm_states
                     .iter()
@@ -11900,6 +11917,7 @@ fn lower_expr_with_expected_inner(
                 validate_stdlib_network_wrapper_call_hir(
                     ctx,
                     ctx.capabilities,
+                    env,
                     name,
                     signature,
                     &lowered_args,
@@ -13075,6 +13093,7 @@ fn lower_expr_with_expected_inner(
                         moved_projections: HashSet::new(),
                         borrow_kind: None,
                         borrow_origin: Some(BorrowOrigin::Local),
+                        net_origin: None,
                         borrowed_owners: HashSet::new(),
                         active_borrow_count: 0,
                         active_mut_borrow_count: 0,
@@ -14001,6 +14020,7 @@ fn validate_net_port_allowlist_hir(
 fn validate_stdlib_network_wrapper_call_hir(
     _ctx: &LowerContext<'_>,
     capabilities: &CapabilityConfig,
+    env: &HashMap<String, Binding>,
     function_name: &str,
     signature: &FunctionSig,
     args: &[Expr],
@@ -14044,7 +14064,7 @@ fn validate_stdlib_network_wrapper_call_hir(
                 &args[1],
                 line,
                 column,
-                false,
+                is_loopback_listener_port_expr(&args[1], env),
             )
         }
         ("<stdlib>/net_tcp.ax", "listen")
@@ -14124,6 +14144,95 @@ fn is_stdlib_http_socket_wrapper(ctx: &LowerContext<'_>) -> bool {
             | ("<stdlib>/http.ax", Some("serve"))
             | ("<stdlib>/http.ax", Some("serve_once"))
     )
+}
+
+fn net_binding_origin_from_expr(
+    expr: &Expr,
+    env: &HashMap<String, Binding>,
+    ctx: &LowerContext<'_>,
+) -> Option<NetBindingOrigin> {
+    match expr {
+        Expr::Await { expr, .. } => net_binding_origin_from_expr(expr, env, ctx),
+        Expr::Call { name, args, .. } if is_tcp_listener_call_name(name, ctx) => {
+            if args
+                .first()
+                .and_then(static_string_literal)
+                .is_some_and(is_loopback_ephemeral_bind)
+            {
+                Some(NetBindingOrigin::LoopbackTcpListener)
+            } else {
+                None
+            }
+        }
+        Expr::Call { name, args, .. } if is_tcp_listener_port_call_name(name, ctx) => {
+            let Some(Expr::VarRef {
+                name: listener_name,
+                ..
+            }) = args.first()
+            else {
+                return None;
+            };
+            env.get(listener_name)
+                .and_then(|binding| binding.net_origin.as_ref())
+                .filter(|origin| matches!(origin, NetBindingOrigin::LoopbackTcpListener))
+                .map(|_| NetBindingOrigin::LoopbackTcpListenerPort)
+        }
+        _ => None,
+    }
+}
+
+fn static_string_literal(expr: &Expr) -> Option<&str> {
+    match expr {
+        Expr::Literal {
+            value: LiteralValue::String(value),
+            ..
+        } => Some(value.as_str()),
+        _ => None,
+    }
+}
+
+fn is_loopback_ephemeral_bind(value: &str) -> bool {
+    split_socket_addr_literal(value)
+        .is_some_and(|(host, port)| port == 0 && matches!(host, "127.0.0.1" | "localhost" | "::1"))
+}
+
+fn is_tcp_listener_call_name(name: &str, ctx: &LowerContext<'_>) -> bool {
+    if name == "net_tcp_listen" {
+        return true;
+    }
+    ctx.functions.get(name).is_some_and(|signature| {
+        matches!(
+            (
+                signature.source_path.as_str(),
+                signature.source_name.as_str()
+            ),
+            ("<stdlib>/net_tcp.ax", "listen") | ("<stdlib>/async_net.ax", "listen")
+        )
+    })
+}
+
+fn is_tcp_listener_port_call_name(name: &str, ctx: &LowerContext<'_>) -> bool {
+    if name == "net_tcp_listener_port" {
+        return true;
+    }
+    ctx.functions.get(name).is_some_and(|signature| {
+        matches!(
+            (
+                signature.source_path.as_str(),
+                signature.source_name.as_str()
+            ),
+            ("<stdlib>/net_tcp.ax", "local_port") | ("<stdlib>/async_net.ax", "local_port")
+        )
+    })
+}
+
+fn is_loopback_listener_port_expr(expr: &Expr, env: &HashMap<String, Binding>) -> bool {
+    let Expr::VarRef { name, .. } = expr else {
+        return false;
+    };
+    env.get(name)
+        .and_then(|binding| binding.net_origin.as_ref())
+        .is_some_and(|origin| matches!(origin, NetBindingOrigin::LoopbackTcpListenerPort))
 }
 
 fn validate_process_command_allowlist_hir(

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -5584,6 +5584,49 @@ net = true
     }
 
     #[test]
+    fn check_project_accepts_stdlib_async_net_loopback_listener_port() {
+        let dir = tempdir().expect("tempdir");
+        let project = dir.path().join("stdlib-async-net-loopback-port");
+        create_project(&project, Some("stdlib-async-net-loopback-port")).expect("create project");
+        fs::write(
+            project.join("axiom.toml"),
+            render_manifest_with_capabilities(
+                "stdlib-async-net-loopback-port",
+                false,
+                true,
+                false,
+                false,
+                false,
+                false,
+            )
+            .replace("async = false", "async = true"),
+        )
+        .expect("write manifest");
+        let manifest = load_manifest(&project).expect("load manifest");
+        fs::write(
+            project.join("axiom.lock"),
+            render_lockfile_for_project(&project, &manifest).expect("lockfile"),
+        )
+        .expect("write lockfile");
+        fs::write(
+            project.join("src/main.ax"),
+            r#"import "std/async.ax"
+import "std/async_net.ax"
+
+let listener: TcpListener = await listen("127.0.0.1:0")
+let port: int = local_port(listener)
+let client: JoinHandle<Option<string>> = spawn<Option<string>>(tcp_dial("127.0.0.1", port, "ping", 1000))
+let _reply: Option<string> = await join<Option<string>>(client)
+let _listener_closed: int = close_listener(listener)
+print "ok"
+"#,
+        )
+        .expect("write source");
+
+        check_project(&project).expect("loopback listener port should satisfy network policy");
+    }
+
+    #[test]
     fn check_project_rejects_dynamic_udp_network_port_with_unrestricted_net() {
         let dir = tempdir().expect("tempdir");
         let project = dir.path().join("net-dynamic-udp-port-unrestricted-denied");


### PR DESCRIPTION
## Summary

- Track HIR provenance for loopback TCP listeners and local ports derived from those listeners.
- Permit stdlib TCP wrapper calls to use a dynamic port only when that port is known to come from a loopback ephemeral listener.
- Keep arbitrary dynamic network ports denied; the existing unrestricted-net dynamic-port regression remains passing.

## Governing Issue

- Refs #1001

## Validation

- [x] cargo fmt --manifest-path stage1/crates/axiomc/Cargo.toml -- --check
- [x] cargo test --manifest-path stage1/Cargo.toml -p axiomc check_project_accepts_stdlib_async_net_loopback_listener_port -- --nocapture
- [x] cargo test --manifest-path stage1/Cargo.toml -p axiomc check_project_rejects_dynamic_stdlib_network_port_with_unrestricted_net -- --nocapture
- [x] cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend cranelift_backend_builds_std_async_net_tcp_binary -- --nocapture --test-threads=1
- [x] bash scripts/ci/test-check-direct-native-runtime-abi.sh
- [x] make stage1-direct-native-runtime-abi
- [x] bash scripts/ci/test-check-rust-exit-readiness.sh
- [x] bash scripts/ci/check-rust-exit-readiness.sh --json exits 1 as expected while #1001 is open and reports 15 incomplete ABI rows with no checker errors
- [x] git diff --check
- [x] bash scripts/ci/run-direct-native-runtime-abi-evidence.sh now passes `cranelift_backend_builds_std_async_net_tcp_binary`; the remaining local failures are socket-environment failures in HTTP client and loopback TCP tests on this sandbox.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue.
- [x] Contributor or PR guidance changes are not applicable.
- [x] Auto-merge is not enabled because this is a stacked follow-up on `codex/direct-native-next-abi-slice`; apply the fallback merge-readiness policy when the stack base is ready.
- [x] No real secrets, runtime auth, or machine-local env files are committed.

## Semantic Layer Checklist

- [x] Semantic node types added/changed: none.
- [x] Schemas added/changed: none.
- [x] Evidence added/changed: adds compiler regression coverage for stdlib async TCP loopback listener-port policy and restores the Cranelift async TCP build evidence path.
- [x] Rust capture check: targeted Cranelift backend evidence test reports `generated_rust` as null and exercises direct-native build output.
- [x] Agent-facing inspection impact: readiness remains `ready=false`, but direct-native ABI evidence no longer fails on the async TCP listener-port capability mismatch.

## Flow Contract

- Owner lane: compiler/runtime
- Repair owner: codex
- Autonomy class: agent-executed
- Risk class: medium

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action.
- [ ] No active blocking requested changes remain.
- [ ] Non-author approval is present when required.
- [ ] Auto-merge is appropriate when gates pass.

## Merge Automation

- [ ] Auto-merge is not enabled while this PR is stacked on `codex/direct-native-next-abi-slice`.

## Notes

- Base: `codex/direct-native-next-abi-slice`.
- This branch intentionally does not modify #1089 directly.
- The full Rust-exit gate is still blocked by #1001 until the remaining ABI rows are implemented.
