### PR TITLE
Enforce async timeout deadlines and decouple async tests from generated Rust

### DIFF
--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -228,6 +228,10 @@ enum SpikeValue {
     Task {
         value: Option<Box<SpikeValue>>,
         canceled: bool,
+        /// Real time the task's body took to evaluate (the spike drives async
+        /// eagerly with real `sleep_ms`). Used by `async_timeout` to decide
+        /// whether the task outran its deadline.
+        duration_ms: i64,
     },
     JoinHandle(Box<SpikeValue>),
     AsyncChannel {
@@ -20138,10 +20142,12 @@ fn eval_call(
         }
         local_env.insert(param.name.clone(), value);
     }
+    let started = current_time_ms()?;
     let returned = run_function_body(&function.body, functions, &mut local_env, lines)?
         .ok_or_else(|| unsupported("cranelift spike functions must return a value"))?;
     if function.is_async {
-        Ok(spike_task(returned))
+        let duration = current_time_ms()?.saturating_sub(started);
+        Ok(spike_task_with_duration(returned, duration))
     } else {
         Ok(returned)
     }
@@ -20223,8 +20229,10 @@ fn eval_call_effectful(
         }
     }
 
+    let started = current_time_ms()?;
     let returned = run_function_body(&function.body, functions, &mut local_env, lines)?
         .ok_or_else(|| unsupported("cranelift spike functions must return a value"))?;
+    let async_duration = current_time_ms()?.saturating_sub(started);
     for (backing_name, target) in writebacks {
         let Some(SpikeValue::Array(elements)) = local_env.get(&backing_name) else {
             return Err(unsupported(
@@ -20234,7 +20242,7 @@ fn eval_call_effectful(
         env.insert(target, SpikeValue::Array(elements.clone()));
     }
     if function.is_async {
-        Ok(spike_task(returned))
+        Ok(spike_task_with_duration(returned, async_duration))
     } else {
         Ok(returned)
     }
@@ -20480,9 +20488,12 @@ fn eval_async_call(
                 return Err(unsupported("async_cancel expects exactly one argument"));
             };
             match eval_expr(task, functions, env, lines)? {
-                SpikeValue::Task { value, .. } => Ok(SpikeValue::Task {
+                SpikeValue::Task {
+                    value, duration_ms, ..
+                } => Ok(SpikeValue::Task {
                     value,
                     canceled: true,
+                    duration_ms,
                 }),
                 _ => Err(unsupported("async_cancel expects a task")),
             }
@@ -20499,11 +20510,21 @@ fn eval_async_call(
             }
         }
         "async_timeout" => {
-            let [task, _milliseconds] = args else {
+            let [task, milliseconds] = args else {
                 return Err(unsupported("async_timeout expects exactly two arguments"));
             };
+            let timeout_ms =
+                expect_signed_integer(eval_expr(milliseconds, functions, env, lines)?)?;
+            // The spike drives async tasks eagerly with real `sleep_ms`, so each
+            // task carries the real time its body took. A task that ran longer
+            // than the deadline reports a timeout (None).
             match eval_expr(task, functions, env, lines)? {
                 SpikeValue::Task { canceled: true, .. } => Ok(spike_task(spike_option(None))),
+                SpikeValue::Task { duration_ms, .. }
+                    if timeout_ms >= 0 && duration_ms > timeout_ms =>
+                {
+                    Ok(spike_task(spike_option(None)))
+                }
                 task @ SpikeValue::Task { .. } => {
                     await_spike_task(task).map(|value| spike_task(spike_option(Some(value))))
                 }
@@ -20588,9 +20609,14 @@ fn eval_async_call(
 }
 
 fn spike_task(value: SpikeValue) -> SpikeValue {
+    spike_task_with_duration(value, 0)
+}
+
+fn spike_task_with_duration(value: SpikeValue, duration_ms: i64) -> SpikeValue {
     SpikeValue::Task {
         value: Some(Box::new(value)),
         canceled: false,
+        duration_ms,
     }
 }
 
@@ -20606,6 +20632,7 @@ fn await_spike_task(value: SpikeValue) -> Result<SpikeValue, Diagnostic> {
         SpikeValue::Task {
             value: Some(value),
             canceled: false,
+            ..
         } => Ok(*value),
         SpikeValue::Task { canceled: true, .. } => Err(unsupported("awaited task was canceled")),
         SpikeValue::Task { value: None, .. } => {

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -2710,12 +2710,6 @@ print 0
         .expect("write source");
 
         let built = build_project(&project).expect("build async timeout project");
-        let generated =
-            fs::read_to_string(generated_rust_path(&built)).expect("read generated rust");
-        assert!(generated.contains("match receiver.recv_timeout(remaining)"));
-        assert!(
-            generated.contains("Err(std::sync::mpsc::RecvTimeoutError::Timeout) => return None")
-        );
         let output = compiled_binary_command(&built.binary)
             .output()
             .expect("run compiled binary");
@@ -8324,12 +8318,6 @@ let _listener_closed: int = close_listener(listener)
         fs::write(project.join("src/main.ax"), source).expect("write source");
 
         let built = build_project(&project).expect("build single-worker async project");
-        let generated =
-            fs::read_to_string(generated_rust_path(&built)).expect("read generated rust");
-        assert!(generated.contains("const AXIOM_RUNTIME_MAX_THREADS_CONFIG: usize = 1;"));
-        assert!(generated.contains("fn axiom_runtime_recv<T>("));
-        assert!(generated.contains("fn try_run_one(&self) -> bool"));
-
         let output = compiled_binary_command(&built.binary)
             .output()
             .expect("run compiled binary");


### PR DESCRIPTION
## Summary

- The direct-native spike drives async tasks **eagerly with real `sleep_ms`**, but `async_timeout` ignored its deadline (`_milliseconds`) and always returned the task's value. So `await timeout<int>(slow(7), 25)` returned `Some(7)` even though `slow` slept 80ms > 25ms.
- **Track each task's real duration** in `SpikeValue::Task` (`duration_ms`), captured around the async function body in both `eval_call` paths, and have `async_timeout` return `None` when a task's duration exceeds the deadline (canceled tasks still short-circuit to `None`).
- **Decouple two async tests** from removed generated-Rust source inspection -- `async_timeout_returns_without_joining_slow_host_task` and `stage1_async_runtime_single_worker_drains_nested_join_and_timeout` now assert direct-native binary behavior only (they previously grepped `built.generated_rust`, which panics now that generated Rust is gone).

## Result (3 of 4 async gaps closed)

- `stage1_async_timeout_uses_real_elapsed_timer_and_returns_none` -> pass (timeout now fires).
- `async_timeout_returns_without_joining_slow_host_task` -> pass (decoupled + timeout).
- `stage1_async_runtime_single_worker_drains_nested_join_and_timeout` -> pass (decoupled; fast child returns `Some`).

`stage1_async_runtime_uses_configured_scheduler_and_timer_wheel` is **left as a tracked gap**: it spawns 32 tasks each sleeping 100ms and asserts `elapsed < 1200`, which requires real concurrent execution. The eager spike runs them sequentially (~3200ms), so that one needs a concurrent async runtime, not a timeout fix.

## Governing Issue

Refs #1255. Resolves three async `direct_native_contract` rows.

## Validation

- [x] The 3 target async tests pass; `stage1_async_timeout_uses_real_elapsed_timer_and_returns_none` verified (timeout -> None, cancel -> None, fast task -> Some).
- [x] Full `-p axiomc --lib --features run-native-tests`: **zero new failures** vs baseline.
- [x] `cargo fmt -- --check` clean (only pre-existing dead-code warnings, #1195-1199).
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks: none

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are not applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed: `SpikeValue::Task` gains a `duration_ms` field.
- [x] Schemas added/changed: none.
- [x] Evidence added/changed: async timeouts now honor their deadline in direct-native runs.
- [x] Rust capture check is satisfied: implements timeout semantics in the direct-native path; the two decoupled tests no longer depend on generated Rust.
- [x] Agent-facing inspection impact: `timeout()` returns `None` for tasks that exceed the deadline.

## Flow Contract

- Owner lane: Ares
- Repair owner: Codex
- Autonomy class: Class 2 - Review-gated autonomous
- Risk class: risk:medium

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- The remaining async gap (`..._scheduler_and_timer_wheel`) needs true concurrent task execution in the spike; a good follow-up once a virtual-clock or thread-pool async model is designed.