### PR TITLE
Lower top-level fs writes in direct native

### DIFF
--- a/stage1/crates/axiomc-backend-cranelift/src/lib.rs
+++ b/stage1/crates/axiomc-backend-cranelift/src/lib.rs
@@ -3691,20 +3691,18 @@ fn emit_i64_runtime_fs_guard_expr(
         0,
     ));
     let resolved_ptr = builder.ins().stack_addr(types::I64, resolved_slot, 0);
-
-    let realpath_call = builder
-        .ins()
-        .call(runtime_refs.realpath, &[path_ptr, resolved_ptr]);
-    let resolved = builder.inst_results(realpath_call)[0];
-
     let fallback_block = builder.create_block();
+    let fallback_check_block = builder.create_block();
     let check_block = builder.create_block();
     let allowed_block = builder.create_block();
     let denied_block = builder.create_block();
     let merge_block = builder.create_block();
     builder.append_block_param(check_block, types::I64);
     builder.append_block_param(merge_block, types::I64);
-
+    let realpath_call = builder
+        .ins()
+        .call(runtime_refs.realpath, &[path_ptr, resolved_ptr]);
+    let resolved = builder.inst_results(realpath_call)[0];
     let missing = builder.ins().icmp_imm(IntCC::Equal, resolved, 0);
     builder.ins().brif(
         missing,
@@ -3716,6 +3714,17 @@ fn emit_i64_runtime_fs_guard_expr(
 
     builder.switch_to_block(fallback_block);
     builder.seal_block(fallback_block);
+    let same_path_rename_call = builder
+        .ins()
+        .call(runtime_refs.rename, &[path_ptr, path_ptr]);
+    let same_path_rename = builder.inst_results(same_path_rename_call)[0];
+    let dangling_entry = builder.ins().icmp_imm(IntCC::Equal, same_path_rename, 0);
+    builder
+        .ins()
+        .brif(dangling_entry, denied_block, &[], fallback_check_block, &[]);
+
+    builder.switch_to_block(fallback_check_block);
+    builder.seal_block(fallback_check_block);
     let fallback_call = builder
         .ins()
         .call(runtime_refs.realpath, &[fallback_ptr, resolved_ptr]);

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -379,6 +379,18 @@ pub fn compile_cranelift_hello_spike(
             Diagnostic::new("build", err.to_string()).with_path(object_path.display().to_string())
         });
     }
+    if let Some(program) =
+        lower_i64_top_level_output_program(program, capabilities, package_root, fs_root)
+    {
+        return axiomc_backend_cranelift::compile_i64_exit_program(
+            program,
+            object_path,
+            binary_path,
+        )
+        .map_err(|err| {
+            Diagnostic::new("build", err.to_string()).with_path(object_path.display().to_string())
+        });
+    }
     if program.stmts.is_empty()
         && program
             .functions
@@ -398,6 +410,153 @@ pub fn compile_cranelift_hello_spike(
     )
     .map_err(|err| {
         Diagnostic::new("build", err.to_string()).with_path(object_path.display().to_string())
+    })
+}
+
+fn lower_i64_top_level_output_program(
+    program: &Program,
+    capabilities: &CapabilityConfig,
+    package_root: &Path,
+    fs_root: &Path,
+) -> Option<I64ExitProgram> {
+    if program.stmts.is_empty() {
+        return None;
+    }
+    let struct_defs = program
+        .structs
+        .iter()
+        .map(|struct_def| (struct_def.name.as_str(), struct_def))
+        .collect::<HashMap<_, _>>();
+    let mut static_bindings = lower_i64_static_bindings(&program.statics)?;
+    static_bindings.package_root = Some(package_root.to_path_buf());
+    static_bindings.fs_root = Some(fs_root.to_path_buf());
+    static_bindings.env_allowed_names = capabilities.env_vars.iter().cloned().collect();
+    static_bindings.env_unrestricted = capabilities.env_unrestricted;
+    static_bindings.net_unrestricted = capabilities.net && capabilities.net_hosts.is_empty();
+    static_bindings.net_allowed_hosts = capabilities.net_hosts.iter().cloned().collect();
+    static_bindings.fs_read_wrappers = program
+        .functions
+        .iter()
+        .filter(|function| is_i64_std_fs_read_wrapper(function))
+        .flat_map(|function| [function.name.clone(), function.source_name.clone()])
+        .collect();
+    static_bindings.fs_write_wrappers = program
+        .functions
+        .iter()
+        .filter_map(|function| {
+            i64_std_fs_write_intrinsic(function).map(|intrinsic| {
+                [
+                    (function.name.clone(), intrinsic.to_string()),
+                    (function.source_name.clone(), intrinsic.to_string()),
+                ]
+            })
+        })
+        .flatten()
+        .collect();
+    static_bindings.fs_shim_wrappers = program
+        .functions
+        .iter()
+        .filter(|function| is_i64_std_fs_shim_wrapper(function))
+        .map(|function| function.name.clone())
+        .collect();
+    static_bindings.has_fs_write_calls = program
+        .stmts
+        .iter()
+        .any(|stmt| i64_stmt_has_fs_write_call(stmt, &static_bindings))
+        || program
+            .functions
+            .iter()
+            .any(|function| i64_stmts_have_fs_write_call(&function.body, &static_bindings));
+    if program
+        .stmts
+        .iter()
+        .any(|stmt| i64_stmt_has_fs_read_call(stmt, &static_bindings))
+    {
+        return None;
+    }
+    static_bindings.structs = program
+        .structs
+        .iter()
+        .map(|struct_def| (struct_def.name.clone(), struct_def.clone()))
+        .collect();
+    static_bindings.enums = program
+        .enums
+        .iter()
+        .map(|enum_def| (enum_def.name.clone(), enum_def.clone()))
+        .collect();
+    static_bindings.functions = program
+        .functions
+        .iter()
+        .map(|function| (function.name.clone(), function.clone()))
+        .collect();
+    let fs_shim_wrappers = static_bindings.fs_shim_wrappers.clone();
+    let helper_functions = program
+        .functions
+        .iter()
+        .filter(|function| {
+            !fs_shim_wrappers.contains(&function.name)
+                && is_i64_function_return_type(&function.return_ty, &struct_defs, &static_bindings)
+                && function
+                    .params
+                    .iter()
+                    .all(|param| is_i64_param_type(&param.ty, &struct_defs, &static_bindings))
+        })
+        .collect::<Vec<_>>();
+    let helper_signatures = helper_functions
+        .iter()
+        .enumerate()
+        .map(|(index, function)| {
+            Some((
+                function.name.as_str(),
+                I64HelperSignature {
+                    function: index,
+                    params: function.params.len(),
+                    returns_bool: matches!(function.return_ty, Type::Bool),
+                    return_ty: function.return_ty.clone(),
+                    returns: i64_return_slot_count_for_type(
+                        &function.return_ty,
+                        &struct_defs,
+                        &static_bindings,
+                    )?,
+                    struct_fields: function
+                        .params
+                        .iter()
+                        .map(|param| match &param.ty {
+                            Type::Struct(name) => Some(
+                                i64_scalar_struct_def(name, &struct_defs)?
+                                    .fields
+                                    .iter()
+                                    .map(|field| field.name.clone())
+                                    .collect(),
+                            ),
+                            _ => None,
+                        })
+                        .collect(),
+                },
+            ))
+        })
+        .collect::<Option<HashMap<_, _>>>()?;
+    let functions = helper_functions
+        .iter()
+        .map(|function| {
+            lower_i64_function(function, &helper_signatures, &static_bindings, &struct_defs)
+        })
+        .collect::<Option<Vec<_>>>()?;
+    let mut locals = Vec::new();
+    let stmts = lower_i64_runtime_stmts(
+        &program.stmts,
+        &mut locals,
+        HashMap::new(),
+        HashMap::new(),
+        &helper_signatures,
+        &static_bindings,
+        true,
+    )?;
+    Some(I64ExitProgram {
+        functions,
+        locals,
+        stmts,
+        body: I64ExitBody::Return(CraneliftI64Expr::Literal(0)),
     })
 }
 
@@ -10141,6 +10300,50 @@ fn i64_stmt_has_fs_write_call(stmt: &Stmt, static_bindings: &I64StaticBindings) 
     }
 }
 
+fn i64_stmt_has_fs_read_call(stmt: &Stmt, static_bindings: &I64StaticBindings) -> bool {
+    match stmt {
+        Stmt::Let { expr, .. }
+        | Stmt::Print { expr, .. }
+        | Stmt::Panic { message: expr, .. }
+        | Stmt::Defer { expr, .. }
+        | Stmt::Return { expr, .. } => i64_expr_has_fs_read_call(expr, static_bindings),
+        Stmt::Assign { target, expr, .. } => {
+            i64_expr_has_fs_read_call(target, static_bindings)
+                || i64_expr_has_fs_read_call(expr, static_bindings)
+        }
+        Stmt::If {
+            cond,
+            then_block,
+            else_block,
+            ..
+        } => {
+            i64_expr_has_fs_read_call(cond, static_bindings)
+                || then_block
+                    .iter()
+                    .any(|stmt| i64_stmt_has_fs_read_call(stmt, static_bindings))
+                || else_block.as_ref().is_some_and(|stmts| {
+                    stmts
+                        .iter()
+                        .any(|stmt| i64_stmt_has_fs_read_call(stmt, static_bindings))
+                })
+        }
+        Stmt::While { cond, body, .. } => {
+            i64_expr_has_fs_read_call(cond, static_bindings)
+                || body
+                    .iter()
+                    .any(|stmt| i64_stmt_has_fs_read_call(stmt, static_bindings))
+        }
+        Stmt::Match { expr, arms, .. } => {
+            i64_expr_has_fs_read_call(expr, static_bindings)
+                || arms.iter().any(|arm| {
+                    arm.body
+                        .iter()
+                        .any(|stmt| i64_stmt_has_fs_read_call(stmt, static_bindings))
+                })
+        }
+    }
+}
+
 fn i64_expr_has_fs_write_call(expr: &Expr, static_bindings: &I64StaticBindings) -> bool {
     match expr {
         Expr::Call { name, args, .. } => {
@@ -10198,6 +10401,69 @@ fn i64_expr_has_fs_write_call(expr: &Expr, static_bindings: &I64StaticBindings) 
                 || arms
                     .iter()
                     .any(|arm| i64_expr_has_fs_write_call(&arm.expr, static_bindings))
+        }
+        Expr::Literal(_) | Expr::VarRef { .. } => false,
+    }
+}
+
+fn i64_expr_has_fs_read_call(expr: &Expr, static_bindings: &I64StaticBindings) -> bool {
+    match expr {
+        Expr::Call { name, args, .. } => {
+            matches!(name.as_str(), "fs_read" | "read_file" | "std_fs_read_file")
+                || static_bindings.fs_read_wrappers.contains(name)
+                || args
+                    .iter()
+                    .any(|arg| i64_expr_has_fs_read_call(arg, static_bindings))
+        }
+        Expr::BinaryAdd { lhs, rhs, .. }
+        | Expr::BinaryCompare { lhs, rhs, .. }
+        | Expr::BinaryLogic { lhs, rhs, .. }
+        | Expr::Index {
+            base: lhs,
+            index: rhs,
+            ..
+        } => {
+            i64_expr_has_fs_read_call(lhs, static_bindings)
+                || i64_expr_has_fs_read_call(rhs, static_bindings)
+        }
+        Expr::Cast { expr, .. }
+        | Expr::MutBorrow { expr, .. }
+        | Expr::Deref { expr, .. }
+        | Expr::Try { expr, .. }
+        | Expr::Await { expr, .. }
+        | Expr::FieldAccess { base: expr, .. }
+        | Expr::TupleIndex { base: expr, .. }
+        | Expr::StringBorrow { expr, .. } => i64_expr_has_fs_read_call(expr, static_bindings),
+        Expr::StructLiteral { fields, .. } => fields
+            .iter()
+            .any(|field| i64_expr_has_fs_read_call(&field.expr, static_bindings)),
+        Expr::TupleLiteral { elements, .. } | Expr::ArrayLiteral { elements, .. } => elements
+            .iter()
+            .any(|element| i64_expr_has_fs_read_call(element, static_bindings)),
+        Expr::MapLiteral { entries, .. } => entries.iter().any(|entry| {
+            i64_expr_has_fs_read_call(&entry.key, static_bindings)
+                || i64_expr_has_fs_read_call(&entry.value, static_bindings)
+        }),
+        Expr::EnumVariant { payloads, .. } => payloads
+            .iter()
+            .any(|payload| i64_expr_has_fs_read_call(payload, static_bindings)),
+        Expr::Closure { body, .. } => i64_expr_has_fs_read_call(body, static_bindings),
+        Expr::Slice {
+            base, start, end, ..
+        } => {
+            i64_expr_has_fs_read_call(base, static_bindings)
+                || start
+                    .as_ref()
+                    .is_some_and(|expr| i64_expr_has_fs_read_call(expr, static_bindings))
+                || end
+                    .as_ref()
+                    .is_some_and(|expr| i64_expr_has_fs_read_call(expr, static_bindings))
+        }
+        Expr::Match { expr, arms, .. } => {
+            i64_expr_has_fs_read_call(expr, static_bindings)
+                || arms
+                    .iter()
+                    .any(|arm| i64_expr_has_fs_read_call(&arm.expr, static_bindings))
         }
         Expr::Literal(_) | Expr::VarRef { .. } => false,
     }
@@ -15002,7 +15268,7 @@ fn lower_i64_fs_write_intrinsic_expr(
         let package_root = static_bindings.package_root.as_deref()?;
         let fs_root = static_bindings.fs_root.as_deref()?;
         let Some(candidate) =
-            spike_fs_write_candidate_for_scope(package_root, fs_root, &path, false)
+            spike_fs_write_candidate_for_scope(package_root, fs_root, &path, true)
         else {
             return i64_audited_fs_expr(
                 name,
@@ -15044,7 +15310,7 @@ fn lower_i64_fs_write_intrinsic_expr(
         let package_root = static_bindings.package_root.as_deref()?;
         let fs_root = static_bindings.fs_root.as_deref()?;
         let Some(candidate) =
-            spike_fs_write_candidate_for_scope(package_root, fs_root, &path, false)
+            spike_fs_write_candidate_for_scope(package_root, fs_root, &path, true)
         else {
             return i64_audited_fs_expr(
                 name,
@@ -15086,7 +15352,7 @@ fn lower_i64_fs_write_intrinsic_expr(
         let package_root = static_bindings.package_root.as_deref()?;
         let fs_root = static_bindings.fs_root.as_deref()?;
         let Some(candidate) =
-            spike_fs_write_candidate_for_scope(package_root, fs_root, &path, false)
+            spike_fs_write_candidate_for_scope(package_root, fs_root, &path, true)
         else {
             return i64_audited_fs_expr(
                 name,
@@ -15141,7 +15407,7 @@ fn lower_i64_fs_write_intrinsic_expr(
         let package_root = static_bindings.package_root.as_deref()?;
         let fs_root = static_bindings.fs_root.as_deref()?;
         let Some(candidate) =
-            spike_fs_write_candidate_for_scope(package_root, fs_root, &path, false)
+            spike_fs_write_candidate_for_scope(package_root, fs_root, &path, true)
         else {
             return i64_audited_fs_expr(
                 name,


### PR DESCRIPTION
## Summary

- Lower supported top-level output statements through the direct-native i64 runtime before static output fallback, so direct `fs_write` top-level programs execute writes at runtime instead of build time.
- Carry filesystem wrapper metadata into the top-level lowering path, while keeping filesystem read programs on the existing path until runtime file-content reads are supported.
- Deny dangling final filesystem entries before parent-root fallback so runtime-created symlink escapes do not become writes outside the manifest root.

## Governing Issue

Part of #1191.

Stacked on #1268 (`codex/rust-exit-fs-scope-runtime`); this PR should be reviewed after or with that base branch.

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Commands run:

- `cargo fmt --manifest-path stage1/Cargo.toml --all --check`
- `git diff --check`
- `RUST_MIN_STACK=8388608 CARGO_TARGET_DIR=/tmp/axiom-top-fs-write-target cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib tests::build_project_scopes_fs_write_to_manifest_root_without_read_capability --features run-native-tests -- --nocapture`
- `RUST_MIN_STACK=8388608 CARGO_TARGET_DIR=/tmp/axiom-top-fs-write-target cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend fs_write --features run-native-tests -- --nocapture`
- `RUST_MIN_STACK=8388608 CARGO_TARGET_DIR=/tmp/axiom-top-fs-write-target cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib tests::build_project_scopes_fs_read_to_manifest_root --features run-native-tests -- --nocapture`
- `make stage1-direct-native-runtime-abi`
- `make rust-exit-readiness` (expected non-zero: `readiness_blockers_closed` still fails because one or more manifest-listed blocker issues are not closed; direct-native runtime ABI and contract gates pass)

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Semantic impact:

- Semantic node types: none.
- Schemas: none.
- Evidence: runtime regression coverage only.
- Rust capture risk: reduced by moving top-level `fs_write` execution to direct-native runtime lowering.
- Agent-facing inspection impact: none.

## Flow Contract

- Owner lane: compiler/runtime
- Repair owner: Codex
- Autonomy class: agent-executed
- Risk class: medium

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [ ] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is appropriate when gates pass

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- This is intentionally stacked on #1268 to avoid duplicating the manifest-root filesystem scope changes.
- Auto-merge is not enabled yet because this stacked PR depends on the base branch and needs normal non-author review.
