### PR TITLE
Track live Rust-exit readiness blocker

### DIFF
--- a/docs/rust-exit-readiness.json
+++ b/docs/rust-exit-readiness.json
@@ -3,11 +3,6 @@
   "finalBootstrapIssue": 721,
   "blockingIssues": [
     {
-      "issue": 1191,
-      "lane": "backend",
-      "check": "Generated-Rust backend, rustc targeted-build fallback, and compatibility alias are removed from the supported toolchain."
-    },
-    {
       "issue": 731,
       "lane": "tooling",
       "check": "Documentation generator, LSP server, and protocol path are AxiOM-owned."

--- a/docs/rust-exit-readiness.md
+++ b/docs/rust-exit-readiness.md
@@ -3,11 +3,11 @@
 This matrix defines the technical bar for making Rust and Cargo unnecessary for
 the supported Axiom toolchain.
 
-The current supported implementation remains the Rust-hosted `stage1/axiomc`
-compiler with generated-Rust backend support. Rust exit is complete only when
-the official check, build, run, test, documentation, LSP, and release paths can
-operate from AxiOM-owned sources and direct native artifacts without requiring
-Cargo, generated Rust, or `rustc`.
+The current implementation still includes the Rust-hosted `stage1/axiomc`
+compiler, but generated Rust is no longer a supported backend path. Rust exit is
+complete only when the official check, build, run, test, documentation, LSP, and
+release paths can operate from AxiOM-owned sources and direct native artifacts
+without requiring Cargo, generated Rust, or `rustc`.
 
 Final Rust bootstrap issue: [#721](https://github.com/OMT-Global/axiomlang/issues/721)
 
@@ -39,10 +39,10 @@ review gates to be satisfied.
 | Surface | Required state | Current disposition | Governing issue |
 | --- | --- | --- | --- |
 | Direct native parity matrix | Every supported stage1 surface has a direct-native status row and linked blocker when incomplete. | Implemented as the checked runtime ABI matrix; no runtime ABI rows remain incomplete. | [#927](https://github.com/OMT-Global/axiomlang/issues/927) |
-| Direct native runtime ABI | Supported values, ownership shapes, stdlib calls, and capability host calls lower through backend-neutral direct-native runtime entrypoints. | Implemented and checked by `scripts/ci/check-direct-native-runtime-abi.py`; default-backend, LSP, and final Rust-removal gates remain separate blockers. | [#1124](https://github.com/OMT-Global/axiomlang/issues/1124) |
+| Direct native runtime ABI | Supported values, ownership shapes, stdlib calls, and capability host calls lower through backend-neutral direct-native runtime entrypoints. | Implemented and checked by `scripts/ci/check-direct-native-runtime-abi.py`; LSP/tooling and final bootstrap gates remain separate blockers. | [#1124](https://github.com/OMT-Global/axiomlang/issues/1124) |
 | Direct native diagnostics and evidence | Direct native builds preserve source diagnostics, provenance, debug manifests, and operator evidence without generated Rust. | Implemented for the Cranelift direct-native spike; broader coverage remains gated by default-backend blockers. | [#929](https://github.com/OMT-Global/axiomlang/issues/929) |
 | Default backend | `axiomc build` defaults to direct native output and no longer invokes `rustc` for supported broad builds. | Host/native builds default to the direct-native Cranelift backend; default targeted builds fail closed instead of falling back to generated Rust, and extended conformance now runs on Cranelift with `generated_rust: null`. | [#1191](https://github.com/OMT-Global/axiomlang/issues/1191) |
-| Generated-Rust removal | The generated-Rust backend and `--backend rust` compatibility path are removed after a release with direct native as default. | Generated Rust remains present only as internal legacy compatibility code and must leave the toolchain before Rust exit completes. The CLI parser no longer accepts `--backend generated-rust` or the old `--backend rust` transition alias. | [#1191](https://github.com/OMT-Global/axiomlang/issues/1191) |
+| Generated-Rust removal | The generated-Rust backend and `--backend rust` compatibility path are removed after a release with direct native as default. | Completed for the supported toolchain in #1191. The CLI parser no longer accepts `--backend generated-rust` or the old `--backend rust` transition alias, targeted builds fail closed instead of using generated Rust, and command/schema fixtures no longer model generated Rust as supported output. | [#1191](https://github.com/OMT-Global/axiomlang/issues/1191) |
 
 ## Bootstrap Matrix
 
@@ -63,9 +63,9 @@ review gates to be satisfied.
   Cranelift spike evaluation alone is not sufficient.
 - #721 may close only after the backend matrix and bootstrap matrix have no
   incomplete rows.
-- Generated Rust may remain as a targeted-build compatibility backend while
-  #1191 is open, but Rust exit may not complete until it is removed from the
-  supported toolchain.
+- Generated Rust must stay outside the supported toolchain; regressions that
+  reintroduce it as a CLI backend, targeted-build fallback, command fixture, or
+  release artifact must fail the readiness gate.
 - Cargo may remain as a developer convenience while #931 is being proven, but it
   may not be required by the official release-chain path.
 - Any new blocked row must name a GitHub issue in

--- a/scripts/ci/check-rust-exit-readiness.sh
+++ b/scripts/ci/check-rust-exit-readiness.sh
@@ -141,6 +141,20 @@ closed_blocking_issues_from_manifest() {
   done < <(blocking_issues_from_manifest)
 }
 
+open_blocking_issues_from_manifest() {
+  local issue
+  local issue_state
+
+  while IFS= read -r issue; do
+    issue_state=""
+    if ! issue_state="$(read_issue_state "$issue")" || [[ -z "$issue_state" ]]; then
+      printf '%s:UNKNOWN\n' "$issue"
+    elif [[ "$issue_state" != "CLOSED" ]]; then
+      printf '%s:%s\n' "$issue" "$issue_state"
+    fi
+  done < <(blocking_issues_from_manifest)
+}
+
 self_hosted_boundary_report() {
   python3 - <<'PY'
 import json
@@ -353,7 +367,7 @@ if payload["finalBootstrapIssue"] in issues:
     print("finalBootstrapIssue must not also be listed as a blocker", file=sys.stderr)
     sys.exit(1)
 
-required = {731, 1191}
+required = {731}
 missing = sorted(required - set(issues))
 if missing:
     print("missing required blocking issues: " + ", ".join(f"#{issue}" for issue in missing), file=sys.stderr)
@@ -394,7 +408,15 @@ if [[ ! -f docs/rust-exit-readiness.json ]]; then
 elif all_blocking_issues_closed; then
   add_check "readiness_blockers_closed" "pass" "All blocking issues listed in docs/rust-exit-readiness.json are CLOSED"
 else
-  add_check "readiness_blockers_closed" "fail" "One or more blocking issues listed in docs/rust-exit-readiness.json are not CLOSED"
+  open_blocking_issues=()
+  while IFS= read -r open_issue; do
+    open_blocking_issues+=("#${open_issue}")
+  done < <(open_blocking_issues_from_manifest)
+  if [[ "${#open_blocking_issues[@]}" -gt 0 ]]; then
+    add_check "readiness_blockers_closed" "fail" "Blocking issue(s) not closed: ${open_blocking_issues[*]}"
+  else
+    add_check "readiness_blockers_closed" "fail" "One or more blocking issues listed in docs/rust-exit-readiness.json are not CLOSED"
+  fi
 fi
 
 if [[ "$abi_ready" != true && -f docs/rust-exit-readiness.json ]]; then

--- a/scripts/ci/test-check-rust-exit-readiness.sh
+++ b/scripts/ci/test-check-rust-exit-readiness.sh
@@ -48,7 +48,6 @@ rust-exit-readiness-test:
 MAKE
 
 cat >"$temp_dir/partial-issues.txt" <<'ISSUES'
-1191 CLOSED
 731 OPEN
 ISSUES
 
@@ -122,7 +121,6 @@ with open(path, "w", encoding="utf-8") as handle:
 PY
 
 cat >"$temp_dir/open-issues.txt" <<'ISSUES'
-1191 OPEN
 731 OPEN
 ISSUES
 
@@ -155,7 +153,6 @@ PY
 )
 
 cat >"$temp_dir/issues.txt" <<'ISSUES'
-1191 CLOSED
 731 CLOSED
 ISSUES
 
@@ -176,7 +173,6 @@ assert payload["ready"] is True
 statuses = {check["name"]: check["status"] for check in payload["checks"]}
 assert statuses["readiness_blockers_closed"] == "pass"
 assert statuses["readiness_blockers_live_when_not_ready"] == "pass"
-assert statuses["rust_exit_issue_1191_closed"] == "pass"
 assert statuses["rust_exit_issue_731_closed"] == "pass"
 assert statuses["direct_native_runtime_abi_ready"] == "pass"
 assert statuses["command_lsp_release_boundary"] == "pass"
@@ -314,22 +310,14 @@ PY
 (
   cd "$case_dir"
   if bash scripts/ci/check-rust-exit-readiness.sh --json --issue-state-file "$temp_dir/issues.txt" >"$temp_dir/stale-closed-blocker.json" 2>"$temp_dir/stale-closed-blocker.err"; then
-    echo "expected readiness check to fail when a closed issue is listed while ABI rows remain incomplete" >&2
+    echo "expected readiness check to fail when an ABI blocker is missing from the manifest" >&2
     exit 1
   fi
-  python3 - "$temp_dir/stale-closed-blocker.json" <<'PY'
-import json
-import sys
-
-with open(sys.argv[1], encoding="utf-8") as handle:
-    payload = json.load(handle)
-
-statuses = {check["name"]: check["status"] for check in payload["checks"]}
-assert statuses["readiness_manifest_valid"] == "pass"
-assert statuses["readiness_blockers_closed"] == "pass"
-assert statuses["readiness_blockers_live_when_not_ready"] == "fail"
-assert statuses["direct_native_runtime_abi_ready"] == "fail"
-PY
+  if ! rg -q "ABI blocker issues missing from readiness manifest: #1191" "$temp_dir/stale-closed-blocker.err"; then
+    echo "expected missing ABI blocker validation error" >&2
+    cat "$temp_dir/stale-closed-blocker.err" >&2
+    exit 1
+  fi
 )
 
 python3 - "$case_dir/stage1/runtime-abi/direct-native-v0.json" <<'PY'


### PR DESCRIPTION
## Summary

- Remove completed backend issue #1191 from `docs/rust-exit-readiness.json` so the readiness manifest tracks only live blockers.
- Update `docs/rust-exit-readiness.md` to describe generated-Rust removal as completed for the supported toolchain.
- Make the readiness checker name not-closed blockers, and update its regression harness for the single remaining live blocker model.

## Governing Issue

Part of #721.

Does not close #731; live GitHub state still reports #731 as `OPEN` and it remains the readiness blocker.

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Commands run:

- `git diff --check`
- `python3 -m json.tool docs/rust-exit-readiness.json >/dev/null`
- `bash -n scripts/ci/check-rust-exit-readiness.sh scripts/ci/test-check-rust-exit-readiness.sh`
- `make rust-exit-readiness-test`
- `make rust-exit-readiness-github` (expected non-zero: now reports `Blocking issue(s) not closed: #731:OPEN`; all ABI, generated-Rust, command/LSP, and MIR/backend gates pass)

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Semantic impact:

- Semantic node types: none.
- Schemas: none.
- Evidence: readiness gate and docs only.
- Rust capture risk: reduced by preventing closed backend issue #1191 from remaining as a live Rust-exit blocker.
- Agent-facing inspection impact: readiness output now names the remaining not-closed blocker.

## Flow Contract

- Owner lane: governance/docs
- Repair owner: Codex
- Autonomy class: agent-executed
- Risk class: low

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [ ] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is appropriate when gates pass

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- Auto-merge is not enabled yet because the PR needs non-author review.
- #731 remains open and is labeled `status:needs-human-approval`; this PR does not implement that Phase-L.3 driver work.
