### PR TITLE
Emit structured assertion traps from direct-native test runs

### DIFF
--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -19396,17 +19396,41 @@ fn eval_assert_call(
             let left = eval_expr(left, functions, env, lines)?;
             let right = eval_expr(right, functions, env, lines)?;
             let equal = spike_values_equal(&left, &right)?;
-            assert_result(equal == (name == "assert_eq"), &format!("{name} failed"))
+            if equal == (name == "assert_eq") {
+                Ok(SpikeValue::Int(0))
+            } else {
+                let op = if name == "assert_eq" { "==" } else { "!=" };
+                Err(cranelift_runtime_trap(
+                    "assertion",
+                    format!(
+                        "expected left {op} right, left={}, right={}",
+                        render_value(&left),
+                        render_value(&right)
+                    ),
+                ))
+            }
         }
         "assert_case_eq" => {
-            let [_label, left, right, _line, _column] = args else {
+            let [label, left, right, _line, _column] = args else {
                 return Err(unsupported(
                     "assert_case_eq expects label, left, right, line, and column",
                 ));
             };
+            let label = expect_text(eval_expr(label, functions, env, lines)?, "assert_case_eq")?;
             let left = eval_expr(left, functions, env, lines)?;
             let right = eval_expr(right, functions, env, lines)?;
-            assert_result(spike_values_equal(&left, &right)?, "assert_case_eq failed")
+            if spike_values_equal(&left, &right)? {
+                Ok(SpikeValue::Int(0))
+            } else {
+                Err(cranelift_runtime_trap(
+                    "assertion",
+                    format!(
+                        "table case {label:?} failed: expected {}, got {}",
+                        render_value(&right),
+                        render_value(&left)
+                    ),
+                ))
+            }
         }
         _ => Err(unsupported(&format!(
             "unsupported cranelift spike assertion call {name:?}"


### PR DESCRIPTION
## Summary

- Failing `assert_eq`/`assert_ne` (builtin) and `assert_case_eq` (used by the `std/testing.ax` helpers, e.g. `assert_eq_int`) in the direct-native Cranelift spike returned a generic build-time `unsupported` diagnostic, so a failing test aborted the build instead of producing a runtime test failure with diagnostic detail.
- Route assertion failures through `cranelift_runtime_trap("assertion", ...)` so the compiled test binary exits non-zero and writes a structured `{"kind":"assertion","message":...}` line to stderr -- the same mechanism the backend already uses for `panic`/`runtime` traps.
- Messages now carry the actual values, restoring the diagnostic fidelity the generated-Rust backend provided:
  - `assert_eq`/`assert_ne`: `expected left == right, left=41, right=42`
  - `assert_case_eq`: `table case "assert_eq_int" failed: expected 42, got 41`

## Governing Issue

Refs #1255 (full lib suite + cross-backend parity gate). Resolves two `update_direct_native_contract` failures from the triage manifest by repairing the direct-native behavior (not by weakening the assertion).

## Validation

- [x] `RUST_MIN_STACK=8388608 cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib --features run-native-tests failure_details` -> 2 passed.
- [x] Full `cargo test -p axiomc --lib --features run-native-tests`: +2 fixed vs `main`, zero new failures (remaining shell-only reds are the network/wasm environment-gated tests).
- [x] `cargo fmt -p axiomc -- --check` clean.
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks: none

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are not applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed: none.
- [x] Schemas added/changed: none (uses the existing `{"kind","message"}` runtime-trap stderr shape).
- [x] Evidence added/changed: direct-native test runs now emit structured `assertion`-kind failure evidence on stderr.
- [x] Rust capture check is satisfied: this restores assertion diagnostics on the direct-native path, removing reliance on generated-Rust for test-failure detail.
- [x] Agent-facing inspection impact: failing native tests now expose structured assertion JSON in `case.stderr`/`case.error`.

## Flow Contract

- Owner lane: Ares
- Repair owner: Codex
- Autonomy class: Class 2 - Review-gated autonomous
- Risk class: risk:low

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- Minimal blast radius: only the `assert_eq`/`assert_ne` and `assert_case_eq` arms change; boolean asserts (`assert_true`, `assert_property`, `assert_contains`, `assert_snapshot`) are untouched. Part of working through the residual full-lib-suite failures toward the #1255 blocking gate.