### PR TITLE
Keep env reads runtime-bound in direct native

### DIFF
--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -4210,6 +4210,9 @@ fn lower_i64_env_option_match_stmt(
         && let Some(binding) = some_arm.bindings.first()
         && binding != "_"
     {
+        if !i64_env_option_payload_uses_len_only(&some_arm.body, binding) {
+            return None;
+        }
         some_static_bindings
             .values
             .insert(binding.clone(), env_len.clone());
@@ -4241,6 +4244,115 @@ fn lower_i64_env_option_match_stmt(
     })
 }
 
+fn i64_env_option_payload_uses_len_only(stmts: &[Stmt], binding: &str) -> bool {
+    stmts
+        .iter()
+        .all(|stmt| i64_env_option_stmt_uses_payload_len_only(stmt, binding))
+}
+
+fn i64_env_option_stmt_uses_payload_len_only(stmt: &Stmt, binding: &str) -> bool {
+    match stmt {
+        Stmt::Let { expr, .. }
+        | Stmt::Assign { expr, .. }
+        | Stmt::Print { expr, .. }
+        | Stmt::Return { expr, .. }
+        | Stmt::Defer { expr, .. } => i64_env_option_expr_uses_payload_len_only(expr, binding),
+        Stmt::Panic { message, .. } => i64_env_option_expr_uses_payload_len_only(message, binding),
+        Stmt::If {
+            cond,
+            then_block,
+            else_block,
+            ..
+        } => {
+            i64_env_option_expr_uses_payload_len_only(cond, binding)
+                && i64_env_option_payload_uses_len_only(then_block, binding)
+                && else_block
+                    .as_ref()
+                    .is_none_or(|block| i64_env_option_payload_uses_len_only(block, binding))
+        }
+        Stmt::While { cond, body, .. } => {
+            i64_env_option_expr_uses_payload_len_only(cond, binding)
+                && i64_env_option_payload_uses_len_only(body, binding)
+        }
+        Stmt::Match { expr, arms, .. } => {
+            i64_env_option_expr_uses_payload_len_only(expr, binding)
+                && arms
+                    .iter()
+                    .all(|arm| i64_env_option_payload_uses_len_only(&arm.body, binding))
+        }
+    }
+}
+
+fn i64_env_option_expr_uses_payload_len_only(expr: &Expr, binding: &str) -> bool {
+    match expr {
+        Expr::VarRef { name, .. } => name != binding,
+        Expr::Call { name, args, .. } if name == "len" => {
+            if let [Expr::VarRef { name, .. }] = args.as_slice()
+                && name == binding
+            {
+                return true;
+            }
+            args.iter()
+                .all(|arg| i64_env_option_expr_uses_payload_len_only(arg, binding))
+        }
+        Expr::Call { args, .. } => args
+            .iter()
+            .all(|arg| i64_env_option_expr_uses_payload_len_only(arg, binding)),
+        Expr::BinaryAdd { lhs, rhs, .. }
+        | Expr::BinaryCompare { lhs, rhs, .. }
+        | Expr::BinaryLogic { lhs, rhs, .. } => {
+            i64_env_option_expr_uses_payload_len_only(lhs, binding)
+                && i64_env_option_expr_uses_payload_len_only(rhs, binding)
+        }
+        Expr::Cast { expr, .. }
+        | Expr::MutBorrow { expr, .. }
+        | Expr::Deref { expr, .. }
+        | Expr::Try { expr, .. }
+        | Expr::Await { expr, .. }
+        | Expr::StringBorrow { expr, .. } => {
+            i64_env_option_expr_uses_payload_len_only(expr, binding)
+        }
+        Expr::StructLiteral { fields, .. } => fields
+            .iter()
+            .all(|field| i64_env_option_expr_uses_payload_len_only(&field.expr, binding)),
+        Expr::FieldAccess { base, .. } => i64_env_option_expr_uses_payload_len_only(base, binding),
+        Expr::TupleLiteral { elements, .. } | Expr::ArrayLiteral { elements, .. } => elements
+            .iter()
+            .all(|element| i64_env_option_expr_uses_payload_len_only(element, binding)),
+        Expr::TupleIndex { base, .. } => i64_env_option_expr_uses_payload_len_only(base, binding),
+        Expr::MapLiteral { entries, .. } => entries.iter().all(|entry| {
+            i64_env_option_expr_uses_payload_len_only(&entry.key, binding)
+                && i64_env_option_expr_uses_payload_len_only(&entry.value, binding)
+        }),
+        Expr::EnumVariant { payloads, .. } => payloads
+            .iter()
+            .all(|payload| i64_env_option_expr_uses_payload_len_only(payload, binding)),
+        Expr::Closure { body, .. } => i64_env_option_expr_uses_payload_len_only(body, binding),
+        Expr::Slice {
+            base, start, end, ..
+        } => {
+            i64_env_option_expr_uses_payload_len_only(base, binding)
+                && start
+                    .as_ref()
+                    .is_none_or(|expr| i64_env_option_expr_uses_payload_len_only(expr, binding))
+                && end
+                    .as_ref()
+                    .is_none_or(|expr| i64_env_option_expr_uses_payload_len_only(expr, binding))
+        }
+        Expr::Index { base, index, .. } => {
+            i64_env_option_expr_uses_payload_len_only(base, binding)
+                && i64_env_option_expr_uses_payload_len_only(index, binding)
+        }
+        Expr::Match { expr, arms, .. } => {
+            i64_env_option_expr_uses_payload_len_only(expr, binding)
+                && arms
+                    .iter()
+                    .all(|arm| i64_env_option_expr_uses_payload_len_only(&arm.expr, binding))
+        }
+        Expr::Literal(_) => true,
+    }
+}
+
 fn lower_i64_option_match_stmt(
     stmt: &Stmt,
     locals: &mut Vec<CraneliftI64Expr>,
@@ -4261,6 +4373,14 @@ fn lower_i64_option_match_stmt(
             &local_conditions,
             static_bindings,
         )?;
+    if matches!(expr.ty(), Type::Option(inner) if matches!(inner.as_ref(), Type::String | Type::Str))
+        && !some_arm.ignore_payloads
+        && let Some(binding) = some_arm.bindings.first()
+        && binding != "_"
+        && !i64_env_option_payload_uses_len_only(&some_arm.body, binding)
+    {
+        return None;
+    }
     Some(CraneliftI64Stmt::If {
         cond,
         then_body: lower_i64_runtime_stmts(

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -4028,6 +4028,16 @@ fn lower_i64_runtime_stmt(
                 allow_stdio_effects,
             ) {
                 Some(stmt)
+            } else if let Some(stmt) = lower_i64_env_option_match_stmt(
+                stmt,
+                locals,
+                local_indexes.clone(),
+                local_conditions.clone(),
+                helper_signatures,
+                static_bindings,
+                allow_stdio_effects,
+            ) {
+                Some(stmt)
             } else if let Some(stmt) = lower_i64_option_match_stmt(
                 stmt,
                 locals,
@@ -4172,6 +4182,63 @@ fn lower_i64_known_string_option_match_stmt(
             )?,
         }),
     }
+}
+
+fn lower_i64_env_option_match_stmt(
+    stmt: &Stmt,
+    locals: &mut Vec<CraneliftI64Expr>,
+    local_indexes: HashMap<String, usize>,
+    local_conditions: HashMap<String, CraneliftI64Condition>,
+    helper_signatures: &HashMap<&str, I64HelperSignature>,
+    static_bindings: &I64StaticBindings,
+    allow_stdio_effects: bool,
+) -> Option<CraneliftI64Stmt> {
+    let Stmt::Match { expr, arms, .. } = stmt else {
+        return None;
+    };
+    let Type::Option(inner) = expr.ty() else {
+        return None;
+    };
+    if !matches!(inner.as_ref(), Type::String | Type::Str) {
+        return None;
+    }
+    let key = i64_env_get_key(expr, static_bindings)?;
+    let env_len = i64_env_len_expr(&key, static_bindings)?;
+    let (some_arm, none_arm) = i64_option_stmt_match_arms(arms)?;
+    let mut some_static_bindings = static_bindings.clone();
+    if !some_arm.ignore_payloads
+        && let Some(binding) = some_arm.bindings.first()
+        && binding != "_"
+    {
+        some_static_bindings
+            .values
+            .insert(binding.clone(), env_len.clone());
+    }
+    Some(CraneliftI64Stmt::If {
+        cond: CraneliftI64Condition::Compare(CraneliftI64Compare {
+            op: CraneliftI64CompareOp::Ge,
+            lhs: env_len,
+            rhs: CraneliftI64Expr::Literal(0),
+        }),
+        then_body: lower_i64_runtime_stmts(
+            &some_arm.body,
+            locals,
+            local_indexes.clone(),
+            local_conditions.clone(),
+            helper_signatures,
+            &some_static_bindings,
+            allow_stdio_effects,
+        )?,
+        else_body: lower_i64_runtime_stmts(
+            &none_arm.body,
+            locals,
+            local_indexes,
+            local_conditions,
+            helper_signatures,
+            static_bindings,
+            allow_stdio_effects,
+        )?,
+    })
 }
 
 fn lower_i64_option_match_stmt(
@@ -12749,18 +12816,6 @@ fn i64_string_option_text(
             let text = i64_string_text(text, static_bindings)?;
             Some(regex_find_span(&pattern, &text).map(|(start, end)| text[start..end].to_string()))
         }
-        "env_get" => {
-            let [key] = args.as_slice() else {
-                return None;
-            };
-            Some(std::env::var(i64_string_text(key, static_bindings)?).ok())
-        }
-        name if static_bindings.env_get_wrappers.contains(name) => {
-            let [key] = args.as_slice() else {
-                return None;
-            };
-            Some(std::env::var(i64_string_text(key, static_bindings)?).ok())
-        }
         "fs_read" | "read_file" | "std_fs_read_file" => {
             let [path] = args.as_slice() else {
                 return None;
@@ -16529,6 +16584,14 @@ fn lower_i64_string_len_expr(
         if let Some(value) = i64_string_text(expr, static_bindings) {
             return Some(CraneliftI64Expr::Literal(value.len() as i64));
         }
+    }
+    if let Expr::VarRef {
+        name,
+        ty: Type::String | Type::Str,
+    } = expr
+        && let Some(value) = static_bindings.values.get(name)
+    {
+        return Some(value.clone());
     }
     match expr {
         Expr::Call { name, args, .. } if is_i64_crypto_sha256_name(name, static_bindings) => {

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -4539,7 +4539,7 @@ print strlen("hello")
 
     #[test]
     #[cfg_attr(not(feature = "run-native-tests"), ignore)]
-    fn env_allowlist_scopes_generated_env_get() {
+    fn env_allowlist_scopes_direct_native_env_get() {
         let dir = tempdir().expect("tempdir");
         let project = dir.path().join("env-scoped");
         create_project(&project, Some("env-scoped-app")).expect("create project");
@@ -4556,29 +4556,27 @@ print strlen("hello")
         .expect("write lockfile");
         fs::write(
             project.join("src/main.ax"),
-            "match env_get(\"FOO\") {\nSome(value) {\nprint value\n}\nNone {\nprint \"missing foo\"\n}\n}\nmatch env_get(\"BAR\") {\nSome(value) {\nprint value\n}\nNone {\nprint \"none bar\"\n}\n}\nmatch env_get(\"AWS_SECRET_ACCESS_KEY\") {\nSome(value) {\nprint value\n}\nNone {\nprint \"none secret\"\n}\n}\n",
+            "fn main(): int {\nmatch env_get(\"FOO\") {\nSome(value) {\nprint len(value)\n}\nNone {\nprint 40\n}\n}\nmatch env_get(\"BAR\") {\nSome(value) {\nprint len(value)\n}\nNone {\nprint 0\n}\n}\nmatch env_get(\"AWS_SECRET_ACCESS_KEY\") {\nSome(value) {\nprint len(value)\n}\nNone {\nprint 0\n}\n}\nreturn 0\n}\n",
         )
         .expect("write source");
 
         let built = build_project(&project).expect("build project");
-        let audit_path = project.join("capability-audit.jsonl");
+        let audit_path = project.join("host-audit.jsonl");
         let output = compiled_binary_command(&built.binary)
             .env("FOO", "allowed")
             .env("BAR", "blocked")
             .env("AWS_SECRET_ACCESS_KEY", "blocked-secret")
-            .env("AXIOM_CAPABILITY_AUDIT_JSONL", &audit_path)
+            .env("AXIOM_HOST_AUDIT_LOG", &audit_path)
             .output()
             .expect("run compiled binary");
 
-        assert_eq!(
-            String::from_utf8_lossy(&output.stdout),
-            "allowed\nnone bar\nnone secret\n"
-        );
+        assert_eq!(output.status.code(), Some(0));
+        assert_eq!(String::from_utf8_lossy(&output.stdout), "7\n0\n0\n");
         let audit = fs::read_to_string(&audit_path).expect("read audit log");
         assert!(audit.contains("\"intrinsic\":\"env_get\""));
-        assert!(audit.contains("\"args\":\"name_len=3\""));
-        assert!(audit.contains("\"outcome\":\"some\""));
-        assert!(audit.contains("\"args\":\"name_len=21\""));
+        assert!(audit.contains("\"args\":{\"key\":\"string:3\"}"));
+        assert!(audit.contains("\"outcome\":\"ok\""));
+        assert!(audit.contains("\"args\":{\"key\":\"string:21\"}"));
         assert_eq!(audit.matches("\"outcome\":\"denied\"").count(), 2);
         assert!(!audit.contains("BAR"));
         assert!(!audit.contains("AWS_SECRET_ACCESS_KEY"));
@@ -6481,8 +6479,7 @@ net = { hosts = ["127.0.0.1"], ports = [8080] }
 
         let err = check_project(&project).expect_err("expected capability denial");
         assert!(
-            err.message
-                .contains("requires [capabilities].env = [\"NAME\"]"),
+            err.message.contains("requires [capabilities].env = true"),
             "unexpected diagnostic: {err:?}",
         );
     }

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -9059,6 +9059,46 @@ fn cranelift_backend_honors_env_allowlist_at_runtime() {
     }
 }
 
+#[cfg(not(windows))]
+#[test]
+fn cranelift_backend_runtime_env_match_rejects_string_payload_rewrite() {
+    if which::which("cc").is_err() {
+        eprintln!("skipping cranelift backend smoke test because cc is unavailable");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("env-runtime-payload");
+    write_env_runtime_payload_project(&project);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .env_remove("AXIOM_CRANELIFT_ENV_READ")
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+    assert!(
+        !output.status.success(),
+        "cranelift env payload build unexpectedly succeeded: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("outside the direct-native i64 ABI subset"),
+        "env string payload use should fail closed instead of lowering to env_len: {combined}"
+    );
+}
+
 #[test]
 fn cranelift_backend_rejects_env_denial_before_backend_lowering() {
     let temp = tempfile::tempdir().expect("tempdir");
@@ -16957,6 +16997,61 @@ return 1
 "#,
     )
     .expect("write env allowlist source");
+}
+
+fn write_env_runtime_payload_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create env runtime payload project src");
+    fs::write(
+        project.join("axiom.toml"),
+        r#"[package]
+name = "cranelift-env-runtime-payload"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = ["AXIOM_CRANELIFT_ENV_READ"]
+clock = false
+crypto = false
+"#,
+    )
+    .expect("write env runtime payload manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        r#"version = 1
+
+[[package]]
+name = "cranelift-env-runtime-payload"
+version = "0.1.0"
+source = "path"
+"#,
+    )
+    .expect("write env runtime payload lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        r#"import "std/env.ax"
+
+static ALLOWED_ENV: string = "AXIOM_CRANELIFT_ENV_READ"
+
+fn main(): int {
+match env_get(ALLOWED_ENV) {
+Some(value) {
+print value
+}
+None {
+print "missing"
+}
+}
+return 0
+}
+"#,
+    )
+    .expect("write env runtime payload source");
 }
 
 fn write_http_client_denial_project(project: &Path) {


### PR DESCRIPTION
## Summary

- Keeps direct-native `env_get` reads runtime-bound by removing compiler-process environment folding from the string-option lowering path.
- Adds direct-native lowering for env `Option<string>` match statements that project `len(value)`, preserving manifest allowlist behavior at runtime.
- Updates the stale env allowlist full-lib test to assert the direct-native host-audit contract and non-allowlisted `None` behavior.

## Governing Issue

Refs #1255

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Commands run:

```bash
RUST_MIN_STACK=8388608 CARGO_TARGET_DIR=/tmp/axiom-env-read-target cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib tests::env_allowlist_scopes_direct_native_env_get --features run-native-tests -- --nocapture
RUST_MIN_STACK=8388608 CARGO_TARGET_DIR=/tmp/axiom-env-read-target cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib tests::stage1_project_rejects_stdlib_env_without_env_capability --features run-native-tests -- --nocapture
RUST_MIN_STACK=8388608 CARGO_TARGET_DIR=/tmp/axiom-env-read-target cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib tests::stage1_project_imports_synthetic_stdlib_env_module --features run-native-tests -- --nocapture
CARGO_TARGET_DIR=/tmp/axiom-env-read-target cargo test --manifest-path stage1/Cargo.toml -p axiomc-backend-cranelift links_i64_exit_program_with_env_len -- --nocapture
git diff --check
```

Full-lib status after this repair:

```bash
RUST_MIN_STACK=8388608 CARGO_TARGET_DIR=/tmp/axiom-full-lib-after-env-target cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib --features run-native-tests
# expected current Rust-exit backlog state: 650 passed; 38 failed
# env_allowlist_scopes_direct_native_env_get ... ok
```

The full suite is still red on the remaining #1255 Rust-exit blockers; this PR removes the env allowlist failure from that set.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Semantic notes:

- Semantic node types: none.
- Schemas: none.
- Evidence: narrows one full-lib native test to direct-native runtime host-audit evidence.
- Rust capture: removes compile-time `std::env::var` capture from direct-native string-option folding for `env_get`.
- Agent-facing inspection impact: none.

## Flow Contract

- Owner lane: Ares
- Repair owner: Codex
- Autonomy class: Class 2 - Review-gated autonomous
- Risk class: Low

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [ ] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is appropriate when gates pass

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- This is a narrow #1255 reduction PR, not the full Rust-exit closure.
