### PR TITLE
Compare assignability fallback directly

### DIFF
--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -7973,6 +7973,14 @@ return ""
     }
 
     #[test]
+    fn type_assignable_fallback_uses_direct_type_equality() {
+        assert!(type_assignable_to(&Type::Bool, &Type::Bool));
+        assert!(!type_assignable_to(&Type::Bool, &Type::Int));
+        assert!(type_assignable_to(&Type::Error, &Type::Int));
+        assert!(type_assignable_to(&Type::Int, &Type::Error));
+    }
+
+    #[test]
     fn never_type_unifies_to_the_other_side() {
         assert_eq!(unify_types(&Type::Never, &Type::Int), Some(Type::Int));
         assert_eq!(unify_types(&Type::Bool, &Type::Never), Some(Type::Bool));

--- a/stage1/crates/axiomc/src/hir/model.rs
+++ b/stage1/crates/axiomc/src/hir/model.rs
@@ -451,7 +451,7 @@ pub(super) fn type_assignable_to(actual: &Type, expected: &Type) -> bool {
                     .all(|(actual, expected)| type_assignable_to(actual, expected))
                 && type_assignable_to(actual_return, expected_return)
         }
-        _ => unify_types(actual, expected).is_some_and(|ty| ty == *expected),
+        _ => actual == expected,
     }
 }
 


### PR DESCRIPTION
## Summary

- Replace the `type_assignable_to` fallback `unify_types(...).is_some_and(...)` path with direct type equality.
- Avoid cloning a `Type` only to compare it back to the expected type.
- Add focused HIR coverage for the fallback equality behavior and the earlier `Error` assignability arms.

## Governing Issue

Refs #1202

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Commands run:

- `cargo fmt --manifest-path stage1/crates/axiomc/Cargo.toml --check`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib type_assignable_fallback_uses_direct_type_equality -- --nocapture`
- `git diff --check`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib`

Skipped checks: none.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Semantic node types: none.
Schemas: none.
Evidence: HIR unit coverage now pins assignability fallback equality and the earlier `Error` assignability arms.
Rust capture: satisfied; this is a stage1 allocation cleanup, not an Axiom semantic contract.
Agent-facing inspection impact: none.

## Flow Contract

- Owner lane: Daedalus
- Repair owner: Codex
- Autonomy class: review-gated
- Risk class: low

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

Next actor/action: non-author reviewer approval is required by governance.

## Merge Automation

- [x] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

Auto-merge will be enabled after the PR is created. If unavailable, fallback merge-readiness applies once required checks pass and non-author approval is present.

## Notes

- This is a partial #1202 cleanup and intentionally leaves the issue open for the remaining allocation findings.
