### PR TITLE
Split HIR reachability helpers

### DIFF
--- a/docs/compiler-source-decomposition-plan.md
+++ b/docs/compiler-source-decomposition-plan.md
@@ -64,7 +64,10 @@ type detection, and active borrow counters into
 `stage1/crates/axiomc/src/hir/ownership.rs`. The HIR property extraction then
 moved property signature validation, static verdict detection, and property
 diagnostic sample/help text into `stage1/crates/axiomc/src/hir/properties.rs`,
-lowering both absolute top-file lines and share.
+lowering both absolute top-file lines and share. The HIR reachability
+extraction then moved stdlib reachability and call-graph discovery into
+`stage1/crates/axiomc/src/hir/reachability.rs`, further lowering the main HIR
+facade without making the Rust helper layout canonical.
 
 ## Current Top Files
 
@@ -74,8 +77,8 @@ Snapshot from 2026-07-02:
 | ---: | --- | ---: | --- | --- |
 | 1 | `stage1/crates/axiomc/src/cranelift_backend.rs` | 27,994 | `compiler.backend.native` | Split direct-native lowering by runtime ABI groups: scalar/aggregate value features, capability shims, host imports, object emission, unsupported diagnostics, and evidence helpers. |
 | 2 | `stage1/crates/axiomc/src/project.rs` | 10,812 | `compiler.package_graph`, `compiler.commands`, `compiler.evidence` | Split manifest/workspace loading, command orchestration, provenance/debug records, and build artifact planning along package ownership. |
-| 3 | `stage1/crates/axiomc/src/hir.rs` | 8,556 | `compiler.hir` | Generic inference and monomorphization now live in `stage1/crates/axiomc/src/hir/generics.rs`; public HIR model types now live in `stage1/crates/axiomc/src/hir/model.rs`; syntax-to-HIR type/literal lowering now lives in `stage1/crates/axiomc/src/hir/types.rs`; type-name, aggregate, and trait-use definition checks now live in `stage1/crates/axiomc/src/hir/definitions.rs`; function/method signatures and trait impl signature validation now live in `stage1/crates/axiomc/src/hir/signatures.rs`; capability analysis now lives in `stage1/crates/axiomc/src/hir/capabilities.rs`; expression typing helpers now live in `stage1/crates/axiomc/src/hir/expressions.rs`; ownership and borrow-state helpers now live in `stage1/crates/axiomc/src/hir/ownership.rs`; property clause checks now live in `stage1/crates/axiomc/src/hir/properties.rs`; next split HIR diagnostics behind the package APIs in `docs/compiler-hir-ownership-capability.md`. |
-| 4 | `stage1/crates/axiomc/src/main.rs` | 10,678 | `compiler.commands` | Move command parsing, JSON envelope construction, check/build/run/test/doc/trace orchestration, and exit handling behind `docs/compiler-command-lsp-packages.md` APIs. |
+| 3 | `stage1/crates/axiomc/src/main.rs` | 10,678 | `compiler.commands` | Move command parsing, JSON envelope construction, check/build/run/test/doc/trace orchestration, and exit handling behind `docs/compiler-command-lsp-packages.md` APIs. |
+| 4 | `stage1/crates/axiomc/src/hir.rs` | 8,399 | `compiler.hir` | Generic inference and monomorphization now live in `stage1/crates/axiomc/src/hir/generics.rs`; public HIR model types now live in `stage1/crates/axiomc/src/hir/model.rs`; syntax-to-HIR type/literal lowering now lives in `stage1/crates/axiomc/src/hir/types.rs`; type-name, aggregate, and trait-use definition checks now live in `stage1/crates/axiomc/src/hir/definitions.rs`; function/method signatures and trait impl signature validation now live in `stage1/crates/axiomc/src/hir/signatures.rs`; capability analysis now lives in `stage1/crates/axiomc/src/hir/capabilities.rs`; expression typing helpers now live in `stage1/crates/axiomc/src/hir/expressions.rs`; ownership and borrow-state helpers now live in `stage1/crates/axiomc/src/hir/ownership.rs`; property clause checks now live in `stage1/crates/axiomc/src/hir/properties.rs`; reachability/call-graph discovery now lives in `stage1/crates/axiomc/src/hir/reachability.rs`; next split HIR diagnostics behind the package APIs in `docs/compiler-hir-ownership-capability.md`. |
 | 5 | `stage1/crates/axiomc/src/codegen.rs` | 7,804 | `compiler.backend.generated_rust`, `compiler.backend.contracts` | Isolate generated-Rust compatibility emission from backend target selection and unsupported-feature contracts. |
 | 6 | `stage1/crates/axiomc/src/syntax.rs` | 6,324 | `compiler.syntax`, `compiler.diagnostics` | Split lexer/parser, parse recovery, source spans, macros, and syntax diagnostics behind the syntax boundary. |
 | 7 | `stage1/crates/axiomc/src/hir/generics.rs` | 4,205 | `compiler.hir` | Keep generic call inference, trait-bound validation, aggregate monomorphization, and generic call rewriting isolated from the main HIR lowering facade. |
@@ -90,10 +93,10 @@ matching ceiling in this table in the same PR.
 
 | Tracked item | Ceiling |
 | --- | ---: |
-| `summary.top_file_line_share` | 0.8569 |
-| `summary.top_file_lines` | 76373 |
+| `summary.top_file_line_share` | 0.8551 |
+| `summary.top_file_lines` | 76216 |
 | `stage1/crates/axiomc/src/cranelift_backend.rs` | 27994 |
-| `stage1/crates/axiomc/src/hir.rs` | 8556 |
+| `stage1/crates/axiomc/src/hir.rs` | 8399 |
 | `stage1/crates/axiomc/src/project.rs` | 10812 |
 | `stage1/crates/axiomc/src/main.rs` | 10678 |
 | `stage1/crates/axiomc/src/codegen.rs` | 7804 |
@@ -105,6 +108,7 @@ matching ceiling in this table in the same PR.
 | `stage1/crates/axiomc/src/hir/model.rs` | 607 |
 | `stage1/crates/axiomc/src/hir/ownership.rs` | 1129 |
 | `stage1/crates/axiomc/src/hir/properties.rs` | 167 |
+| `stage1/crates/axiomc/src/hir/reachability.rs` | 161 |
 | `stage1/crates/axiomc/src/hir/signatures.rs` | 471 |
 | `stage1/crates/axiomc/src/hir/types.rs` | 241 |
 | `stage1/crates/axiomc/src/registry.rs` | 2159 |
@@ -122,7 +126,8 @@ matching ceiling in this table in the same PR.
    syntax-to-HIR type/literal lowering, and type/aggregate definition collection
    are split; function/method signatures, trait impl signature validation,
    capability analysis, expression typing helpers, ownership/borrow helpers,
-   and property checks are split; continue with HIR diagnostics.
+   property checks, and reachability/call-graph discovery are split; continue
+   with HIR diagnostics.
 4. `compiler.commands` and `compiler.package_graph`: separate command envelopes
    from package loading so the snapshot bootstrap can invoke package APIs
    without Cargo assumptions.

--- a/scripts/ci/report-compiler-source-monoliths.py
+++ b/scripts/ci/report-compiler-source-monoliths.py
@@ -42,6 +42,7 @@ BOUNDARY_MAP: dict[str, list[str]] = {
     "new_project.rs": ["compiler.commands"],
     "ownership.rs": ["compiler.hir"],
     "properties.rs": ["compiler.hir"],
+    "reachability.rs": ["compiler.hir"],
     "project.rs": ["compiler.package_graph", "compiler.commands", "compiler.evidence"],
     "registry.rs": ["compiler.package_graph"],
     "signatures.rs": ["compiler.hir"],

--- a/scripts/ci/test-report-compiler-source-monoliths.py
+++ b/scripts/ci/test-report-compiler-source-monoliths.py
@@ -50,17 +50,18 @@ class CompilerSourceMonolithTests(unittest.TestCase):
             write_lines(hir_dir / "model.rs", 1)
             write_lines(hir_dir / "ownership.rs", 1)
             write_lines(hir_dir / "properties.rs", 1)
+            write_lines(hir_dir / "reachability.rs", 1)
             write_lines(hir_dir / "signatures.rs", 1)
             write_lines(hir_dir / "types.rs", 1)
 
-            report = compiler_source_monoliths.build_report(source_root, top=11)
+            report = compiler_source_monoliths.build_report(source_root, top=12)
 
         self.assertEqual(report["schema_version"], "axiom.compiler_source.monoliths.v0")
         self.assertEqual(report["collected_at"], "2026-06-21T10:00:00Z")
-        self.assertEqual(report["summary"]["total_files"], 11)
-        self.assertEqual(report["summary"]["total_lines"], 18)
+        self.assertEqual(report["summary"]["total_files"], 12)
+        self.assertEqual(report["summary"]["total_lines"], 19)
         self.assertEqual(report["summary"]["largest_file_lines"], 5)
-        self.assertEqual(report["summary"]["top_file_lines"], 18)
+        self.assertEqual(report["summary"]["top_file_lines"], 19)
         self.assertEqual(report["summary"]["top_file_line_share"], 1.0)
         self.assertEqual(report["top_files"][0]["package_boundaries"], ["compiler.backend.native"])
         self.assertEqual(report["top_files"][1]["package_boundaries"], ["compiler.hir"])
@@ -73,6 +74,7 @@ class CompilerSourceMonolithTests(unittest.TestCase):
         self.assertEqual(report["top_files"][8]["package_boundaries"], ["compiler.hir"])
         self.assertEqual(report["top_files"][9]["package_boundaries"], ["compiler.hir"])
         self.assertEqual(report["top_files"][10]["package_boundaries"], ["compiler.hir"])
+        self.assertEqual(report["top_files"][11]["package_boundaries"], ["compiler.hir"])
 
     def test_check_plan_requires_top_file_and_boundary_mentions(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -2,7 +2,7 @@ use crate::borrowck;
 use crate::diagnostics::{Diagnostic, message_with_suggestion};
 use crate::manifest::{CapabilityConfig, CapabilityKind};
 use crate::syntax;
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, HashSet};
 
 mod capabilities;
 mod definitions;
@@ -11,6 +11,7 @@ mod generics;
 mod model;
 mod ownership;
 mod properties;
+mod reachability;
 mod signatures;
 mod types;
 
@@ -48,6 +49,7 @@ use self::ownership::{
     release_active_borrow_owners, release_scope_borrows, release_temporary_borrows,
 };
 use self::properties::{validate_property_signature, validate_property_verdict};
+use self::reachability::reachable_function_names;
 use self::signatures::{
     FunctionSig, MethodSig, collect_function_signatures, collect_method_signatures,
     function_symbol_name, validate_trait_impls,
@@ -329,165 +331,6 @@ fn sort_diagnostics(diagnostics: &mut [Diagnostic]) {
             .then_with(|| left.kind.cmp(&right.kind))
             .then_with(|| left.message.cmp(&right.message))
     });
-}
-
-fn reachable_function_names(program: &syntax::Program) -> HashSet<String> {
-    let functions_by_name: HashMap<&str, &syntax::Function> = program
-        .functions
-        .iter()
-        .map(|function| (function.name.as_str(), function))
-        .collect();
-    let mut reachable = HashSet::new();
-    let mut queue = VecDeque::new();
-    for stmt in &program.stmts {
-        collect_stmt_calls(stmt, &mut queue);
-    }
-    while let Some(name) = queue.pop_front() {
-        if !reachable.insert(name.clone()) {
-            continue;
-        }
-        if let Some(function) = functions_by_name.get(name.as_str()) {
-            for stmt in &function.body {
-                collect_stmt_calls(stmt, &mut queue);
-            }
-        }
-    }
-    reachable
-}
-
-fn collect_stmt_calls(stmt: &syntax::Stmt, calls: &mut VecDeque<String>) {
-    match stmt {
-        syntax::Stmt::Let { expr, .. }
-        | syntax::Stmt::Print { expr, .. }
-        | syntax::Stmt::Panic { expr, .. }
-        | syntax::Stmt::Defer { expr, .. }
-        | syntax::Stmt::Return { expr, .. } => collect_expr_calls(expr, calls),
-        syntax::Stmt::Assign { target, expr, .. } => {
-            collect_expr_calls(target, calls);
-            collect_expr_calls(expr, calls);
-        }
-        syntax::Stmt::If {
-            cond,
-            then_block,
-            else_block,
-            ..
-        } => {
-            collect_expr_calls(cond, calls);
-            for stmt in then_block {
-                collect_stmt_calls(stmt, calls);
-            }
-            if let Some(else_block) = else_block {
-                for stmt in else_block {
-                    collect_stmt_calls(stmt, calls);
-                }
-            }
-        }
-        syntax::Stmt::IfLet {
-            expr,
-            then_block,
-            else_block,
-            ..
-        } => {
-            collect_expr_calls(expr, calls);
-            for stmt in then_block {
-                collect_stmt_calls(stmt, calls);
-            }
-            if let Some(else_block) = else_block {
-                for stmt in else_block {
-                    collect_stmt_calls(stmt, calls);
-                }
-            }
-        }
-        syntax::Stmt::While { cond, body, .. } => {
-            collect_expr_calls(cond, calls);
-            for stmt in body {
-                collect_stmt_calls(stmt, calls);
-            }
-        }
-        syntax::Stmt::Match { expr, arms, .. } => {
-            collect_expr_calls(expr, calls);
-            for arm in arms {
-                for stmt in &arm.body {
-                    collect_stmt_calls(stmt, calls);
-                }
-            }
-        }
-    }
-}
-
-fn collect_expr_calls(expr: &syntax::Expr, calls: &mut VecDeque<String>) {
-    match expr {
-        syntax::Expr::Literal(_) | syntax::Expr::VarRef { .. } => {}
-        syntax::Expr::Call { name, args, .. } => {
-            calls.push_back(name.clone());
-            for arg in args {
-                collect_expr_calls(arg, calls);
-            }
-        }
-        syntax::Expr::MethodCall { base, args, .. } => {
-            collect_expr_calls(base, calls);
-            for arg in args {
-                collect_expr_calls(arg, calls);
-            }
-        }
-        syntax::Expr::BinaryAdd { lhs, rhs, .. }
-        | syntax::Expr::BinaryCompare { lhs, rhs, .. }
-        | syntax::Expr::BinaryLogic { lhs, rhs, .. } => {
-            collect_expr_calls(lhs, calls);
-            collect_expr_calls(rhs, calls);
-        }
-        syntax::Expr::Try { expr, .. }
-        | syntax::Expr::Await { expr, .. }
-        | syntax::Expr::Cast { expr, .. }
-        | syntax::Expr::MutBorrow { expr, .. }
-        | syntax::Expr::Deref { expr, .. } => {
-            collect_expr_calls(expr, calls);
-        }
-        syntax::Expr::StructLiteral { fields, .. } => {
-            for field in fields {
-                collect_expr_calls(&field.expr, calls);
-            }
-        }
-        syntax::Expr::FieldAccess { base, .. } | syntax::Expr::TupleIndex { base, .. } => {
-            collect_expr_calls(base, calls);
-        }
-        syntax::Expr::TupleLiteral { elements, .. }
-        | syntax::Expr::ArrayLiteral { elements, .. } => {
-            for element in elements {
-                collect_expr_calls(element, calls);
-            }
-        }
-        syntax::Expr::MapLiteral { entries, .. } => {
-            for entry in entries {
-                collect_expr_calls(&entry.key, calls);
-                collect_expr_calls(&entry.value, calls);
-            }
-        }
-        syntax::Expr::Slice {
-            base, start, end, ..
-        } => {
-            collect_expr_calls(base, calls);
-            if let Some(start) = start {
-                collect_expr_calls(start, calls);
-            }
-            if let Some(end) = end {
-                collect_expr_calls(end, calls);
-            }
-        }
-        syntax::Expr::Index { base, index, .. } => {
-            collect_expr_calls(base, calls);
-            collect_expr_calls(index, calls);
-        }
-        syntax::Expr::Closure { body, .. } => {
-            collect_expr_calls(body, calls);
-        }
-        syntax::Expr::Match { expr, arms, .. } => {
-            collect_expr_calls(expr, calls);
-            for arm in arms {
-                collect_expr_calls(&arm.expr, calls);
-            }
-        }
-    }
 }
 
 fn monomorphized_function_name(name: &str, type_args: &[syntax::TypeName]) -> String {

--- a/stage1/crates/axiomc/src/hir/reachability.rs
+++ b/stage1/crates/axiomc/src/hir/reachability.rs
@@ -1,0 +1,161 @@
+use crate::syntax;
+use std::collections::{HashMap, HashSet, VecDeque};
+
+pub(super) fn reachable_function_names(program: &syntax::Program) -> HashSet<String> {
+    let functions_by_name: HashMap<&str, &syntax::Function> = program
+        .functions
+        .iter()
+        .map(|function| (function.name.as_str(), function))
+        .collect();
+    let mut reachable = HashSet::new();
+    let mut queue = VecDeque::new();
+    for stmt in &program.stmts {
+        collect_stmt_calls(stmt, &mut queue);
+    }
+    while let Some(name) = queue.pop_front() {
+        if !reachable.insert(name.clone()) {
+            continue;
+        }
+        if let Some(function) = functions_by_name.get(name.as_str()) {
+            for stmt in &function.body {
+                collect_stmt_calls(stmt, &mut queue);
+            }
+        }
+    }
+    reachable
+}
+
+fn collect_stmt_calls(stmt: &syntax::Stmt, calls: &mut VecDeque<String>) {
+    match stmt {
+        syntax::Stmt::Let { expr, .. }
+        | syntax::Stmt::Print { expr, .. }
+        | syntax::Stmt::Panic { expr, .. }
+        | syntax::Stmt::Defer { expr, .. }
+        | syntax::Stmt::Return { expr, .. } => collect_expr_calls(expr, calls),
+        syntax::Stmt::Assign { target, expr, .. } => {
+            collect_expr_calls(target, calls);
+            collect_expr_calls(expr, calls);
+        }
+        syntax::Stmt::If {
+            cond,
+            then_block,
+            else_block,
+            ..
+        } => {
+            collect_expr_calls(cond, calls);
+            for stmt in then_block {
+                collect_stmt_calls(stmt, calls);
+            }
+            if let Some(else_block) = else_block {
+                for stmt in else_block {
+                    collect_stmt_calls(stmt, calls);
+                }
+            }
+        }
+        syntax::Stmt::IfLet {
+            expr,
+            then_block,
+            else_block,
+            ..
+        } => {
+            collect_expr_calls(expr, calls);
+            for stmt in then_block {
+                collect_stmt_calls(stmt, calls);
+            }
+            if let Some(else_block) = else_block {
+                for stmt in else_block {
+                    collect_stmt_calls(stmt, calls);
+                }
+            }
+        }
+        syntax::Stmt::While { cond, body, .. } => {
+            collect_expr_calls(cond, calls);
+            for stmt in body {
+                collect_stmt_calls(stmt, calls);
+            }
+        }
+        syntax::Stmt::Match { expr, arms, .. } => {
+            collect_expr_calls(expr, calls);
+            for arm in arms {
+                for stmt in &arm.body {
+                    collect_stmt_calls(stmt, calls);
+                }
+            }
+        }
+    }
+}
+
+fn collect_expr_calls(expr: &syntax::Expr, calls: &mut VecDeque<String>) {
+    match expr {
+        syntax::Expr::Literal(_) | syntax::Expr::VarRef { .. } => {}
+        syntax::Expr::Call { name, args, .. } => {
+            calls.push_back(name.clone());
+            for arg in args {
+                collect_expr_calls(arg, calls);
+            }
+        }
+        syntax::Expr::MethodCall { base, args, .. } => {
+            collect_expr_calls(base, calls);
+            for arg in args {
+                collect_expr_calls(arg, calls);
+            }
+        }
+        syntax::Expr::BinaryAdd { lhs, rhs, .. }
+        | syntax::Expr::BinaryCompare { lhs, rhs, .. }
+        | syntax::Expr::BinaryLogic { lhs, rhs, .. } => {
+            collect_expr_calls(lhs, calls);
+            collect_expr_calls(rhs, calls);
+        }
+        syntax::Expr::Try { expr, .. }
+        | syntax::Expr::Await { expr, .. }
+        | syntax::Expr::Cast { expr, .. }
+        | syntax::Expr::MutBorrow { expr, .. }
+        | syntax::Expr::Deref { expr, .. } => {
+            collect_expr_calls(expr, calls);
+        }
+        syntax::Expr::StructLiteral { fields, .. } => {
+            for field in fields {
+                collect_expr_calls(&field.expr, calls);
+            }
+        }
+        syntax::Expr::FieldAccess { base, .. } | syntax::Expr::TupleIndex { base, .. } => {
+            collect_expr_calls(base, calls);
+        }
+        syntax::Expr::TupleLiteral { elements, .. }
+        | syntax::Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                collect_expr_calls(element, calls);
+            }
+        }
+        syntax::Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                collect_expr_calls(&entry.key, calls);
+                collect_expr_calls(&entry.value, calls);
+            }
+        }
+        syntax::Expr::Slice {
+            base, start, end, ..
+        } => {
+            collect_expr_calls(base, calls);
+            if let Some(start) = start {
+                collect_expr_calls(start, calls);
+            }
+            if let Some(end) = end {
+                collect_expr_calls(end, calls);
+            }
+        }
+        syntax::Expr::Index { base, index, .. } => {
+            collect_expr_calls(base, calls);
+            collect_expr_calls(index, calls);
+        }
+        syntax::Expr::Closure { body, .. } => {
+            collect_expr_calls(body, calls);
+        }
+        syntax::Expr::Match { expr, arms, .. } => {
+            collect_expr_calls(expr, calls);
+            for arm in arms {
+                collect_expr_calls(&arm.expr, calls);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Split stdlib reachability and call-graph discovery out of the main HIR lowering facade into `stage1/crates/axiomc/src/hir/reachability.rs`.
- Track the new HIR child file in the compiler source boundary report and update its regression fixture.
- Lower the compiler source monolith ratchet to the measured values: `hir.rs` 8,399 lines, top-seven lines 76,216, top-seven share 0.8551.

## Governing Issue

Refs #1254

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Commands:

- `cargo fmt --manifest-path stage1/Cargo.toml --all --check` - passed
- `cargo check --manifest-path stage1/Cargo.toml -p axiomc --lib` - passed with existing dead-code warnings
- `python3 scripts/ci/test-report-compiler-source-monoliths.py` - passed
- `make stage1-compiler-source-monoliths` - passed; plan and ratchet checks passed
- `make stage1-compiler-source-monoliths-test` - passed
- `make stage1-hir-boundary` - passed
- `make stage1-hir-boundary-test` - passed
- `TMPDIR=/private/tmp/axiom-prop-validation-1306 make stage1-compiler-property-test` - passed with existing Rust/Xcode warning noise
- `git diff --check` - passed
- `git diff --cached --check` - passed

Skipped checks:

- None.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Semantic notes:

- Semantic node types: none added or changed.
- Schemas: none added or changed.
- Evidence: compiler source monolith evidence now tracks `stage1/crates/axiomc/src/hir/reachability.rs`; the measured HIR facade and top-seven ceilings are reduced.
- Rust capture risk: low. This is a source-ownership extraction under `compiler.hir`; Rust module paths remain migration references, not semantic contracts.
- Agent-facing inspection impact: reachability/call-graph discovery now has a dedicated `compiler.hir` child boundary, making later self-hosting package migration easier to inspect.

## Flow Contract

- Owner lane: compiler/runtime
- Repair owner: codex
- Autonomy class: supervised
- Risk class: low

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- This PR is stacked on `codex/compiler-monolith-ratchet`.
