### PR TITLE
Trap on sized-integer overflow in direct-native debug builds

### DIFF
--- a/stage1/crates/axiomc-backend-cranelift/src/lib.rs
+++ b/stage1/crates/axiomc-backend-cranelift/src/lib.rs
@@ -1,6 +1,6 @@
 use cranelift_codegen::ir::{
     AbiParam, ArgumentPurpose, BlockArg, FuncRef, InstBuilder, MemFlags, StackSlotData,
-    StackSlotKind, Value, condcodes::IntCC, types,
+    StackSlotKind, TrapCode, Value, condcodes::IntCC, types,
 };
 use cranelift_codegen::isa;
 use cranelift_codegen::isa::CallConv;
@@ -263,6 +263,16 @@ pub enum I64Expr {
         op: I64BinaryOp,
         lhs: Box<I64Expr>,
         rhs: Box<I64Expr>,
+    },
+    /// Evaluate `value` and trap (write `message` to stderr and exit non-zero)
+    /// when it falls outside `[min, max]`; otherwise yield the value unchanged.
+    /// Used to enforce sized-integer overflow policy in debug builds before the
+    /// wrapping cast to the narrower type.
+    CheckedSignedRange {
+        value: Box<I64Expr>,
+        min: i64,
+        max: i64,
+        message: String,
     },
     Select {
         cond: Box<I64Condition>,
@@ -3046,6 +3056,15 @@ fn emit_i64_expr(
                 I64BinaryOp::Div => builder.ins().sdiv(lhs, rhs),
             })
         }
+        I64Expr::CheckedSignedRange {
+            value,
+            min,
+            max,
+            message,
+        } => {
+            let value = emit_i64_expr(builder, locals, function_refs, runtime_refs, value)?;
+            emit_i64_checked_signed_range(builder, runtime_refs, value, *min, *max, message)
+        }
         I64Expr::Select {
             cond,
             then_result,
@@ -3060,6 +3079,65 @@ fn emit_i64_expr(
             else_result,
         ),
     }
+}
+
+fn emit_i64_checked_signed_range(
+    builder: &mut FunctionBuilder<'_>,
+    runtime_refs: I64RuntimeRefs,
+    value: Value,
+    min: i64,
+    max: i64,
+    message: &str,
+) -> Result<Value, CraneliftBackendError> {
+    let ok_block = builder.create_block();
+    let trap_block = builder.create_block();
+    let merge_block = builder.create_block();
+    builder.append_block_param(merge_block, types::I64);
+
+    let min_value = builder.ins().iconst(types::I64, min);
+    let max_value = builder.ins().iconst(types::I64, max);
+    let above_min = builder
+        .ins()
+        .icmp(IntCC::SignedGreaterThanOrEqual, value, min_value);
+    let below_max = builder
+        .ins()
+        .icmp(IntCC::SignedLessThanOrEqual, value, max_value);
+    let in_range = builder.ins().band(above_min, below_max);
+    builder.ins().brif(in_range, ok_block, &[], trap_block, &[]);
+
+    builder.switch_to_block(ok_block);
+    builder.seal_block(ok_block);
+    builder.ins().jump(merge_block, &[BlockArg::Value(value)]);
+
+    // Overflow: write the structured runtime error to stderr (unbuffered write
+    // syscall, so it reaches fd 2 before the trap) and abort with a non-zero
+    // exit via a Cranelift trap.
+    builder.switch_to_block(trap_block);
+    builder.seal_block(trap_block);
+    let bytes_len = u32::try_from(message.len() + 1)
+        .map_err(|_| CraneliftBackendError::new("overflow trap message is too large"))?;
+    let message_slot = builder.create_sized_stack_slot(StackSlotData::new(
+        StackSlotKind::ExplicitSlot,
+        bytes_len,
+        0,
+    ));
+    for (offset, byte) in message.bytes().chain(std::iter::once(b'\n')).enumerate() {
+        let byte_value = builder.ins().iconst(types::I8, i64::from(byte));
+        builder
+            .ins()
+            .stack_store(byte_value, message_slot, offset as i32);
+    }
+    let message_ptr = builder.ins().stack_addr(types::I64, message_slot, 0);
+    let fd = builder.ins().iconst(types::I32, 2);
+    let len = builder.ins().iconst(types::I64, i64::from(bytes_len));
+    builder
+        .ins()
+        .call(runtime_refs.write, &[fd, message_ptr, len]);
+    builder.ins().trap(TrapCode::INTEGER_OVERFLOW);
+
+    builder.switch_to_block(merge_block);
+    builder.seal_block(merge_block);
+    Ok(builder.block_params(merge_block)[0])
 }
 
 fn emit_i64_select_expr(

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -352,6 +352,35 @@ static SPIKE_UDP_SOCKETS: OnceLock<Mutex<HashMap<i64, SpikeUdpSocket>>> = OnceLo
 
 thread_local! {
     static SPIKE_STDIN: RefCell<SpikeStdin> = RefCell::new(SpikeStdin::default());
+    // Whether the current compilation is a debug build. Read while lowering
+    // sized-integer arithmetic to decide between overflow-trapping (debug) and
+    // wrapping (release) semantics.
+    static I64_DEBUG_BUILD: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+fn i64_debug_build() -> bool {
+    I64_DEBUG_BUILD.with(std::cell::Cell::get)
+}
+
+/// Signed integer bounds and display name for integer types narrower than the
+/// native i64 lowering width. `None` for i64/isize (no narrowing overflow) and
+/// non-integer types.
+fn i64_sized_signed_overflow_bounds(ty: &Type) -> Option<(i64, i64, &'static str)> {
+    match ty {
+        Type::Numeric(NumericType::I8) => Some((i64::from(i8::MIN), i64::from(i8::MAX), "i8")),
+        Type::Numeric(NumericType::I16) => Some((i64::from(i16::MIN), i64::from(i16::MAX), "i16")),
+        Type::Numeric(NumericType::I32) => Some((i64::from(i32::MIN), i64::from(i32::MAX), "i32")),
+        _ => None,
+    }
+}
+
+fn i64_arithmetic_word(op: ArithmeticOp) -> &'static str {
+    match op {
+        ArithmeticOp::Add => "addition",
+        ArithmeticOp::Sub => "subtraction",
+        ArithmeticOp::Mul => "multiplication",
+        ArithmeticOp::Div => "division",
+    }
 }
 
 pub fn compile_cranelift_hello_spike(
@@ -363,13 +392,14 @@ pub fn compile_cranelift_hello_spike(
     object_path: &Path,
     binary_path: &Path,
     target: Option<&str>,
-    _debug: bool,
+    debug: bool,
 ) -> Result<(), Diagnostic> {
     if target.is_some() {
         return Err(unsupported(
             "the cranelift backend spike currently supports only the host target",
         ));
     }
+    I64_DEBUG_BUILD.with(|flag| flag.set(debug));
     if let Some(program) = lower_i64_exit_program(program, capabilities, package_root, fs_root) {
         return axiomc_backend_cranelift::compile_i64_exit_program(
             program,
@@ -13985,6 +14015,7 @@ fn lower_i64_expr(
             })
         }
         Expr::BinaryAdd { op, lhs, rhs, ty } if is_i64_compatible_type(ty) => {
+            let arith_op = *op;
             let op = match op {
                 ArithmeticOp::Add => CraneliftI64BinaryOp::Add,
                 ArithmeticOp::Sub => CraneliftI64BinaryOp::Sub,
@@ -14007,6 +14038,22 @@ fn lower_i64_expr(
                     helper_signatures,
                     static_bindings,
                 )?),
+            };
+            // Debug builds trap on sized-integer overflow before the wrapping
+            // cast; release builds keep the wrapping behavior.
+            let expr = match i64_sized_signed_overflow_bounds(ty) {
+                Some((min, max, ty_name)) if i64_debug_build() => {
+                    CraneliftI64Expr::CheckedSignedRange {
+                        value: Box::new(expr),
+                        min,
+                        max,
+                        message: format!(
+                            "{{\"kind\":\"runtime\",\"message\":\"numeric overflow: {ty_name} {}\"}}",
+                            i64_arithmetic_word(arith_op)
+                        ),
+                    }
+                }
+                _ => expr,
             };
             lower_i64_cast_expr(expr, ty)
         }


### PR DESCRIPTION
## Summary

- `let max_i32: i32 = 2147483647i32; print max_i32 + 1i32` lowered as an i64 add followed by a **wrapping** `Signed32` cast, so **both** debug and release builds silently printed `-2147483648`. The `--debug` profile reached the backend but was unused (`_debug`), so the overflow policy (debug traps, release wraps) was never applied.
- Added a `CheckedSignedRange` i64 runtime expression to `axiomc-backend-cranelift`: it range-checks the value and, on overflow, writes the structured runtime error to stderr (unbuffered `write` syscall) and aborts with a Cranelift `trap` (non-zero exit); otherwise it yields the value unchanged.
- Threaded the build profile to the lowering via a thread-local set at the compile entry, and wrapped sized-signed (`i8`/`i16`/`i32`) `+`/`-`/`*` results in `CheckedSignedRange` **for debug builds only**. Release keeps the wrapping cast.

## Result

- **Debug:** overflow emits `{"kind":"runtime","message":"numeric overflow: i32 addition"}` to stderr and exits non-zero.
- **Release:** still wraps (`-2147483648`), unchanged.

## Governing Issue

Refs #1255. Resolves the `stage1_numeric_overflow_policy_checks_signed_debug_and_wraps_release` `direct_native_contract` row by implementing the profile-dependent overflow semantics in the direct-native backend.

## Validation

- [x] `cargo test -p axiomc --lib --features run-native-tests stage1_numeric_overflow_policy_checks_signed_debug_and_wraps_release` -> pass (debug traps with the exact JSON, release wraps).
- [x] Full `-p axiomc --lib --features run-native-tests`: **zero new failures** vs baseline (the wrap path is unchanged in release, and the trap only applies to debug sized-signed arithmetic).
- [x] `cargo build -p axiomc-backend-cranelift` / `-p axiomc` clean (only pre-existing dead-code warnings, #1195-1199).
- [x] `cargo fmt -- --check` clean.
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks: none

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are not applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed: `I64Expr::CheckedSignedRange` runtime check.
- [x] Schemas added/changed: none.
- [x] Evidence added/changed: debug builds now emit a structured `kind:runtime` overflow error on stderr.
- [x] Rust capture check is satisfied: implements overflow policy in direct-native codegen, no generated-Rust dependency.
- [x] Agent-facing inspection impact: debug binaries fail closed on sized-integer overflow instead of silently wrapping.

## Flow Contract

- Owner lane: Ares
- Repair owner: Codex
- Autonomy class: Class 2 - Review-gated autonomous
- Risk class: risk:medium

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- Scope is signed `i8`/`i16`/`i32` `+`/`-`/`*` (the narrower-than-i64 signed types) in debug builds. `i64`/`isize` need no narrowing check; unsigned and division overflow can be added the same way if future tests require them.