### PR TITLE
Restore generated Rust proof HTTP fast check

### DIFF
--- a/scripts/ci/run-fast-checks.sh
+++ b/scripts/ci/run-fast-checks.sh
@@ -67,5 +67,11 @@ for example in proof_cli proof_worker proof_http_service; do
   if [[ "$example" != "proof_http_service" ]]; then
     cargo run --manifest-path stage1/Cargo.toml -p axiomc -- run "stage1/examples/${example}"
   fi
-  cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test "stage1/examples/${example}" --json
+  if [[ "$example" == "proof_http_service" ]]; then
+    # Manifest HTTP service fixtures still require the generated-Rust runtime
+    # server path; the proof service build/run smoke stays on the Cranelift default.
+    cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test "stage1/examples/${example}" --backend generated-rust --json
+  else
+    cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test "stage1/examples/${example}" --json
+  fi
 done

--- a/scripts/ci/test-pr-fast-ci-workflow.sh
+++ b/scripts/ci/test-pr-fast-ci-workflow.sh
@@ -52,6 +52,12 @@ ci_gate_base_ref_line=$(printf '%s\n' "$ci_gate_section" | nl -ba | { grep -F 'r
 ci_gate_head_ref=$(printf '%s\n' "$ci_gate_section" | grep -F 'github.event.pull_request.head.sha' || true)
 benchmark_gate_reference=$(grep -nE 'check-stage1-benchmarks\.py|stage1-comparison-report\.json' "$workflow" || true)
 runtime_abi_status_check=$(grep -nF 'scripts/ci/render-direct-native-runtime-abi-status.py' "$fast_checks_script" || true)
+proof_http_generated_rust_test=$(awk '
+  /"\$example" == "proof_http_service"/ { in_http_service = 1 }
+  in_http_service && /--backend generated-rust/ { found = 1 }
+  in_http_service && /^  fi$/ { in_http_service = 0 }
+  END { if (found) print "yes" }
+' "$fast_checks_script")
 
 if [[ -n "$checkout_line" ]]; then
   echo "validate-pr-description job must not checkout untrusted pull request code" >&2
@@ -146,6 +152,11 @@ fi
 
 if [[ -z "$runtime_abi_status_check" ]]; then
   echo "run-fast-checks must validate that the direct-native runtime ABI status block matches the JSON contract" >&2
+  exit 1
+fi
+
+if [[ -z "$proof_http_generated_rust_test" ]]; then
+  echo "run-fast-checks must test proof_http_service with --backend generated-rust because its HTTP fixture service is not Cranelift-ready" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Restore the generated-Rust test backend for `proof_http_service` inside fast PR checks.
- Add a workflow self-test assertion so the HTTP service fixture fallback cannot be dropped silently.

## Governing Issue
Refs #1068.

## Validation
- [x] `bash scripts/ci/test-pr-fast-ci-workflow.sh`
- [x] `bash scripts/ci/test-toolchain-supply-chain.sh`
- [x] `python3 scripts/ci/render-direct-native-runtime-abi-status.py --check-doc docs/direct-native-runtime-abi-v0.md`
- [x] `git diff --check`
- [ ] `cargo run --manifest-path stage1/Cargo.toml -p axiomc -- test stage1/examples/proof_http_service --backend generated-rust --json` was attempted locally, but the local sandbox blocked the HTTP fixture listener with `Operation not permitted`.

## Bootstrap Governance
- No bootstrap policy changes.

## Notes
The failing #1068 Fast Checks job executes `scripts/ci/run-fast-checks.sh` from the trusted base checkout. The current base script runs the HTTP service fixture through the Cranelift test path and fails waiting for fixture readiness. This restores the prior generated-Rust test path while keeping Cranelift check/build coverage for the proof service.
