### PR TITLE
Split HIR symbol helpers

### DIFF
--- a/docs/compiler-source-decomposition-plan.md
+++ b/docs/compiler-source-decomposition-plan.md
@@ -70,6 +70,8 @@ extraction then moved stdlib reachability and call-graph discovery into
 facade without making the Rust helper layout canonical. The HIR diagnostic
 recovery extraction then moved primary/related diagnostic selection, flattening,
 and deterministic sorting into `stage1/crates/axiomc/src/hir/diagnostics.rs`.
+The HIR symbol extraction then moved monomorphized symbol naming and async or
+collection intrinsic classification into `stage1/crates/axiomc/src/hir/symbols.rs`.
 
 ## Current Top Files
 
@@ -80,7 +82,7 @@ Snapshot from 2026-07-02:
 | 1 | `stage1/crates/axiomc/src/cranelift_backend.rs` | 27,994 | `compiler.backend.native` | Split direct-native lowering by runtime ABI groups: scalar/aggregate value features, capability shims, host imports, object emission, unsupported diagnostics, and evidence helpers. |
 | 2 | `stage1/crates/axiomc/src/project.rs` | 10,812 | `compiler.package_graph`, `compiler.commands`, `compiler.evidence` | Split manifest/workspace loading, command orchestration, provenance/debug records, and build artifact planning along package ownership. |
 | 3 | `stage1/crates/axiomc/src/main.rs` | 10,678 | `compiler.commands` | Move command parsing, JSON envelope construction, check/build/run/test/doc/trace orchestration, and exit handling behind `docs/compiler-command-lsp-packages.md` APIs. |
-| 4 | `stage1/crates/axiomc/src/hir.rs` | 8,376 | `compiler.hir` | Generic inference and monomorphization now live in `stage1/crates/axiomc/src/hir/generics.rs`; public HIR model types now live in `stage1/crates/axiomc/src/hir/model.rs`; syntax-to-HIR type/literal lowering now lives in `stage1/crates/axiomc/src/hir/types.rs`; type-name, aggregate, and trait-use definition checks now live in `stage1/crates/axiomc/src/hir/definitions.rs`; function/method signatures and trait impl signature validation now live in `stage1/crates/axiomc/src/hir/signatures.rs`; capability analysis now lives in `stage1/crates/axiomc/src/hir/capabilities.rs`; expression typing helpers now live in `stage1/crates/axiomc/src/hir/expressions.rs`; ownership and borrow-state helpers now live in `stage1/crates/axiomc/src/hir/ownership.rs`; property clause checks now live in `stage1/crates/axiomc/src/hir/properties.rs`; reachability/call-graph discovery now lives in `stage1/crates/axiomc/src/hir/reachability.rs`; diagnostic recovery helpers now live in `stage1/crates/axiomc/src/hir/diagnostics.rs`; continue splitting remaining HIR diagnostics and helper clusters behind the package APIs in `docs/compiler-hir-ownership-capability.md`. |
+| 4 | `stage1/crates/axiomc/src/hir.rs` | 8,248 | `compiler.hir` | Generic inference and monomorphization now live in `stage1/crates/axiomc/src/hir/generics.rs`; public HIR model types now live in `stage1/crates/axiomc/src/hir/model.rs`; syntax-to-HIR type/literal lowering now lives in `stage1/crates/axiomc/src/hir/types.rs`; type-name, aggregate, and trait-use definition checks now live in `stage1/crates/axiomc/src/hir/definitions.rs`; function/method signatures and trait impl signature validation now live in `stage1/crates/axiomc/src/hir/signatures.rs`; capability analysis now lives in `stage1/crates/axiomc/src/hir/capabilities.rs`; expression typing helpers now live in `stage1/crates/axiomc/src/hir/expressions.rs`; ownership and borrow-state helpers now live in `stage1/crates/axiomc/src/hir/ownership.rs`; property clause checks now live in `stage1/crates/axiomc/src/hir/properties.rs`; reachability/call-graph discovery now lives in `stage1/crates/axiomc/src/hir/reachability.rs`; diagnostic recovery helpers now live in `stage1/crates/axiomc/src/hir/diagnostics.rs`; monomorphized symbol and intrinsic helpers now live in `stage1/crates/axiomc/src/hir/symbols.rs`; continue splitting remaining HIR helper clusters behind the package APIs in `docs/compiler-hir-ownership-capability.md`. |
 | 5 | `stage1/crates/axiomc/src/codegen.rs` | 7,804 | `compiler.backend.generated_rust`, `compiler.backend.contracts` | Isolate generated-Rust compatibility emission from backend target selection and unsupported-feature contracts. |
 | 6 | `stage1/crates/axiomc/src/syntax.rs` | 6,324 | `compiler.syntax`, `compiler.diagnostics` | Split lexer/parser, parse recovery, source spans, macros, and syntax diagnostics behind the syntax boundary. |
 | 7 | `stage1/crates/axiomc/src/hir/generics.rs` | 4,205 | `compiler.hir` | Keep generic call inference, trait-bound validation, aggregate monomorphization, and generic call rewriting isolated from the main HIR lowering facade. |
@@ -95,10 +97,10 @@ matching ceiling in this table in the same PR.
 
 | Tracked item | Ceiling |
 | --- | ---: |
-| `summary.top_file_line_share` | 0.8548 |
-| `summary.top_file_lines` | 76193 |
+| `summary.top_file_line_share` | 0.8533 |
+| `summary.top_file_lines` | 76065 |
 | `stage1/crates/axiomc/src/cranelift_backend.rs` | 27994 |
-| `stage1/crates/axiomc/src/hir.rs` | 8376 |
+| `stage1/crates/axiomc/src/hir.rs` | 8248 |
 | `stage1/crates/axiomc/src/project.rs` | 10812 |
 | `stage1/crates/axiomc/src/main.rs` | 10678 |
 | `stage1/crates/axiomc/src/codegen.rs` | 7804 |
@@ -113,6 +115,7 @@ matching ceiling in this table in the same PR.
 | `stage1/crates/axiomc/src/hir/properties.rs` | 167 |
 | `stage1/crates/axiomc/src/hir/reachability.rs` | 161 |
 | `stage1/crates/axiomc/src/hir/signatures.rs` | 471 |
+| `stage1/crates/axiomc/src/hir/symbols.rs` | 137 |
 | `stage1/crates/axiomc/src/hir/types.rs` | 241 |
 | `stage1/crates/axiomc/src/registry.rs` | 2159 |
 | `stage1/crates/axiomc/src/lib.rs` | 21 |
@@ -129,9 +132,9 @@ matching ceiling in this table in the same PR.
    syntax-to-HIR type/literal lowering, and type/aggregate definition collection
    are split; function/method signatures, trait impl signature validation,
    capability analysis, expression typing helpers, ownership/borrow helpers,
-   property checks, reachability/call-graph discovery, and diagnostic recovery
-   helpers are split; continue with remaining HIR diagnostics and helper
-   clusters.
+   property checks, reachability/call-graph discovery, diagnostic recovery
+   helpers, and monomorphized symbol/intrinsic helpers are split; continue with
+   remaining HIR helper clusters.
 4. `compiler.commands` and `compiler.package_graph`: separate command envelopes
    from package loading so the snapshot bootstrap can invoke package APIs
    without Cargo assumptions.

--- a/scripts/ci/report-compiler-source-monoliths.py
+++ b/scripts/ci/report-compiler-source-monoliths.py
@@ -47,6 +47,7 @@ BOUNDARY_MAP: dict[str, list[str]] = {
     "registry.rs": ["compiler.package_graph"],
     "signatures.rs": ["compiler.hir"],
     "stdlib.rs": ["compiler.stdlib"],
+    "symbols.rs": ["compiler.hir"],
     "syntax.rs": ["compiler.syntax", "compiler.diagnostics"],
     "types.rs": ["compiler.hir"],
 }

--- a/scripts/ci/test-report-compiler-source-monoliths.py
+++ b/scripts/ci/test-report-compiler-source-monoliths.py
@@ -54,16 +54,17 @@ class CompilerSourceMonolithTests(unittest.TestCase):
             write_lines(hir_dir / "properties.rs", 1)
             write_lines(hir_dir / "reachability.rs", 1)
             write_lines(hir_dir / "signatures.rs", 1)
+            write_lines(hir_dir / "symbols.rs", 1)
             write_lines(hir_dir / "types.rs", 1)
 
-            report = compiler_source_monoliths.build_report(source_root, top=14)
+            report = compiler_source_monoliths.build_report(source_root, top=15)
 
         self.assertEqual(report["schema_version"], "axiom.compiler_source.monoliths.v0")
         self.assertEqual(report["collected_at"], "2026-06-21T10:00:00Z")
-        self.assertEqual(report["summary"]["total_files"], 14)
-        self.assertEqual(report["summary"]["total_lines"], 21)
+        self.assertEqual(report["summary"]["total_files"], 15)
+        self.assertEqual(report["summary"]["total_lines"], 22)
         self.assertEqual(report["summary"]["largest_file_lines"], 5)
-        self.assertEqual(report["summary"]["top_file_lines"], 21)
+        self.assertEqual(report["summary"]["top_file_lines"], 22)
         self.assertEqual(report["summary"]["top_file_line_share"], 1.0)
         boundaries_by_suffix = {
             Path(item["path"]).as_posix().removeprefix(source_root.as_posix() + "/"): item[
@@ -87,6 +88,7 @@ class CompilerSourceMonolithTests(unittest.TestCase):
             "hir/properties.rs",
             "hir/reachability.rs",
             "hir/signatures.rs",
+            "hir/symbols.rs",
             "hir/types.rs",
         ]:
             self.assertEqual(boundaries_by_suffix[path], ["compiler.hir"])

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -14,6 +14,7 @@ mod ownership;
 mod properties;
 mod reachability;
 mod signatures;
+mod symbols;
 mod types;
 
 use self::capabilities::{
@@ -57,6 +58,10 @@ use self::reachability::reachable_function_names;
 use self::signatures::{
     FunctionSig, MethodSig, collect_function_signatures, collect_method_signatures,
     function_symbol_name, validate_trait_impls,
+};
+use self::symbols::{
+    is_async_runtime_intrinsic, is_async_runtime_type, monomorphized_function_name,
+    monomorphized_type_name, preserves_intrinsic_type_args,
 };
 use self::types::{lower_compare_op, lower_literal, lower_logic_op, lower_type};
 
@@ -308,139 +313,6 @@ fn lower_with_capabilities_impl(
         functions: lowered_functions,
         stmts,
     })
-}
-
-fn monomorphized_function_name(name: &str, type_args: &[syntax::TypeName]) -> String {
-    monomorphized_name(name, type_args)
-}
-
-fn monomorphized_type_name(name: &str, type_args: &[syntax::TypeName]) -> String {
-    monomorphized_name(name, type_args)
-}
-
-fn monomorphized_name(name: &str, type_args: &[syntax::TypeName]) -> String {
-    let suffix = type_args
-        .iter()
-        .map(type_name_monomorph_suffix)
-        .collect::<Vec<_>>()
-        .join("__");
-    format!("{name}__{suffix}")
-}
-
-fn is_async_runtime_type(name: &str) -> bool {
-    matches!(
-        name,
-        "Task" | "JoinHandle" | "AsyncChannel" | "SelectResult"
-    )
-}
-
-fn is_async_runtime_intrinsic(name: &str) -> bool {
-    matches!(
-        name,
-        "async_ready"
-            | "async_spawn"
-            | "async_join"
-            | "async_cancel"
-            | "async_is_canceled"
-            | "async_timeout"
-            | "async_channel"
-            | "async_send"
-            | "async_recv"
-            | "async_select"
-            | "async_selected"
-            | "async_selected_value"
-    )
-}
-
-fn preserves_intrinsic_type_args(name: &str) -> bool {
-    is_async_runtime_intrinsic(name)
-        || matches!(
-            name,
-            "map_get"
-                | "map_contains_key"
-                | "map_keys"
-                | "contains"
-                | "get"
-                | "get_or_default"
-                | "keys"
-        )
-}
-
-fn type_name_monomorph_suffix(ty: &syntax::TypeName) -> String {
-    match ty {
-        syntax::TypeName::Int => String::from("int"),
-        syntax::TypeName::Numeric(numeric) => numeric.as_str().to_string(),
-        syntax::TypeName::Bool => String::from("bool"),
-        syntax::TypeName::String => String::from("string"),
-        syntax::TypeName::Str => String::from("str"),
-        syntax::TypeName::Named(name, args) if args.is_empty() => name.clone(),
-        syntax::TypeName::Named(name, args) => monomorphized_type_name(name, args),
-        syntax::TypeName::Ptr(inner) => format!("ptr_{}", type_name_monomorph_suffix(inner)),
-        syntax::TypeName::MutPtr(inner) => {
-            format!("mutptr_{}", type_name_monomorph_suffix(inner))
-        }
-        syntax::TypeName::MutRef(inner) => {
-            format!("mutref_{}", type_name_monomorph_suffix(inner))
-        }
-        syntax::TypeName::Slice(inner) => format!("slice_{}", type_name_monomorph_suffix(inner)),
-        syntax::TypeName::MutSlice(inner) => {
-            format!("mutslice_{}", type_name_monomorph_suffix(inner))
-        }
-        syntax::TypeName::LifetimeSlice(lifetime, inner) => format!(
-            "lslice_{}_{}",
-            sanitize_symbol_suffix(lifetime),
-            type_name_monomorph_suffix(inner)
-        ),
-        syntax::TypeName::LifetimeMutSlice(lifetime, inner) => format!(
-            "lmutslice_{}_{}",
-            sanitize_symbol_suffix(lifetime),
-            type_name_monomorph_suffix(inner)
-        ),
-        syntax::TypeName::Option(inner) => {
-            format!("option_{}", type_name_monomorph_suffix(inner))
-        }
-        syntax::TypeName::Result(ok, err) => format!(
-            "result_{}_{}",
-            type_name_monomorph_suffix(ok),
-            type_name_monomorph_suffix(err)
-        ),
-        syntax::TypeName::Tuple(elements) => format!(
-            "tuple_{}",
-            elements
-                .iter()
-                .map(type_name_monomorph_suffix)
-                .collect::<Vec<_>>()
-                .join("_")
-        ),
-        syntax::TypeName::Map(key, value) => format!(
-            "map_{}_{}",
-            type_name_monomorph_suffix(key),
-            type_name_monomorph_suffix(value)
-        ),
-        syntax::TypeName::Array(inner, len) => match len {
-            Some(len) => format!(
-                "array_{}_{}",
-                type_name_monomorph_suffix(inner),
-                sanitize_symbol_suffix(len)
-            ),
-            None => format!("array_{}", type_name_monomorph_suffix(inner)),
-        },
-        syntax::TypeName::Fn(params, return_ty) => format!(
-            "fn_{}_{}",
-            params
-                .iter()
-                .map(type_name_monomorph_suffix)
-                .collect::<Vec<_>>()
-                .join("_"),
-            type_name_monomorph_suffix(return_ty)
-        ),
-    }
-}
-
-fn sanitize_symbol_suffix(raw: &str) -> String {
-    raw.chars()
-        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' })
-        .collect()
 }
 
 fn ownership_error(code: &'static str, message: impl Into<String>) -> Diagnostic {

--- a/stage1/crates/axiomc/src/hir/symbols.rs
+++ b/stage1/crates/axiomc/src/hir/symbols.rs
@@ -1,0 +1,134 @@
+use crate::syntax;
+
+pub(super) fn monomorphized_function_name(name: &str, type_args: &[syntax::TypeName]) -> String {
+    monomorphized_name(name, type_args)
+}
+
+pub(super) fn monomorphized_type_name(name: &str, type_args: &[syntax::TypeName]) -> String {
+    monomorphized_name(name, type_args)
+}
+
+fn monomorphized_name(name: &str, type_args: &[syntax::TypeName]) -> String {
+    let suffix = type_args
+        .iter()
+        .map(type_name_monomorph_suffix)
+        .collect::<Vec<_>>()
+        .join("__");
+    format!("{name}__{suffix}")
+}
+
+pub(super) fn is_async_runtime_type(name: &str) -> bool {
+    matches!(
+        name,
+        "Task" | "JoinHandle" | "AsyncChannel" | "SelectResult"
+    )
+}
+
+pub(super) fn is_async_runtime_intrinsic(name: &str) -> bool {
+    matches!(
+        name,
+        "async_ready"
+            | "async_spawn"
+            | "async_join"
+            | "async_cancel"
+            | "async_is_canceled"
+            | "async_timeout"
+            | "async_channel"
+            | "async_send"
+            | "async_recv"
+            | "async_select"
+            | "async_selected"
+            | "async_selected_value"
+    )
+}
+
+pub(super) fn preserves_intrinsic_type_args(name: &str) -> bool {
+    is_async_runtime_intrinsic(name)
+        || matches!(
+            name,
+            "map_get"
+                | "map_contains_key"
+                | "map_keys"
+                | "contains"
+                | "get"
+                | "get_or_default"
+                | "keys"
+        )
+}
+
+fn type_name_monomorph_suffix(ty: &syntax::TypeName) -> String {
+    match ty {
+        syntax::TypeName::Int => String::from("int"),
+        syntax::TypeName::Numeric(numeric) => numeric.as_str().to_string(),
+        syntax::TypeName::Bool => String::from("bool"),
+        syntax::TypeName::String => String::from("string"),
+        syntax::TypeName::Str => String::from("str"),
+        syntax::TypeName::Named(name, args) if args.is_empty() => name.clone(),
+        syntax::TypeName::Named(name, args) => monomorphized_type_name(name, args),
+        syntax::TypeName::Ptr(inner) => format!("ptr_{}", type_name_monomorph_suffix(inner)),
+        syntax::TypeName::MutPtr(inner) => {
+            format!("mutptr_{}", type_name_monomorph_suffix(inner))
+        }
+        syntax::TypeName::MutRef(inner) => {
+            format!("mutref_{}", type_name_monomorph_suffix(inner))
+        }
+        syntax::TypeName::Slice(inner) => format!("slice_{}", type_name_monomorph_suffix(inner)),
+        syntax::TypeName::MutSlice(inner) => {
+            format!("mutslice_{}", type_name_monomorph_suffix(inner))
+        }
+        syntax::TypeName::LifetimeSlice(lifetime, inner) => format!(
+            "lslice_{}_{}",
+            sanitize_symbol_suffix(lifetime),
+            type_name_monomorph_suffix(inner)
+        ),
+        syntax::TypeName::LifetimeMutSlice(lifetime, inner) => format!(
+            "lmutslice_{}_{}",
+            sanitize_symbol_suffix(lifetime),
+            type_name_monomorph_suffix(inner)
+        ),
+        syntax::TypeName::Option(inner) => {
+            format!("option_{}", type_name_monomorph_suffix(inner))
+        }
+        syntax::TypeName::Result(ok, err) => format!(
+            "result_{}_{}",
+            type_name_monomorph_suffix(ok),
+            type_name_monomorph_suffix(err)
+        ),
+        syntax::TypeName::Tuple(elements) => format!(
+            "tuple_{}",
+            elements
+                .iter()
+                .map(type_name_monomorph_suffix)
+                .collect::<Vec<_>>()
+                .join("_")
+        ),
+        syntax::TypeName::Map(key, value) => format!(
+            "map_{}_{}",
+            type_name_monomorph_suffix(key),
+            type_name_monomorph_suffix(value)
+        ),
+        syntax::TypeName::Array(inner, len) => match len {
+            Some(len) => format!(
+                "array_{}_{}",
+                type_name_monomorph_suffix(inner),
+                sanitize_symbol_suffix(len)
+            ),
+            None => format!("array_{}", type_name_monomorph_suffix(inner)),
+        },
+        syntax::TypeName::Fn(params, return_ty) => format!(
+            "fn_{}_{}",
+            params
+                .iter()
+                .map(type_name_monomorph_suffix)
+                .collect::<Vec<_>>()
+                .join("_"),
+            type_name_monomorph_suffix(return_ty)
+        ),
+    }
+}
+
+fn sanitize_symbol_suffix(raw: &str) -> String {
+    raw.chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' })
+        .collect()
+}


### PR DESCRIPTION
## Summary

- Split HIR monomorphized symbol naming and async/intrinsic classification helpers out of the main lowering facade into `stage1/crates/axiomc/src/hir/symbols.rs`.
- Track the new HIR child file in the compiler source boundary report and regression fixture.
- Lower the compiler source monolith ratchet to the measured values: `hir.rs` 8,248 lines, top-seven lines 76,065, top-seven share 0.8533.

## Governing Issue

Refs #1254

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Commands:

- `cargo fmt --manifest-path stage1/Cargo.toml --all --check` - passed
- `cargo check --manifest-path stage1/Cargo.toml -p axiomc --lib` - passed with existing dead-code warnings
- `python3 scripts/ci/test-report-compiler-source-monoliths.py` - passed
- `make stage1-compiler-source-monoliths` - passed; plan and ratchet checks passed
- `make stage1-compiler-source-monoliths-test` - passed
- `make stage1-hir-boundary` - passed
- `make stage1-hir-boundary-test` - passed
- `TMPDIR=/private/tmp/axiom-prop-validation-1308 make stage1-compiler-property-test` - passed with existing Rust/Xcode warning noise
- `git diff --check` - passed
- `git diff --cached --check` - passed

Skipped checks:

- None.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Semantic notes:

- Semantic node types: none added or changed.
- Schemas: none added or changed.
- Evidence: compiler source monolith evidence now tracks `stage1/crates/axiomc/src/hir/symbols.rs`; the measured HIR facade and top-seven ceilings are reduced.
- Rust capture risk: low. This is a source-ownership extraction under `compiler.hir`; Rust module paths remain migration references, not semantic contracts.
- Agent-facing inspection impact: monomorphized symbol naming and intrinsic classification now have a dedicated `compiler.hir` child boundary, making later self-hosting package migration easier to inspect.

## Flow Contract

- Owner lane: compiler/runtime
- Repair owner: codex
- Autonomy class: supervised
- Risk class: low

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- This PR is stacked on `codex/compiler-monolith-ratchet`.
