### PR TITLE
fix: reject dangling symlink leaves for fs write/append

### DIFF
--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -1988,6 +1988,12 @@ fn axiom_fs_candidate(path: &str, allow_missing_ancestors: bool) -> Option<std::
         if !canonical_parent.starts_with(&canonical_fs_root) {
             return None;
         }
+        if std::fs::symlink_metadata(&candidate)
+            .map(|metadata| metadata.file_type().is_symlink())
+            .unwrap_or(false)
+        {
+            return None;
+        }
         let file_name = candidate.file_name()?;
         return Some(canonical_parent.join(file_name));
     }

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -6400,23 +6400,36 @@ crypto = false
             r#"print fs_write("data/inside.txt", "inside") == 0
 print fs_write("outside.txt", "outside") == -1
 print fs_write("data/../outside.txt", "traversal") == -1
+print fs_write("data/dangling", "escape") == -1
+print fs_append("data/dangling", "escape") == -1
 "#,
         )
         .expect("write source");
 
         let built = build_project(&project).expect("build project");
+        let outside_symlink_target = dir.path().join("outside-symlink-target.txt");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&outside_symlink_target, project.join("data/dangling"))
+            .expect("create dangling fs_write symlink escape fixture");
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_file(&outside_symlink_target, project.join("data/dangling"))
+            .expect("create dangling fs_write symlink escape fixture");
         let output = compiled_binary_command(&built.binary)
             .output()
             .expect("run compiled binary");
         assert_eq!(
             String::from_utf8_lossy(&output.stdout),
-            "true\ntrue\ntrue\n"
+            "true\ntrue\ntrue\ntrue\ntrue\n"
         );
         assert_eq!(
             fs::read_to_string(project.join("data/inside.txt")).expect("inside write"),
             "inside",
         );
         assert!(!project.join("outside.txt").exists());
+        assert!(
+            !outside_symlink_target.exists(),
+            "fs_write/fs_append must not create a dangling symlink target outside fs_root"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Reject dangling symlink leaf paths for `fs_write` and `fs_append` when resolving missing-file candidates under an allowed `fs_root`.
- Add regression coverage that verifies an outside dangling-symlink target is not created through write or append.
- Keep the behavior limited to the missing-leaf fallback path; canonicalized in-root path handling is unchanged.

## Governing Issue
- No linked issue: repair was requested directly for this PR after CI reported description validation and branch freshness blockers.

## Validation
- [x] cargo fmt --manifest-path stage1/crates/axiomc/Cargo.toml --check
- [x] cargo test --manifest-path stage1/Cargo.toml -p axiomc build_project_scopes_fs_write_to_manifest_root_without_read_capability
- [x] git diff --check

## Bootstrap Governance
- No bootstrap changes.

## Notes
- Rebases the PR branch onto current `origin/main` to clear the behind merge state.
