### PR TITLE
Add CLI args ABI row

### DIFF
--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -133,6 +133,7 @@ stage1 capability and stdlib surface:
 - network DNS, TCP, UDP, HTTP client, HTTP server, and async HTTP service
   operations;
 - process status execution;
+- ambient process argument reads through `std/cli.ax`;
 - environment reads with manifest allowlists;
 - clock and sleep operations;
 - crypto hash, MAC, random, signature, and AEAD helpers;
@@ -710,6 +711,16 @@ host audit JSONL entries when `AXIOM_HOST_AUDIT_LOG` is set, recording only the
 command string length and the `ok`/`denied` outcome without recording command
 text. Arguments, broader command policy, environment control, and host-process
 policy coverage remain open under #1001.
+
+The CLI arguments row now has narrow direct-native evidence: the native
+`std/cli.ax` no-argument smoke builds with `generated_rust: null`, runs the
+produced binary, and proves `arg_count()`, `args()`, and `arg(0)` cover the
+empty forwarded-argument surface by printing `0`, `0`, and the `None` arm's
+`missing` text. This row tracks ambient process input separately from
+`std/process.ax` command execution because the CLI surface does not require the
+filesystem, network, process, environment, clock, or crypto capability gates.
+Forwarded arguments through `axiomc run --`, broader argv string storage, and
+host-audit treatment remain open under #1001.
 
 The regex row now has partial direct-native evidence: the Cranelift spike covers
 `std/regex.ax` `is_match`, `find`, and `replace_all` for the stage1-safe NFA

--- a/scripts/ci/check-direct-native-runtime-abi.py
+++ b/scripts/ci/check-direct-native-runtime-abi.py
@@ -42,6 +42,7 @@ REQUIRED_CAPABILITY_SHIMS = {
     "network.http.server",
     "network.http.async_server",
     "process.status",
+    "cli.args",
     "env.read",
     "clock.now_sleep",
     "crypto.hash",

--- a/scripts/ci/test-check-direct-native-runtime-abi.sh
+++ b/scripts/ci/test-check-direct-native-runtime-abi.sh
@@ -20,17 +20,17 @@ assert report["ready"] is False
 assert report["target_id"] == "axiom://target/stage1-direct-native"
 assert report["contract_status"] == "partial"
 assert report["value_feature_count"] == 12
-assert report["capability_shim_count"] == 22
+assert report["capability_shim_count"] == 23
 assert report["status_counts"]["value_features"]["implemented"] == 1
 assert report["status_counts"]["value_features"]["partial"] == 11
-assert report["status_counts"]["capability_shims"]["implemented"] == 22
+assert report["status_counts"]["capability_shims"]["implemented"] == 23
 assert report["status_counts"]["capability_shims"]["partial"] == 0
 assert report["blocked_rows"] == []
 assert len(report["incomplete_rows"]) == 11
 assert report["evidence_test_manifest"]["present"] is True
 assert report["evidence_test_manifest"]["value_feature_rows"] == 12
 assert report["evidence_test_manifest"]["value_feature_test_count"] >= 40
-assert report["evidence_test_manifest"]["capability_shim_rows"] == 22
+assert report["evidence_test_manifest"]["capability_shim_rows"] == 23
 assert report["evidence_test_manifest"]["capability_shim_test_count"] >= 70
 assert "owned.move_state" not in report["incomplete_rows"]
 assert "ffi.call" not in report["incomplete_rows"]
@@ -45,6 +45,7 @@ assert "env.read" not in report["incomplete_rows"]
 assert "fs.read" not in report["incomplete_rows"]
 assert "fs.write" not in report["incomplete_rows"]
 assert "process.status" not in report["incomplete_rows"]
+assert "cli.args" not in report["incomplete_rows"]
 assert "sync.primitives" not in report["incomplete_rows"]
 assert "regex.match_replace" not in report["incomplete_rows"]
 assert "io.logging_stdio" not in report["incomplete_rows"]
@@ -72,10 +73,10 @@ assert report["ready"] is False
 assert report["target_id"] == "axiom://target/stage1-direct-native"
 assert report["contract_status"] == "partial"
 assert report["value_feature_count"] == 12
-assert report["capability_shim_count"] == 22
-assert len(report["rows"]) == 34
+assert report["capability_shim_count"] == 23
+assert len(report["rows"]) == 35
 assert report["status_counts"]["value_features"]["implemented"] == 1
-assert report["status_counts"]["capability_shims"]["implemented"] == 22
+assert report["status_counts"]["capability_shims"]["implemented"] == 23
 assert report["blocker_issues"] == [1124]
 assert report["errors"] == []
 
@@ -96,11 +97,20 @@ assert rows["fs.read"]["test_count"] >= 2
 assert "cranelift_backend_lowers_fs_read_to_runtime_exit_code" in rows["fs.read"]["tests"]
 assert "stage1/crates/axiomc/tests/cranelift_backend.rs" in rows["fs.read"]["denial_evidence"]
 assert "stage1/crates/axiomc/src/cranelift_backend.rs" in rows["fs.read"]["runtime_evidence"]
+
+assert rows["cli.args"]["group"] == "capability_shims"
+assert rows["cli.args"]["status"] == "implemented"
+assert rows["cli.args"]["blockers"] == []
+assert rows["cli.args"]["test_count"] >= 1
+assert "cranelift_backend_builds_std_cli_no_args_binary" in rows["cli.args"]["tests"]
+assert "stage1/crates/axiomc/tests/cranelift_backend.rs" in rows["cli.args"]["evidence"]
+assert "stage1/crates/axiomc/src/cranelift_backend.rs" in rows["cli.args"]["runtime_evidence"]
 PY
 
 python3 "$script" --contract "$contract" --list-evidence-rows >"$temp_dir/row-list.txt"
 grep -Fq "value_features option partial" "$temp_dir/row-list.txt"
 grep -Fq "capability_shims fs.read implemented" "$temp_dir/row-list.txt"
+grep -Fq "capability_shims cli.args implemented" "$temp_dir/row-list.txt"
 grep -Fq "blockers=#1124" "$temp_dir/row-list.txt"
 grep -Fq "blockers=-" "$temp_dir/row-list.txt"
 
@@ -231,6 +241,7 @@ assert "stage1/crates/axiomc/src/cranelift_backend.rs" in capability_rows["netwo
 assert "stage1/crates/axiomc/src/cranelift_backend.rs" in capability_rows["network.http.client"]["runtime_evidence"]
 assert "stage1/crates/axiomc/src/cranelift_backend.rs" in capability_rows["network.http.server"]["runtime_evidence"]
 assert "stage1/crates/axiomc/src/cranelift_backend.rs" in capability_rows["network.http.async_server"]["runtime_evidence"]
+assert "stage1/crates/axiomc/src/cranelift_backend.rs" in capability_rows["cli.args"]["runtime_evidence"]
 assert "stage1/crates/axiomc/src/cranelift_backend.rs" in capability_rows["crypto.signature"]["runtime_evidence"]
 assert "stage1/crates/axiomc/src/cranelift_backend.rs" in capability_rows["crypto.aead"]["runtime_evidence"]
 assert "stage1/crates/axiomc/src/cranelift_backend.rs" in capability_rows["ffi.call"]["runtime_evidence"]

--- a/stage1/runtime-abi/direct-native-v0-evidence-tests.json
+++ b/stage1/runtime-abi/direct-native-v0-evidence-tests.json
@@ -256,6 +256,9 @@
       "cranelift_backend_rejects_unapproved_process_status_command",
       "cranelift_backend_rejects_process_denial_before_backend_lowering"
     ],
+    "cli.args": [
+      "cranelift_backend_builds_std_cli_no_args_binary"
+    ],
     "regex.match_replace": [
       "cranelift_backend_lowers_known_regex_text_to_runtime_exit_code",
       "cranelift_backend_lowers_std_regex_wrappers_to_runtime_exit_code",

--- a/stage1/runtime-abi/direct-native-v0.json
+++ b/stage1/runtime-abi/direct-native-v0.json
@@ -213,6 +213,14 @@
       "notes": "The Cranelift spike records positive compiler-side evidence for std/process.ax run_status over literal, allowlisted deterministic commands and the checked-in missing-binary sentinel while the public smoke asserts generated_rust is null, rejects unapproved commands, and rejects missing process capability before backend lowering. The direct-native i64 path also lowers literal process_status calls and the std/process.ax run_status wrapper for the deterministic /usr/bin/true, /usr/bin/false, and __axiom_stage1_missing_binary__ commands into native runtime executable checks and process-status execution through the object backend without generated Rust. The missing sentinel maps to -1 through the native executable check, while the existing true/false helpers run and normalize their process status at runtime. That direct-native path also appends host audit JSONL entries when AXIOM_HOST_AUDIT_LOG is set, recording only the command string length and the ok/denied outcome without recording command text. Arguments, broader command policy, environment control, and host-process policy coverage remain open."
     },
     {
+      "id": "cli.args",
+      "status": "implemented",
+      "capability": "ambient process arguments exposed through std/cli.ax",
+      "evidence": ["stage1/crates/axiomc/tests/cranelift_backend.rs"],
+      "runtime_evidence": ["stage1/crates/axiomc/src/cranelift_backend.rs"],
+      "notes": "The direct-native path builds and runs the public std/cli.ax no-argument program without generated Rust, covering arg_count(), args(), arg(0), empty argument-array length, and the None arm for missing arguments from the native binary. The surface is ambient process input and remains separate from std/process.ax command execution; argument forwarding through axiomc run -- and broader argv string storage remain open."
+    },
+    {
       "id": "env.read",
       "status": "implemented",
       "capability": "env",


### PR DESCRIPTION
Part of #1124.

## Summary

- Add `cli.args` as a first-class direct-native runtime ABI capability row.
- Count the existing `cranelift_backend_builds_std_cli_no_args_binary` smoke as focused row evidence.
- Update the ABI checker required row set and regression expectations from 22 to 23 capability shim rows.
- Document why `std/cli.ax` is tracked separately from `std/process.ax` command execution.

## Validation

- `python3 -m json.tool stage1/runtime-abi/direct-native-v0.json`
- `python3 -m json.tool stage1/runtime-abi/direct-native-v0-evidence-tests.json`
- `python3 scripts/ci/check-direct-native-runtime-abi.py --contract stage1/runtime-abi/direct-native-v0.json --json`
- `CARGO_TARGET_DIR=/tmp/axiom-cli-args-abi-row-target cargo test --manifest-path stage1/crates/axiomc/Cargo.toml --test cranelift_backend cranelift_backend_builds_std_cli_no_args_binary -- --nocapture`
- `bash scripts/ci/test-check-direct-native-runtime-abi.sh`
- `bash scripts/ci/test-run-direct-native-runtime-abi-evidence.sh`
- `bash scripts/ci/test-check-rust-exit-readiness.sh`
- `git diff --check`

## Risk

- Contract/evidence accounting change. No compiler lowering behavior changed.
- Readiness remains intentionally false while #1124 is open.
- Stacked above #1171 and should not merge before its base stack.

## Semantic Notes

- Semantic node types changed: none.
- Schemas changed: none.
- Evidence changed: `stage1/runtime-abi/direct-native-v0.json` now includes the `cli.args` capability row and the evidence manifest now has 23 capability-shim rows.
- Rust capture risk: reduced by making ambient CLI argument reads part of the direct-native ABI contract instead of leaving them implicit.
- Agent-facing inspection impact: ABI row listing and row inspection now expose `cli.args` with its focused native smoke.
