### PR TITLE
Run package-local programs in direct-native process_status

### DIFF
--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -24845,9 +24845,31 @@ fn eval_process_status_call(
         "/usr/bin/false" => 1,
         "__axiom_stage1_missing_binary__" => -1,
         _ => {
-            return Err(unsupported(
-                "process_status spike only permits allowlisted deterministic commands",
-            ));
+            // Beyond the deterministic sentinels, only programs owned by the
+            // package itself may run: the command must canonicalize inside the
+            // package root, mirroring the filesystem scope model. System paths
+            // outside the package stay rejected so compile-time folding cannot
+            // execute arbitrary host binaries.
+            let (package_root, _) = spike_fs_scope(env)?;
+            let package_local = std::fs::canonicalize(&package_root)
+                .ok()
+                .zip(std::fs::canonicalize(&command).ok())
+                .filter(|(root, candidate)| candidate.starts_with(root))
+                .map(|(_, candidate)| candidate);
+            let Some(candidate) = package_local else {
+                return Err(unsupported(
+                    "process_status spike only permits allowlisted deterministic commands or package-local programs",
+                ));
+            };
+            // Run the package-local program, mirroring the generated runtime's
+            // process contract (exit code, or -1 when the process cannot spawn
+            // or is signal-terminated).
+            std::process::Command::new(candidate)
+                .status()
+                .ok()
+                .and_then(|status| status.code())
+                .map(i64::from)
+                .unwrap_or(-1)
         }
     };
     Ok(SpikeValue::Int(status))

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -6257,7 +6257,7 @@ net = { hosts = ["127.0.0.1"], ports = [8080] }
         .expect("write test");
         fs::write(
             project.join("src/main_test.stdout"),
-            "fs ok\n\nfalse\n7\nba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad\ntrue\nnone\n",
+            "fs ok\n\ntrue\n7\nba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad\ntrue\nnone\n",
         )
         .expect("write golden");
 
@@ -6267,7 +6267,7 @@ net = { hosts = ["127.0.0.1"], ports = [8080] }
             .expect("run compiled binary");
         assert_eq!(
             String::from_utf8_lossy(&output.stdout),
-            "fs ok\n\nfalse\n7\nba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad\ntrue\nnone\n"
+            "fs ok\n\ntrue\n7\nba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad\ntrue\nnone\n"
         );
 
         let tests = run_project_tests(&project).expect("run tests");


### PR DESCRIPTION
## Summary

- The capability-intrinsics kitchen-sink program (fs_read + net_resolve + **process_status of a project-owned script** + crypto + clock + env_get) could not build on the direct-native backend: the spike's `process_status` only permitted three hardcoded sentinels, so the fixture script failed with `only permits allowlisted deterministic commands`.
- **Permit commands that canonicalize inside the package root**, mirroring the filesystem scope model: package-owned programs execute for real (generated-runtime process contract -- exit code, `-1` when the process cannot spawn), while **system paths outside the package stay rejected** so compile-time folding still cannot execute arbitrary host binaries.
- The deterministic sentinels (`/usr/bin/true`/`/usr/bin/false`/`__axiom_stage1_missing_binary__`) keep their fixed statuses.
- Also updated the test's `net_resolve("localhost")` expectation `false -> true`, aligning with the direct-native resolve contract ratified in #1274 (unrestricted net resolves localhost to a loopback address).

## Security posture (guards verified)

All six cranelift process integration tests stay green, including the three rejection guards:
- `cranelift_backend_rejects_unapproved_process_status_command` (`/bin/sh` -- outside the package -> still fails the build)
- `cranelift_backend_rejects_shadowed_process_status_const_allowlist`
- `cranelift_backend_rejects_match_bound_process_status_const_allowlist`

The scope rule is the same one the fs layer uses (`canonicalize` + `starts_with` package root), so symlinks out of the package do not qualify.

## Governing Issue

Refs #1255. Resolves the `build_project_emits_native_binary_with_capability_intrinsics` `stale_generated_rust_expectation` row.

## Validation

- [x] `cargo test -p axiomc --lib --features run-native-tests build_project_emits_native_binary_with_capability_intrinsics` -> pass (script exits 7, sha256/clock/env/fs all fold correctly, `run_project_tests` 1/1).
- [x] `cargo test -p axiomc --test cranelift_backend --features run-native-tests process` -> 6/6 including all rejection guards.
- [x] Full `-p axiomc --lib --features run-native-tests`: **zero new failures** vs baseline.
- [x] `cargo fmt -- --check` clean.
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks: none

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are not applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed: none.
- [x] Schemas added/changed: none.
- [x] Evidence added/changed: process_status now covers package-local programs on the direct-native path with the same scope rule as fs.
- [x] Rust capture check is satisfied: ports the process contract into the direct-native path; sentinel + package-scope gating replaces reliance on the removed generated runtime.
- [x] Agent-facing inspection impact: package-owned scripts can be status-checked in direct-native builds.

## Flow Contract

- Owner lane: Ares
- Repair owner: Codex
- Autonomy class: Class 2 - Review-gated autonomous
- Risk class: risk:medium

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- The spike folds this at compile time with real host effects, consistent with its existing fs/net/sleep model; the runtime i64 `ProcessStatus` lowering and its sentinel gate are unchanged.