### PR TITLE
Track live Rust-exit blockers

### DIFF
--- a/scripts/ci/check-rust-exit-readiness.sh
+++ b/scripts/ci/check-rust-exit-readiness.sh
@@ -112,6 +112,25 @@ all_blocking_issues_closed() {
   done < <(blocking_issues_from_manifest)
 }
 
+all_blocking_issues_live() {
+  local issue_state
+  local issue
+
+  if [[ ! -f docs/rust-exit-readiness.json ]]; then
+    return 1
+  fi
+
+  while IFS= read -r issue; do
+    issue_state=""
+    if ! issue_state="$(read_issue_state "$issue")" || [[ -z "$issue_state" ]]; then
+      return 1
+    fi
+    if [[ "$issue_state" != "OPEN" ]]; then
+      return 1
+    fi
+  done < <(blocking_issues_from_manifest)
+}
+
 direct_native_runtime_abi_report() {
   if [[ ! -f scripts/ci/check-direct-native-runtime-abi.py ]]; then
     return 1
@@ -216,8 +235,18 @@ if abi_report="$(direct_native_runtime_abi_report 2>/dev/null)" && [[ -n "$abi_r
   fi
 fi
 
+if [[ ! -f docs/rust-exit-readiness.json ]]; then
+  add_check "readiness_blockers_live" "fail" "Rust exit readiness manifest is unavailable"
+elif [[ -z "$issue_state_file" && "$require_issue_states" != true ]] && ! command -v gh >/dev/null 2>&1; then
+  add_check "readiness_blockers_live" "pass" "blocker liveness not checked; pass --require-issue-states for deletion PRs"
+elif all_blocking_issues_live; then
+  add_check "readiness_blockers_live" "pass" "All blocking issues listed in docs/rust-exit-readiness.json are OPEN"
+else
+  add_check "readiness_blockers_live" "fail" "One or more blocking issues listed in docs/rust-exit-readiness.json are CLOSED or unavailable"
+fi
+
 if [[ -f docs/rust-exit-readiness.json ]]; then
-  python3 - <<'PY'
+  if python3 - <<'PY'
 import json
 import sys
 
@@ -236,20 +265,26 @@ if not isinstance(blocking_entries, list) or not blocking_entries:
     print("blockingIssues must be a non-empty list", file=sys.stderr)
     sys.exit(1)
 
+allowed_lanes = {"backend", "bootstrap", "verification", "tooling"}
 issues = []
 for index, entry in enumerate(blocking_entries):
     if not isinstance(entry, dict):
         print(f"blockingIssues[{index}] must be an object", file=sys.stderr)
         sys.exit(1)
     issue = entry.get("issue")
-    if not isinstance(issue, int):
-        print(f"blockingIssues[{index}].issue must be an integer", file=sys.stderr)
+    if not isinstance(issue, int) or issue <= 0:
+        print(f"blockingIssues[{index}].issue must be a positive integer", file=sys.stderr)
         sys.exit(1)
-    if not entry.get("lane"):
-        print(f"blockingIssues[{index}].lane must be non-empty", file=sys.stderr)
+    lane = entry.get("lane")
+    if lane not in allowed_lanes:
+        print(
+            f"blockingIssues[{index}].lane must be one of {sorted(allowed_lanes)}",
+            file=sys.stderr,
+        )
         sys.exit(1)
-    if not entry.get("check"):
-        print(f"blockingIssues[{index}].check must be non-empty", file=sys.stderr)
+    check = entry.get("check")
+    if not isinstance(check, str) or not check.strip():
+        print(f"blockingIssues[{index}].check must be a non-empty string", file=sys.stderr)
         sys.exit(1)
     issues.append(issue)
 
@@ -258,14 +293,15 @@ if payload["finalBootstrapIssue"] in issues:
     sys.exit(1)
 
 required = {731, 1124, 1191}
-missing = sorted(required - set(issues))
-if missing:
-    print("missing required blocking issues: " + ", ".join(f"#{issue}" for issue in missing), file=sys.stderr)
-    sys.exit(1)
 unexpected = sorted(set(issues) - required)
 if unexpected:
     print("unexpected stale blocking issues: " + ", ".join(f"#{issue}" for issue in unexpected), file=sys.stderr)
     sys.exit(1)
+missing = sorted(required - set(issues))
+if missing:
+    print("missing required blocking issues: " + ", ".join(f"#{issue}" for issue in missing), file=sys.stderr)
+    sys.exit(1)
+
 if len(set(issues)) != len(issues):
     print("blocking issue list contains duplicates", file=sys.stderr)
     sys.exit(1)
@@ -288,7 +324,11 @@ if missing_abi_blockers:
     )
     sys.exit(1)
 PY
-  add_check "readiness_manifest_valid" "pass" "docs/rust-exit-readiness.json has schema-valid live blockers and covers ABI blockers"
+  then
+    add_check "readiness_manifest_valid" "pass" "docs/rust-exit-readiness.json has schema-valid live blockers and covers ABI blockers"
+  else
+    add_check "readiness_manifest_valid" "fail" "docs/rust-exit-readiness.json does not match the required schema, blocker shape, or ABI blocker coverage"
+  fi
 else
   add_check "readiness_manifest_valid" "fail" "docs/rust-exit-readiness.json cannot be validated"
 fi
@@ -356,12 +396,18 @@ if [[ -f docs/rust-exit-readiness.json ]]; then
   while IFS= read -r issue; do
     issue_state=""
     if issue_state="$(read_issue_state "$issue")" && [[ -n "$issue_state" ]]; then
+      if [[ "$issue_state" == "OPEN" ]]; then
+        add_check "rust_exit_issue_${issue}_live" "pass" "issue #$issue is OPEN"
+      else
+        add_check "rust_exit_issue_${issue}_live" "fail" "issue #$issue is $issue_state; remove closed blockers from docs/rust-exit-readiness.json"
+      fi
       if [[ "$issue_state" == "CLOSED" ]]; then
         add_check "rust_exit_issue_${issue}_closed" "pass" "issue #$issue is CLOSED"
       else
         add_check "rust_exit_issue_${issue}_closed" "fail" "issue #$issue is $issue_state"
       fi
     elif [[ "$require_issue_states" == true ]]; then
+      add_check "rust_exit_issue_${issue}_live" "fail" "issue #$issue state is unavailable"
       add_check "rust_exit_issue_${issue}_closed" "fail" "issue #$issue state is unavailable"
     fi
   done < <(blocking_issues_from_manifest)

--- a/scripts/ci/test-check-rust-exit-readiness.sh
+++ b/scripts/ci/test-check-rust-exit-readiness.sh
@@ -109,12 +109,86 @@ statuses = {check["name"]: check["status"] for check in payload["checks"]}
 assert statuses["readiness_doc_present"] == "pass"
 assert statuses["readiness_manifest_valid"] == "pass"
 assert statuses["readiness_blockers_closed"] == "fail"
+assert statuses["readiness_blockers_live"] == "pass"
 assert statuses["readiness_blockers_live_when_not_ready"] == "pass"
 assert statuses["direct_native_runtime_abi_ready"] == "pass"
 assert statuses["command_lsp_release_boundary"] == "pass"
 assert statuses["mir_backend_direct_native_boundary"] == "pass"
 PY
 )
+
+cat >"$temp_dir/stale-issues.txt" <<'ISSUES'
+1124 CLOSED
+1191 OPEN
+731 OPEN
+ISSUES
+
+(
+  cd "$case_dir"
+  if bash scripts/ci/check-rust-exit-readiness.sh --json --issue-state-file "$temp_dir/stale-issues.txt" >"$temp_dir/stale.json" 2>"$temp_dir/stale.err"; then
+    echo "expected readiness check to fail while the manifest lists a closed stale blocker" >&2
+    exit 1
+  fi
+  python3 - "$temp_dir/stale.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    payload = json.load(handle)
+
+statuses = {check["name"]: check["status"] for check in payload["checks"]}
+assert statuses["readiness_blockers_live"] == "fail"
+assert statuses["readiness_blockers_live_when_not_ready"] == "pass"
+assert statuses["rust_exit_issue_1124_live"] == "fail"
+assert statuses["rust_exit_issue_1124_closed"] == "pass"
+assert statuses["direct_native_runtime_abi_ready"] == "pass"
+assert statuses["command_lsp_release_boundary"] == "pass"
+assert statuses["mir_backend_direct_native_boundary"] == "pass"
+PY
+)
+
+python3 - "$case_dir/docs/rust-exit-readiness.json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, encoding="utf-8") as handle:
+    payload = json.load(handle)
+
+payload["blockingIssues"] = [
+    entry for entry in payload["blockingIssues"] if entry["issue"] != 1191
+]
+
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(payload, handle)
+PY
+
+(
+  cd "$case_dir"
+  if bash scripts/ci/check-rust-exit-readiness.sh --json --issue-state-file "$temp_dir/open-issues.txt" >"$temp_dir/missing-required.json" 2>"$temp_dir/missing-required.err"; then
+    echo "expected readiness check to fail when required live blockers are omitted" >&2
+    exit 1
+  fi
+  if ! grep -q "missing required blocking issues: #1191" "$temp_dir/missing-required.err"; then
+    echo "expected missing required blocking issue detail" >&2
+    cat "$temp_dir/missing-required.err" >&2
+    exit 1
+  fi
+  python3 - "$temp_dir/missing-required.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    payload = json.load(handle)
+
+assert payload["ready"] is False
+statuses = {check["name"]: check["status"] for check in payload["checks"]}
+assert statuses["readiness_manifest_valid"] == "fail"
+assert statuses["direct_native_runtime_abi_ready"] == "pass"
+PY
+)
+
+cp "$repo_root/docs/rust-exit-readiness.json" "$case_dir/docs/rust-exit-readiness.json"
 
 cat >"$temp_dir/issues.txt" <<'ISSUES'
 1124 CLOSED
@@ -122,33 +196,6 @@ cat >"$temp_dir/issues.txt" <<'ISSUES'
 731 CLOSED
 721 OPEN
 ISSUES
-
-(
-  cd "$case_dir"
-  if ! bash scripts/ci/check-rust-exit-readiness.sh --json --issue-state-file "$temp_dir/issues.txt" >"$temp_dir/ready.json" 2>"$temp_dir/ready.err"; then
-    echo "expected readiness check to pass once blocking issues are closed and the ABI report is ready" >&2
-    exit 1
-  fi
-  python3 - "$temp_dir/ready.json" <<'PY'
-import json
-import sys
-
-with open(sys.argv[1], encoding="utf-8") as handle:
-    payload = json.load(handle)
-
-assert payload["ready"] is True
-statuses = {check["name"]: check["status"] for check in payload["checks"]}
-assert statuses["readiness_blockers_closed"] == "pass"
-assert statuses["readiness_blockers_live_when_not_ready"] == "pass"
-assert statuses["rust_exit_issue_1124_closed"] == "pass"
-assert statuses["rust_exit_issue_1191_closed"] == "pass"
-assert statuses["rust_exit_issue_731_closed"] == "pass"
-assert "rust_exit_issue_721_closed" not in statuses
-assert statuses["direct_native_runtime_abi_ready"] == "pass"
-assert statuses["command_lsp_release_boundary"] == "pass"
-assert statuses["mir_backend_direct_native_boundary"] == "pass"
-PY
-)
 
 python3 - "$case_dir/docs/rust-exit-readiness.json" <<'PY'
 import json
@@ -203,6 +250,7 @@ with open(sys.argv[1], encoding="utf-8") as handle:
 statuses = {check["name"]: check["status"] for check in payload["checks"]}
 assert statuses["readiness_manifest_valid"] == "pass"
 assert statuses["readiness_blockers_closed"] == "pass"
+assert statuses["readiness_blockers_live"] == "fail"
 assert statuses["readiness_blockers_live_when_not_ready"] == "fail"
 assert statuses["direct_native_runtime_abi_ready"] == "fail"
 PY


### PR DESCRIPTION
## Summary

- Replace stale closed Rust-exit manifest blockers with live blockers #1124, #1191, and #731.
- Add blocker-liveness validation so a closed issue left in `docs/rust-exit-readiness.json` fails instead of being silently accepted.
- Refresh Rust-exit readiness docs to distinguish historical closed evidence from the live blocker manifest.

## Governing Issue

Closes #1160

## Validation

- [x] Relevant local checks passed
  - `make rust-exit-readiness-test`
  - `make stage1-direct-native-runtime-abi`
  - `git diff --check`
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below
  - `make rust-exit-readiness` was run and is expected to fail while live blockers remain open. It now reports `readiness_blockers_live: pass` for open issues #1124, #1191, and #731, and fails on open blockers plus 34 incomplete ABI rows.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
  - Evidence surface changed: Rust-exit readiness manifest/check output now reports blocker liveness.
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact
  - Agent-facing readiness inspection now distinguishes live open blockers from stale closed blockers.

## Flow Contract

- Owner lane: Pheidon
- Repair owner: Codex
- Autonomy class: bounded readiness-gate repair
- Risk class: low

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is appropriate when gates pass

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below
- Auto-merge is not enabled yet because the PR still has an outstanding CHANGES_REQUESTED review pending renewed review after commit 1defc38.

## Notes

- This PR intentionally does not mark any runtime ABI rows implemented or claim Rust exit is complete.

