### PR TITLE
Run ABI evidence by row status

### DIFF
--- a/docs/rust-exit-readiness.md
+++ b/docs/rust-exit-readiness.md
@@ -43,7 +43,13 @@ python3 scripts/ci/check-direct-native-runtime-abi.py --list-evidence-rows --jso
 ```
 
 Use `--evidence-row <row-id>` for the focused single-row test list when running
-or repairing one ABI row.
+or repairing one ABI row. To execute all focused evidence tests for rows with a
+shared status, use the evidence runner status selector, for example:
+
+```bash
+AXIOM_DIRECT_NATIVE_RUNTIME_ABI_STATUS=partial \
+  bash scripts/ci/run-direct-native-runtime-abi-evidence.sh
+```
 
 ## Backend Matrix
 

--- a/scripts/ci/run-direct-native-runtime-abi-evidence.sh
+++ b/scripts/ci/run-direct-native-runtime-abi-evidence.sh
@@ -8,12 +8,24 @@ target_dir="${CARGO_TARGET_DIR:-${RUNNER_TEMP:-/tmp}/axiom-direct-native-runtime
 mkdir -p "$target_dir"
 export CARGO_TARGET_DIR="$target_dir"
 row_test_file=""
-trap '[[ -z "${row_test_file:-}" ]] || rm -f "$row_test_file"' EXIT
+row_list_file=""
+trap '[[ -z "${row_test_file:-}" ]] || rm -f "$row_test_file"; [[ -z "${row_list_file:-}" ]] || rm -f "$row_list_file"' EXIT
 
 python3 scripts/ci/check-direct-native-runtime-abi.py --json
 
-if [[ -n "${AXIOM_DIRECT_NATIVE_RUNTIME_ABI_ROW:-}" && -n "${AXIOM_DIRECT_NATIVE_RUNTIME_ABI_TEST_FILTER:-}" ]]; then
-  echo "set either AXIOM_DIRECT_NATIVE_RUNTIME_ABI_ROW or AXIOM_DIRECT_NATIVE_RUNTIME_ABI_TEST_FILTER, not both" >&2
+selector_count=0
+for selector in \
+  "${AXIOM_DIRECT_NATIVE_RUNTIME_ABI_ROW:-}" \
+  "${AXIOM_DIRECT_NATIVE_RUNTIME_ABI_STATUS:-}" \
+  "${AXIOM_DIRECT_NATIVE_RUNTIME_ABI_TEST_FILTER:-}"
+do
+  if [[ -n "$selector" ]]; then
+    selector_count=$((selector_count + 1))
+  fi
+done
+
+if ((selector_count > 1)); then
+  echo "set only one of AXIOM_DIRECT_NATIVE_RUNTIME_ABI_ROW, AXIOM_DIRECT_NATIVE_RUNTIME_ABI_STATUS, or AXIOM_DIRECT_NATIVE_RUNTIME_ABI_TEST_FILTER" >&2
   exit 1
 fi
 
@@ -38,6 +50,54 @@ if [[ -n "${AXIOM_DIRECT_NATIVE_RUNTIME_ABI_ROW:-}" ]]; then
 
   if ((${#row_tests[@]} == 0)); then
     echo "direct native runtime ABI evidence row has no tests: $AXIOM_DIRECT_NATIVE_RUNTIME_ABI_ROW" >&2
+    exit 1
+  fi
+
+  for row_test in "${row_tests[@]}"; do
+    "${cranelift_cargo_base[@]}" "$row_test" -- --nocapture --test-threads=1
+  done
+elif [[ -n "${AXIOM_DIRECT_NATIVE_RUNTIME_ABI_STATUS:-}" ]]; then
+  row_test_file="$target_dir/abi-row-status-tests-$$.txt"
+  row_list_file="$target_dir/abi-row-status-list-$$.json"
+  row_tests=()
+  python3 scripts/ci/check-direct-native-runtime-abi.py \
+    --list-evidence-rows \
+    --json >"$row_list_file"
+  python3 - "$AXIOM_DIRECT_NATIVE_RUNTIME_ABI_STATUS" "$row_list_file" >"$row_test_file" <<'PY'
+import json
+import sys
+
+status = sys.argv[1]
+row_list_path = sys.argv[2]
+valid_statuses = {"implemented", "partial", "blocked"}
+if status not in valid_statuses:
+    print(
+        "unknown direct native runtime ABI row status: "
+        f"{status}; expected one of {', '.join(sorted(valid_statuses))}",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+
+with open(row_list_path, encoding="utf-8") as handle:
+    report = json.load(handle)
+seen = set()
+for row in report.get("rows", []):
+    if row.get("status") != status:
+        continue
+    for test_name in row.get("tests", []):
+        if not isinstance(test_name, str) or test_name in seen:
+            continue
+        print(test_name)
+        seen.add(test_name)
+PY
+
+  while IFS= read -r test_name; do
+    row_tests+=("$test_name")
+  done < "$row_test_file"
+  rm -f "$row_test_file"
+
+  if ((${#row_tests[@]} == 0)); then
+    echo "direct native runtime ABI status has no tests: $AXIOM_DIRECT_NATIVE_RUNTIME_ABI_STATUS" >&2
     exit 1
   fi
 

--- a/scripts/ci/test-run-direct-native-runtime-abi-evidence.sh
+++ b/scripts/ci/test-run-direct-native-runtime-abi-evidence.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 script="$repo_root/scripts/ci/run-direct-native-runtime-abi-evidence.sh"
 makefile="$repo_root/Makefile"
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "$temp_dir"' EXIT
 
 [[ -x "$script" ]] || {
   echo "missing executable direct native runtime ABI evidence runner: $script" >&2
@@ -30,13 +32,23 @@ grep -Fq 'AXIOM_DIRECT_NATIVE_RUNTIME_ABI_ROW' "$script" || {
   exit 1
 }
 
+grep -Fq 'AXIOM_DIRECT_NATIVE_RUNTIME_ABI_STATUS' "$script" || {
+  echo "evidence runner must expose a row-status-focused test filter for ABI evidence loops" >&2
+  exit 1
+}
+
 grep -Fq -- '--evidence-row "$AXIOM_DIRECT_NATIVE_RUNTIME_ABI_ROW"' "$script" || {
   echo "evidence runner must resolve row-focused tests through the ABI checker" >&2
   exit 1
 }
 
-grep -Fq 'set either AXIOM_DIRECT_NATIVE_RUNTIME_ABI_ROW or AXIOM_DIRECT_NATIVE_RUNTIME_ABI_TEST_FILTER, not both' "$script" || {
-  echo "evidence runner must reject ambiguous row and test filter combinations" >&2
+grep -Fq -- '--list-evidence-rows' "$script" || {
+  echo "evidence runner must resolve row-status tests through the ABI row inventory" >&2
+  exit 1
+}
+
+grep -Fq 'set only one of AXIOM_DIRECT_NATIVE_RUNTIME_ABI_ROW, AXIOM_DIRECT_NATIVE_RUNTIME_ABI_STATUS, or AXIOM_DIRECT_NATIVE_RUNTIME_ABI_TEST_FILTER' "$script" || {
+  echo "evidence runner must reject ambiguous row, status, and test filter combinations" >&2
   exit 1
 }
 
@@ -44,6 +56,28 @@ grep -Fq 'direct native runtime ABI evidence row has no tests' "$script" || {
   echo "evidence runner must fail clearly for unknown ABI evidence rows" >&2
   exit 1
 }
+
+grep -Fq 'direct native runtime ABI status has no tests' "$script" || {
+  echo "evidence runner must fail clearly for ABI statuses without focused tests" >&2
+  exit 1
+}
+
+grep -Fq 'unknown direct native runtime ABI row status' "$script" || {
+  echo "evidence runner must fail clearly for unknown ABI row statuses" >&2
+  exit 1
+}
+
+if AXIOM_DIRECT_NATIVE_RUNTIME_ABI_STATUS=unknown "$script" >"$temp_dir/unknown-status.out" 2>"$temp_dir/unknown-status.err"; then
+  echo "expected unknown ABI row statuses to fail" >&2
+  exit 1
+fi
+grep -Fq 'unknown direct native runtime ABI row status: unknown' "$temp_dir/unknown-status.err"
+
+if AXIOM_DIRECT_NATIVE_RUNTIME_ABI_STATUS=blocked "$script" >"$temp_dir/blocked-status.out" 2>"$temp_dir/blocked-status.err"; then
+  echo "expected ABI row statuses without focused tests to fail" >&2
+  exit 1
+fi
+grep -Fq 'direct native runtime ABI status has no tests: blocked' "$temp_dir/blocked-status.err"
 
 grep -Fq -- '--test-threads=1' "$script" || {
   echo "evidence runner must serialize localhost-backed Cranelift evidence tests" >&2


### PR DESCRIPTION
## Summary

- Adds `AXIOM_DIRECT_NATIVE_RUNTIME_ABI_STATUS=partial|implemented|blocked` to the direct-native runtime ABI evidence runner.
- Uses the ABI row inventory from #1121 to dedupe and run all focused Cranelift evidence tests for rows with the requested status.
- Documents the status selector for agent triage and covers invalid statuses, empty status selections, and selector conflicts in the runner regression.

## Governing Issue

- Refs #1001. This does not close #1001; it improves the evidence execution loop for the remaining partial direct-native runtime ABI rows.

## Validation

- [x] `bash -n scripts/ci/run-direct-native-runtime-abi-evidence.sh`
- [x] `bash scripts/ci/test-run-direct-native-runtime-abi-evidence.sh`
- [x] `bash scripts/ci/test-check-direct-native-runtime-abi.sh`
- [x] `bash scripts/ci/test-check-rust-exit-readiness.sh`
- [x] `python3 scripts/ci/check-direct-native-runtime-abi.py --list-evidence-rows --json`
- [x] `git diff --check`
- [x] `AXIOM_DIRECT_NATIVE_RUNTIME_ABI_STATUS=unknown bash scripts/ci/run-direct-native-runtime-abi-evidence.sh` failed with the expected invalid-status error
- [x] `AXIOM_DIRECT_NATIVE_RUNTIME_ABI_STATUS=blocked bash scripts/ci/run-direct-native-runtime-abi-evidence.sh` failed with the expected no-tests error
- [ ] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

## Flow Contract

- Owner lane: pheidon
- Repair owner: codex
- Autonomy class: agent-evidence
- Risk class: low

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is appropriate when gates pass

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- Stacked on #1121 (`codex/direct-native-row-list-inspection`).
- CI runners are expected to be behind; no approved PR heads were rewritten.
- I did not run `AXIOM_DIRECT_NATIVE_RUNTIME_ABI_STATUS=partial bash scripts/ci/run-direct-native-runtime-abi-evidence.sh` because that intentionally expands to the full partial-row evidence suite. The selector resolution and failure paths are covered by the local regression tests above.
