### PR TITLE
Gate Rust exit on full lib triage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test smoke supply-chain docs-python-exit docs-python-exit-test python-exit-readiness python-exit-readiness-github rust-exit-readiness rust-exit-readiness-github rust-exit-readiness-test stage1-compiler-source-monoliths stage1-compiler-source-monoliths-test stage1-direct-native-runtime-abi stage1-direct-native-runtime-abi-coverage stage1-direct-native-runtime-abi-evidence stage1-direct-native-runtime-abi-test stage1-direct-native-example-smoke stage1-direct-native-example-smoke-test stage1-axiom-dwarf-readiness-test stage1-package-graph-boundary stage1-package-graph-boundary-test stage1-diagnostics-syntax-boundary stage1-diagnostics-syntax-boundary-test stage1-command-lsp-boundary stage1-command-lsp-boundary-test stage1-hir-boundary stage1-hir-boundary-test stage1-mir-backend-boundary stage1-mir-backend-boundary-test stage1-test stage1-proof-test stage1-stdlib-test stage1-basic-smoke stage1-stdlib-smoke stage1-compiler-property-test stage1-conformance stage1-smoke stage1-bench stage1-bench-update-baseline stage1-bench-gate stage1-crap-proposal stage1-crap-thresholds stage1-crap-thresholds-test mutation-rust-smoke mutation-survivor-report stage1-run
+.PHONY: test smoke supply-chain docs-python-exit docs-python-exit-test python-exit-readiness python-exit-readiness-github rust-exit-readiness rust-exit-readiness-github rust-exit-readiness-test stage1-compiler-source-monoliths stage1-compiler-source-monoliths-test stage1-full-lib-triage stage1-full-lib-triage-test stage1-direct-native-runtime-abi stage1-direct-native-runtime-abi-coverage stage1-direct-native-runtime-abi-evidence stage1-direct-native-runtime-abi-test stage1-direct-native-example-smoke stage1-direct-native-example-smoke-test stage1-axiom-dwarf-readiness-test stage1-package-graph-boundary stage1-package-graph-boundary-test stage1-diagnostics-syntax-boundary stage1-diagnostics-syntax-boundary-test stage1-command-lsp-boundary stage1-command-lsp-boundary-test stage1-hir-boundary stage1-hir-boundary-test stage1-mir-backend-boundary stage1-mir-backend-boundary-test stage1-test stage1-proof-test stage1-stdlib-test stage1-basic-smoke stage1-stdlib-smoke stage1-compiler-property-test stage1-conformance stage1-smoke stage1-bench stage1-bench-update-baseline stage1-bench-gate stage1-crap-proposal stage1-crap-thresholds stage1-crap-thresholds-test mutation-rust-smoke mutation-survivor-report stage1-run
 
 test: docs-python-exit python-exit-readiness stage1-test
 
@@ -35,6 +35,12 @@ stage1-compiler-source-monoliths:
 
 stage1-compiler-source-monoliths-test:
 	python3 scripts/ci/test-report-compiler-source-monoliths.py
+
+stage1-full-lib-triage:
+	python3 scripts/ci/check-stage1-full-lib-triage.py --json
+
+stage1-full-lib-triage-test:
+	bash scripts/ci/test-check-stage1-full-lib-triage.sh
 
 stage1-direct-native-runtime-abi:
 	python3 scripts/ci/check-direct-native-runtime-abi.py --json

--- a/docs/rust-exit-full-lib-triage.json
+++ b/docs/rust-exit-full-lib-triage.json
@@ -1,0 +1,297 @@
+{
+  "schemaVersion": 1,
+  "issue": 1255,
+  "status": "blocked",
+  "command": "RUST_MIN_STACK=8388608 cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib --features run-native-tests",
+  "expectedFailureCount": 40,
+  "generatedRustCliStatus": "removed",
+  "notes": "This manifest records the current full axiomc lib-suite failures after the direct-native default-backend flip. It is a triage gate, not a green-suite substitute.",
+  "resolutionKinds": [
+    "pin_generated_rust_backend",
+    "update_direct_native_contract",
+    "ignore_with_linked_blocker",
+    "environment_gate"
+  ],
+  "failures": [
+    {
+      "name": "project::tests::property_tests_recover_read_only_artifact_directory",
+      "category": "direct_native_contract",
+      "resolution": "update_direct_native_contract",
+      "blockerIssue": 1255,
+      "rationale": "Repair the default direct-native artifact path behavior or update the assertion to the direct-native artifact contract."
+    },
+    {
+      "name": "tests::async_timeout_returns_without_joining_slow_host_task",
+      "category": "direct_native_contract",
+      "resolution": "update_direct_native_contract",
+      "blockerIssue": 1255,
+      "rationale": "Async host-task timeout semantics need direct-native coverage or an explicit unsupported-feature diagnostic."
+    },
+    {
+      "name": "tests::build_project_accepts_mutable_local_borrow_write_through",
+      "category": "direct_native_contract",
+      "resolution": "update_direct_native_contract",
+      "blockerIssue": 1255,
+      "rationale": "The test exercises supported ownership behavior and should pass under the direct-native default contract."
+    },
+    {
+      "name": "tests::build_project_emits_native_binary_with_capability_intrinsics",
+      "category": "stale_generated_rust_expectation",
+      "resolution": "update_direct_native_contract",
+      "blockerIssue": 1255,
+      "rationale": "The build assertion should validate native artifacts and generated_rust absence instead of generated-Rust output."
+    },
+    {
+      "name": "tests::build_project_emits_native_binary_with_imported_public_static_globals",
+      "category": "direct_native_contract",
+      "resolution": "update_direct_native_contract",
+      "blockerIssue": 1255,
+      "rationale": "Imported public static global lowering should either work natively or fail with a linked unsupported-feature diagnostic."
+    },
+    {
+      "name": "tests::build_project_emits_native_binary_with_static_globals",
+      "category": "direct_native_contract",
+      "resolution": "update_direct_native_contract",
+      "blockerIssue": 1255,
+      "rationale": "Static global lowering is part of the current direct-native ABI surface and needs full-suite coverage."
+    },
+    {
+      "name": "tests::build_project_folds_static_string_comparisons",
+      "category": "direct_native_contract",
+      "resolution": "update_direct_native_contract",
+      "blockerIssue": 1255,
+      "rationale": "Static string comparison folding needs to align with the direct-native default backend."
+    },
+    {
+      "name": "tests::build_project_preserves_static_source_names_for_recursion_tracking",
+      "category": "direct_native_contract",
+      "resolution": "update_direct_native_contract",
+      "blockerIssue": 1255,
+      "rationale": "Source-name preservation should remain observable without generated-Rust artifacts."
+    },
+    {
+      "name": "tests::build_project_runs_try_operator",
+      "category": "unsupported_construct",
+      "resolution": "ignore_with_linked_blocker",
+      "blockerIssue": 1255,
+      "rationale": "The try operator needs either direct-native lowering or an explicit ignored blocker until that lowering lands."
+    },
+    {
+      "name": "tests::build_project_scopes_fs_read_to_manifest_root",
+      "category": "stale_generated_rust_expectation",
+      "resolution": "update_direct_native_contract",
+      "blockerIssue": 1255,
+      "rationale": "Filesystem capability assertions need to validate direct-native host-shim behavior instead of generated runtime output."
+    },
+    {
+      "name": "tests::build_project_scopes_fs_write_to_manifest_root_without_read_capability",
+      "category": "stale_generated_rust_expectation",
+      "resolution": "update_direct_native_contract",
+      "blockerIssue": 1255,
+      "rationale": "Filesystem write capability assertions need direct-native host-shim expectations."
+    },
+    {
+      "name": "tests::check_project_accepts_dynamic_stdlib_network_port_with_unrestricted_net",
+      "category": "direct_native_contract",
+      "resolution": "update_direct_native_contract",
+      "blockerIssue": 1255,
+      "rationale": "Dynamic stdlib network port checking needs to match the direct-native capability policy."
+    },
+    {
+      "name": "tests::check_project_accepts_dynamic_stdlib_peer_network_port_with_unrestricted_net",
+      "category": "direct_native_contract",
+      "resolution": "update_direct_native_contract",
+      "blockerIssue": 1255,
+      "rationale": "Dynamic peer network port checking needs to match the direct-native capability policy."
+    },
+    {
+      "name": "tests::checked_in_proof_workload_examples_build_run_and_test",
+      "category": "environment_gated",
+      "resolution": "environment_gate",
+      "blockerIssue": 1255,
+      "rationale": "Proof workload examples should be split so runner-only host, network, or wasm prerequisites cannot hide direct-native regressions."
+    },
+    {
+      "name": "tests::env_allowlist_scopes_generated_env_get",
+      "category": "stale_generated_rust_expectation",
+      "resolution": "update_direct_native_contract",
+      "blockerIssue": 1255,
+      "rationale": "Environment allowlist tests still name generated runtime behavior and need direct-native capability-shim assertions."
+    },
+    {
+      "name": "tests::generated_runtime_audits_failed_network_intrinsic_paths",
+      "category": "stale_generated_rust_expectation",
+      "resolution": "update_direct_native_contract",
+      "blockerIssue": 1255,
+      "rationale": "Audit assertions need to move from generated runtime paths to direct-native host-shim evidence."
+    },
+    {
+      "name": "tests::generated_runtime_audits_write_and_http_host_intrinsics",
+      "category": "stale_generated_rust_expectation",
+      "resolution": "update_direct_native_contract",
+      "blockerIssue": 1255,
+      "rationale": "Write and HTTP audit assertions need direct-native evidence contracts."
+    },
+    {
+      "name": "tests::generated_runtime_emits_optional_host_audit_jsonl_without_secret_values",
+      "category": "stale_generated_rust_expectation",
+      "resolution": "update_direct_native_contract",
+      "blockerIssue": 1255,
+      "rationale": "Host audit JSONL coverage must be re-expressed for direct-native output."
+    },
+    {
+      "name": "tests::legacy_env_bool_still_checks_with_deprecation_warning",
+      "category": "stale_generated_rust_expectation",
+      "resolution": "update_direct_native_contract",
+      "blockerIssue": 1255,
+      "rationale": "Legacy env compatibility should be checked without relying on generated-Rust backend behavior."
+    },
+    {
+      "name": "tests::run_project_executes_defer_on_return_panic_and_nested_scope",
+      "category": "unsupported_construct",
+      "resolution": "ignore_with_linked_blocker",
+      "blockerIssue": 1255,
+      "rationale": "Defer-on-panic behavior needs direct-native lowering or a linked ignored blocker."
+    },
+    {
+      "name": "tests::run_project_forwards_cli_args_to_stdlib_cli",
+      "category": "direct_native_contract",
+      "resolution": "update_direct_native_contract",
+      "blockerIssue": 1255,
+      "rationale": "Run-command CLI argument forwarding needs direct-native runtime coverage."
+    },
+    {
+      "name": "tests::run_project_tests_reports_assertion_failure_details",
+      "category": "direct_native_contract",
+      "resolution": "update_direct_native_contract",
+      "blockerIssue": 1255,
+      "rationale": "Test-command failure diagnostics should stay stable under the direct-native default backend."
+    },
+    {
+      "name": "tests::run_project_tests_reports_std_testing_helper_failure_details",
+      "category": "direct_native_contract",
+      "resolution": "update_direct_native_contract",
+      "blockerIssue": 1255,
+      "rationale": "Std testing helper diagnostics need direct-native test-runner coverage."
+    },
+    {
+      "name": "tests::stage1_async_runtime_single_worker_drains_nested_join_and_timeout",
+      "category": "direct_native_contract",
+      "resolution": "update_direct_native_contract",
+      "blockerIssue": 1255,
+      "rationale": "Async runtime join and timeout behavior needs direct-native runtime coverage."
+    },
+    {
+      "name": "tests::stage1_async_runtime_uses_configured_scheduler_and_timer_wheel",
+      "category": "direct_native_contract",
+      "resolution": "update_direct_native_contract",
+      "blockerIssue": 1255,
+      "rationale": "Configured scheduler and timer-wheel behavior needs direct-native runtime coverage."
+    },
+    {
+      "name": "tests::stage1_async_timeout_uses_real_elapsed_timer_and_returns_none",
+      "category": "direct_native_contract",
+      "resolution": "update_direct_native_contract",
+      "blockerIssue": 1255,
+      "rationale": "Elapsed timer behavior needs direct-native runtime coverage or an explicit unsupported diagnostic."
+    },
+    {
+      "name": "tests::stage1_numeric_overflow_policy_checks_signed_debug_and_wraps_release",
+      "category": "direct_native_contract",
+      "resolution": "update_direct_native_contract",
+      "blockerIssue": 1255,
+      "rationale": "Numeric overflow policy must be proven under direct-native debug and release behavior."
+    },
+    {
+      "name": "tests::stage1_project_imports_synthetic_stdlib_fs_write_helpers",
+      "category": "stale_generated_rust_expectation",
+      "resolution": "update_direct_native_contract",
+      "blockerIssue": 1255,
+      "rationale": "Synthetic stdlib fs-write helper imports need direct-native capability-shim expectations."
+    },
+    {
+      "name": "tests::stage1_project_imports_synthetic_stdlib_net_module",
+      "category": "stale_generated_rust_expectation",
+      "resolution": "update_direct_native_contract",
+      "blockerIssue": 1255,
+      "rationale": "Synthetic stdlib net imports need direct-native capability-shim expectations."
+    },
+    {
+      "name": "tests::stage1_project_imports_synthetic_stdlib_net_tcp_module",
+      "category": "stale_generated_rust_expectation",
+      "resolution": "update_direct_native_contract",
+      "blockerIssue": 1255,
+      "rationale": "Synthetic stdlib net TCP imports need direct-native capability-shim expectations."
+    },
+    {
+      "name": "tests::stage1_project_imports_synthetic_stdlib_net_udp_module",
+      "category": "stale_generated_rust_expectation",
+      "resolution": "update_direct_native_contract",
+      "blockerIssue": 1255,
+      "rationale": "Synthetic stdlib net UDP imports need direct-native capability-shim expectations."
+    },
+    {
+      "name": "tests::stage1_project_imports_synthetic_stdlib_serdes_module",
+      "category": "stale_generated_rust_expectation",
+      "resolution": "update_direct_native_contract",
+      "blockerIssue": 1255,
+      "rationale": "Synthetic stdlib serdes imports need direct-native artifact and output expectations."
+    },
+    {
+      "name": "tests::stage1_project_reads_lines_from_stdlib_io_module",
+      "category": "direct_native_contract",
+      "resolution": "update_direct_native_contract",
+      "blockerIssue": 1255,
+      "rationale": "Stdlib IO line-reading behavior needs direct-native runtime coverage."
+    },
+    {
+      "name": "tests::stage1_project_reads_stdin_to_string_from_stdlib_io_module",
+      "category": "direct_native_contract",
+      "resolution": "update_direct_native_contract",
+      "blockerIssue": 1255,
+      "rationale": "Stdlib IO read-to-string behavior needs direct-native runtime coverage."
+    },
+    {
+      "name": "tests::stage1_project_rejects_stdlib_env_without_env_capability",
+      "category": "direct_native_contract",
+      "resolution": "update_direct_native_contract",
+      "blockerIssue": 1255,
+      "rationale": "Env denial diagnostics need to match direct-native capability-shim behavior."
+    },
+    {
+      "name": "tests::stage1_project_supports_async_runtime_surface",
+      "category": "direct_native_contract",
+      "resolution": "update_direct_native_contract",
+      "blockerIssue": 1255,
+      "rationale": "The async runtime surface needs direct-native coverage or explicit unsupported diagnostics."
+    },
+    {
+      "name": "tests::stage1_runtime_reports_structured_error_for_slice_failures",
+      "category": "direct_native_contract",
+      "resolution": "update_direct_native_contract",
+      "blockerIssue": 1255,
+      "rationale": "Structured slice errors need direct-native runtime diagnostics."
+    },
+    {
+      "name": "tests::stage1_runtime_reports_structured_slice_error_in_debug_and_release",
+      "category": "direct_native_contract",
+      "resolution": "update_direct_native_contract",
+      "blockerIssue": 1255,
+      "rationale": "Structured slice errors must be validated in direct-native debug and release modes."
+    },
+    {
+      "name": "tests::stage1_stdlib_http_routed_service_rejects_non_loopback_bind",
+      "category": "environment_gated",
+      "resolution": "environment_gate",
+      "blockerIssue": 1255,
+      "rationale": "HTTP service bind tests need runner policy separation so shell-only environments do not produce false reds."
+    },
+    {
+      "name": "tests::stage1_stdlib_http_service_rejects_non_loopback_bind",
+      "category": "environment_gated",
+      "resolution": "environment_gate",
+      "blockerIssue": 1255,
+      "rationale": "HTTP service bind tests need runner policy separation so shell-only environments do not produce false reds."
+    }
+  ]
+}

--- a/docs/rust-exit-full-lib-triage.json
+++ b/docs/rust-exit-full-lib-triage.json
@@ -172,7 +172,8 @@
       "resolution": "ignore_with_linked_blocker",
       "blockerIssue": 1255,
       "rationale": "Defer-on-panic behavior needs direct-native lowering or a linked ignored blocker.",
-      "resolutionStatus": "open"
+      "resolutionStatus": "fixed_pending_merge",
+      "resolvedBy": 1273
     },
     {
       "name": "tests::run_project_forwards_cli_args_to_stdlib_cli",
@@ -340,11 +341,11 @@
   "resolutionTracking": {
     "updated": "2026-06-30",
     "evidence": "https://github.com/OMT-Global/axiomlang/issues/1255#issuecomment-4840906364",
-    "summary": "Integration of the open Rust-exit stack onto main resolves 19/40 rows (addressed_by_open_stack); PRs #1271/#1272 resolve 3 more (fixed_pending_merge). expectedFailureCount stays 40 until these PRs merge to main.",
+    "summary": "Integration of the open Rust-exit stack onto main resolves 19/40 rows (addressed_by_open_stack); PRs #1271/#1272/#1273 resolve 4 more (fixed_pending_merge: read-only artifact contract, structured assertion traps, defer). expectedFailureCount stays 40 until these PRs merge to main.",
     "statuses": {
-      "addressed_by_open_stack": 19,
-      "fixed_pending_merge": 3,
-      "open": 18
+      "fixed_pending_merge": 4,
+      "open": 17,
+      "addressed_by_open_stack": 19
     }
   }
 }

--- a/docs/rust-exit-full-lib-triage.json
+++ b/docs/rust-exit-full-lib-triage.json
@@ -239,7 +239,8 @@
       "resolution": "update_direct_native_contract",
       "blockerIssue": 1255,
       "rationale": "Synthetic stdlib fs-write helper imports need direct-native capability-shim expectations.",
-      "resolutionStatus": "open"
+      "resolutionStatus": "addressed_by_open_stack",
+      "resolvedBy": 1268
     },
     {
       "name": "tests::stage1_project_imports_synthetic_stdlib_net_module",
@@ -341,11 +342,11 @@
   "resolutionTracking": {
     "updated": "2026-06-30",
     "evidence": "https://github.com/OMT-Global/axiomlang/issues/1255#issuecomment-4840906364",
-    "summary": "Integration of the open Rust-exit stack onto main resolves 19/40 rows (addressed_by_open_stack); PRs #1271/#1272/#1273 resolve 4 more (fixed_pending_merge: read-only artifact contract, structured assertion traps, defer). expectedFailureCount stays 40 until these PRs merge to main.",
+    "summary": "Integration of the open Rust-exit stack onto main resolves 20/40 rows (addressed_by_open_stack, incl. fs_write_helpers via the completed #1268 fs-write scoping); PRs #1271/#1272/#1273 resolve 4 more (fixed_pending_merge: read-only artifact contract, structured assertion traps, defer). expectedFailureCount stays 40 until these PRs merge to main.",
     "statuses": {
       "fixed_pending_merge": 4,
-      "open": 17,
-      "addressed_by_open_stack": 19
+      "open": 16,
+      "addressed_by_open_stack": 20
     }
   }
 }

--- a/docs/rust-exit-full-lib-triage.json
+++ b/docs/rust-exit-full-lib-triage.json
@@ -18,280 +18,333 @@
       "category": "direct_native_contract",
       "resolution": "update_direct_native_contract",
       "blockerIssue": 1255,
-      "rationale": "Repair the default direct-native artifact path behavior or update the assertion to the direct-native artifact contract."
+      "rationale": "Repair the default direct-native artifact path behavior or update the assertion to the direct-native artifact contract.",
+      "resolutionStatus": "fixed_pending_merge",
+      "resolvedBy": 1271
     },
     {
       "name": "tests::async_timeout_returns_without_joining_slow_host_task",
       "category": "direct_native_contract",
       "resolution": "update_direct_native_contract",
       "blockerIssue": 1255,
-      "rationale": "Async host-task timeout semantics need direct-native coverage or an explicit unsupported-feature diagnostic."
+      "rationale": "Async host-task timeout semantics need direct-native coverage or an explicit unsupported-feature diagnostic.",
+      "resolutionStatus": "open"
     },
     {
       "name": "tests::build_project_accepts_mutable_local_borrow_write_through",
       "category": "direct_native_contract",
       "resolution": "update_direct_native_contract",
       "blockerIssue": 1255,
-      "rationale": "The test exercises supported ownership behavior and should pass under the direct-native default contract."
+      "rationale": "The test exercises supported ownership behavior and should pass under the direct-native default contract.",
+      "resolutionStatus": "addressed_by_open_stack"
     },
     {
       "name": "tests::build_project_emits_native_binary_with_capability_intrinsics",
       "category": "stale_generated_rust_expectation",
       "resolution": "update_direct_native_contract",
       "blockerIssue": 1255,
-      "rationale": "The build assertion should validate native artifacts and generated_rust absence instead of generated-Rust output."
+      "rationale": "The build assertion should validate native artifacts and generated_rust absence instead of generated-Rust output.",
+      "resolutionStatus": "open"
     },
     {
       "name": "tests::build_project_emits_native_binary_with_imported_public_static_globals",
       "category": "direct_native_contract",
       "resolution": "update_direct_native_contract",
       "blockerIssue": 1255,
-      "rationale": "Imported public static global lowering should either work natively or fail with a linked unsupported-feature diagnostic."
+      "rationale": "Imported public static global lowering should either work natively or fail with a linked unsupported-feature diagnostic.",
+      "resolutionStatus": "addressed_by_open_stack"
     },
     {
       "name": "tests::build_project_emits_native_binary_with_static_globals",
       "category": "direct_native_contract",
       "resolution": "update_direct_native_contract",
       "blockerIssue": 1255,
-      "rationale": "Static global lowering is part of the current direct-native ABI surface and needs full-suite coverage."
+      "rationale": "Static global lowering is part of the current direct-native ABI surface and needs full-suite coverage.",
+      "resolutionStatus": "addressed_by_open_stack"
     },
     {
       "name": "tests::build_project_folds_static_string_comparisons",
       "category": "direct_native_contract",
       "resolution": "update_direct_native_contract",
       "blockerIssue": 1255,
-      "rationale": "Static string comparison folding needs to align with the direct-native default backend."
+      "rationale": "Static string comparison folding needs to align with the direct-native default backend.",
+      "resolutionStatus": "addressed_by_open_stack"
     },
     {
       "name": "tests::build_project_preserves_static_source_names_for_recursion_tracking",
       "category": "direct_native_contract",
       "resolution": "update_direct_native_contract",
       "blockerIssue": 1255,
-      "rationale": "Source-name preservation should remain observable without generated-Rust artifacts."
+      "rationale": "Source-name preservation should remain observable without generated-Rust artifacts.",
+      "resolutionStatus": "addressed_by_open_stack"
     },
     {
       "name": "tests::build_project_runs_try_operator",
       "category": "unsupported_construct",
       "resolution": "ignore_with_linked_blocker",
       "blockerIssue": 1255,
-      "rationale": "The try operator needs either direct-native lowering or an explicit ignored blocker until that lowering lands."
+      "rationale": "The try operator needs either direct-native lowering or an explicit ignored blocker until that lowering lands.",
+      "resolutionStatus": "addressed_by_open_stack"
     },
     {
       "name": "tests::build_project_scopes_fs_read_to_manifest_root",
       "category": "stale_generated_rust_expectation",
       "resolution": "update_direct_native_contract",
       "blockerIssue": 1255,
-      "rationale": "Filesystem capability assertions need to validate direct-native host-shim behavior instead of generated runtime output."
+      "rationale": "Filesystem capability assertions need to validate direct-native host-shim behavior instead of generated runtime output.",
+      "resolutionStatus": "addressed_by_open_stack"
     },
     {
       "name": "tests::build_project_scopes_fs_write_to_manifest_root_without_read_capability",
       "category": "stale_generated_rust_expectation",
       "resolution": "update_direct_native_contract",
       "blockerIssue": 1255,
-      "rationale": "Filesystem write capability assertions need direct-native host-shim expectations."
+      "rationale": "Filesystem write capability assertions need direct-native host-shim expectations.",
+      "resolutionStatus": "addressed_by_open_stack"
     },
     {
       "name": "tests::check_project_accepts_dynamic_stdlib_network_port_with_unrestricted_net",
       "category": "direct_native_contract",
       "resolution": "update_direct_native_contract",
       "blockerIssue": 1255,
-      "rationale": "Dynamic stdlib network port checking needs to match the direct-native capability policy."
+      "rationale": "Dynamic stdlib network port checking needs to match the direct-native capability policy.",
+      "resolutionStatus": "open"
     },
     {
       "name": "tests::check_project_accepts_dynamic_stdlib_peer_network_port_with_unrestricted_net",
       "category": "direct_native_contract",
       "resolution": "update_direct_native_contract",
       "blockerIssue": 1255,
-      "rationale": "Dynamic peer network port checking needs to match the direct-native capability policy."
+      "rationale": "Dynamic peer network port checking needs to match the direct-native capability policy.",
+      "resolutionStatus": "open"
     },
     {
       "name": "tests::checked_in_proof_workload_examples_build_run_and_test",
       "category": "environment_gated",
       "resolution": "environment_gate",
       "blockerIssue": 1255,
-      "rationale": "Proof workload examples should be split so runner-only host, network, or wasm prerequisites cannot hide direct-native regressions."
+      "rationale": "Proof workload examples should be split so runner-only host, network, or wasm prerequisites cannot hide direct-native regressions.",
+      "resolutionStatus": "open"
     },
     {
       "name": "tests::env_allowlist_scopes_generated_env_get",
       "category": "stale_generated_rust_expectation",
       "resolution": "update_direct_native_contract",
       "blockerIssue": 1255,
-      "rationale": "Environment allowlist tests still name generated runtime behavior and need direct-native capability-shim assertions."
+      "rationale": "Environment allowlist tests still name generated runtime behavior and need direct-native capability-shim assertions.",
+      "resolutionStatus": "addressed_by_open_stack"
     },
     {
       "name": "tests::generated_runtime_audits_failed_network_intrinsic_paths",
       "category": "stale_generated_rust_expectation",
       "resolution": "update_direct_native_contract",
       "blockerIssue": 1255,
-      "rationale": "Audit assertions need to move from generated runtime paths to direct-native host-shim evidence."
+      "rationale": "Audit assertions need to move from generated runtime paths to direct-native host-shim evidence.",
+      "resolutionStatus": "addressed_by_open_stack"
     },
     {
       "name": "tests::generated_runtime_audits_write_and_http_host_intrinsics",
       "category": "stale_generated_rust_expectation",
       "resolution": "update_direct_native_contract",
       "blockerIssue": 1255,
-      "rationale": "Write and HTTP audit assertions need direct-native evidence contracts."
+      "rationale": "Write and HTTP audit assertions need direct-native evidence contracts.",
+      "resolutionStatus": "addressed_by_open_stack"
     },
     {
       "name": "tests::generated_runtime_emits_optional_host_audit_jsonl_without_secret_values",
       "category": "stale_generated_rust_expectation",
       "resolution": "update_direct_native_contract",
       "blockerIssue": 1255,
-      "rationale": "Host audit JSONL coverage must be re-expressed for direct-native output."
+      "rationale": "Host audit JSONL coverage must be re-expressed for direct-native output.",
+      "resolutionStatus": "addressed_by_open_stack"
     },
     {
       "name": "tests::legacy_env_bool_still_checks_with_deprecation_warning",
       "category": "stale_generated_rust_expectation",
       "resolution": "update_direct_native_contract",
       "blockerIssue": 1255,
-      "rationale": "Legacy env compatibility should be checked without relying on generated-Rust backend behavior."
+      "rationale": "Legacy env compatibility should be checked without relying on generated-Rust backend behavior.",
+      "resolutionStatus": "open"
     },
     {
       "name": "tests::run_project_executes_defer_on_return_panic_and_nested_scope",
       "category": "unsupported_construct",
       "resolution": "ignore_with_linked_blocker",
       "blockerIssue": 1255,
-      "rationale": "Defer-on-panic behavior needs direct-native lowering or a linked ignored blocker."
+      "rationale": "Defer-on-panic behavior needs direct-native lowering or a linked ignored blocker.",
+      "resolutionStatus": "open"
     },
     {
       "name": "tests::run_project_forwards_cli_args_to_stdlib_cli",
       "category": "direct_native_contract",
       "resolution": "update_direct_native_contract",
       "blockerIssue": 1255,
-      "rationale": "Run-command CLI argument forwarding needs direct-native runtime coverage."
+      "rationale": "Run-command CLI argument forwarding needs direct-native runtime coverage.",
+      "resolutionStatus": "addressed_by_open_stack"
     },
     {
       "name": "tests::run_project_tests_reports_assertion_failure_details",
       "category": "direct_native_contract",
       "resolution": "update_direct_native_contract",
       "blockerIssue": 1255,
-      "rationale": "Test-command failure diagnostics should stay stable under the direct-native default backend."
+      "rationale": "Test-command failure diagnostics should stay stable under the direct-native default backend.",
+      "resolutionStatus": "fixed_pending_merge",
+      "resolvedBy": 1272
     },
     {
       "name": "tests::run_project_tests_reports_std_testing_helper_failure_details",
       "category": "direct_native_contract",
       "resolution": "update_direct_native_contract",
       "blockerIssue": 1255,
-      "rationale": "Std testing helper diagnostics need direct-native test-runner coverage."
+      "rationale": "Std testing helper diagnostics need direct-native test-runner coverage.",
+      "resolutionStatus": "fixed_pending_merge",
+      "resolvedBy": 1272
     },
     {
       "name": "tests::stage1_async_runtime_single_worker_drains_nested_join_and_timeout",
       "category": "direct_native_contract",
       "resolution": "update_direct_native_contract",
       "blockerIssue": 1255,
-      "rationale": "Async runtime join and timeout behavior needs direct-native runtime coverage."
+      "rationale": "Async runtime join and timeout behavior needs direct-native runtime coverage.",
+      "resolutionStatus": "open"
     },
     {
       "name": "tests::stage1_async_runtime_uses_configured_scheduler_and_timer_wheel",
       "category": "direct_native_contract",
       "resolution": "update_direct_native_contract",
       "blockerIssue": 1255,
-      "rationale": "Configured scheduler and timer-wheel behavior needs direct-native runtime coverage."
+      "rationale": "Configured scheduler and timer-wheel behavior needs direct-native runtime coverage.",
+      "resolutionStatus": "open"
     },
     {
       "name": "tests::stage1_async_timeout_uses_real_elapsed_timer_and_returns_none",
       "category": "direct_native_contract",
       "resolution": "update_direct_native_contract",
       "blockerIssue": 1255,
-      "rationale": "Elapsed timer behavior needs direct-native runtime coverage or an explicit unsupported diagnostic."
+      "rationale": "Elapsed timer behavior needs direct-native runtime coverage or an explicit unsupported diagnostic.",
+      "resolutionStatus": "open"
     },
     {
       "name": "tests::stage1_numeric_overflow_policy_checks_signed_debug_and_wraps_release",
       "category": "direct_native_contract",
       "resolution": "update_direct_native_contract",
       "blockerIssue": 1255,
-      "rationale": "Numeric overflow policy must be proven under direct-native debug and release behavior."
+      "rationale": "Numeric overflow policy must be proven under direct-native debug and release behavior.",
+      "resolutionStatus": "open"
     },
     {
       "name": "tests::stage1_project_imports_synthetic_stdlib_fs_write_helpers",
       "category": "stale_generated_rust_expectation",
       "resolution": "update_direct_native_contract",
       "blockerIssue": 1255,
-      "rationale": "Synthetic stdlib fs-write helper imports need direct-native capability-shim expectations."
+      "rationale": "Synthetic stdlib fs-write helper imports need direct-native capability-shim expectations.",
+      "resolutionStatus": "open"
     },
     {
       "name": "tests::stage1_project_imports_synthetic_stdlib_net_module",
       "category": "stale_generated_rust_expectation",
       "resolution": "update_direct_native_contract",
       "blockerIssue": 1255,
-      "rationale": "Synthetic stdlib net imports need direct-native capability-shim expectations."
+      "rationale": "Synthetic stdlib net imports need direct-native capability-shim expectations.",
+      "resolutionStatus": "open"
     },
     {
       "name": "tests::stage1_project_imports_synthetic_stdlib_net_tcp_module",
       "category": "stale_generated_rust_expectation",
       "resolution": "update_direct_native_contract",
       "blockerIssue": 1255,
-      "rationale": "Synthetic stdlib net TCP imports need direct-native capability-shim expectations."
+      "rationale": "Synthetic stdlib net TCP imports need direct-native capability-shim expectations.",
+      "resolutionStatus": "open"
     },
     {
       "name": "tests::stage1_project_imports_synthetic_stdlib_net_udp_module",
       "category": "stale_generated_rust_expectation",
       "resolution": "update_direct_native_contract",
       "blockerIssue": 1255,
-      "rationale": "Synthetic stdlib net UDP imports need direct-native capability-shim expectations."
+      "rationale": "Synthetic stdlib net UDP imports need direct-native capability-shim expectations.",
+      "resolutionStatus": "open"
     },
     {
       "name": "tests::stage1_project_imports_synthetic_stdlib_serdes_module",
       "category": "stale_generated_rust_expectation",
       "resolution": "update_direct_native_contract",
       "blockerIssue": 1255,
-      "rationale": "Synthetic stdlib serdes imports need direct-native artifact and output expectations."
+      "rationale": "Synthetic stdlib serdes imports need direct-native artifact and output expectations.",
+      "resolutionStatus": "open"
     },
     {
       "name": "tests::stage1_project_reads_lines_from_stdlib_io_module",
       "category": "direct_native_contract",
       "resolution": "update_direct_native_contract",
       "blockerIssue": 1255,
-      "rationale": "Stdlib IO line-reading behavior needs direct-native runtime coverage."
+      "rationale": "Stdlib IO line-reading behavior needs direct-native runtime coverage.",
+      "resolutionStatus": "addressed_by_open_stack"
     },
     {
       "name": "tests::stage1_project_reads_stdin_to_string_from_stdlib_io_module",
       "category": "direct_native_contract",
       "resolution": "update_direct_native_contract",
       "blockerIssue": 1255,
-      "rationale": "Stdlib IO read-to-string behavior needs direct-native runtime coverage."
+      "rationale": "Stdlib IO read-to-string behavior needs direct-native runtime coverage.",
+      "resolutionStatus": "addressed_by_open_stack"
     },
     {
       "name": "tests::stage1_project_rejects_stdlib_env_without_env_capability",
       "category": "direct_native_contract",
       "resolution": "update_direct_native_contract",
       "blockerIssue": 1255,
-      "rationale": "Env denial diagnostics need to match direct-native capability-shim behavior."
+      "rationale": "Env denial diagnostics need to match direct-native capability-shim behavior.",
+      "resolutionStatus": "addressed_by_open_stack"
     },
     {
       "name": "tests::stage1_project_supports_async_runtime_surface",
       "category": "direct_native_contract",
       "resolution": "update_direct_native_contract",
       "blockerIssue": 1255,
-      "rationale": "The async runtime surface needs direct-native coverage or explicit unsupported diagnostics."
+      "rationale": "The async runtime surface needs direct-native coverage or explicit unsupported diagnostics.",
+      "resolutionStatus": "addressed_by_open_stack"
     },
     {
       "name": "tests::stage1_runtime_reports_structured_error_for_slice_failures",
       "category": "direct_native_contract",
       "resolution": "update_direct_native_contract",
       "blockerIssue": 1255,
-      "rationale": "Structured slice errors need direct-native runtime diagnostics."
+      "rationale": "Structured slice errors need direct-native runtime diagnostics.",
+      "resolutionStatus": "addressed_by_open_stack"
     },
     {
       "name": "tests::stage1_runtime_reports_structured_slice_error_in_debug_and_release",
       "category": "direct_native_contract",
       "resolution": "update_direct_native_contract",
       "blockerIssue": 1255,
-      "rationale": "Structured slice errors must be validated in direct-native debug and release modes."
+      "rationale": "Structured slice errors must be validated in direct-native debug and release modes.",
+      "resolutionStatus": "addressed_by_open_stack"
     },
     {
       "name": "tests::stage1_stdlib_http_routed_service_rejects_non_loopback_bind",
       "category": "environment_gated",
       "resolution": "environment_gate",
       "blockerIssue": 1255,
-      "rationale": "HTTP service bind tests need runner policy separation so shell-only environments do not produce false reds."
+      "rationale": "HTTP service bind tests need runner policy separation so shell-only environments do not produce false reds.",
+      "resolutionStatus": "open"
     },
     {
       "name": "tests::stage1_stdlib_http_service_rejects_non_loopback_bind",
       "category": "environment_gated",
       "resolution": "environment_gate",
       "blockerIssue": 1255,
-      "rationale": "HTTP service bind tests need runner policy separation so shell-only environments do not produce false reds."
+      "rationale": "HTTP service bind tests need runner policy separation so shell-only environments do not produce false reds.",
+      "resolutionStatus": "open"
     }
-  ]
+  ],
+  "resolutionTracking": {
+    "updated": "2026-06-30",
+    "evidence": "https://github.com/OMT-Global/axiomlang/issues/1255#issuecomment-4840906364",
+    "summary": "Integration of the open Rust-exit stack onto main resolves 19/40 rows (addressed_by_open_stack); PRs #1271/#1272 resolve 3 more (fixed_pending_merge). expectedFailureCount stays 40 until these PRs merge to main.",
+    "statuses": {
+      "addressed_by_open_stack": 19,
+      "fixed_pending_merge": 3,
+      "open": 18
+    }
+  }
 }

--- a/docs/rust-exit-readiness.json
+++ b/docs/rust-exit-readiness.json
@@ -8,6 +8,11 @@
       "check": "Generated-Rust backend, rustc targeted-build fallback, and compatibility alias are removed from the supported toolchain."
     },
     {
+      "issue": 1255,
+      "lane": "qa",
+      "check": "The full axiomc lib suite is triaged, the blocking direct-native failures are repaired or explicitly gated, and backend parity evidence is green before final Rust removal."
+    },
+    {
       "issue": 731,
       "lane": "tooling",
       "check": "Documentation generator, LSP server, and protocol path are AxiOM-owned."

--- a/docs/rust-exit-readiness.md
+++ b/docs/rust-exit-readiness.md
@@ -41,6 +41,7 @@ review gates to be satisfied.
 | Direct native parity matrix | Every supported stage1 surface has a direct-native status row and linked blocker when incomplete. | Implemented as the checked runtime ABI matrix; no runtime ABI rows remain incomplete. | [#927](https://github.com/OMT-Global/axiomlang/issues/927) |
 | Direct native runtime ABI | Supported values, ownership shapes, stdlib calls, and capability host calls lower through backend-neutral direct-native runtime entrypoints. | Implemented and checked by `scripts/ci/check-direct-native-runtime-abi.py`; default-backend, LSP, and final Rust-removal gates remain separate blockers. | [#1124](https://github.com/OMT-Global/axiomlang/issues/1124) |
 | Direct native diagnostics and evidence | Direct native builds preserve source diagnostics, provenance, debug manifests, and operator evidence without generated Rust. | Implemented for the Cranelift direct-native spike; broader coverage remains gated by default-backend blockers. | [#929](https://github.com/OMT-Global/axiomlang/issues/929) |
+| Full lib-suite and backend parity gate | The full `axiomc --lib --features run-native-tests` suite is triaged, environment-gated cases are separated, direct-native failures are repaired or explicitly linked to blockers, and parity evidence is green before final Rust removal. | Blocked by [#1255](https://github.com/OMT-Global/axiomlang/issues/1255). The current triage is checked by `make stage1-full-lib-triage`; it records 40 known full-suite failures and keeps the gap visible without pretending the suite is green. | [#1255](https://github.com/OMT-Global/axiomlang/issues/1255) |
 | Default backend | `axiomc build` defaults to direct native output and no longer invokes `rustc` for supported broad builds. | Host/native builds default to the direct-native Cranelift backend; default targeted builds fail closed instead of falling back to generated Rust, and extended conformance now runs on Cranelift with `generated_rust: null`. | [#1191](https://github.com/OMT-Global/axiomlang/issues/1191) |
 | Generated-Rust removal | The generated-Rust backend and `--backend rust` compatibility path are removed after a release with direct native as default. | Generated Rust remains present only as internal legacy compatibility code and must leave the toolchain before Rust exit completes. The CLI parser no longer accepts `--backend generated-rust` or the old `--backend rust` transition alias. | [#1191](https://github.com/OMT-Global/axiomlang/issues/1191) |
 
@@ -58,6 +59,10 @@ review gates to be satisfied.
 
 - The direct native backend may replace generated Rust only after the backend
   matrix has no incomplete rows (`partial` or `blocked`).
+- Final Rust removal also requires the full lib-suite and backend parity gate in
+  #1255 to be green; direct-native ABI readiness alone is not enough while
+  `cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib --features
+  run-native-tests` has known untriaged or unrepaired failures.
 - A direct-native runtime ABI row may be marked `implemented` only when it has
   runtime-entrypoint or backend-emitted codegen evidence; compiler-side
   Cranelift spike evaluation alone is not sufficient.

--- a/scripts/ci/check-rust-exit-readiness.sh
+++ b/scripts/ci/check-rust-exit-readiness.sh
@@ -353,7 +353,7 @@ if payload["finalBootstrapIssue"] in issues:
     print("finalBootstrapIssue must not also be listed as a blocker", file=sys.stderr)
     sys.exit(1)
 
-required = {731, 1191}
+required = {731, 1191, 1255}
 missing = sorted(required - set(issues))
 if missing:
     print("missing required blocking issues: " + ", ".join(f"#{issue}" for issue in missing), file=sys.stderr)

--- a/scripts/ci/check-stage1-full-lib-triage.py
+++ b/scripts/ci/check-stage1-full-lib-triage.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Validate the Rust-exit full axiomc lib-suite triage manifest."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MANIFEST = REPO_ROOT / "docs/rust-exit-full-lib-triage.json"
+REQUIRED_COMMAND_PARTS = [
+    "RUST_MIN_STACK=8388608",
+    "cargo test",
+    "--manifest-path stage1/Cargo.toml",
+    "-p axiomc",
+    "--lib",
+    "--features run-native-tests",
+]
+ALLOWED_CATEGORIES = {
+    "direct_native_contract",
+    "environment_gated",
+    "stale_generated_rust_expectation",
+    "unsupported_construct",
+}
+ALLOWED_RESOLUTIONS = {
+    "environment_gate",
+    "ignore_with_linked_blocker",
+    "pin_generated_rust_backend",
+    "update_direct_native_contract",
+}
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise SystemExit(f"{path} must contain a JSON object")
+    return payload
+
+
+def validate(payload: dict[str, Any]) -> tuple[list[str], dict[str, Any]]:
+    errors: list[str] = []
+    failures = payload.get("failures")
+    if not isinstance(failures, list):
+        failures = []
+        errors.append("failures must be a list")
+
+    if payload.get("schemaVersion") != 1:
+        errors.append("schemaVersion must be 1")
+    if payload.get("issue") != 1255:
+        errors.append("issue must be 1255")
+    if payload.get("status") not in {"blocked", "ready"}:
+        errors.append("status must be blocked or ready")
+    if payload.get("generatedRustCliStatus") != "removed":
+        errors.append("generatedRustCliStatus must record removed")
+
+    command = payload.get("command")
+    if not isinstance(command, str) or not command:
+        errors.append("command must be a non-empty string")
+    else:
+        for required in REQUIRED_COMMAND_PARTS:
+            if required not in command:
+                errors.append(f"command must include {required!r}")
+
+    expected = payload.get("expectedFailureCount")
+    if expected != len(failures):
+        errors.append(
+            f"expectedFailureCount must equal failures length ({expected!r} != {len(failures)})"
+        )
+
+    names: list[str] = []
+    category_counts: Counter[str] = Counter()
+    resolution_counts: Counter[str] = Counter()
+    for index, failure in enumerate(failures):
+        if not isinstance(failure, dict):
+            errors.append(f"failures[{index}] must be an object")
+            continue
+
+        name = failure.get("name")
+        category = failure.get("category")
+        resolution = failure.get("resolution")
+        blocker = failure.get("blockerIssue")
+        rationale = failure.get("rationale")
+
+        if not isinstance(name, str) or not name:
+            errors.append(f"failures[{index}].name must be a non-empty string")
+        else:
+            names.append(name)
+        if category not in ALLOWED_CATEGORIES:
+            errors.append(f"{name or index}: unknown category {category!r}")
+        else:
+            category_counts[category] += 1
+        if resolution not in ALLOWED_RESOLUTIONS:
+            errors.append(f"{name or index}: unknown resolution {resolution!r}")
+        else:
+            resolution_counts[resolution] += 1
+        if category == "environment_gated" and resolution != "environment_gate":
+            errors.append(f"{name or index}: environment_gated rows must use environment_gate")
+        if category != "environment_gated" and resolution == "environment_gate":
+            errors.append(f"{name or index}: only environment_gated rows may use environment_gate")
+        if resolution == "ignore_with_linked_blocker" and not isinstance(blocker, int):
+            errors.append(f"{name or index}: ignored rows must name a numeric blockerIssue")
+        if not isinstance(blocker, int):
+            errors.append(f"{name or index}: blockerIssue must be a number")
+        if not isinstance(rationale, str) or len(rationale.strip()) < 20:
+            errors.append(f"{name or index}: rationale must explain the triage")
+
+    duplicates = sorted(name for name, count in Counter(names).items() if count > 1)
+    if duplicates:
+        errors.append("duplicate failure rows: " + ", ".join(duplicates))
+    if names != sorted(names):
+        errors.append("failure rows must be sorted by name")
+
+    if failures and not category_counts.get("stale_generated_rust_expectation"):
+        errors.append("triage must identify stale generated-Rust expectations")
+    if failures and not category_counts.get("direct_native_contract"):
+        errors.append("triage must identify direct-native contract repairs")
+    if failures and not category_counts.get("environment_gated"):
+        errors.append("triage must identify environment-gated failures separately")
+
+    summary = {
+        "failure_count": len(failures),
+        "categories": dict(sorted(category_counts.items())),
+        "resolutions": dict(sorted(resolution_counts.items())),
+    }
+    return errors, summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    payload = load_json(args.manifest)
+    errors, summary = validate(payload)
+    report = {
+        "schema": "axiom.stage1.full_lib_triage.v1",
+        "ready": not errors and payload.get("status") == "ready",
+        "triaged": not errors,
+        "issue": payload.get("issue"),
+        "status": payload.get("status"),
+        "summary": summary,
+        "errors": errors,
+    }
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    elif errors:
+        for error in errors:
+            print(error)
+
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/run-fast-checks.sh
+++ b/scripts/ci/run-fast-checks.sh
@@ -14,6 +14,10 @@ bash "$script_repo_root/scripts/ci/validate-capability-manifests.sh"
 bash "$script_repo_root/scripts/ci/test-validate-capability-manifests.sh"
 bash "$script_repo_root/scripts/ci/test-pr-fast-ci-workflow.sh"
 bash "$script_repo_root/scripts/ci/test-run-extended-stage1-checks.sh"
+python3 "$script_repo_root/scripts/ci/check-stage1-full-lib-triage.py" \
+  --manifest "$repo_root/docs/rust-exit-full-lib-triage.json" \
+  --json >/dev/null
+bash "$script_repo_root/scripts/ci/test-check-stage1-full-lib-triage.sh"
 python3 "$script_repo_root/scripts/ci/render-direct-native-runtime-abi-status.py" \
   --contract "$repo_root/stage1/runtime-abi/direct-native-v0.json" \
   --check-doc "$repo_root/docs/direct-native-runtime-abi-v0.md"

--- a/scripts/ci/test-check-rust-exit-readiness.sh
+++ b/scripts/ci/test-check-rust-exit-readiness.sh
@@ -49,6 +49,7 @@ MAKE
 
 cat >"$temp_dir/partial-issues.txt" <<'ISSUES'
 1191 CLOSED
+1255 OPEN
 731 OPEN
 ISSUES
 
@@ -123,6 +124,7 @@ PY
 
 cat >"$temp_dir/open-issues.txt" <<'ISSUES'
 1191 OPEN
+1255 OPEN
 731 OPEN
 ISSUES
 
@@ -156,6 +158,7 @@ PY
 
 cat >"$temp_dir/issues.txt" <<'ISSUES'
 1191 CLOSED
+1255 CLOSED
 731 CLOSED
 ISSUES
 
@@ -177,6 +180,7 @@ statuses = {check["name"]: check["status"] for check in payload["checks"]}
 assert statuses["readiness_blockers_closed"] == "pass"
 assert statuses["readiness_blockers_live_when_not_ready"] == "pass"
 assert statuses["rust_exit_issue_1191_closed"] == "pass"
+assert statuses["rust_exit_issue_1255_closed"] == "pass"
 assert statuses["rust_exit_issue_731_closed"] == "pass"
 assert statuses["direct_native_runtime_abi_ready"] == "pass"
 assert statuses["command_lsp_release_boundary"] == "pass"

--- a/scripts/ci/test-check-stage1-full-lib-triage.sh
+++ b/scripts/ci/test-check-stage1-full-lib-triage.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+script="$repo_root/scripts/ci/check-stage1-full-lib-triage.py"
+manifest="$repo_root/docs/rust-exit-full-lib-triage.json"
+temp_dir="$(mktemp -d "${TMPDIR:-/tmp}/axiom-full-lib-triage-test.XXXXXX")"
+trap 'rm -rf "$temp_dir"' EXIT
+
+python3 "$script" --manifest "$manifest" --json >"$temp_dir/report.json"
+python3 - "$temp_dir/report.json" <<'PY'
+import json
+import sys
+
+report = json.load(open(sys.argv[1], encoding="utf-8"))
+assert report["schema"] == "axiom.stage1.full_lib_triage.v1"
+assert report["triaged"] is True
+assert report["ready"] is False
+assert report["summary"]["failure_count"] == 40
+assert report["summary"]["categories"]["stale_generated_rust_expectation"] >= 1
+assert report["summary"]["categories"]["direct_native_contract"] >= 1
+assert report["summary"]["categories"]["environment_gated"] >= 1
+PY
+
+python3 - "$manifest" "$temp_dir/bad-count.json" <<'PY'
+import json
+import sys
+
+payload = json.load(open(sys.argv[1], encoding="utf-8"))
+payload["expectedFailureCount"] = payload["expectedFailureCount"] + 1
+json.dump(payload, open(sys.argv[2], "w", encoding="utf-8"))
+PY
+if python3 "$script" --manifest "$temp_dir/bad-count.json" >/tmp/axiom-bad-count.out 2>&1; then
+  echo "expected mismatched failure count to fail validation" >&2
+  exit 1
+fi
+
+python3 - "$manifest" "$temp_dir/bad-env.json" <<'PY'
+import json
+import sys
+
+payload = json.load(open(sys.argv[1], encoding="utf-8"))
+for failure in payload["failures"]:
+    if failure["category"] == "environment_gated":
+        failure["resolution"] = "update_direct_native_contract"
+        break
+json.dump(payload, open(sys.argv[2], "w", encoding="utf-8"))
+PY
+if python3 "$script" --manifest "$temp_dir/bad-env.json" >/tmp/axiom-bad-env.out 2>&1; then
+  echo "expected environment-gated resolution mismatch to fail validation" >&2
+  exit 1
+fi
+
+python3 - "$manifest" "$temp_dir/duplicate.json" <<'PY'
+import json
+import sys
+
+payload = json.load(open(sys.argv[1], encoding="utf-8"))
+payload["failures"][1]["name"] = payload["failures"][0]["name"]
+json.dump(payload, open(sys.argv[2], "w", encoding="utf-8"))
+PY
+if python3 "$script" --manifest "$temp_dir/duplicate.json" >/tmp/axiom-duplicate.out 2>&1; then
+  echo "expected duplicate failure rows to fail validation" >&2
+  exit 1
+fi
+
+echo "stage1 full lib triage regression cases passed"

--- a/scripts/ci/test-pr-fast-ci-workflow.sh
+++ b/scripts/ci/test-pr-fast-ci-workflow.sh
@@ -53,6 +53,7 @@ ci_gate_head_ref=$(printf '%s\n' "$ci_gate_section" | grep -F 'github.event.pull
 benchmark_gate_reference=$(grep -nE 'check-stage1-benchmarks\.py|stage1-comparison-report\.json' "$workflow" || true)
 runtime_abi_status_check=$(grep -nF 'scripts/ci/render-direct-native-runtime-abi-status.py' "$fast_checks_script" || true)
 runtime_abi_coverage_check=$(grep -nF -- '--coverage-matrix' "$fast_checks_script" || true)
+full_lib_triage_check=$(grep -nF 'scripts/ci/check-stage1-full-lib-triage.py' "$fast_checks_script" || true)
 proof_workload_test=$(grep -nF 'bash scripts/ci/run-stage1-proof-test.sh' "$fast_checks_script" || true)
 
 if [[ -n "$checkout_line" ]]; then
@@ -153,6 +154,11 @@ fi
 
 if [[ -z "$runtime_abi_coverage_check" ]]; then
   echo "run-fast-checks must validate the direct-native runtime ABI coverage matrix" >&2
+  exit 1
+fi
+
+if [[ -z "$full_lib_triage_check" ]]; then
+  echo "run-fast-checks must validate the stage1 full lib triage manifest" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Add a checked `docs/rust-exit-full-lib-triage.json` manifest for the current full `axiomc --lib --features run-native-tests` failure set after the direct-native default-backend flip.
- Add `scripts/ci/check-stage1-full-lib-triage.py`, a regression test, Make targets, and fast-check wiring so the 40 known failures stay classified instead of becoming an invisible Rust-exit blocker.
- Update Rust-exit readiness so #1255 is an explicit live blocker alongside #1191 and #731; final Rust removal now requires the full lib-suite/parity gate, not just ABI readiness.

## Governing Issue
- Refs #1255

## Validation
- [x] `RUST_MIN_STACK=8388608 CARGO_TARGET_DIR=/tmp/axiom-full-lib-target cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib --features run-native-tests` fails as expected on current `main` with `648 passed; 40 failed`; those 40 failures are recorded in the new triage manifest.
- [x] `python3 scripts/ci/check-stage1-full-lib-triage.py --json`
- [x] `bash scripts/ci/test-check-stage1-full-lib-triage.sh`
- [x] `make stage1-full-lib-triage`
- [x] `make stage1-full-lib-triage-test`
- [x] `bash scripts/ci/test-check-rust-exit-readiness.sh`
- [x] `bash scripts/ci/check-rust-exit-readiness.sh --json --require-issue-states` fails as expected with #1255 and #731 open; ABI and generated-Rust gates pass.
- [x] `bash scripts/ci/test-pr-fast-ci-workflow.sh`
- [x] `python3 -m py_compile scripts/ci/check-stage1-full-lib-triage.py`
- [x] `bash -n scripts/ci/check-rust-exit-readiness.sh scripts/ci/test-check-rust-exit-readiness.sh scripts/ci/test-check-stage1-full-lib-triage.sh scripts/ci/run-fast-checks.sh scripts/ci/test-pr-fast-ci-workflow.sh`
- [x] `python3 -m json.tool docs/rust-exit-readiness.json`
- [x] `python3 -m json.tool docs/rust-exit-full-lib-triage.json`
- [x] `git diff --check`
- [ ] `CARGO_TARGET_DIR=/tmp/axiom-fast-checks-target bash scripts/ci/run-fast-checks.sh` was attempted locally but stopped before this change's checks on Python deletion issue-state SSL verification: `certificate verify failed: unable to get local issuer certificate`.

## Bootstrap Governance
- [x] Changes are scoped to the linked issue.
- [x] Contributor or PR guidance changes are not applicable.
- [x] Auto-merge can be considered after required checks pass and review is satisfied.
- [x] No real secrets, runtime auth, or machine-local env files are committed.

## Semantic Layer Checklist
- [x] Semantic node types added/changed: none.
- [x] Schemas added/changed: `axiom.stage1.full_lib_triage.v1` validator output and `docs/rust-exit-full-lib-triage.json` manifest shape.
- [x] Evidence added/changed: full lib-suite failure triage evidence and Rust-exit readiness blocker #1255.
- [x] Rust capture check is satisfied: this PR blocks final Rust removal on direct-native full-suite/parity evidence instead of relying on Rust-only test assumptions.
- [x] Agent-facing inspection impact: agents can run `make stage1-full-lib-triage` to inspect the current full-suite blocker split.

## Flow Contract
- Owner lane: Ares
- Repair owner: Codex
- Autonomy class: review-gated
- Risk class: medium

## Flow Merge Readiness
- [x] Every blocker has a next actor and next action.
- [ ] No active blocking requested changes remain.
- [ ] Non-author approval is present when required.
- [ ] Auto-merge is appropriate when gates pass.

## Merge Automation
- [ ] Auto-merge is not enabled yet; this PR needs required checks and non-author review first.

## Notes
- This PR does not make the full lib suite green. It makes the current red state explicit and machine-checked so the remaining #1255 repairs can be worked down without pretending Rust exit is closer than it is.
