### PR TITLE
[codex] Use literal async TCP evidence port

### DIFF
--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -1,7 +1,7 @@
 use serde_json::Value;
 use std::fs;
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Output};
 
 #[cfg(not(windows))]
 #[test]
@@ -5027,42 +5027,61 @@ fn cranelift_backend_builds_std_async_net_tcp_binary() {
     }
 
     let temp = tempfile::tempdir().expect("tempdir");
-    let project = temp.path().join("std-async-net-tcp");
-    let Some(port) = reserve_loopback_port() else {
-        return;
-    };
-    write_std_async_net_tcp_project(&project, port);
+    let mut bind_race_reports = Vec::new();
+    for attempt in 1..=5 {
+        let project = temp.path().join(format!("std-async-net-tcp-{attempt}"));
+        let Some(port) = reserve_loopback_port() else {
+            return;
+        };
+        write_std_async_net_tcp_project(&project, port);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
-        .args([
-            "build",
-            project.to_str().expect("project path"),
-            "--backend",
-            "cranelift",
-            "--json",
-        ])
-        .output()
-        .expect("run axiomc build --backend cranelift");
-    assert!(
-        output.status.success(),
-        "cranelift std async net TCP build failed: stdout={} stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
+        let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+            .args([
+                "build",
+                project.to_str().expect("project path"),
+                "--backend",
+                "cranelift",
+                "--json",
+            ])
+            .output()
+            .expect("run axiomc build --backend cranelift");
+        assert!(
+            output.status.success(),
+            "cranelift std async net TCP build failed: stdout={} stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
 
-    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
-    assert_eq!(payload["backend"], "cranelift");
-    assert_eq!(payload["generated_rust"], Value::Null);
-    let binary = payload["binary"].as_str().expect("binary path");
-    let run = Command::new(binary)
-        .output()
-        .expect("run cranelift std async net TCP binary");
-    assert!(
-        run.status.success(),
-        "cranelift std async net TCP binary failed: stderr={}",
-        String::from_utf8_lossy(&run.stderr)
+        let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
+        assert_eq!(payload["backend"], "cranelift");
+        assert_eq!(payload["generated_rust"], Value::Null);
+        let binary = payload["binary"].as_str().expect("binary path");
+        let run = Command::new(binary)
+            .output()
+            .expect("run cranelift std async net TCP binary");
+        if run.status.success() {
+            assert_eq!(String::from_utf8_lossy(&run.stdout), "alpha\nbeta\n");
+            return;
+        }
+        if !std_async_net_tcp_bind_race(&run) {
+            panic!(
+                "cranelift std async net TCP binary failed: stdout={} stderr={}",
+                String::from_utf8_lossy(&run.stdout),
+                String::from_utf8_lossy(&run.stderr)
+            );
+        }
+        bind_race_reports.push(String::from_utf8_lossy(&run.stderr).into_owned());
+    }
+
+    panic!(
+        "cranelift std async net TCP binary exhausted literal-port retries after bind races: {}",
+        bind_race_reports.join("\n--- retry ---\n")
     );
-    assert_eq!(String::from_utf8_lossy(&run.stdout), "alpha\nbeta\n");
+}
+
+#[cfg(not(windows))]
+fn std_async_net_tcp_bind_race(run: &Output) -> bool {
+    String::from_utf8_lossy(&run.stderr).contains("\"message\":\"net_tcp_listen failed\"")
 }
 
 #[cfg(not(windows))]

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -5028,7 +5028,10 @@ fn cranelift_backend_builds_std_async_net_tcp_binary() {
 
     let temp = tempfile::tempdir().expect("tempdir");
     let project = temp.path().join("std-async-net-tcp");
-    write_std_async_net_tcp_project(&project);
+    let Some(port) = reserve_loopback_port() else {
+        return;
+    };
+    write_std_async_net_tcp_project(&project, port);
 
     let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
         .args([
@@ -11015,11 +11018,12 @@ print "none"
     .expect("write std async source");
 }
 
-fn write_std_async_net_tcp_project(project: &Path) {
+fn write_std_async_net_tcp_project(project: &Path, port: u16) {
     fs::create_dir_all(project.join("src")).expect("create std async net TCP project src");
     fs::write(
         project.join("axiom.toml"),
-        r#"[package]
+        format!(
+            r#"[package]
 name = "cranelift-std-async-net-tcp"
 version = "0.1.0"
 
@@ -11030,7 +11034,7 @@ out_dir = "dist"
 [capabilities]
 fs = false
 "fs:write" = false
-net = true
+net = {{ hosts = ["127.0.0.1"], ports = [{port}] }}
 process = false
 env = false
 clock = false
@@ -11041,7 +11045,8 @@ async = true
 [unsafe_rationale]
 net = "Cranelift ABI regression covers compiler-side std/async_net.ax loopback TCP evaluation for issue 928."
 async = "Cranelift ABI regression covers compiler-side std/async_net.ax loopback TCP evaluation for issue 928."
-"#,
+"#
+        ),
     )
     .expect("write std async net TCP manifest");
     fs::write(
@@ -11057,45 +11062,46 @@ source = "path"
     .expect("write std async net TCP lockfile");
     fs::write(
         project.join("src/main.ax"),
-        r#"import "std/async.ax"
+        format!(
+            r#"import "std/async.ax"
 import "std/async_net.ax"
 
-async fn echo_once(listener: TcpListener): int {
+async fn echo_once(listener: TcpListener): int {{
 let stream: TcpStream = await accept(listener)
 let received: string = await recv_text(stream, 64)
 let _written: int = await send_text(stream, received)
 return close(stream)
-}
+}}
 
-let listener: TcpListener = await listen("127.0.0.1:0")
-let port: int = local_port(listener)
+let listener: TcpListener = await listen("127.0.0.1:{port}")
 let first_handler: JoinHandle<int> = spawn<int>(echo_once(listener))
 let second_handler: JoinHandle<int> = spawn<int>(echo_once(listener))
-let first_client: JoinHandle<Option<string>> = spawn<Option<string>>(tcp_dial("127.0.0.1", port, "alpha", 1000))
-let second_client: JoinHandle<Option<string>> = spawn<Option<string>>(tcp_dial("127.0.0.1", port, "beta", 1000))
+let first_client: JoinHandle<Option<string>> = spawn<Option<string>>(tcp_dial("127.0.0.1", {port}, "alpha", 1000))
+let second_client: JoinHandle<Option<string>> = spawn<Option<string>>(tcp_dial("127.0.0.1", {port}, "beta", 1000))
 
-match await join<Option<string>>(first_client) {
-Some(reply) {
+match await join<Option<string>>(first_client) {{
+Some(reply) {{
 print reply
-}
-None {
+}}
+None {{
 print "first none"
-}
-}
+}}
+}}
 
-match await join<Option<string>>(second_client) {
-Some(reply) {
+match await join<Option<string>>(second_client) {{
+Some(reply) {{
 print reply
-}
-None {
+}}
+None {{
 print "second none"
-}
-}
+}}
+}}
 
 let _first_done: int = await join<int>(first_handler)
 let _second_done: int = await join<int>(second_handler)
 let _listener_closed: int = close_listener(listener)
-"#,
+"#
+        ),
     )
     .expect("write std async net TCP source");
 }


### PR DESCRIPTION
## Summary

- Update the direct-native `std/async_net.ax` TCP evidence fixture to reserve a loopback port in the Rust test harness.
- Generate the Axiom manifest and source with that literal port instead of using a dynamic `local_port(listener)` value for public `tcp_dial`.
- Preserve the capability policy that rejects dynamic public network ports while allowing the async TCP evidence suite to run through the checked, literal host/port path.

## Governing Issue

- Refs #1124

## Validation

- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc cranelift_backend_builds_std_async_net_tcp_binary -- --nocapture`
- [x] `make stage1-direct-native-runtime-abi-evidence`
- [x] `cargo fmt --manifest-path stage1/crates/axiomc/Cargo.toml --check`
- [x] `git diff --check`
- [x] `bash scripts/ci/test-check-direct-native-runtime-abi.sh`
- [x] `bash scripts/ci/test-check-rust-exit-readiness.sh`
- [ ] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

No checks were intentionally skipped. `make stage1-direct-native-runtime-abi-evidence` was run with local network/bind permissions because the suite exercises native loopback binaries.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Evidence added/changed:
- Direct-native async TCP evidence fixture now satisfies the manifest network policy with literal loopback host/port values.

Rust capture / semantic impact:
- Backend evidence fixture only; no Axiom semantic contract is defined in Rust-specific terms.
- No schema or agent-facing inspection shape changes.

## Flow Contract

- Owner lane: compiler/runtime
- Repair owner: Codex
- Autonomy class: focused implementation
- Risk class: low

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [ ] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is appropriate when gates pass

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below
- Stacked on `#1189`; auto-merge stays off until the base stack lands.

## Notes

- This PR is stacked on #1189 because the full evidence target also depends on the aggregate reassignment fix from that branch.
- The ABI remains intentionally `ready: false`; this removes a false evidence-suite failure while #1124 remains open.