### PR TITLE
Split HIR signature resolution

### DIFF
--- a/docs/compiler-source-decomposition-plan.md
+++ b/docs/compiler-source-decomposition-plan.md
@@ -49,7 +49,10 @@ and the HIR type-lowering extraction moved syntax-to-HIR literal, type, and
 operator lowering into `stage1/crates/axiomc/src/hir/types.rs`. The HIR
 definitions extraction then moved type-name collection, aggregate definitions,
 trait type-use validation, and recursive aggregate checks into
-`stage1/crates/axiomc/src/hir/definitions.rs`, lowering both absolute top-file
+`stage1/crates/axiomc/src/hir/definitions.rs`. The HIR signature extraction
+then moved function/method signature collection, trait impl signature
+validation, and HIR symbol-name resolution into
+`stage1/crates/axiomc/src/hir/signatures.rs`, lowering both absolute top-file
 lines and share.
 
 ## Current Top Files
@@ -59,8 +62,8 @@ Snapshot from 2026-07-02:
 | Rank | Current Rust file | Lines | Target package boundary | First extraction slice |
 | ---: | --- | ---: | --- | --- |
 | 1 | `stage1/crates/axiomc/src/cranelift_backend.rs` | 27,994 | `compiler.backend.native` | Split direct-native lowering by runtime ABI groups: scalar/aggregate value features, capability shims, host imports, object emission, unsupported diagnostics, and evidence helpers. |
-| 2 | `stage1/crates/axiomc/src/hir.rs` | 11,214 | `compiler.hir` | Generic inference and monomorphization now live in `stage1/crates/axiomc/src/hir/generics.rs`; public HIR model types now live in `stage1/crates/axiomc/src/hir/model.rs`; syntax-to-HIR type/literal lowering now lives in `stage1/crates/axiomc/src/hir/types.rs`; type-name, aggregate, and trait-use definition checks now live in `stage1/crates/axiomc/src/hir/definitions.rs`; next split function/method resolution, type checking, capability analysis, ownership/borrow validation, property clauses, and HIR diagnostics behind the package APIs in `docs/compiler-hir-ownership-capability.md`. |
-| 3 | `stage1/crates/axiomc/src/project.rs` | 10,812 | `compiler.package_graph`, `compiler.commands`, `compiler.evidence` | Split manifest/workspace loading, command orchestration, provenance/debug records, and build artifact planning along package ownership. |
+| 2 | `stage1/crates/axiomc/src/project.rs` | 10,812 | `compiler.package_graph`, `compiler.commands`, `compiler.evidence` | Split manifest/workspace loading, command orchestration, provenance/debug records, and build artifact planning along package ownership. |
+| 3 | `stage1/crates/axiomc/src/hir.rs` | 10,754 | `compiler.hir` | Generic inference and monomorphization now live in `stage1/crates/axiomc/src/hir/generics.rs`; public HIR model types now live in `stage1/crates/axiomc/src/hir/model.rs`; syntax-to-HIR type/literal lowering now lives in `stage1/crates/axiomc/src/hir/types.rs`; type-name, aggregate, and trait-use definition checks now live in `stage1/crates/axiomc/src/hir/definitions.rs`; function/method signatures and trait impl signature validation now live in `stage1/crates/axiomc/src/hir/signatures.rs`; next split expression typing, capability analysis, ownership/borrow validation, property clauses, and HIR diagnostics behind the package APIs in `docs/compiler-hir-ownership-capability.md`. |
 | 4 | `stage1/crates/axiomc/src/main.rs` | 10,678 | `compiler.commands` | Move command parsing, JSON envelope construction, check/build/run/test/doc/trace orchestration, and exit handling behind `docs/compiler-command-lsp-packages.md` APIs. |
 | 5 | `stage1/crates/axiomc/src/codegen.rs` | 7,804 | `compiler.backend.generated_rust`, `compiler.backend.contracts` | Isolate generated-Rust compatibility emission from backend target selection and unsupported-feature contracts. |
 | 6 | `stage1/crates/axiomc/src/syntax.rs` | 6,324 | `compiler.syntax`, `compiler.diagnostics` | Split lexer/parser, parse recovery, source spans, macros, and syntax diagnostics behind the syntax boundary. |
@@ -76,10 +79,10 @@ matching ceiling in this table in the same PR.
 
 | Tracked item | Ceiling |
 | --- | ---: |
-| `summary.top_file_line_share` | 0.8876 |
-| `summary.top_file_lines` | 79031 |
+| `summary.top_file_line_share` | 0.8823 |
+| `summary.top_file_lines` | 78571 |
 | `stage1/crates/axiomc/src/cranelift_backend.rs` | 27994 |
-| `stage1/crates/axiomc/src/hir.rs` | 11214 |
+| `stage1/crates/axiomc/src/hir.rs` | 10754 |
 | `stage1/crates/axiomc/src/project.rs` | 10812 |
 | `stage1/crates/axiomc/src/main.rs` | 10678 |
 | `stage1/crates/axiomc/src/codegen.rs` | 7804 |
@@ -87,6 +90,7 @@ matching ceiling in this table in the same PR.
 | `stage1/crates/axiomc/src/hir/definitions.rs` | 684 |
 | `stage1/crates/axiomc/src/hir/generics.rs` | 4205 |
 | `stage1/crates/axiomc/src/hir/model.rs` | 607 |
+| `stage1/crates/axiomc/src/hir/signatures.rs` | 471 |
 | `stage1/crates/axiomc/src/hir/types.rs` | 241 |
 | `stage1/crates/axiomc/src/registry.rs` | 2159 |
 | `stage1/crates/axiomc/src/lib.rs` | 21 |
@@ -101,8 +105,9 @@ matching ceiling in this table in the same PR.
    gate.
 3. `compiler.hir`: generic inference/monomorphization, public HIR model types,
    syntax-to-HIR type/literal lowering, and type/aggregate definition collection
-   are split; continue with function/method resolution, typing, capability,
-   ownership, and property checks in that order so diagnostics stay stable.
+   are split; function/method signatures and trait impl signature validation are
+   split; continue with expression typing, capability, ownership, and property
+   checks in that order so diagnostics stay stable.
 4. `compiler.commands` and `compiler.package_graph`: separate command envelopes
    from package loading so the snapshot bootstrap can invoke package APIs
    without Cargo assumptions.

--- a/scripts/ci/report-compiler-source-monoliths.py
+++ b/scripts/ci/report-compiler-source-monoliths.py
@@ -40,6 +40,7 @@ BOUNDARY_MAP: dict[str, list[str]] = {
     "new_project.rs": ["compiler.commands"],
     "project.rs": ["compiler.package_graph", "compiler.commands", "compiler.evidence"],
     "registry.rs": ["compiler.package_graph"],
+    "signatures.rs": ["compiler.hir"],
     "stdlib.rs": ["compiler.stdlib"],
     "syntax.rs": ["compiler.syntax", "compiler.diagnostics"],
     "types.rs": ["compiler.hir"],

--- a/scripts/ci/test-report-compiler-source-monoliths.py
+++ b/scripts/ci/test-report-compiler-source-monoliths.py
@@ -46,16 +46,17 @@ class CompilerSourceMonolithTests(unittest.TestCase):
             write_lines(hir_dir / "generics.rs", 2)
             write_lines(hir_dir / "definitions.rs", 1)
             write_lines(hir_dir / "model.rs", 1)
+            write_lines(hir_dir / "signatures.rs", 1)
             write_lines(hir_dir / "types.rs", 1)
 
-            report = compiler_source_monoliths.build_report(source_root, top=6)
+            report = compiler_source_monoliths.build_report(source_root, top=7)
 
         self.assertEqual(report["schema_version"], "axiom.compiler_source.monoliths.v0")
         self.assertEqual(report["collected_at"], "2026-06-21T10:00:00Z")
-        self.assertEqual(report["summary"]["total_files"], 6)
-        self.assertEqual(report["summary"]["total_lines"], 13)
+        self.assertEqual(report["summary"]["total_files"], 7)
+        self.assertEqual(report["summary"]["total_lines"], 14)
         self.assertEqual(report["summary"]["largest_file_lines"], 5)
-        self.assertEqual(report["summary"]["top_file_lines"], 13)
+        self.assertEqual(report["summary"]["top_file_lines"], 14)
         self.assertEqual(report["summary"]["top_file_line_share"], 1.0)
         self.assertEqual(report["top_files"][0]["package_boundaries"], ["compiler.backend.native"])
         self.assertEqual(report["top_files"][1]["package_boundaries"], ["compiler.hir"])
@@ -63,6 +64,7 @@ class CompilerSourceMonolithTests(unittest.TestCase):
         self.assertEqual(report["top_files"][3]["package_boundaries"], ["compiler.hir"])
         self.assertEqual(report["top_files"][4]["package_boundaries"], ["compiler.hir"])
         self.assertEqual(report["top_files"][5]["package_boundaries"], ["compiler.hir"])
+        self.assertEqual(report["top_files"][6]["package_boundaries"], ["compiler.hir"])
 
     def test_check_plan_requires_top_file_and_boundary_mentions(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -7,6 +7,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 mod definitions;
 mod generics;
 mod model;
+mod signatures;
 mod types;
 
 use self::definitions::{
@@ -17,6 +18,10 @@ use self::definitions::{
 use self::generics::monomorphize_program;
 use self::model::type_assignable_to;
 pub use self::model::*;
+use self::signatures::{
+    FunctionSig, MethodSig, collect_function_signatures, collect_method_signatures,
+    function_symbol_name, validate_trait_impls,
+};
 use self::types::{
     lower_arithmetic_op, lower_compare_op, lower_literal, lower_logic_op, lower_type,
 };
@@ -97,26 +102,6 @@ enum ProjectionSegment {
     TupleIndex(usize),
 }
 
-#[derive(Debug, Clone)]
-struct FunctionSig {
-    source_name: String,
-    source_path: String,
-    params: Vec<Type>,
-    return_ty: Type,
-    borrow_return_params: Vec<usize>,
-    is_extern: bool,
-    is_const: bool,
-}
-
-#[derive(Debug, Clone)]
-struct MethodSig {
-    function_name: String,
-    params: Vec<Type>,
-    return_ty: Type,
-    borrow_return_params: Vec<usize>,
-    has_self: bool,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum BorrowOrigin {
     Param(String),
@@ -154,13 +139,6 @@ const OWNERSHIP_BORROW_RETURN_REQUIRES_PARAM_ORIGIN: &str =
     borrowck::BORROW_RETURN_REQUIRES_PARAM_ORIGIN;
 const OWNERSHIP_MOVE_WHILE_BORROWED: &str = borrowck::MOVE_WHILE_BORROWED;
 const OWNERSHIP_USE_AFTER_MOVE: &str = borrowck::USE_AFTER_MOVE;
-
-fn function_symbol_name(function: &syntax::Function) -> String {
-    match &function.impl_target {
-        Some(target) => format!("{target}__{}", function.name),
-        None => function.name.clone(),
-    }
-}
 
 fn is_castable_numeric(ty: &Type) -> bool {
     matches!(ty, Type::Int | Type::Numeric(_))
@@ -548,77 +526,6 @@ fn collect_expr_calls(expr: &syntax::Expr, calls: &mut VecDeque<String>) {
     }
 }
 
-fn substitute_self_type_name(
-    ty: &syntax::TypeName,
-    self_ty: &syntax::TypeName,
-) -> syntax::TypeName {
-    match ty {
-        syntax::TypeName::Named(name, args) if name == "Self" && args.is_empty() => self_ty.clone(),
-        syntax::TypeName::Named(name, args) => syntax::TypeName::Named(
-            name.clone(),
-            args.iter()
-                .map(|arg| substitute_self_type_name(arg, self_ty))
-                .collect(),
-        ),
-        syntax::TypeName::Ptr(inner) => {
-            syntax::TypeName::Ptr(Box::new(substitute_self_type_name(inner, self_ty)))
-        }
-        syntax::TypeName::MutPtr(inner) => {
-            syntax::TypeName::MutPtr(Box::new(substitute_self_type_name(inner, self_ty)))
-        }
-        syntax::TypeName::MutRef(inner) => {
-            syntax::TypeName::MutRef(Box::new(substitute_self_type_name(inner, self_ty)))
-        }
-        syntax::TypeName::Slice(inner) => {
-            syntax::TypeName::Slice(Box::new(substitute_self_type_name(inner, self_ty)))
-        }
-        syntax::TypeName::MutSlice(inner) => {
-            syntax::TypeName::MutSlice(Box::new(substitute_self_type_name(inner, self_ty)))
-        }
-        syntax::TypeName::LifetimeSlice(lifetime, inner) => syntax::TypeName::LifetimeSlice(
-            lifetime.clone(),
-            Box::new(substitute_self_type_name(inner, self_ty)),
-        ),
-        syntax::TypeName::LifetimeMutSlice(lifetime, inner) => syntax::TypeName::LifetimeMutSlice(
-            lifetime.clone(),
-            Box::new(substitute_self_type_name(inner, self_ty)),
-        ),
-        syntax::TypeName::Option(inner) => {
-            syntax::TypeName::Option(Box::new(substitute_self_type_name(inner, self_ty)))
-        }
-        syntax::TypeName::Result(ok, err) => syntax::TypeName::Result(
-            Box::new(substitute_self_type_name(ok, self_ty)),
-            Box::new(substitute_self_type_name(err, self_ty)),
-        ),
-        syntax::TypeName::Tuple(elements) => syntax::TypeName::Tuple(
-            elements
-                .iter()
-                .map(|element| substitute_self_type_name(element, self_ty))
-                .collect(),
-        ),
-        syntax::TypeName::Map(key, value) => syntax::TypeName::Map(
-            Box::new(substitute_self_type_name(key, self_ty)),
-            Box::new(substitute_self_type_name(value, self_ty)),
-        ),
-        syntax::TypeName::Array(inner, len) => syntax::TypeName::Array(
-            Box::new(substitute_self_type_name(inner, self_ty)),
-            len.clone(),
-        ),
-        syntax::TypeName::Fn(params, return_ty) => syntax::TypeName::Fn(
-            params
-                .iter()
-                .map(|param| substitute_self_type_name(param, self_ty))
-                .collect(),
-            Box::new(substitute_self_type_name(return_ty, self_ty)),
-        ),
-        syntax::TypeName::Int => syntax::TypeName::Int,
-        syntax::TypeName::Numeric(numeric) => syntax::TypeName::Numeric(*numeric),
-        syntax::TypeName::Bool => syntax::TypeName::Bool,
-        syntax::TypeName::String => syntax::TypeName::String,
-        syntax::TypeName::Str => syntax::TypeName::Str,
-    }
-}
-
 fn monomorphized_function_name(name: &str, type_args: &[syntax::TypeName]) -> String {
     monomorphized_name(name, type_args)
 }
@@ -813,362 +720,6 @@ impl Type {
             | Type::Fn(_, _) => false,
         }
     }
-}
-
-fn collect_function_signatures(
-    functions: &[syntax::Function],
-    structs: &HashMap<String, StructDef>,
-    enums: &HashMap<String, EnumDef>,
-    aliases: &HashMap<String, syntax::TypeAliasDecl>,
-    consts: &HashMap<String, syntax::ConstDecl>,
-) -> Result<HashMap<String, FunctionSig>, Diagnostic> {
-    let mut signatures = HashMap::new();
-    for function in functions {
-        let return_ty = lower_type(
-            &function.return_ty,
-            structs,
-            enums,
-            aliases,
-            consts,
-            function.line,
-            function.column,
-        )?;
-        let mut params = Vec::new();
-        if let Some(target_name) = &function.impl_target {
-            let self_ty = lower_type(
-                &syntax::TypeName::Named(target_name.clone(), Vec::new()),
-                structs,
-                enums,
-                aliases,
-                consts,
-                function.line,
-                function.column,
-            )?;
-            if function.receiver.is_some() {
-                params.push(self_ty);
-            }
-        }
-        for param in &function.params {
-            params.push(lower_type(
-                &param.ty,
-                structs,
-                enums,
-                aliases,
-                consts,
-                param.line,
-                param.column,
-            )?);
-        }
-        let signature_return_ty = if function.is_async {
-            Type::Task(Box::new(return_ty.clone()))
-        } else {
-            return_ty.clone()
-        };
-        let borrow_return_params = classify_borrow_return(
-            &params,
-            &signature_return_ty,
-            structs,
-            enums,
-            function.line,
-            function.column,
-        )?;
-        if signatures
-            .insert(
-                function_symbol_name(function),
-                FunctionSig {
-                    source_name: function.source_name.clone(),
-                    source_path: function.path.clone(),
-                    params,
-                    return_ty: signature_return_ty,
-                    borrow_return_params,
-                    is_extern: function.is_extern,
-                    is_const: function.is_const,
-                },
-            )
-            .is_some()
-        {
-            let message = if let Some(target) = &function.impl_target {
-                format!(
-                    "duplicate impl method {:?} for {:?}",
-                    function.source_name, target
-                )
-            } else {
-                format!("duplicate function {:?}", function.name)
-            };
-            return Err(Diagnostic::new("type", message).with_span(function.line, function.column));
-        }
-    }
-    Ok(signatures)
-}
-
-fn collect_method_signatures(
-    functions: &[syntax::Function],
-    structs: &HashMap<String, StructDef>,
-    enums: &HashMap<String, EnumDef>,
-    aliases: &HashMap<String, syntax::TypeAliasDecl>,
-    consts: &HashMap<String, syntax::ConstDecl>,
-) -> Result<HashMap<String, HashMap<String, MethodSig>>, Diagnostic> {
-    let mut methods: HashMap<String, HashMap<String, MethodSig>> = HashMap::new();
-    for function in functions {
-        let Some(target_name) = &function.impl_target else {
-            continue;
-        };
-        if !function.type_params.is_empty() {
-            return Err(Diagnostic::new(
-                "type",
-                format!("impl method {:?} cannot be generic yet", function.name),
-            )
-            .with_span(function.line, function.column));
-        }
-        let target_ty = lower_type(
-            &syntax::TypeName::Named(target_name.clone(), Vec::new()),
-            structs,
-            enums,
-            aliases,
-            consts,
-            function.line,
-            function.column,
-        )?;
-        if !matches!(target_ty, Type::Struct(_) | Type::Enum(_)) {
-            return Err(Diagnostic::new(
-                "type",
-                format!("impl target {:?} must be a struct or enum", target_name),
-            )
-            .with_span(function.line, function.column));
-        }
-        let return_ty = lower_type(
-            &function.return_ty,
-            structs,
-            enums,
-            aliases,
-            consts,
-            function.line,
-            function.column,
-        )?;
-        let mut params = Vec::new();
-        if function.receiver.is_some() {
-            params.push(target_ty.clone());
-        }
-        for param in &function.params {
-            params.push(lower_type(
-                &param.ty,
-                structs,
-                enums,
-                aliases,
-                consts,
-                param.line,
-                param.column,
-            )?);
-        }
-        let return_ty = if function.is_async {
-            Type::Task(Box::new(return_ty))
-        } else {
-            return_ty
-        };
-        let borrow_return_params = classify_borrow_return(
-            &params,
-            &return_ty,
-            structs,
-            enums,
-            function.line,
-            function.column,
-        )?;
-        let method = MethodSig {
-            function_name: function_symbol_name(function),
-            params,
-            return_ty,
-            borrow_return_params,
-            has_self: function.receiver.is_some(),
-        };
-        let entry = methods.entry(target_name.clone()).or_default();
-        if entry.insert(function.source_name.clone(), method).is_some() {
-            return Err(Diagnostic::new(
-                "type",
-                format!(
-                    "duplicate impl method {:?} for {:?}",
-                    function.name, target_name
-                ),
-            )
-            .with_span(function.line, function.column));
-        }
-    }
-    Ok(methods)
-}
-
-fn validate_trait_impls(
-    functions: &[syntax::Function],
-    traits: &HashMap<String, TraitDef>,
-    structs: &HashMap<String, StructDef>,
-    enums: &HashMap<String, EnumDef>,
-    aliases: &HashMap<String, syntax::TypeAliasDecl>,
-    consts: &HashMap<String, syntax::ConstDecl>,
-    methods: &HashMap<String, HashMap<String, MethodSig>>,
-) -> Result<(), Diagnostic> {
-    let mut impls: HashMap<(String, String), Vec<&syntax::Function>> = HashMap::new();
-    for function in functions {
-        let Some(trait_name) = &function.impl_trait else {
-            continue;
-        };
-        let Some(target_name) = &function.impl_target else {
-            continue;
-        };
-        if !traits.contains_key(trait_name) {
-            return Err(Diagnostic::new(
-                "type",
-                format!("impl references unknown trait {trait_name:?}"),
-            )
-            .with_span(function.line, function.column));
-        }
-        let target_ty = lower_type(
-            &syntax::TypeName::Named(target_name.clone(), Vec::new()),
-            structs,
-            enums,
-            aliases,
-            consts,
-            function.line,
-            function.column,
-        )?;
-        if !matches!(target_ty, Type::Struct(_) | Type::Enum(_)) {
-            return Err(Diagnostic::new(
-                "type",
-                format!("impl target {target_name:?} must be a local struct or enum"),
-            )
-            .with_span(function.line, function.column));
-        }
-        impls
-            .entry((trait_name.clone(), target_name.clone()))
-            .or_default()
-            .push(function);
-    }
-
-    for ((trait_name, target_name), impl_functions) in impls {
-        let trait_def = traits
-            .get(&trait_name)
-            .expect("trait impl keys are validated while grouping");
-        let method_sigs = methods.get(&target_name).ok_or_else(|| {
-            Diagnostic::new(
-                "type",
-                format!("impl {trait_name} for {target_name} does not define any methods"),
-            )
-            .with_span(impl_functions[0].line, impl_functions[0].column)
-        })?;
-        for required in &trait_def.methods {
-            let implementation = impl_functions
-                .iter()
-                .find(|function| function.source_name == required.name)
-                .ok_or_else(|| {
-                    Diagnostic::new(
-                        "type",
-                        format!(
-                            "impl {trait_name} for {target_name} is missing required method {:?}",
-                            required.name
-                        ),
-                    )
-                    .with_span(impl_functions[0].line, impl_functions[0].column)
-                })?;
-            validate_trait_method_signature(
-                required,
-                implementation,
-                &trait_name,
-                &target_name,
-                structs,
-                enums,
-                aliases,
-                consts,
-                method_sigs,
-            )?;
-        }
-    }
-    Ok(())
-}
-
-fn validate_trait_method_signature(
-    required: &TraitMethodDef,
-    implementation: &syntax::Function,
-    trait_name: &str,
-    target_name: &str,
-    structs: &HashMap<String, StructDef>,
-    enums: &HashMap<String, EnumDef>,
-    aliases: &HashMap<String, syntax::TypeAliasDecl>,
-    consts: &HashMap<String, syntax::ConstDecl>,
-    method_sigs: &HashMap<String, MethodSig>,
-) -> Result<(), Diagnostic> {
-    if required.has_self != implementation.receiver.is_some() {
-        return Err(Diagnostic::new(
-            "type",
-            format!(
-                "impl {trait_name} for {target_name} method {:?} has an incompatible self receiver",
-                required.name
-            ),
-        )
-        .with_span(implementation.line, implementation.column));
-    }
-    if required.params.len() != implementation.params.len() {
-        return Err(Diagnostic::new(
-            "type",
-            format!(
-                "impl {trait_name} for {target_name} method {:?} expects {} parameters, got {}",
-                required.name,
-                required.params.len(),
-                implementation.params.len()
-            ),
-        )
-        .with_span(implementation.line, implementation.column));
-    }
-    let target_ty = syntax::TypeName::Named(target_name.to_string(), Vec::new());
-    for (expected, actual) in required.params.iter().zip(&implementation.params) {
-        let expected = lower_type(
-            &substitute_self_type_name(expected, &target_ty),
-            structs,
-            enums,
-            aliases,
-            consts,
-            actual.line,
-            actual.column,
-        )?;
-        let actual = lower_type(
-            &actual.ty,
-            structs,
-            enums,
-            aliases,
-            consts,
-            actual.line,
-            actual.column,
-        )?;
-        if expected != actual {
-            return Err(Diagnostic::new(
-                "type",
-                format!(
-                    "impl {trait_name} for {target_name} method {:?} has parameter type {}, expected {}",
-                    required.name, actual, expected
-                ),
-            )
-            .with_span(implementation.line, implementation.column));
-        }
-    }
-    let expected_return = lower_type(
-        &substitute_self_type_name(&required.return_ty, &target_ty),
-        structs,
-        enums,
-        aliases,
-        consts,
-        implementation.line,
-        implementation.column,
-    )?;
-    let method_sig = method_sigs
-        .get(&implementation.source_name)
-        .expect("method signature should be collected before trait impl validation");
-    if expected_return != method_sig.return_ty {
-        return Err(Diagnostic::new(
-            "type",
-            format!(
-                "impl {trait_name} for {target_name} method {:?} returns {}, expected {}",
-                required.name, method_sig.return_ty, expected_return
-            ),
-        )
-        .with_span(implementation.line, implementation.column));
-    }
-    Ok(())
 }
 
 fn lower_static_decls(
@@ -10178,17 +9729,6 @@ fn contains_mut_borrowed_slice_type_inner(
             contains
         }
     }
-}
-
-fn classify_borrow_return(
-    params: &[Type],
-    return_ty: &Type,
-    structs: &HashMap<String, StructDef>,
-    enums: &HashMap<String, EnumDef>,
-    line: usize,
-    column: usize,
-) -> Result<Vec<usize>, Diagnostic> {
-    borrowck::classify_borrow_return(params, return_ty, structs, enums, line, column)
 }
 
 fn borrow_kind_for_type(

--- a/stage1/crates/axiomc/src/hir/signatures.rs
+++ b/stage1/crates/axiomc/src/hir/signatures.rs
@@ -1,0 +1,471 @@
+use super::model::{EnumDef, StructDef, TraitDef, TraitMethodDef, Type};
+use super::types::lower_type;
+use crate::borrowck;
+use crate::diagnostics::Diagnostic;
+use crate::syntax;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+pub(super) struct FunctionSig {
+    pub(super) source_name: String,
+    pub(super) source_path: String,
+    pub(super) params: Vec<Type>,
+    pub(super) return_ty: Type,
+    pub(super) borrow_return_params: Vec<usize>,
+    pub(super) is_extern: bool,
+    pub(super) is_const: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct MethodSig {
+    pub(super) function_name: String,
+    pub(super) params: Vec<Type>,
+    pub(super) return_ty: Type,
+    pub(super) borrow_return_params: Vec<usize>,
+    pub(super) has_self: bool,
+}
+
+pub(super) fn function_symbol_name(function: &syntax::Function) -> String {
+    match &function.impl_target {
+        Some(target) => format!("{target}__{}", function.name),
+        None => function.name.clone(),
+    }
+}
+
+fn substitute_self_type_name(
+    ty: &syntax::TypeName,
+    self_ty: &syntax::TypeName,
+) -> syntax::TypeName {
+    match ty {
+        syntax::TypeName::Named(name, args) if name == "Self" && args.is_empty() => self_ty.clone(),
+        syntax::TypeName::Named(name, args) => syntax::TypeName::Named(
+            name.clone(),
+            args.iter()
+                .map(|arg| substitute_self_type_name(arg, self_ty))
+                .collect(),
+        ),
+        syntax::TypeName::Ptr(inner) => {
+            syntax::TypeName::Ptr(Box::new(substitute_self_type_name(inner, self_ty)))
+        }
+        syntax::TypeName::MutPtr(inner) => {
+            syntax::TypeName::MutPtr(Box::new(substitute_self_type_name(inner, self_ty)))
+        }
+        syntax::TypeName::MutRef(inner) => {
+            syntax::TypeName::MutRef(Box::new(substitute_self_type_name(inner, self_ty)))
+        }
+        syntax::TypeName::Slice(inner) => {
+            syntax::TypeName::Slice(Box::new(substitute_self_type_name(inner, self_ty)))
+        }
+        syntax::TypeName::MutSlice(inner) => {
+            syntax::TypeName::MutSlice(Box::new(substitute_self_type_name(inner, self_ty)))
+        }
+        syntax::TypeName::LifetimeSlice(lifetime, inner) => syntax::TypeName::LifetimeSlice(
+            lifetime.clone(),
+            Box::new(substitute_self_type_name(inner, self_ty)),
+        ),
+        syntax::TypeName::LifetimeMutSlice(lifetime, inner) => syntax::TypeName::LifetimeMutSlice(
+            lifetime.clone(),
+            Box::new(substitute_self_type_name(inner, self_ty)),
+        ),
+        syntax::TypeName::Option(inner) => {
+            syntax::TypeName::Option(Box::new(substitute_self_type_name(inner, self_ty)))
+        }
+        syntax::TypeName::Result(ok, err) => syntax::TypeName::Result(
+            Box::new(substitute_self_type_name(ok, self_ty)),
+            Box::new(substitute_self_type_name(err, self_ty)),
+        ),
+        syntax::TypeName::Tuple(elements) => syntax::TypeName::Tuple(
+            elements
+                .iter()
+                .map(|element| substitute_self_type_name(element, self_ty))
+                .collect(),
+        ),
+        syntax::TypeName::Map(key, value) => syntax::TypeName::Map(
+            Box::new(substitute_self_type_name(key, self_ty)),
+            Box::new(substitute_self_type_name(value, self_ty)),
+        ),
+        syntax::TypeName::Array(inner, len) => syntax::TypeName::Array(
+            Box::new(substitute_self_type_name(inner, self_ty)),
+            len.clone(),
+        ),
+        syntax::TypeName::Fn(params, return_ty) => syntax::TypeName::Fn(
+            params
+                .iter()
+                .map(|param| substitute_self_type_name(param, self_ty))
+                .collect(),
+            Box::new(substitute_self_type_name(return_ty, self_ty)),
+        ),
+        syntax::TypeName::Int => syntax::TypeName::Int,
+        syntax::TypeName::Numeric(numeric) => syntax::TypeName::Numeric(*numeric),
+        syntax::TypeName::Bool => syntax::TypeName::Bool,
+        syntax::TypeName::String => syntax::TypeName::String,
+        syntax::TypeName::Str => syntax::TypeName::Str,
+    }
+}
+
+pub(super) fn collect_function_signatures(
+    functions: &[syntax::Function],
+    structs: &HashMap<String, StructDef>,
+    enums: &HashMap<String, EnumDef>,
+    aliases: &HashMap<String, syntax::TypeAliasDecl>,
+    consts: &HashMap<String, syntax::ConstDecl>,
+) -> Result<HashMap<String, FunctionSig>, Diagnostic> {
+    let mut signatures = HashMap::new();
+    for function in functions {
+        let return_ty = lower_type(
+            &function.return_ty,
+            structs,
+            enums,
+            aliases,
+            consts,
+            function.line,
+            function.column,
+        )?;
+        let mut params = Vec::new();
+        if let Some(target_name) = &function.impl_target {
+            let self_ty = lower_type(
+                &syntax::TypeName::Named(target_name.clone(), Vec::new()),
+                structs,
+                enums,
+                aliases,
+                consts,
+                function.line,
+                function.column,
+            )?;
+            if function.receiver.is_some() {
+                params.push(self_ty);
+            }
+        }
+        for param in &function.params {
+            params.push(lower_type(
+                &param.ty,
+                structs,
+                enums,
+                aliases,
+                consts,
+                param.line,
+                param.column,
+            )?);
+        }
+        let signature_return_ty = if function.is_async {
+            Type::Task(Box::new(return_ty.clone()))
+        } else {
+            return_ty.clone()
+        };
+        let borrow_return_params = classify_borrow_return(
+            &params,
+            &signature_return_ty,
+            structs,
+            enums,
+            function.line,
+            function.column,
+        )?;
+        if signatures
+            .insert(
+                function_symbol_name(function),
+                FunctionSig {
+                    source_name: function.source_name.clone(),
+                    source_path: function.path.clone(),
+                    params,
+                    return_ty: signature_return_ty,
+                    borrow_return_params,
+                    is_extern: function.is_extern,
+                    is_const: function.is_const,
+                },
+            )
+            .is_some()
+        {
+            let message = if let Some(target) = &function.impl_target {
+                format!(
+                    "duplicate impl method {:?} for {:?}",
+                    function.source_name, target
+                )
+            } else {
+                format!("duplicate function {:?}", function.name)
+            };
+            return Err(Diagnostic::new("type", message).with_span(function.line, function.column));
+        }
+    }
+    Ok(signatures)
+}
+
+pub(super) fn collect_method_signatures(
+    functions: &[syntax::Function],
+    structs: &HashMap<String, StructDef>,
+    enums: &HashMap<String, EnumDef>,
+    aliases: &HashMap<String, syntax::TypeAliasDecl>,
+    consts: &HashMap<String, syntax::ConstDecl>,
+) -> Result<HashMap<String, HashMap<String, MethodSig>>, Diagnostic> {
+    let mut methods: HashMap<String, HashMap<String, MethodSig>> = HashMap::new();
+    for function in functions {
+        let Some(target_name) = &function.impl_target else {
+            continue;
+        };
+        if !function.type_params.is_empty() {
+            return Err(Diagnostic::new(
+                "type",
+                format!("impl method {:?} cannot be generic yet", function.name),
+            )
+            .with_span(function.line, function.column));
+        }
+        let target_ty = lower_type(
+            &syntax::TypeName::Named(target_name.clone(), Vec::new()),
+            structs,
+            enums,
+            aliases,
+            consts,
+            function.line,
+            function.column,
+        )?;
+        if !matches!(target_ty, Type::Struct(_) | Type::Enum(_)) {
+            return Err(Diagnostic::new(
+                "type",
+                format!("impl target {:?} must be a struct or enum", target_name),
+            )
+            .with_span(function.line, function.column));
+        }
+        let return_ty = lower_type(
+            &function.return_ty,
+            structs,
+            enums,
+            aliases,
+            consts,
+            function.line,
+            function.column,
+        )?;
+        let mut params = Vec::new();
+        if function.receiver.is_some() {
+            params.push(target_ty.clone());
+        }
+        for param in &function.params {
+            params.push(lower_type(
+                &param.ty,
+                structs,
+                enums,
+                aliases,
+                consts,
+                param.line,
+                param.column,
+            )?);
+        }
+        let return_ty = if function.is_async {
+            Type::Task(Box::new(return_ty))
+        } else {
+            return_ty
+        };
+        let borrow_return_params = classify_borrow_return(
+            &params,
+            &return_ty,
+            structs,
+            enums,
+            function.line,
+            function.column,
+        )?;
+        let method = MethodSig {
+            function_name: function_symbol_name(function),
+            params,
+            return_ty,
+            borrow_return_params,
+            has_self: function.receiver.is_some(),
+        };
+        let entry = methods.entry(target_name.clone()).or_default();
+        if entry.insert(function.source_name.clone(), method).is_some() {
+            return Err(Diagnostic::new(
+                "type",
+                format!(
+                    "duplicate impl method {:?} for {:?}",
+                    function.name, target_name
+                ),
+            )
+            .with_span(function.line, function.column));
+        }
+    }
+    Ok(methods)
+}
+
+pub(super) fn validate_trait_impls(
+    functions: &[syntax::Function],
+    traits: &HashMap<String, TraitDef>,
+    structs: &HashMap<String, StructDef>,
+    enums: &HashMap<String, EnumDef>,
+    aliases: &HashMap<String, syntax::TypeAliasDecl>,
+    consts: &HashMap<String, syntax::ConstDecl>,
+    methods: &HashMap<String, HashMap<String, MethodSig>>,
+) -> Result<(), Diagnostic> {
+    let mut impls: HashMap<(String, String), Vec<&syntax::Function>> = HashMap::new();
+    for function in functions {
+        let Some(trait_name) = &function.impl_trait else {
+            continue;
+        };
+        let Some(target_name) = &function.impl_target else {
+            continue;
+        };
+        if !traits.contains_key(trait_name) {
+            return Err(Diagnostic::new(
+                "type",
+                format!("impl references unknown trait {trait_name:?}"),
+            )
+            .with_span(function.line, function.column));
+        }
+        let target_ty = lower_type(
+            &syntax::TypeName::Named(target_name.clone(), Vec::new()),
+            structs,
+            enums,
+            aliases,
+            consts,
+            function.line,
+            function.column,
+        )?;
+        if !matches!(target_ty, Type::Struct(_) | Type::Enum(_)) {
+            return Err(Diagnostic::new(
+                "type",
+                format!("impl target {target_name:?} must be a local struct or enum"),
+            )
+            .with_span(function.line, function.column));
+        }
+        impls
+            .entry((trait_name.clone(), target_name.clone()))
+            .or_default()
+            .push(function);
+    }
+
+    for ((trait_name, target_name), impl_functions) in impls {
+        let trait_def = traits
+            .get(&trait_name)
+            .expect("trait impl keys are validated while grouping");
+        let method_sigs = methods.get(&target_name).ok_or_else(|| {
+            Diagnostic::new(
+                "type",
+                format!("impl {trait_name} for {target_name} does not define any methods"),
+            )
+            .with_span(impl_functions[0].line, impl_functions[0].column)
+        })?;
+        for required in &trait_def.methods {
+            let implementation = impl_functions
+                .iter()
+                .find(|function| function.source_name == required.name)
+                .ok_or_else(|| {
+                    Diagnostic::new(
+                        "type",
+                        format!(
+                            "impl {trait_name} for {target_name} is missing required method {:?}",
+                            required.name
+                        ),
+                    )
+                    .with_span(impl_functions[0].line, impl_functions[0].column)
+                })?;
+            validate_trait_method_signature(
+                required,
+                implementation,
+                &trait_name,
+                &target_name,
+                structs,
+                enums,
+                aliases,
+                consts,
+                method_sigs,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_trait_method_signature(
+    required: &TraitMethodDef,
+    implementation: &syntax::Function,
+    trait_name: &str,
+    target_name: &str,
+    structs: &HashMap<String, StructDef>,
+    enums: &HashMap<String, EnumDef>,
+    aliases: &HashMap<String, syntax::TypeAliasDecl>,
+    consts: &HashMap<String, syntax::ConstDecl>,
+    method_sigs: &HashMap<String, MethodSig>,
+) -> Result<(), Diagnostic> {
+    if required.has_self != implementation.receiver.is_some() {
+        return Err(Diagnostic::new(
+            "type",
+            format!(
+                "impl {trait_name} for {target_name} method {:?} has an incompatible self receiver",
+                required.name
+            ),
+        )
+        .with_span(implementation.line, implementation.column));
+    }
+    if required.params.len() != implementation.params.len() {
+        return Err(Diagnostic::new(
+            "type",
+            format!(
+                "impl {trait_name} for {target_name} method {:?} expects {} parameters, got {}",
+                required.name,
+                required.params.len(),
+                implementation.params.len()
+            ),
+        )
+        .with_span(implementation.line, implementation.column));
+    }
+    let target_ty = syntax::TypeName::Named(target_name.to_string(), Vec::new());
+    for (expected, actual) in required.params.iter().zip(&implementation.params) {
+        let expected = lower_type(
+            &substitute_self_type_name(expected, &target_ty),
+            structs,
+            enums,
+            aliases,
+            consts,
+            actual.line,
+            actual.column,
+        )?;
+        let actual = lower_type(
+            &actual.ty,
+            structs,
+            enums,
+            aliases,
+            consts,
+            actual.line,
+            actual.column,
+        )?;
+        if expected != actual {
+            return Err(Diagnostic::new(
+                "type",
+                format!(
+                    "impl {trait_name} for {target_name} method {:?} has parameter type {}, expected {}",
+                    required.name, actual, expected
+                ),
+            )
+            .with_span(implementation.line, implementation.column));
+        }
+    }
+    let expected_return = lower_type(
+        &substitute_self_type_name(&required.return_ty, &target_ty),
+        structs,
+        enums,
+        aliases,
+        consts,
+        implementation.line,
+        implementation.column,
+    )?;
+    let method_sig = method_sigs
+        .get(&implementation.source_name)
+        .expect("method signature should be collected before trait impl validation");
+    if expected_return != method_sig.return_ty {
+        return Err(Diagnostic::new(
+            "type",
+            format!(
+                "impl {trait_name} for {target_name} method {:?} returns {}, expected {}",
+                required.name, method_sig.return_ty, expected_return
+            ),
+        )
+        .with_span(implementation.line, implementation.column));
+    }
+    Ok(())
+}
+
+fn classify_borrow_return(
+    params: &[Type],
+    return_ty: &Type,
+    structs: &HashMap<String, StructDef>,
+    enums: &HashMap<String, EnumDef>,
+    line: usize,
+    column: usize,
+) -> Result<Vec<usize>, Diagnostic> {
+    borrowck::classify_borrow_return(params, return_ty, structs, enums, line, column)
+}


### PR DESCRIPTION
## Summary

- Move HIR function/method signature collection, trait impl signature validation, borrow-return signature classification, and HIR symbol-name resolution from `hir.rs` into `hir/signatures.rs`.
- Register `hir/signatures.rs` as `compiler.hir` in the compiler source monolith reporter and test fixture.
- Refresh the decomposition plan and ratchet ceilings for the reduced HIR facade line count.

## Governing Issue

Refs #1254.

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Local checks:

- `cargo fmt --manifest-path stage1/Cargo.toml --all`
- `cargo fmt --manifest-path stage1/Cargo.toml --all --check`
- `cargo check --manifest-path stage1/Cargo.toml -p axiomc --lib`
- `python3 scripts/ci/test-report-compiler-source-monoliths.py`
- `make stage1-compiler-source-monoliths`
- `make stage1-compiler-source-monoliths-test`
- `make stage1-hir-boundary`
- `make stage1-mir-backend-boundary`
- `make stage1-command-lsp-boundary`
- `make stage1-diagnostics-syntax-boundary`
- `git diff --check`
- `RUST_MIN_STACK=8388608 cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib hir_lowering_owns_duplicate_symbol_validation --features run-native-tests -- --test-threads=1`
- `RUST_MIN_STACK=8388608 cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib hir_lowers_static_trait_impl_and_bounded_generic_call --features run-native-tests -- --test-threads=1`
- `RUST_MIN_STACK=8388608 cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib hir_rejects_trait_impl_missing_required_method --features run-native-tests -- --test-threads=1`
- `RUST_MIN_STACK=8388608 cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib hir_rejects_trait_impl_signature_mismatch --features run-native-tests -- --test-threads=1`

Skipped checks:

- Full library execution is covered on the integration readiness PR stack; this source-only split preserves behavior and is validated with focused HIR signature/trait tests plus boundary/ratchet checks.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Semantic notes:

- Semantic node types: no semantic node changes.
- Schemas: no schema changes.
- Evidence: monolith ratchet evidence is updated for the new `hir/signatures.rs` split; no runtime evidence model changes.
- Rust capture risk: low. This is a mechanical Rust-hosted source split that keeps the Axiom-neutral HIR contract unchanged.
- Agent-facing inspection impact: HIR signature collection and trait impl signature validation now have a dedicated module and ratchet row, making follow-on expression typing decomposition easier to inspect.

## Flow Contract

- Owner lane: semantic IR
- Repair owner: Codex
- Autonomy class: autonomous scoped implementation
- Risk class: low; source decomposition with focused HIR/compiler validation

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

## Merge Automation

- [x] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- Stacked on #1295 / `codex/compiler-monolith-ratchet` so it can merge into the monolith-ratchet branch before the main readiness PR is approved.
