### PR TITLE
Parse and emit JSON surrogate pairs in direct-native serdes

### DIFF
--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -21061,7 +21061,25 @@ fn json_parse_string(text: &str) -> Option<String> {
                 for _ in 0..4 {
                     value = (value << 4) + chars.next()?.to_digit(16)?;
                 }
-                out.push(char::from_u32(value)?);
+                if (0xD800..=0xDBFF).contains(&value) {
+                    // High surrogate: require a `\uDC00..=\uDFFF` low surrogate
+                    // escape and combine, matching the generated-runtime JSON
+                    // contract.
+                    if chars.next()? != '\\' || chars.next()? != 'u' {
+                        return None;
+                    }
+                    let mut low = 0u32;
+                    for _ in 0..4 {
+                        low = (low << 4) + chars.next()?.to_digit(16)?;
+                    }
+                    if !(0xDC00..=0xDFFF).contains(&low) {
+                        return None;
+                    }
+                    let scalar = 0x10000 + ((value - 0xD800) << 10) + (low - 0xDC00);
+                    out.push(char::from_u32(scalar)?);
+                } else {
+                    out.push(char::from_u32(value)?);
+                }
             }
             _ => return None,
         }
@@ -21639,6 +21657,36 @@ fn json_serdes_value_variant(variant: &str, payloads: Vec<SpikeValue>) -> SpikeV
     }
 }
 
+/// Escape a std/serdes string for JSON output. Unlike `json_escape_string`,
+/// this emits ASCII-safe output: BMP characters above 0x7f become `\uxxxx`
+/// escapes and astral characters become lowercase surrogate pairs, matching
+/// the generated-runtime serdes contract.
+fn json_serdes_escape_string(value: &str) -> String {
+    let mut out = String::from("\"");
+    for ch in value.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '\u{0008}' => out.push_str("\\b"),
+            '\u{000C}' => out.push_str("\\f"),
+            ch if ch.is_control() => out.push_str(&format!("\\u{:04x}", ch as u32)),
+            ch if (ch as u32) <= 0x7f => out.push(ch),
+            ch if (ch as u32) <= 0xffff => out.push_str(&format!("\\u{:04x}", ch as u32)),
+            ch => {
+                let scalar = (ch as u32) - 0x10000;
+                let high = 0xd800 + (scalar >> 10);
+                let low = 0xdc00 + (scalar & 0x3ff);
+                out.push_str(&format!("\\u{high:04x}\\u{low:04x}"));
+            }
+        }
+    }
+    out.push('"');
+    out
+}
+
 fn json_serdes_value_to_json(value: &SpikeValue) -> Result<String, Diagnostic> {
     let SpikeValue::Enum {
         enum_name,
@@ -21661,7 +21709,7 @@ fn json_serdes_value_to_json(value: &SpikeValue) -> Result<String, Diagnostic> {
         ("Bool", [SpikeValue::Bool(value)]) => Ok(value.to_string()),
         ("Int", [SpikeValue::Int(value)]) => Ok(value.to_string()),
         ("Float", [SpikeValue::Float(value)]) => Ok(json_serdes_float_to_json(*value)),
-        ("Text", [SpikeValue::Text(value)]) => Ok(json_escape_string(value)),
+        ("Text", [SpikeValue::Text(value)]) => Ok(json_serdes_escape_string(value)),
         ("Array", [SpikeValue::Array(values)]) => {
             let rendered = values
                 .iter()
@@ -21686,7 +21734,7 @@ fn json_serdes_object_to_json(entries: &[(SpikeValue, SpikeValue)]) -> Result<St
                 key.clone(),
                 format!(
                     "{}:{}",
-                    json_escape_string(key),
+                    json_serdes_escape_string(key),
                     json_serdes_value_to_json(value)?
                 ),
             ))

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -7656,7 +7656,7 @@ print "none"
             .expect("run compiled binary");
         assert_eq!(
             String::from_utf8_lossy(&output.stdout),
-            "0\n0\n0\n0\n{\"a\":\"alpha\",\"b\":2}\n"
+            "0\n0\n0\n0\n0\n0\n0\n0\n0\n0\n{\"a\":\"alpha\",\"b\":2}\n"
         );
 
         let tests = run_project_tests(&project).expect("run stdlib serdes tests");


### PR DESCRIPTION
## Summary

- `from_json("\"\\uD834\\uDD1E\"")` failed with `invalid JSON string` on the direct-native path: `json_parse_string` decoded each `\uXXXX` escape with `char::from_u32`, which rejects surrogate code points, so surrogate-pair escapes could not parse at all.
- **Parse:** combine `\uD800..=\uDBFF` high surrogates with a required following `\uDC00..=\uDFFF` low surrogate escape, matching the generated-runtime JSON contract (mirrors `codegen.rs`'s parser). Unpaired surrogates still fail closed.
- **Serialize:** add `json_serdes_escape_string` for std/serdes output -- ASCII-safe, BMP characters above 0x7f become `\uxxxx` escapes, astral characters become lowercase surrogate pairs (mirrors the generated runtime's `axiom_json_serdes_string_to_json`). Serdes `Text` values and object keys use it; the general `json_escape_string` used elsewhere (audit lines etc.) is unchanged.
- **Test reconciliation:** the serdes lib test's inline expectation predated #915's typed-accessor expansion (5 lines vs the fixture's 11 prints; the fixture's own checked-in golden already has 11 lines). Updated the inline expectation to match the fixture.

## Governing Issue

Refs #1255. Resolves the `stage1_project_imports_synthetic_stdlib_serdes_module` `stale_generated_rust_expectation` row -- one real engine gap (surrogate pairs) plus one stale assertion.

## Validation

- [x] `cargo test -p axiomc --lib --features run-native-tests stage1_project_imports_synthetic_stdlib_serdes_module` -> pass (all 10 fixture functions return 0; `stringify` round-trips U+1D11E as `"𝄞"`; `run_project_tests` passes 2/2 against the checked-in golden).
- [x] Full `-p axiomc --lib --features run-native-tests`: **zero new failures** vs baseline.
- [x] `cargo fmt -- --check` clean (only pre-existing dead-code warnings, #1195-1199).
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks: none

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are not applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed: none.
- [x] Schemas added/changed: none.
- [x] Evidence added/changed: direct-native serdes now matches the generated-runtime surrogate-pair contract on both parse and serialize.
- [x] Rust capture check is satisfied: ports the JSON contract into the direct-native path instead of relying on the removed generated runtime.
- [x] Agent-facing inspection impact: `from_json`/`stringify` handle non-BMP characters.

## Flow Contract

- Owner lane: Ares
- Repair owner: Codex
- Autonomy class: Class 2 - Review-gated autonomous
- Risk class: risk:medium

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- Local investigation note: a stale untracked `dist/` in the checked-in fixture (containing pre-flip `.generated.rs` artifacts) can mask this fix locally -- delete it if the test unexpectedly still fails; CI checkouts never have it.