### PR TITLE
Assert async raw TCP uses direct native

### DIFF
--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -8286,11 +8286,11 @@ let _listener_closed: int = close_listener(listener)
         fs::write(project.join("src/main.ax"), source).expect("write source");
 
         let built = build_project(&project).expect("build project");
-        let generated =
-            fs::read_to_string(generated_rust_path(&built)).expect("read generated rust");
-        assert!(generated.contains("axiom_net_tcp_read_string"));
-        assert!(generated.contains("axiom_net_tcp_write_string"));
-        assert!(generated.contains("net_tcp_accept(listener)"));
+        assert_eq!(built.backend, NativeBackendKind::Cranelift);
+        assert!(
+            built.generated_rust.is_none(),
+            "default direct-native raw TCP builds must not emit generated Rust"
+        );
         let output = compiled_binary_command(&built.binary)
             .output()
             .expect("run compiled binary");


### PR DESCRIPTION
## Summary

- Update the async-net raw TCP regression to assert the default direct-native Cranelift backend.
- Replace generated-Rust source inspection with an explicit `generated_rust.is_none()` check before the runtime echo probe.
- Keep #1287 evidence aligned with the Rust-exit contract on top of the runtime-serving stack.

## Governing Issue

Refs #1287. Refs #1255.

## Validation

- [x] Relevant local checks passed
  - `cargo fmt --manifest-path stage1/Cargo.toml --all --check`
  - `cargo test --manifest-path stage1/Cargo.toml -p axiomc stage1_async_net_accepts_two_raw_tcp_clients --features run-native-tests -- --nocapture`
  - `make stage1-full-lib-triage-test`
  - `make stage1-direct-native-runtime-abi-test`
  - `make stage1-full-lib-triage`
  - `make rust-exit-readiness`
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are not applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed: none.
- [x] Schemas added/changed: none.
- [x] Evidence added/changed: `stage1_async_net_accepts_two_raw_tcp_clients` now proves direct-native/no-generated-Rust output before runtime echo behavior.
- [x] Rust capture check is satisfied: the test no longer treats generated Rust internals as the evidence source for raw TCP behavior.
- [x] Agent-facing inspection impact: raw TCP Rust-exit evidence now reports the backend contract directly.

## Flow Contract

- Owner lane: Ares
- Repair owner: Codex
- Autonomy class: Class 2 - Review-gated autonomous
- Risk class: risk:low

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- Stacked on #1290 / `codex/rust-exit-runtime-serve`; merge after that stack base lands or keep this PR targeting the stack branch.
