### PR TITLE
Split HIR expression typing helpers

### DIFF
--- a/docs/compiler-source-decomposition-plan.md
+++ b/docs/compiler-source-decomposition-plan.md
@@ -55,7 +55,10 @@ validation, and HIR symbol-name resolution into
 `stage1/crates/axiomc/src/hir/signatures.rs`. The HIR capability extraction
 then moved FFI validation, capability checks, network/process allowlist
 validation, and capability-focused tests into
-`stage1/crates/axiomc/src/hir/capabilities.rs`, lowering both absolute top-file
+`stage1/crates/axiomc/src/hir/capabilities.rs`. The HIR expression typing
+extraction then moved numeric type predicates, method-owner typing, string
+borrow coercion, binary-add typing, and static expression value helpers into
+`stage1/crates/axiomc/src/hir/expressions.rs`, lowering both absolute top-file
 lines and share.
 
 ## Current Top Files
@@ -66,7 +69,7 @@ Snapshot from 2026-07-02:
 | ---: | --- | ---: | --- | --- |
 | 1 | `stage1/crates/axiomc/src/cranelift_backend.rs` | 27,994 | `compiler.backend.native` | Split direct-native lowering by runtime ABI groups: scalar/aggregate value features, capability shims, host imports, object emission, unsupported diagnostics, and evidence helpers. |
 | 2 | `stage1/crates/axiomc/src/project.rs` | 10,812 | `compiler.package_graph`, `compiler.commands`, `compiler.evidence` | Split manifest/workspace loading, command orchestration, provenance/debug records, and build artifact planning along package ownership. |
-| 3 | `stage1/crates/axiomc/src/hir.rs` | 10,001 | `compiler.hir` | Generic inference and monomorphization now live in `stage1/crates/axiomc/src/hir/generics.rs`; public HIR model types now live in `stage1/crates/axiomc/src/hir/model.rs`; syntax-to-HIR type/literal lowering now lives in `stage1/crates/axiomc/src/hir/types.rs`; type-name, aggregate, and trait-use definition checks now live in `stage1/crates/axiomc/src/hir/definitions.rs`; function/method signatures and trait impl signature validation now live in `stage1/crates/axiomc/src/hir/signatures.rs`; capability analysis now lives in `stage1/crates/axiomc/src/hir/capabilities.rs`; next split expression typing, ownership/borrow validation, property clauses, and HIR diagnostics behind the package APIs in `docs/compiler-hir-ownership-capability.md`. |
+| 3 | `stage1/crates/axiomc/src/hir.rs` | 9,815 | `compiler.hir` | Generic inference and monomorphization now live in `stage1/crates/axiomc/src/hir/generics.rs`; public HIR model types now live in `stage1/crates/axiomc/src/hir/model.rs`; syntax-to-HIR type/literal lowering now lives in `stage1/crates/axiomc/src/hir/types.rs`; type-name, aggregate, and trait-use definition checks now live in `stage1/crates/axiomc/src/hir/definitions.rs`; function/method signatures and trait impl signature validation now live in `stage1/crates/axiomc/src/hir/signatures.rs`; capability analysis now lives in `stage1/crates/axiomc/src/hir/capabilities.rs`; expression typing helpers now live in `stage1/crates/axiomc/src/hir/expressions.rs`; next split ownership/borrow validation, property clauses, and HIR diagnostics behind the package APIs in `docs/compiler-hir-ownership-capability.md`. |
 | 4 | `stage1/crates/axiomc/src/main.rs` | 10,678 | `compiler.commands` | Move command parsing, JSON envelope construction, check/build/run/test/doc/trace orchestration, and exit handling behind `docs/compiler-command-lsp-packages.md` APIs. |
 | 5 | `stage1/crates/axiomc/src/codegen.rs` | 7,804 | `compiler.backend.generated_rust`, `compiler.backend.contracts` | Isolate generated-Rust compatibility emission from backend target selection and unsupported-feature contracts. |
 | 6 | `stage1/crates/axiomc/src/syntax.rs` | 6,324 | `compiler.syntax`, `compiler.diagnostics` | Split lexer/parser, parse recovery, source spans, macros, and syntax diagnostics behind the syntax boundary. |
@@ -82,16 +85,17 @@ matching ceiling in this table in the same PR.
 
 | Tracked item | Ceiling |
 | --- | ---: |
-| `summary.top_file_line_share` | 0.8736 |
-| `summary.top_file_lines` | 77818 |
+| `summary.top_file_line_share` | 0.8714 |
+| `summary.top_file_lines` | 77632 |
 | `stage1/crates/axiomc/src/cranelift_backend.rs` | 27994 |
-| `stage1/crates/axiomc/src/hir.rs` | 10001 |
+| `stage1/crates/axiomc/src/hir.rs` | 9815 |
 | `stage1/crates/axiomc/src/project.rs` | 10812 |
 | `stage1/crates/axiomc/src/main.rs` | 10678 |
 | `stage1/crates/axiomc/src/codegen.rs` | 7804 |
 | `stage1/crates/axiomc/src/syntax.rs` | 6324 |
 | `stage1/crates/axiomc/src/hir/capabilities.rs` | 773 |
 | `stage1/crates/axiomc/src/hir/definitions.rs` | 684 |
+| `stage1/crates/axiomc/src/hir/expressions.rs` | 205 |
 | `stage1/crates/axiomc/src/hir/generics.rs` | 4205 |
 | `stage1/crates/axiomc/src/hir/model.rs` | 607 |
 | `stage1/crates/axiomc/src/hir/signatures.rs` | 471 |
@@ -109,9 +113,9 @@ matching ceiling in this table in the same PR.
    gate.
 3. `compiler.hir`: generic inference/monomorphization, public HIR model types,
    syntax-to-HIR type/literal lowering, and type/aggregate definition collection
-   are split; function/method signatures, trait impl signature validation, and
-   capability analysis are split; continue with expression typing, ownership,
-   and property checks in that order so diagnostics stay stable.
+   are split; function/method signatures, trait impl signature validation,
+   capability analysis, and expression typing helpers are split; continue with
+   ownership and property checks in that order so diagnostics stay stable.
 4. `compiler.commands` and `compiler.package_graph`: separate command envelopes
    from package loading so the snapshot bootstrap can invoke package APIs
    without Cargo assumptions.

--- a/scripts/ci/report-compiler-source-monoliths.py
+++ b/scripts/ci/report-compiler-source-monoliths.py
@@ -28,6 +28,7 @@ BOUNDARY_MAP: dict[str, list[str]] = {
     "diagnostic_catalog.rs": ["compiler.diagnostics"],
     "diagnostics.rs": ["compiler.diagnostics"],
     "definitions.rs": ["compiler.hir"],
+    "expressions.rs": ["compiler.hir"],
     "generics.rs": ["compiler.hir"],
     "hir.rs": ["compiler.hir"],
     "json_contract.rs": ["compiler.commands"],

--- a/scripts/ci/test-report-compiler-source-monoliths.py
+++ b/scripts/ci/test-report-compiler-source-monoliths.py
@@ -46,18 +46,19 @@ class CompilerSourceMonolithTests(unittest.TestCase):
             write_lines(hir_dir / "generics.rs", 2)
             write_lines(hir_dir / "capabilities.rs", 1)
             write_lines(hir_dir / "definitions.rs", 1)
+            write_lines(hir_dir / "expressions.rs", 1)
             write_lines(hir_dir / "model.rs", 1)
             write_lines(hir_dir / "signatures.rs", 1)
             write_lines(hir_dir / "types.rs", 1)
 
-            report = compiler_source_monoliths.build_report(source_root, top=8)
+            report = compiler_source_monoliths.build_report(source_root, top=9)
 
         self.assertEqual(report["schema_version"], "axiom.compiler_source.monoliths.v0")
         self.assertEqual(report["collected_at"], "2026-06-21T10:00:00Z")
-        self.assertEqual(report["summary"]["total_files"], 8)
-        self.assertEqual(report["summary"]["total_lines"], 15)
+        self.assertEqual(report["summary"]["total_files"], 9)
+        self.assertEqual(report["summary"]["total_lines"], 16)
         self.assertEqual(report["summary"]["largest_file_lines"], 5)
-        self.assertEqual(report["summary"]["top_file_lines"], 15)
+        self.assertEqual(report["summary"]["top_file_lines"], 16)
         self.assertEqual(report["summary"]["top_file_line_share"], 1.0)
         self.assertEqual(report["top_files"][0]["package_boundaries"], ["compiler.backend.native"])
         self.assertEqual(report["top_files"][1]["package_boundaries"], ["compiler.hir"])
@@ -67,6 +68,7 @@ class CompilerSourceMonolithTests(unittest.TestCase):
         self.assertEqual(report["top_files"][5]["package_boundaries"], ["compiler.hir"])
         self.assertEqual(report["top_files"][6]["package_boundaries"], ["compiler.hir"])
         self.assertEqual(report["top_files"][7]["package_boundaries"], ["compiler.hir"])
+        self.assertEqual(report["top_files"][8]["package_boundaries"], ["compiler.hir"])
 
     def test_check_plan_requires_top_file_and_boundary_mentions(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -6,6 +6,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 
 mod capabilities;
 mod definitions;
+mod expressions;
 mod generics;
 mod model;
 mod signatures;
@@ -25,6 +26,11 @@ use self::definitions::{
     collect_type_names, validate_recursive_type_cycles, validate_trait_bounds_in_program,
     validate_trait_type_uses_in_program,
 };
+use self::expressions::{
+    coerce_lowered_expr_to_expected, is_castable_numeric, is_ordered_numeric, is_string_like_type,
+    lower_binary_add_chain, lower_call_arg_with_expected, method_owner_name,
+    numeric_method_return_ty, static_bool_value,
+};
 use self::generics::monomorphize_program;
 use self::model::type_assignable_to;
 pub use self::model::*;
@@ -32,9 +38,7 @@ use self::signatures::{
     FunctionSig, MethodSig, collect_function_signatures, collect_method_signatures,
     function_symbol_name, validate_trait_impls,
 };
-use self::types::{
-    lower_arithmetic_op, lower_compare_op, lower_literal, lower_logic_op, lower_type,
-};
+use self::types::{lower_compare_op, lower_literal, lower_logic_op, lower_type};
 
 #[derive(Debug, Clone)]
 struct MatchArmInput {
@@ -149,48 +153,6 @@ const OWNERSHIP_BORROW_RETURN_REQUIRES_PARAM_ORIGIN: &str =
     borrowck::BORROW_RETURN_REQUIRES_PARAM_ORIGIN;
 const OWNERSHIP_MOVE_WHILE_BORROWED: &str = borrowck::MOVE_WHILE_BORROWED;
 const OWNERSHIP_USE_AFTER_MOVE: &str = borrowck::USE_AFTER_MOVE;
-
-fn is_castable_numeric(ty: &Type) -> bool {
-    matches!(ty, Type::Int | Type::Numeric(_))
-}
-
-fn is_ordered_numeric(ty: &Type) -> bool {
-    matches!(ty, Type::Int | Type::Numeric(_))
-}
-
-fn is_addable_numeric(ty: &Type) -> bool {
-    matches!(ty, Type::Int | Type::Numeric(_))
-}
-
-fn numeric_method_return_ty(receiver: &Type, method: &str) -> Option<Type> {
-    let is_integer = match receiver {
-        Type::Int => true,
-        Type::Numeric(numeric) => {
-            !matches!(numeric, syntax::NumericType::F32 | syntax::NumericType::F64)
-        }
-        _ => false,
-    };
-    if !is_integer {
-        return None;
-    }
-    match method {
-        "wrapping_add" | "wrapping_sub" | "wrapping_mul" | "wrapping_div" | "wrapping_rem" => {
-            Some(receiver.clone())
-        }
-        "checked_add" | "checked_sub" | "checked_mul" | "checked_div" | "checked_rem" => {
-            Some(Type::Option(Box::new(receiver.clone())))
-        }
-        "saturating_add" | "saturating_sub" | "saturating_mul" => Some(receiver.clone()),
-        _ => None,
-    }
-}
-
-fn method_owner_name(ty: &Type) -> Option<&str> {
-    match ty {
-        Type::Struct(name) | Type::Enum(name) => Some(name.as_str()),
-        _ => None,
-    }
-}
 
 pub fn lower(program: &syntax::Program) -> Result<Program, Diagnostic> {
     let capabilities = CapabilityConfig::default();
@@ -3145,39 +3107,6 @@ fn lower_expr(
     lower_expr_with_expected(expr, None, env, ctx)
 }
 
-fn is_string_like_type(ty: &Type) -> bool {
-    matches!(ty, Type::String | Type::Str)
-}
-
-fn coerce_expr_to_expected(
-    expr: Expr,
-    expected: Option<&Type>,
-    allow_temporary_string_borrow: bool,
-) -> Result<Expr, Diagnostic> {
-    match expected {
-        Some(Type::Str) if expr.ty() == &Type::String => {
-            if !allow_temporary_string_borrow && !is_stable_string_borrow_owner(&expr) {
-                return Err(Diagnostic::new(
-                    "ownership",
-                    "cannot borrow a temporary String as &str; bind the String to a local first",
-                ));
-            }
-            Ok(Expr::StringBorrow {
-                expr: Box::new(expr),
-                ty: Type::Str,
-            })
-        }
-        _ => Ok(expr),
-    }
-}
-
-fn is_stable_string_borrow_owner(expr: &Expr) -> bool {
-    matches!(
-        expr,
-        Expr::VarRef { .. } | Expr::FieldAccess { .. } | Expr::TupleIndex { .. }
-    )
-}
-
 fn lower_expr_with_expected(
     expr: &syntax::Expr,
     expected: Option<&Type>,
@@ -3185,72 +3114,7 @@ fn lower_expr_with_expected(
     ctx: &LowerContext<'_>,
 ) -> Result<Expr, Diagnostic> {
     lower_expr_with_expected_inner(expr, expected, env, ctx)
-        .and_then(|lowered| coerce_expr_to_expected(lowered, expected, false))
-}
-
-fn lower_call_arg_with_expected(
-    expr: &syntax::Expr,
-    expected: Option<&Type>,
-    env: &mut HashMap<String, Binding>,
-    ctx: &LowerContext<'_>,
-    allow_temporary_string_borrow: bool,
-) -> Result<Expr, Diagnostic> {
-    lower_expr_with_expected_inner(expr, expected, env, ctx).and_then(|lowered| {
-        coerce_expr_to_expected(lowered, expected, allow_temporary_string_borrow)
-    })
-}
-
-fn lower_binary_add_chain(
-    expr: &syntax::Expr,
-    env: &mut HashMap<String, Binding>,
-    ctx: &LowerContext<'_>,
-) -> Result<Expr, Diagnostic> {
-    let mut current = expr;
-    let mut pending = Vec::new();
-    while let syntax::Expr::BinaryAdd {
-        op,
-        lhs,
-        rhs,
-        line,
-        column,
-    } = current
-    {
-        pending.push((*op, rhs.as_ref(), *line, *column));
-        current = lhs.as_ref();
-    }
-
-    let mut lowered = lower_expr(current, env, ctx)?;
-    for (op, rhs, line, column) in pending.into_iter().rev() {
-        let lowered_rhs = lower_expr(rhs, env, ctx)?;
-        let lhs_ty = lowered.ty().clone();
-        let rhs_ty = lowered_rhs.ty().clone();
-        let result_ty = if lhs_ty == rhs_ty && is_addable_numeric(&lhs_ty) {
-            lhs_ty.clone()
-        } else if op == syntax::ArithmeticOp::Add
-            && is_string_like_type(&lhs_ty)
-            && is_string_like_type(&rhs_ty)
-        {
-            Type::String
-        } else {
-            return Err(
-                Diagnostic::new(
-                    "type",
-                    format!(
-                        "operator '{}' expects matching numeric or string operands, got {lhs_ty} and {rhs_ty}",
-                        op.lexeme()
-                    ),
-                )
-                .with_span(line, column),
-            );
-        };
-        lowered = Expr::BinaryAdd {
-            op: lower_arithmetic_op(op),
-            lhs: Box::new(lowered),
-            rhs: Box::new(lowered_rhs),
-            ty: result_ty,
-        };
-    }
-    Ok(lowered)
+        .and_then(|lowered| coerce_lowered_expr_to_expected(lowered, expected))
 }
 
 fn lower_expr_with_expected_inner(
@@ -9162,56 +9026,6 @@ fn with_assert_location(args: Vec<Expr>, line: usize, column: usize) -> Vec<Expr
         value: LiteralValue::Int(column as i64),
     });
     args
-}
-
-fn static_bool_value(expr: &Expr) -> Option<bool> {
-    match expr {
-        Expr::Literal {
-            value: LiteralValue::Bool(value),
-            ..
-        } => Some(*value),
-        Expr::BinaryCompare { op, lhs, rhs, .. } => {
-            let lhs = literal_value(lhs)?;
-            let rhs = literal_value(rhs)?;
-            Some(match (lhs, rhs) {
-                (LiteralValue::Int(lhs), LiteralValue::Int(rhs)) => match op {
-                    CompareOp::Eq => lhs == rhs,
-                    CompareOp::Ne => lhs != rhs,
-                    CompareOp::Lt => lhs < rhs,
-                    CompareOp::Le => lhs <= rhs,
-                    CompareOp::Gt => lhs > rhs,
-                    CompareOp::Ge => lhs >= rhs,
-                },
-                (LiteralValue::Bool(lhs), LiteralValue::Bool(rhs)) => match op {
-                    CompareOp::Eq => lhs == rhs,
-                    CompareOp::Ne => lhs != rhs,
-                    _ => return None,
-                },
-                (LiteralValue::String(lhs), LiteralValue::String(rhs)) => match op {
-                    CompareOp::Eq => lhs == rhs,
-                    CompareOp::Ne => lhs != rhs,
-                    _ => return None,
-                },
-                _ => return None,
-            })
-        }
-        Expr::BinaryLogic { op, lhs, rhs, .. } => {
-            let lhs = static_bool_value(lhs)?;
-            let rhs = static_bool_value(rhs)?;
-            Some(match op {
-                LogicOp::And => lhs && rhs,
-                LogicOp::Or => lhs || rhs,
-            })
-        }
-        _ => None,
-    }
-}
-
-fn literal_value(expr: &Expr) -> Option<&LiteralValue> {
-    match expr {
-        Expr::Literal { value, .. } => Some(value),
-        _ => None,
-    }
 }
 
 #[cfg(test)]

--- a/stage1/crates/axiomc/src/hir/expressions.rs
+++ b/stage1/crates/axiomc/src/hir/expressions.rs
@@ -1,0 +1,205 @@
+use std::collections::HashMap;
+
+use crate::diagnostics::Diagnostic;
+use crate::syntax;
+
+use super::model::{CompareOp, Expr, LiteralValue, LogicOp, Type};
+use super::types::lower_arithmetic_op;
+use super::{Binding, LowerContext, lower_expr};
+
+pub(super) fn is_castable_numeric(ty: &Type) -> bool {
+    matches!(ty, Type::Int | Type::Numeric(_))
+}
+
+pub(super) fn is_ordered_numeric(ty: &Type) -> bool {
+    matches!(ty, Type::Int | Type::Numeric(_))
+}
+
+fn is_addable_numeric(ty: &Type) -> bool {
+    matches!(ty, Type::Int | Type::Numeric(_))
+}
+
+pub(super) fn numeric_method_return_ty(receiver: &Type, method: &str) -> Option<Type> {
+    let is_integer = match receiver {
+        Type::Int => true,
+        Type::Numeric(numeric) => {
+            !matches!(numeric, syntax::NumericType::F32 | syntax::NumericType::F64)
+        }
+        _ => false,
+    };
+    if !is_integer {
+        return None;
+    }
+    match method {
+        "wrapping_add" | "wrapping_sub" | "wrapping_mul" | "wrapping_div" | "wrapping_rem" => {
+            Some(receiver.clone())
+        }
+        "checked_add" | "checked_sub" | "checked_mul" | "checked_div" | "checked_rem" => {
+            Some(Type::Option(Box::new(receiver.clone())))
+        }
+        "saturating_add" | "saturating_sub" | "saturating_mul" => Some(receiver.clone()),
+        _ => None,
+    }
+}
+
+pub(super) fn method_owner_name(ty: &Type) -> Option<&str> {
+    match ty {
+        Type::Struct(name) | Type::Enum(name) => Some(name.as_str()),
+        _ => None,
+    }
+}
+
+pub(super) fn is_string_like_type(ty: &Type) -> bool {
+    matches!(ty, Type::String | Type::Str)
+}
+
+fn coerce_expr_to_expected(
+    expr: Expr,
+    expected: Option<&Type>,
+    allow_temporary_string_borrow: bool,
+) -> Result<Expr, Diagnostic> {
+    match expected {
+        Some(Type::Str) if expr.ty() == &Type::String => {
+            if !allow_temporary_string_borrow && !is_stable_string_borrow_owner(&expr) {
+                return Err(Diagnostic::new(
+                    "ownership",
+                    "cannot borrow a temporary String as &str; bind the String to a local first",
+                ));
+            }
+            Ok(Expr::StringBorrow {
+                expr: Box::new(expr),
+                ty: Type::Str,
+            })
+        }
+        _ => Ok(expr),
+    }
+}
+
+fn is_stable_string_borrow_owner(expr: &Expr) -> bool {
+    matches!(
+        expr,
+        Expr::VarRef { .. } | Expr::FieldAccess { .. } | Expr::TupleIndex { .. }
+    )
+}
+
+pub(super) fn coerce_lowered_expr_to_expected(
+    lowered: Expr,
+    expected: Option<&Type>,
+) -> Result<Expr, Diagnostic> {
+    coerce_expr_to_expected(lowered, expected, false)
+}
+
+pub(super) fn lower_call_arg_with_expected(
+    expr: &syntax::Expr,
+    expected: Option<&Type>,
+    env: &mut HashMap<String, Binding>,
+    ctx: &LowerContext<'_>,
+    allow_temporary_string_borrow: bool,
+) -> Result<Expr, Diagnostic> {
+    super::lower_expr_with_expected_inner(expr, expected, env, ctx).and_then(|lowered| {
+        coerce_expr_to_expected(lowered, expected, allow_temporary_string_borrow)
+    })
+}
+
+pub(super) fn lower_binary_add_chain(
+    expr: &syntax::Expr,
+    env: &mut HashMap<String, Binding>,
+    ctx: &LowerContext<'_>,
+) -> Result<Expr, Diagnostic> {
+    let mut current = expr;
+    let mut pending = Vec::new();
+    while let syntax::Expr::BinaryAdd {
+        op,
+        lhs,
+        rhs,
+        line,
+        column,
+    } = current
+    {
+        pending.push((*op, rhs.as_ref(), *line, *column));
+        current = lhs.as_ref();
+    }
+
+    let mut lowered = lower_expr(current, env, ctx)?;
+    for (op, rhs, line, column) in pending.into_iter().rev() {
+        let lowered_rhs = lower_expr(rhs, env, ctx)?;
+        let lhs_ty = lowered.ty().clone();
+        let rhs_ty = lowered_rhs.ty().clone();
+        let result_ty = if lhs_ty == rhs_ty && is_addable_numeric(&lhs_ty) {
+            lhs_ty.clone()
+        } else if op == syntax::ArithmeticOp::Add
+            && is_string_like_type(&lhs_ty)
+            && is_string_like_type(&rhs_ty)
+        {
+            Type::String
+        } else {
+            return Err(
+                Diagnostic::new(
+                    "type",
+                    format!(
+                        "operator '{}' expects matching numeric or string operands, got {lhs_ty} and {rhs_ty}",
+                        op.lexeme()
+                    ),
+                )
+                .with_span(line, column),
+            );
+        };
+        lowered = Expr::BinaryAdd {
+            op: lower_arithmetic_op(op),
+            lhs: Box::new(lowered),
+            rhs: Box::new(lowered_rhs),
+            ty: result_ty,
+        };
+    }
+    Ok(lowered)
+}
+
+pub(super) fn static_bool_value(expr: &Expr) -> Option<bool> {
+    match expr {
+        Expr::Literal {
+            value: LiteralValue::Bool(value),
+            ..
+        } => Some(*value),
+        Expr::BinaryCompare { op, lhs, rhs, .. } => {
+            let lhs = literal_value(lhs)?;
+            let rhs = literal_value(rhs)?;
+            Some(match (lhs, rhs) {
+                (LiteralValue::Int(lhs), LiteralValue::Int(rhs)) => match op {
+                    CompareOp::Eq => lhs == rhs,
+                    CompareOp::Ne => lhs != rhs,
+                    CompareOp::Lt => lhs < rhs,
+                    CompareOp::Le => lhs <= rhs,
+                    CompareOp::Gt => lhs > rhs,
+                    CompareOp::Ge => lhs >= rhs,
+                },
+                (LiteralValue::Bool(lhs), LiteralValue::Bool(rhs)) => match op {
+                    CompareOp::Eq => lhs == rhs,
+                    CompareOp::Ne => lhs != rhs,
+                    _ => return None,
+                },
+                (LiteralValue::String(lhs), LiteralValue::String(rhs)) => match op {
+                    CompareOp::Eq => lhs == rhs,
+                    CompareOp::Ne => lhs != rhs,
+                    _ => return None,
+                },
+                _ => return None,
+            })
+        }
+        Expr::BinaryLogic { op, lhs, rhs, .. } => {
+            let lhs = static_bool_value(lhs)?;
+            let rhs = static_bool_value(rhs)?;
+            Some(match op {
+                LogicOp::And => lhs && rhs,
+                LogicOp::Or => lhs || rhs,
+            })
+        }
+        _ => None,
+    }
+}
+
+fn literal_value(expr: &Expr) -> Option<&LiteralValue> {
+    match expr {
+        Expr::Literal { value, .. } => Some(value),
+        _ => None,
+    }
+}


### PR DESCRIPTION
## Summary

- Split HIR expression typing helpers into `stage1/crates/axiomc/src/hir/expressions.rs`.
- Move numeric type predicates, method-owner typing, string borrow coercion, binary-add typing, and static expression value helpers out of the HIR monolith.
- Update compiler source monolith reporting and ratchet ceilings for the new `compiler.hir` expression helper module.

## Governing Issue

Refs #1254

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Commands run:

- `cargo fmt --manifest-path stage1/Cargo.toml --all --check`
- `cargo check --manifest-path stage1/Cargo.toml -p axiomc --lib`
- `python3 scripts/ci/test-report-compiler-source-monoliths.py`
- `make stage1-compiler-source-monoliths`
- `make stage1-compiler-source-monoliths-test`
- `make stage1-hir-boundary`
- `make stage1-hir-boundary-test`
- `TMPDIR=/private/tmp/axiom-prop-validation-1303 make stage1-compiler-property-test`
- `git diff --cached --check`

Notes:

- The first default-`TMPDIR` run of `make stage1-compiler-property-test` completed the check phase but stopped on a local stale temp-file collision for `axiom-compiler-property-cranelift.XXXXXX.json`. Rerunning the same make target with a fresh `TMPDIR` passed.
- Existing Rust warnings remain unchanged.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Semantic notes:

- Semantic node types: none.
- Schemas: none.
- Evidence: compiler source monolith ratchet now tracks `stage1/crates/axiomc/src/hir/expressions.rs`; `hir.rs` ceiling drops to 9,815, top-file lines drop to 77,632, and top-file share drops to 0.8714.
- Rust capture risk: low. This is a source-ownership extraction under the existing AxiOM-neutral `compiler.hir` boundary and does not define new semantics in Rust-specific terms.
- Agent-facing inspection impact: expression typing helpers now have a dedicated module boundary for later self-hosting package migration.

## Flow Contract

- Owner lane: compiler/runtime
- Repair owner: codex
- Autonomy class: supervised
- Risk class: low

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [ ] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

## Merge Automation

- [x] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- Stacked on `codex/compiler-monolith-ratchet`.
