### PR TITLE
Update net_module resolve expectation to direct-native contract

### DIFF
--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -7154,9 +7154,9 @@ print "missing"
             .output()
             .expect("run compiled binary");
         let expected = if loopback_socket_bind_available() {
-            "false\ntcp listen ok\nudp bind ok\n"
+            "true\ntcp listen ok\nudp bind ok\n"
         } else {
-            "false\ntcp listen none\nudp bind none\n"
+            "true\ntcp listen none\nudp bind none\n"
         };
         assert_eq!(String::from_utf8_lossy(&output.stdout), expected);
     }


### PR DESCRIPTION
## Summary

- `stage1_project_imports_synthetic_stdlib_net_module` expected `resolve("localhost")` to print `false` (`None`) -- a stale expectation from before direct-native implemented net resolution.
- The project grants `net = true` (unrestricted), and direct-native resolves `localhost` to a loopback address (`Some`). This is the **same behavior the Cranelift integration tests already assert** (`cranelift_backend_builds_net_resolve_binary` etc., with `localhost` allowlisted -- the issue #928 DNS-resolution regression). `net = true` is a superset of that allowlist, so `resolve("localhost") -> Some` is correct here too.
- Only the `resolve` line was stale; `tcp_listen_loopback_once`/`udp_bind_loopback_once` already matched. Updated the expected first line `false -> true` in both loopback branches.

## Governing Issue

Refs #1255. Resolves a `stale_generated_rust_expectation` row in the full-lib triage manifest by aligning the assertion to the direct-native `resolve` contract (no backend behavior changed).

## Validation

- [x] `RUST_MIN_STACK=8388608 cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib --features run-native-tests stage1_project_imports_synthetic_stdlib_net_module` -> 1 passed.
- [x] Pure test-expectation change in a single test; the `resolve` lowering and the Cranelift integration regressions (which assert `Some`) are untouched.
- [x] `cargo fmt -p axiomc -- --check` clean.
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks: none

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are not applicable (test-only)
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed: none.
- [x] Schemas added/changed: none.
- [x] Evidence added/changed: none (assertion aligned to the direct-native resolve contract).
- [x] Rust capture check is satisfied: removes a stale generated-Rust-era expectation from a default-backend test.
- [x] Agent-facing inspection impact: none.

## Flow Contract

- Owner lane: Ares
- Repair owner: Codex
- Autonomy class: Class 2 - Review-gated autonomous
- Risk class: risk:low

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- This started as a suspected `resolve` design contradiction between the lib test (expected `None`) and the Cranelift integration tests (expected `Some`). On closer inspection the manifests differ and `net = true` should resolve, so the lib test's `false` was simply stale -- a one-line assertion fix, no design change or `resolve` denial needed. The `net_tcp`/`net_udp` import tests still need real runtime socket roundtrips and are out of scope here.