### PR TITLE
Update read-only artifact property test to direct-native contract

### DIFF
--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -10001,7 +10001,10 @@ return async_serve_route(1, "/", "ok", 1)
         assert_eq!(output.failed, 0);
         assert_eq!(output.cases.len(), 1);
         assert_eq!(output.cases[0].kind, TestKind::Property);
-        assert!(output.cases[0].generated_rust.is_some());
+        assert!(
+            output.cases[0].generated_rust.is_none(),
+            "default direct-native property runs must not emit generated Rust"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `property_tests_recover_read_only_artifact_directory` (in `project.rs`) still asserted `output.cases[0].generated_rust.is_some()`, a stale generated-Rust assumption from before the default-backend flip to direct-native Cranelift.
- Updated only the trailing backend assertion to the direct-native contract (`generated_rust.is_none()`), matching the convention already used for the `lib.rs` default-backend tests.
- The test's real subject -- recovering a read-only `dist/tests` artifact directory without failing the run -- is unchanged.

## Governing Issue

Refs #1255 (full lib suite + cross-backend parity gate). This resolves one of the `update_direct_native_contract` failures recorded in the triage manifest via the sanctioned "update the assertion to the direct-native artifact contract" path.

## Validation

- [x] `RUST_MIN_STACK=8388608 cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib --features run-native-tests property_tests_recover_read_only_artifact_directory` passes (1 passed; 0 failed).
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks: none

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are not applicable (test-only)
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed: none.
- [x] Schemas added/changed: none.
- [x] Evidence added/changed: none (test assertion aligned to direct-native contract).
- [x] Rust capture check is satisfied: this PR removes a generated-Rust presence assumption from a default-backend test.
- [x] Agent-facing inspection impact: none.

## Flow Contract

- Owner lane: Ares
- Repair owner: Codex
- Autonomy class: Class 2 - Review-gated autonomous
- Risk class: risk:low

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- Test-only change; no backend or runtime behavior is modified. Part of working through the residual full-lib-suite failures toward the #1255 blocking gate.