### PR TITLE
Account for helper stdio ABI evidence

### DIFF
--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -1028,6 +1028,9 @@ stderr writes while preserving newline-inclusive byte-count return values and
 statics, `string_clone(...)`, concatenation, pure helper string returns, and
 branch-local known string lets; scalar and aggregate-return helper functions can
 emit the same known stderr writes and return byte counts through native calls.
+The focused evidence manifest now links the scalar-helper and aggregate-helper
+stderr smokes to this row so those helper-call paths are exercised by the
+stdio evidence runner.
 Dynamic scalar `std/json.ax` `stringify_int` and `stringify_bool` expressions,
 including scalar stringify results first assigned to string locals, can also
 feed public `std/io.ax` `eprintln` lets in direct-native i64 `main` functions,
@@ -1053,7 +1056,10 @@ and scalar and aggregate-return helpers without generated Rust. Boolean and
 integer source-level `print` statements also lower to native stdout writes in
 direct-native i64 `main` functions and scalar and aggregate-return helpers
 without generated Rust, including runtime integer values formatted through the
-native object backend. Dynamic scalar `std/json.ax`
+native object backend.
+The focused evidence manifest now also links the scalar-helper and
+aggregate-helper stdout smokes to this row so native helper-call output remains
+explicitly covered. Dynamic scalar `std/json.ax`
 `stringify_int` and
 `stringify_bool` print expressions, including scalar stringify results first
 assigned to string locals, reuse those same native stdout writers in

--- a/stage1/runtime-abi/direct-native-v0-evidence-tests.json
+++ b/stage1/runtime-abi/direct-native-v0-evidence-tests.json
@@ -164,6 +164,10 @@
       "cranelift_backend_lowers_std_log_dynamic_scalar_lengths_to_runtime_exit_code",
       "cranelift_backend_lowers_std_log_dynamic_scalar_info_attrs_to_runtime_stderr",
       "cranelift_backend_lowers_std_log_dynamic_event_print_to_runtime_stdout",
+      "cranelift_backend_lowers_helper_eprintln_to_native_stderr",
+      "cranelift_backend_lowers_aggregate_helper_eprintln_to_native_stderr",
+      "cranelift_backend_lowers_helper_print_to_native_stdout",
+      "cranelift_backend_lowers_aggregate_helper_print_to_native_stdout",
       "cranelift_backend_lowers_std_log_level_wrapper_to_runtime_stderr"
     ],
     "json.serdes": [


### PR DESCRIPTION
## Summary

- Count the existing scalar-helper and aggregate-helper stdout/stderr smokes under the `io.logging_stdio` direct-native runtime ABI row.
- Document that those helper-call paths are now explicitly covered by the focused stdio evidence runner.

## Governing Issue

Refs #1124

## Validation

- [x] `python3 -c 'import json; json.load(open("stage1/runtime-abi/direct-native-v0-evidence-tests.json")); print("evidence tests json ok")'`
- [x] `python3 scripts/ci/check-direct-native-runtime-abi.py --evidence-row io.logging_stdio --json`
- [x] `bash scripts/ci/test-check-direct-native-runtime-abi.sh`
- [x] `AXIOM_DIRECT_NATIVE_RUNTIME_ABI_DRY_RUN=1 AXIOM_DIRECT_NATIVE_RUNTIME_ABI_ROW=io.logging_stdio bash scripts/ci/run-direct-native-runtime-abi-evidence.sh`
- [x] `bash scripts/ci/test-check-rust-exit-readiness.sh`
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend helper_ -- --nocapture --test-threads=1`
- [x] `cargo fmt --manifest-path stage1/crates/axiomc/Cargo.toml --check`
- [x] `git diff --check`
- [x] `make stage1-direct-native-runtime-abi`
- [x] `bash scripts/ci/check-rust-exit-readiness.sh --json` reports the expected not-ready state while #1124 remains open and 11 value-feature rows remain incomplete.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue.
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable.
- [x] Auto-merge is not enabled yet because this PR is stacked and runner checks are expected to lag.
- [x] No real secrets, runtime auth, or machine-local env files are committed.

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior.
- [x] Schemas added/changed are listed, or this PR does not touch schemas.
- [x] Evidence added/changed: `io.logging_stdio` now references scalar-helper and aggregate-helper stdout/stderr smokes.
- [x] Rust capture check is satisfied: the linked smokes assert direct-native stdio behavior with `generated_rust: null`.
- [x] Agent-facing inspection impact: evidence consumers now see helper-call stdio coverage in the ABI row.

## Flow Contract

- Owner lane: semantic runtime ABI evidence
- Repair owner: codex
- Autonomy class: scoped evidence-accounting PR
- Risk class: low, manifest and documentation only

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action.
- [x] No active blocking requested changes remain.
- [ ] Non-author approval is present when required.
- [ ] Auto-merge is appropriate when gates pass.

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below.

## Notes

- Runtime ABI readiness remains intentionally partial until #1124 is complete.
- Runner checks may remain queued behind the current CI backlog.
