### PR TITLE
Decouple mutable borrow test from generated Rust

### DIFF
--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -12675,11 +12675,12 @@ print takes_two(three)
         .expect("write source");
 
         let built = build_project(&project).expect("build project");
-        let generated =
-            fs::read_to_string(generated_rust_path(&built)).expect("read generated rust");
-        assert!(generated.contains("let mut value: String"));
-        assert!(generated.contains("let local: &mut String = &mut value;"));
-        assert!(generated.contains("*local = String::from(\"beta\");"));
+        if let Some(generated_rust) = built.generated_rust.as_deref() {
+            let generated = fs::read_to_string(generated_rust).expect("read generated rust");
+            assert!(generated.contains("let mut value: String"));
+            assert!(generated.contains("let local: &mut String = &mut value;"));
+            assert!(generated.contains("*local = String::from(\"beta\");"));
+        }
         let output = compiled_binary_command(&built.binary)
             .output()
             .expect("run compiled binary");


### PR DESCRIPTION
## Summary

- Let `build_project_accepts_mutable_local_borrow_write_through` pass on direct-native builds where no generated Rust artifact is emitted.
- Keep the legacy generated-Rust shape assertions when `BuildOutput.generated_rust` is present, while preserving the compiled binary runtime assertion as the backend-neutral source of truth.

## Governing Issue

Part of #1191

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Validation run:

- `RUST_MIN_STACK=8388608 CARGO_TARGET_DIR=/tmp/axiom-mut-borrow-target cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib tests::build_project_accepts_mutable_local_borrow_write_through --features run-native-tests -- --nocapture` - passed
- `RUST_MIN_STACK=8388608 CARGO_TARGET_DIR=/tmp/axiom-mut-borrow-target cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib cranelift_backend::tests::folds_mutable_local_borrow_write_through_into_print_lines --features run-native-tests -- --nocapture` - passed
- `cargo fmt --manifest-path stage1/Cargo.toml --all --check` - passed
- `git diff --check` - passed
- `make stage1-direct-native-runtime-abi` - passed, `ready: true`
- `make rust-exit-readiness` - expected failure: `ready: false` because `readiness_blockers_closed` still fails while documented Rust-exit blockers remain open

Skipped checks:

- Full `make stage1-test` was not run for this single test-contract change; the focused project test, matching Cranelift unit, and Rust-exit gates were run instead.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Semantic-layer notes:

- Semantic node types: not changed.
- Schemas: not changed.
- Evidence: direct-native mutable local borrow project coverage no longer requires generated Rust output to exist.
- Rust capture risk: reduced; the test now treats generated Rust as optional legacy evidence rather than required output.
- Agent-facing inspection impact: none.

## Flow Contract

- Owner lane: backend
- Repair owner: Codex
- Autonomy class: direct
- Risk class: low

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [ ] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is appropriate when gates pass

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

Auto-merge is not enabled by the authoring agent because review is required and the author cannot approve their own PR.

## Notes

- This is one small Rust-exit follow-up. It does not close #1191 by itself.
