### PR TITLE
Emit direct-native slice runtime traps

### DIFF
--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -18783,8 +18783,17 @@ fn eval_expr(
                 Some(expr) => expect_non_negative_index(eval_expr(expr, functions, env, lines)?)?,
                 None => elements.len(),
             };
-            if start > end || end > elements.len() {
-                return Err(unsupported("slice range is outside the array length"));
+            if start > end {
+                return Err(cranelift_runtime_trap(
+                    "runtime",
+                    "array slice start after end",
+                ));
+            }
+            if end > elements.len() {
+                return Err(cranelift_runtime_trap(
+                    "runtime",
+                    "array slice end out of bounds",
+                ));
             }
             if matches!(ty, Type::MutSlice(_))
                 && let Expr::VarRef { name, .. } = base.as_ref()
@@ -25384,6 +25393,46 @@ mod tests {
             StaticOutputProgram {
                 lines: vec![OutputLine::stderr(
                     "{\"kind\":\"runtime\",\"message\":\"array index out of bounds\"}"
+                )],
+                exit_code: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn folds_slice_bounds_trap_into_stderr_exit_program() {
+        let program = Program {
+            stmts: vec![Stmt::Print {
+                expr: Expr::Call {
+                    name: String::from("len"),
+                    args: vec![Expr::Slice {
+                        base: Box::new(Expr::ArrayLiteral {
+                            elements: vec![Expr::Literal(LiteralValue::Int(1))],
+                            ty: Type::Array(Box::new(Type::Int), None),
+                        }),
+                        start: Some(Box::new(Expr::Literal(LiteralValue::Int(0)))),
+                        end: Some(Box::new(Expr::Literal(LiteralValue::Int(2)))),
+                        ty: Type::Slice(Box::new(Type::Int)),
+                    }],
+                    ty: Type::Int,
+                },
+                span: crate::mir::SourceSpan { line: 1, column: 1 },
+            }],
+            ..hello_program()
+        };
+
+        assert_eq!(
+            collect_output_program(
+                &program,
+                &CapabilityConfig::default(),
+                Path::new("."),
+                Path::new("."),
+                None,
+            )
+            .expect("fold slice bounds trap"),
+            StaticOutputProgram {
+                lines: vec![OutputLine::stderr(
+                    "{\"kind\":\"runtime\",\"message\":\"array slice end out of bounds\"}"
                 )],
                 exit_code: 1,
             }


### PR DESCRIPTION
## Summary

- Convert out-of-range direct-native slice evaluation into structured runtime traps.
- Preserve the existing static-output trap shape used by panic and array bounds failures.
- Add unit coverage for slice bounds trap folding alongside the existing array-bounds trap coverage.

## Governing Issue

Contributes to #1255.

## Validation

- [x] Relevant local checks passed
- [ ] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Commands run:

- `cargo fmt --manifest-path stage1/Cargo.toml --all`
- `RUST_MIN_STACK=8388608 CARGO_TARGET_DIR=/tmp/axiom-slice-runtime-target cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib cranelift_backend::tests::folds_slice_bounds_trap_into_stderr_exit_program --features run-native-tests -- --nocapture`
- `RUST_MIN_STACK=8388608 CARGO_TARGET_DIR=/tmp/axiom-slice-runtime-target cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib tests::stage1_runtime_reports_structured_error_for_slice_failures --features run-native-tests -- --nocapture`
- `RUST_MIN_STACK=8388608 CARGO_TARGET_DIR=/tmp/axiom-slice-runtime-target cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib tests::stage1_runtime_reports_structured_slice_error_in_debug_and_release --features run-native-tests -- --nocapture`
- `git diff --check`
- `make stage1-direct-native-runtime-abi`

Broader ledger checks:

- `RUST_MIN_STACK=8388608 CARGO_TARGET_DIR=/tmp/axiom-slice-runtime-target cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib --features run-native-tests -- --nocapture` remains partial on this independent `main` branch: `651 passed; 38 failed`. The slice runtime tests touched here pass in that sweep. Separate sibling PR fixes such as CLI/stdin are not included in this branch.
- `make rust-exit-readiness` remains false because the readiness manifest still lists open blocking issues. The direct-native runtime ABI check itself reports `ready: true`.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Semantic notes:

- Semantic node types added/changed: none.
- Schemas added/changed: none.
- Evidence added/changed: direct-native slice runtime trap tests only.
- Rust capture risk: backend-only Cranelift spike runtime behavior; no generated-Rust dependency added.
- Agent-facing inspection impact: direct-native binaries now report this slice failure at runtime instead of failing the build.

## Flow Contract

- Owner lane: compiler/runtime
- Repair owner: Codex
- Autonomy class: issue-scoped implementation
- Risk class: low

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [ ] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is appropriate when gates pass

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- This is an incremental Rust-exit slice. It does not claim full Rust independence; full native-lib and readiness gates remain intentionally partial.
