### PR TITLE
Account for integer stdout ABI evidence

### DIFF
--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -193,6 +193,9 @@ is counted explicitly.
 The public integer stdout smoke also asserts `generated_rust: null` while
 printing helper-returned integer locals and arithmetic derived from those locals
 from a direct-native main function.
+The focused evidence manifest now links that smoke to both the numeric scalar
+row and the stdio capability row so native integer formatting and native stdout
+emission are counted together.
 The same path now has narrow boolean runtime
 evidence for signed i64 comparisons, bool local bindings backed by i64 slots,
 simple bool static values, and boolean literals composed with `&&`/`||` driving

--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -772,6 +772,9 @@ conditions.
 The map helper-local runtime-exit smoke proves a known map direct index can be
 lowered inside an Axiom helper and returned through a native helper call into
 process exit status.
+The focused evidence manifest now also links the runtime-selected `keys(...)`
+projection smoke to this row, covering finite map-key selection through public
+`std/log.ax` length projection without generated Rust.
 Broader map ownership, runtime map storage, general payload lookup bindings,
 map helper parameters, runtime key array value projection, and host-boundary
 representation remain tracked by issue #1124.
@@ -1013,7 +1016,10 @@ projections and empty attribute objects. Supported dynamic `std/log.ax`
 `event(...)` expressions can also feed source-level `print` statements as
 native stdout JSON-line writes without generated Rust, including event messages
 and `field_string(...)` values backed by `std/json.ax` `stringify_string(...)`
-over supported scalar/bool projection locals. It also lowers known-string public
+over supported scalar/bool projection locals. The focused evidence manifest now
+links the selected projection, dynamic scalar length, dynamic `info_attrs`
+stderr, and dynamic event stdout smokes to this stdio row so the evidence
+runner exercises those public logging paths explicitly. It also lowers known-string public
 `std/io.ax`
 `eprintln` lets in direct-native i64 `main` functions and helper functions,
 including runtime-scope lets after assignments and inside branches, into native
@@ -1022,6 +1028,9 @@ stderr writes while preserving newline-inclusive byte-count return values and
 statics, `string_clone(...)`, concatenation, pure helper string returns, and
 branch-local known string lets; scalar and aggregate-return helper functions can
 emit the same known stderr writes and return byte counts through native calls.
+The focused evidence manifest now links the scalar-helper and aggregate-helper
+stderr smokes to this row so those helper-call paths are exercised by the
+stdio evidence runner.
 Dynamic scalar `std/json.ax` `stringify_int` and `stringify_bool` expressions,
 including scalar stringify results first assigned to string locals, can also
 feed public `std/io.ax` `eprintln` lets in direct-native i64 `main` functions,
@@ -1047,7 +1056,10 @@ and scalar and aggregate-return helpers without generated Rust. Boolean and
 integer source-level `print` statements also lower to native stdout writes in
 direct-native i64 `main` functions and scalar and aggregate-return helpers
 without generated Rust, including runtime integer values formatted through the
-native object backend. Dynamic scalar `std/json.ax`
+native object backend.
+The focused evidence manifest now also links the scalar-helper and
+aggregate-helper stdout smokes to this row so native helper-call output remains
+explicitly covered. Dynamic scalar `std/json.ax`
 `stringify_int` and
 `stringify_bool` print expressions, including scalar stringify results first
 assigned to string locals, reuse those same native stdout writers in

--- a/stage1/runtime-abi/direct-native-v0-evidence-tests.json
+++ b/stage1/runtime-abi/direct-native-v0-evidence-tests.json
@@ -29,6 +29,7 @@
       "cranelift_backend_lowers_map_get_or_default_to_runtime_exit_code",
       "cranelift_backend_lowers_static_bool_map_keys_to_runtime_exit_code",
       "cranelift_backend_lowers_std_collection_wrappers_to_runtime_exit_code",
+      "cranelift_backend_lowers_std_log_selected_projection_lengths_to_runtime_exit_code",
       "cranelift_backend_lowers_map_helper_local_lookups_to_runtime_exit_code"
     ],
     "numeric.scalars": [
@@ -159,6 +160,14 @@
       "cranelift_backend_lowers_integer_print_runtime_stdout_in_direct_native_main",
       "cranelift_backend_lowers_json_scalar_stringify_print_to_native_stdout",
       "cranelift_backend_lowers_std_log_format_wrappers_to_runtime_exit_code",
+      "cranelift_backend_lowers_std_log_selected_projection_lengths_to_runtime_exit_code",
+      "cranelift_backend_lowers_std_log_dynamic_scalar_lengths_to_runtime_exit_code",
+      "cranelift_backend_lowers_std_log_dynamic_scalar_info_attrs_to_runtime_stderr",
+      "cranelift_backend_lowers_std_log_dynamic_event_print_to_runtime_stdout",
+      "cranelift_backend_lowers_helper_eprintln_to_native_stderr",
+      "cranelift_backend_lowers_aggregate_helper_eprintln_to_native_stderr",
+      "cranelift_backend_lowers_helper_print_to_native_stdout",
+      "cranelift_backend_lowers_aggregate_helper_print_to_native_stdout",
       "cranelift_backend_lowers_std_log_level_wrapper_to_runtime_stderr"
     ],
     "json.serdes": [

--- a/stage1/runtime-abi/direct-native-v0-evidence-tests.json
+++ b/stage1/runtime-abi/direct-native-v0-evidence-tests.json
@@ -37,6 +37,7 @@
       "cranelift_backend_lowers_i64_typed_numeric_returning_main_to_runtime_exit_code",
       "cranelift_backend_lowers_numeric_cross_width_to_runtime_exit_code",
       "cranelift_backend_builds_numeric_cross_width_binary",
+      "cranelift_backend_lowers_integer_print_runtime_stdout_in_direct_native_main",
       "cranelift_backend_lowers_i64_while_loop_to_runtime_exit_code"
     ],
     "option": [
@@ -155,6 +156,7 @@
       "cranelift_backend_builds_logging_stdio_binary",
       "cranelift_backend_lowers_known_eprintln_runtime_stderr_in_direct_native_main",
       "cranelift_backend_lowers_known_print_runtime_stdout_in_direct_native_main",
+      "cranelift_backend_lowers_integer_print_runtime_stdout_in_direct_native_main",
       "cranelift_backend_lowers_json_scalar_stringify_print_to_native_stdout",
       "cranelift_backend_lowers_std_log_format_wrappers_to_runtime_exit_code",
       "cranelift_backend_lowers_std_log_level_wrapper_to_runtime_stderr"


### PR DESCRIPTION
## Summary

- Count the existing integer stdout runtime smoke under `numeric.scalars` and `io.logging_stdio` in the direct-native runtime ABI evidence manifest.
- Document that the smoke proves native integer formatting and native stdout emission together while preserving `generated_rust: null`.

## Governing Issue

Refs #1124

## Validation

- [x] `python3 -c 'import json; json.load(open("stage1/runtime-abi/direct-native-v0-evidence-tests.json")); print("evidence tests json ok")'`
- [x] `python3 scripts/ci/check-direct-native-runtime-abi.py --evidence-row numeric.scalars --json`
- [x] `python3 scripts/ci/check-direct-native-runtime-abi.py --evidence-row io.logging_stdio --json`
- [x] `bash scripts/ci/test-check-direct-native-runtime-abi.sh`
- [x] `AXIOM_DIRECT_NATIVE_RUNTIME_ABI_DRY_RUN=1 AXIOM_DIRECT_NATIVE_RUNTIME_ABI_ROW=numeric.scalars bash scripts/ci/run-direct-native-runtime-abi-evidence.sh`
- [x] `AXIOM_DIRECT_NATIVE_RUNTIME_ABI_DRY_RUN=1 AXIOM_DIRECT_NATIVE_RUNTIME_ABI_ROW=io.logging_stdio bash scripts/ci/run-direct-native-runtime-abi-evidence.sh`
- [x] `bash scripts/ci/test-check-rust-exit-readiness.sh`
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend cranelift_backend_lowers_integer_print_runtime_stdout_in_direct_native_main -- --nocapture --test-threads=1`
- [x] `cargo fmt --manifest-path stage1/crates/axiomc/Cargo.toml --check`
- [x] `git diff --check`
- [x] `make stage1-direct-native-runtime-abi`
- [x] `bash scripts/ci/check-rust-exit-readiness.sh --json` reports the expected not-ready state while #1124 remains open and 11 value-feature rows remain incomplete.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue.
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable.
- [x] Auto-merge is not enabled yet because this PR is stacked and runner checks are expected to lag.
- [x] No real secrets, runtime auth, or machine-local env files are committed.

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior.
- [x] Schemas added/changed are listed, or this PR does not touch schemas.
- [x] Evidence added/changed: `cranelift_backend_lowers_integer_print_runtime_stdout_in_direct_native_main` is now listed for `numeric.scalars` and `io.logging_stdio`.
- [x] Rust capture check is satisfied: the linked smoke asserts direct-native stdout behavior with `generated_rust: null`.
- [x] Agent-facing inspection impact: evidence consumers now see integer stdout coverage in both the numeric and stdio ABI rows.

## Flow Contract

- Owner lane: semantic runtime ABI evidence
- Repair owner: codex
- Autonomy class: scoped evidence-accounting PR
- Risk class: low, manifest and documentation only

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action.
- [x] No active blocking requested changes remain.
- [ ] Non-author approval is present when required.
- [ ] Auto-merge is appropriate when gates pass.

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below.

## Notes

- Runtime ABI readiness remains intentionally partial until #1124 is complete.
- Runner checks may remain queued behind the current CI backlog.
