### PR TITLE
Drop generated Rust assertions from default backend tests

### DIFF
--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -8063,34 +8063,10 @@ true
         .expect("write golden");
 
         let built = build_project(&project).expect("build project");
-        let generated =
-            fs::read_to_string(generated_rust_path(&built)).expect("read generated rust");
-        assert!(generated.contains("axiom_task_deferred(move ||"));
-        assert!(generated.contains("struct AxiomRuntimeScheduler"));
         assert!(
-            generated.contains("fn schedule<T: Send + 'static>(&mut self, task: AxiomTask<T>)")
+            built.generated_rust.is_none(),
+            "default direct-native builds must not emit generated Rust"
         );
-        assert!(
-            generated
-                .contains("fn join<T: Send + 'static>(&mut self, mut handle: AxiomJoinHandle<T>)")
-        );
-        assert!(!generated.contains("AXIOM_ASYNC_EXECUTOR"));
-        assert!(!generated.contains("std::thread::JoinHandle"));
-        assert!(
-            !generated.contains("std::thread::spawn(move || axiom_task_ready(axiom_await(task)))")
-        );
-        assert!(generated.contains("struct AxiomRuntimePool"));
-        assert!(generated.contains("static AXIOM_RUNTIME_POOL: OnceLock<AxiomRuntimePool>"));
-        assert!(generated.contains("AxiomRuntimePool::new(axiom_runtime_max_threads())"));
-        assert!(generated.contains("struct AxiomTimerWheel"));
-        assert!(generated.contains("static AXIOM_TIMER_WHEEL: OnceLock<AxiomTimerWheel>"));
-        assert!(generated.contains("axiom_timer_sleep_ms(milliseconds);"));
-        assert!(generated.contains("milliseconds.clamp(0, 30_000)"));
-        assert!(generated.contains("clock_sleep_ms(milliseconds)"));
-        assert!(generated.contains("net_tcp_dial(host, port, message, timeout_ms)"));
-        assert!(generated.contains("std::net::TcpStream::connect_timeout"));
-        assert!(generated.contains("scheduler.schedule(task)"));
-        assert!(!generated.contains("return axiom_task_ready(value + 1);"));
         let output = compiled_binary_command(&built.binary)
             .output()
             .expect("run compiled binary");
@@ -11525,12 +11501,9 @@ print takes_two(three)
         )
         .expect("write source");
         let built = build_project(&project).expect("build project with static globals");
-        let generated =
-            fs::read_to_string(generated_rust_path(&built)).expect("read generated rust");
-        assert!(generated.contains("static static_globals_app_main_LIMIT: i64 = 40 + 2;"));
-        assert!(generated.contains("static static_globals_app_main_READY: bool = 40 + 2 == 42;"));
         assert!(
-            generated.contains("static static_globals_app_main_LABEL: &'static str = \"stage1\";")
+            built.generated_rust.is_none(),
+            "default direct-native builds must not emit generated Rust"
         );
         let output = compiled_binary_command(&built.binary)
             .output()
@@ -11553,11 +11526,9 @@ print takes_two(three)
         .expect("write source");
 
         let built = build_project(&project).expect("build project with static string comparisons");
-        let generated =
-            fs::read_to_string(generated_rust_path(&built)).expect("read generated rust");
-        assert!(generated.contains("static static_string_comparison_app_main_SAME: bool = true;"));
         assert!(
-            generated.contains("static static_string_comparison_app_main_DIFFERENT: bool = true;")
+            built.generated_rust.is_none(),
+            "default direct-native builds must not emit generated Rust"
         );
         let output = compiled_binary_command(&built.binary)
             .output()
@@ -11577,10 +11548,10 @@ print takes_two(three)
         .expect("write source");
 
         let built = build_project(&project).expect("static names should not false-recurse");
-        let generated =
-            fs::read_to_string(generated_rust_path(&built)).expect("read generated rust");
-        assert!(generated.contains("static p_main_A: i64 = 1;"));
-        assert!(generated.contains("static p_main_p_main_A: i64 = 1;"));
+        assert!(
+            built.generated_rust.is_none(),
+            "default direct-native builds must not emit generated Rust"
+        );
         let output = compiled_binary_command(&built.binary)
             .output()
             .expect("run compiled binary");
@@ -11603,12 +11574,9 @@ print takes_two(three)
         )
         .expect("write values");
         let built = build_project(&project).expect("build project with imported static globals");
-        let generated =
-            fs::read_to_string(generated_rust_path(&built)).expect("read generated rust");
-        assert!(generated.contains("static public_static_globals_app_values_LIMIT: i64 = 40 + 2;"));
         assert!(
-            generated
-                .contains("static public_static_globals_app_values_READY: bool = 40 + 2 == 42;")
+            built.generated_rust.is_none(),
+            "default direct-native builds must not emit generated Rust"
         );
         let output = compiled_binary_command(&built.binary)
             .output()


### PR DESCRIPTION
## Summary

- Removes stale generated-Rust source assertions from default-backend tests for static globals, imported public static globals, static string comparisons, static source-name handling, and async runtime surface behavior.
- Keeps the meaningful runtime checks: each fixture still builds and runs through the default direct-native backend and asserts the compiled binary output.
- Asserts the current default-backend contract explicitly: `generated_rust` is absent for these direct-native builds.

## Governing Issue

Refs #1255

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Commands run:

```bash
RUST_MIN_STACK=8388608 CARGO_TARGET_DIR=/tmp/axiom-static-globals-target cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib tests::build_project_emits_native_binary_with_static_globals --features run-native-tests -- --nocapture
RUST_MIN_STACK=8388608 CARGO_TARGET_DIR=/tmp/axiom-static-globals-target cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib tests::build_project_folds_static_string_comparisons --features run-native-tests -- --nocapture
RUST_MIN_STACK=8388608 CARGO_TARGET_DIR=/tmp/axiom-static-globals-target cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib tests::build_project_preserves_static_source_names_for_recursion_tracking --features run-native-tests -- --nocapture
RUST_MIN_STACK=8388608 CARGO_TARGET_DIR=/tmp/axiom-static-globals-target cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib tests::build_project_emits_native_binary_with_imported_public_static_globals --features run-native-tests -- --nocapture
RUST_MIN_STACK=8388608 CARGO_TARGET_DIR=/tmp/axiom-static-globals-target cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib tests::stage1_project_supports_async_runtime_surface --features run-native-tests -- --nocapture
git diff --check
```

Full-lib status after this repair:

```bash
RUST_MIN_STACK=8388608 CARGO_TARGET_DIR=/tmp/axiom-full-lib-after-static-target cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib --features run-native-tests
# expected current Rust-exit backlog state: 653 passed; 35 failed
```

The full suite is still red on the remaining #1255 Rust-exit blockers; this PR removes five generated-Rust-coupled failures from that set.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Semantic notes:

- Semantic node types: none.
- Schemas: none.
- Evidence: test evidence now targets direct-native runtime output instead of generated-Rust source text.
- Rust capture: removes default-backend test dependence on generated Rust artifacts.
- Agent-facing inspection impact: none.

## Flow Contract

- Owner lane: Ares
- Repair owner: Codex
- Autonomy class: Class 2 - Review-gated autonomous
- Risk class: Low

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [ ] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is appropriate when gates pass

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- This is a narrow #1255 reduction PR, not the full Rust-exit closure.
