### PR TITLE
Extract HIR async runtime helpers

### DIFF
--- a/docs/compiler-source-decomposition-plan.md
+++ b/docs/compiler-source-decomposition-plan.md
@@ -94,6 +94,9 @@ The HIR variant-constructor extraction then moved enum variant resolution and
 positional/named payload constructor lowering into
 `stage1/crates/axiomc/src/hir/variants.rs`, keeping variant payload validation
 inside the `compiler.hir` boundary.
+The HIR async-runtime extraction then moved async runtime intrinsic capability
+and type lowering into `stage1/crates/axiomc/src/hir/async_runtime.rs`,
+keeping async capability validation inside the `compiler.hir` boundary.
 The direct-native runtime-serving stack then raised the native backend baseline
 before this ratchet merged; the ceilings below reflect that post-merge snapshot
 so future backend growth must be paid down or accompanied by an explicit
@@ -110,7 +113,7 @@ Snapshot from 2026-07-02:
 | 3 | `stage1/crates/axiomc/src/main.rs` | 10,678 | `compiler.commands` | Move command parsing, JSON envelope construction, check/build/run/test/doc/trace orchestration, and exit handling behind `docs/compiler-command-lsp-packages.md` APIs. |
 | 4 | `stage1/crates/axiomc/src/codegen.rs` | 7,804 | `compiler.backend.generated_rust`, `compiler.backend.contracts` | Isolate generated-Rust compatibility emission from backend target selection and unsupported-feature contracts. |
 | 5 | `stage1/crates/axiomc/src/syntax.rs` | 6,324 | `compiler.syntax`, `compiler.diagnostics` | Split lexer/parser, parse recovery, source spans, macros, and syntax diagnostics behind the syntax boundary. |
-| 6 | `stage1/crates/axiomc/src/hir.rs` | 6,259 | `compiler.hir` | Generic inference and monomorphization now live in `stage1/crates/axiomc/src/hir/generics.rs`; public HIR model types now live in `stage1/crates/axiomc/src/hir/model.rs`; syntax-to-HIR type/literal lowering now lives in `stage1/crates/axiomc/src/hir/types.rs`; type-name, aggregate, and trait-use definition checks now live in `stage1/crates/axiomc/src/hir/definitions.rs`; function/method signatures and trait impl signature validation now live in `stage1/crates/axiomc/src/hir/signatures.rs`; capability analysis now lives in `stage1/crates/axiomc/src/hir/capabilities.rs`; expression typing helpers now live in `stage1/crates/axiomc/src/hir/expressions.rs`; ownership and borrow-state helpers now live in `stage1/crates/axiomc/src/hir/ownership.rs`; property clause checks now live in `stage1/crates/axiomc/src/hir/properties.rs`; reachability/call-graph discovery now lives in `stage1/crates/axiomc/src/hir/reachability.rs`; diagnostic recovery helpers now live in `stage1/crates/axiomc/src/hir/diagnostics.rs`; monomorphized symbol and intrinsic helpers now live in `stage1/crates/axiomc/src/hir/symbols.rs`; source-location helpers now live in `stage1/crates/axiomc/src/hir/source_locations.rs`; return-flow analysis now lives in `stage1/crates/axiomc/src/hir/control_flow.rs`; const-array length validation now lives in `stage1/crates/axiomc/src/hir/const_arrays.rs`; match lowering now lives in `stage1/crates/axiomc/src/hir/matches.rs`; enum variant constructor helpers now live in `stage1/crates/axiomc/src/hir/variants.rs`; HIR boundary regression tests now live in `stage1/crates/axiomc/tests/hir_unit.rs`; continue splitting remaining HIR helper clusters behind the package APIs in `docs/compiler-hir-ownership-capability.md`. |
+| 6 | `stage1/crates/axiomc/src/hir.rs` | 6,074 | `compiler.hir` | Generic inference and monomorphization now live in `stage1/crates/axiomc/src/hir/generics.rs`; public HIR model types now live in `stage1/crates/axiomc/src/hir/model.rs`; syntax-to-HIR type/literal lowering now lives in `stage1/crates/axiomc/src/hir/types.rs`; type-name, aggregate, and trait-use definition checks now live in `stage1/crates/axiomc/src/hir/definitions.rs`; function/method signatures and trait impl signature validation now live in `stage1/crates/axiomc/src/hir/signatures.rs`; capability analysis now lives in `stage1/crates/axiomc/src/hir/capabilities.rs`; expression typing helpers now live in `stage1/crates/axiomc/src/hir/expressions.rs`; ownership and borrow-state helpers now live in `stage1/crates/axiomc/src/hir/ownership.rs`; property clause checks now live in `stage1/crates/axiomc/src/hir/properties.rs`; reachability/call-graph discovery now lives in `stage1/crates/axiomc/src/hir/reachability.rs`; diagnostic recovery helpers now live in `stage1/crates/axiomc/src/hir/diagnostics.rs`; monomorphized symbol and intrinsic helpers now live in `stage1/crates/axiomc/src/hir/symbols.rs`; source-location helpers now live in `stage1/crates/axiomc/src/hir/source_locations.rs`; return-flow analysis now lives in `stage1/crates/axiomc/src/hir/control_flow.rs`; const-array length validation now lives in `stage1/crates/axiomc/src/hir/const_arrays.rs`; match lowering now lives in `stage1/crates/axiomc/src/hir/matches.rs`; enum variant constructor helpers now live in `stage1/crates/axiomc/src/hir/variants.rs`; async runtime intrinsic lowering now lives in `stage1/crates/axiomc/src/hir/async_runtime.rs`; HIR boundary regression tests now live in `stage1/crates/axiomc/tests/hir_unit.rs`; continue splitting remaining HIR helper clusters behind the package APIs in `docs/compiler-hir-ownership-capability.md`. |
 | 7 | `stage1/crates/axiomc/src/hir/generics.rs` | 4,205 | `compiler.hir` | Keep generic call inference, trait-bound validation, aggregate monomorphization, and generic call rewriting isolated from the main HIR lowering facade. |
 
 ## Ratchet Ceilings
@@ -123,14 +126,15 @@ matching ceiling in this table in the same PR.
 
 | Tracked item | Ceiling |
 | --- | ---: |
-| `summary.top_file_line_share` | 0.8376 |
-| `summary.top_file_lines` | 74448 |
+| `summary.top_file_line_share` | 0.8355 |
+| `summary.top_file_lines` | 74263 |
 | `stage1/crates/axiomc/src/cranelift_backend.rs` | 28366 |
-| `stage1/crates/axiomc/src/hir.rs` | 6259 |
+| `stage1/crates/axiomc/src/hir.rs` | 6074 |
 | `stage1/crates/axiomc/src/project.rs` | 10812 |
 | `stage1/crates/axiomc/src/main.rs` | 10678 |
 | `stage1/crates/axiomc/src/codegen.rs` | 7804 |
 | `stage1/crates/axiomc/src/syntax.rs` | 6324 |
+| `stage1/crates/axiomc/src/hir/async_runtime.rs` | 188 |
 | `stage1/crates/axiomc/src/hir/capabilities.rs` | 773 |
 | `stage1/crates/axiomc/src/hir/const_arrays.rs` | 330 |
 | `stage1/crates/axiomc/src/hir/control_flow.rs` | 36 |
@@ -165,9 +169,9 @@ matching ceiling in this table in the same PR.
    capability analysis, expression typing helpers, ownership/borrow helpers,
    property checks, reachability/call-graph discovery, diagnostic recovery
    helpers, monomorphized symbol/intrinsic helpers, source-location helpers,
-   return-flow analysis, const-array validation, match lowering, and enum
-   variant constructor lowering are split; continue with remaining HIR helper
-   clusters.
+   return-flow analysis, const-array validation, match lowering, enum variant
+   constructor lowering, and async runtime intrinsic lowering are split;
+   continue with remaining HIR helper clusters.
 4. `compiler.commands` and `compiler.package_graph`: separate command envelopes
    from package loading so the snapshot bootstrap can invoke package APIs
    without Cargo assumptions.

--- a/docs/compiler-source-decomposition-plan.md
+++ b/docs/compiler-source-decomposition-plan.md
@@ -97,6 +97,9 @@ inside the `compiler.hir` boundary.
 The HIR async-runtime extraction then moved async runtime intrinsic capability
 and type lowering into `stage1/crates/axiomc/src/hir/async_runtime.rs`,
 keeping async capability validation inside the `compiler.hir` boundary.
+The HIR map-intrinsic extraction then moved map lookup/key/default intrinsic
+type and ownership lowering into `stage1/crates/axiomc/src/hir/maps.rs`,
+keeping collection intrinsic validation inside the `compiler.hir` boundary.
 The direct-native runtime-serving stack then raised the native backend baseline
 before this ratchet merged; the ceilings below reflect that post-merge snapshot
 so future backend growth must be paid down or accompanied by an explicit
@@ -113,7 +116,7 @@ Snapshot from 2026-07-02:
 | 3 | `stage1/crates/axiomc/src/main.rs` | 10,678 | `compiler.commands` | Move command parsing, JSON envelope construction, check/build/run/test/doc/trace orchestration, and exit handling behind `docs/compiler-command-lsp-packages.md` APIs. |
 | 4 | `stage1/crates/axiomc/src/codegen.rs` | 7,804 | `compiler.backend.generated_rust`, `compiler.backend.contracts` | Isolate generated-Rust compatibility emission from backend target selection and unsupported-feature contracts. |
 | 5 | `stage1/crates/axiomc/src/syntax.rs` | 6,324 | `compiler.syntax`, `compiler.diagnostics` | Split lexer/parser, parse recovery, source spans, macros, and syntax diagnostics behind the syntax boundary. |
-| 6 | `stage1/crates/axiomc/src/hir.rs` | 6,074 | `compiler.hir` | Generic inference and monomorphization now live in `stage1/crates/axiomc/src/hir/generics.rs`; public HIR model types now live in `stage1/crates/axiomc/src/hir/model.rs`; syntax-to-HIR type/literal lowering now lives in `stage1/crates/axiomc/src/hir/types.rs`; type-name, aggregate, and trait-use definition checks now live in `stage1/crates/axiomc/src/hir/definitions.rs`; function/method signatures and trait impl signature validation now live in `stage1/crates/axiomc/src/hir/signatures.rs`; capability analysis now lives in `stage1/crates/axiomc/src/hir/capabilities.rs`; expression typing helpers now live in `stage1/crates/axiomc/src/hir/expressions.rs`; ownership and borrow-state helpers now live in `stage1/crates/axiomc/src/hir/ownership.rs`; property clause checks now live in `stage1/crates/axiomc/src/hir/properties.rs`; reachability/call-graph discovery now lives in `stage1/crates/axiomc/src/hir/reachability.rs`; diagnostic recovery helpers now live in `stage1/crates/axiomc/src/hir/diagnostics.rs`; monomorphized symbol and intrinsic helpers now live in `stage1/crates/axiomc/src/hir/symbols.rs`; source-location helpers now live in `stage1/crates/axiomc/src/hir/source_locations.rs`; return-flow analysis now lives in `stage1/crates/axiomc/src/hir/control_flow.rs`; const-array length validation now lives in `stage1/crates/axiomc/src/hir/const_arrays.rs`; match lowering now lives in `stage1/crates/axiomc/src/hir/matches.rs`; enum variant constructor helpers now live in `stage1/crates/axiomc/src/hir/variants.rs`; async runtime intrinsic lowering now lives in `stage1/crates/axiomc/src/hir/async_runtime.rs`; HIR boundary regression tests now live in `stage1/crates/axiomc/tests/hir_unit.rs`; continue splitting remaining HIR helper clusters behind the package APIs in `docs/compiler-hir-ownership-capability.md`. |
+| 6 | `stage1/crates/axiomc/src/hir.rs` | 5,953 | `compiler.hir` | Generic inference and monomorphization now live in `stage1/crates/axiomc/src/hir/generics.rs`; public HIR model types now live in `stage1/crates/axiomc/src/hir/model.rs`; syntax-to-HIR type/literal lowering now lives in `stage1/crates/axiomc/src/hir/types.rs`; type-name, aggregate, and trait-use definition checks now live in `stage1/crates/axiomc/src/hir/definitions.rs`; function/method signatures and trait impl signature validation now live in `stage1/crates/axiomc/src/hir/signatures.rs`; capability analysis now lives in `stage1/crates/axiomc/src/hir/capabilities.rs`; expression typing helpers now live in `stage1/crates/axiomc/src/hir/expressions.rs`; ownership and borrow-state helpers now live in `stage1/crates/axiomc/src/hir/ownership.rs`; property clause checks now live in `stage1/crates/axiomc/src/hir/properties.rs`; reachability/call-graph discovery now lives in `stage1/crates/axiomc/src/hir/reachability.rs`; diagnostic recovery helpers now live in `stage1/crates/axiomc/src/hir/diagnostics.rs`; monomorphized symbol and intrinsic helpers now live in `stage1/crates/axiomc/src/hir/symbols.rs`; source-location helpers now live in `stage1/crates/axiomc/src/hir/source_locations.rs`; return-flow analysis now lives in `stage1/crates/axiomc/src/hir/control_flow.rs`; const-array length validation now lives in `stage1/crates/axiomc/src/hir/const_arrays.rs`; match lowering now lives in `stage1/crates/axiomc/src/hir/matches.rs`; enum variant constructor helpers now live in `stage1/crates/axiomc/src/hir/variants.rs`; async runtime intrinsic lowering now lives in `stage1/crates/axiomc/src/hir/async_runtime.rs`; map intrinsic lowering now lives in `stage1/crates/axiomc/src/hir/maps.rs`; HIR boundary regression tests now live in `stage1/crates/axiomc/tests/hir_unit.rs`; continue splitting remaining HIR helper clusters behind the package APIs in `docs/compiler-hir-ownership-capability.md`. |
 | 7 | `stage1/crates/axiomc/src/hir/generics.rs` | 4,205 | `compiler.hir` | Keep generic call inference, trait-bound validation, aggregate monomorphization, and generic call rewriting isolated from the main HIR lowering facade. |
 
 ## Ratchet Ceilings
@@ -126,10 +129,10 @@ matching ceiling in this table in the same PR.
 
 | Tracked item | Ceiling |
 | --- | ---: |
-| `summary.top_file_line_share` | 0.8355 |
-| `summary.top_file_lines` | 74263 |
+| `summary.top_file_line_share` | 0.8341 |
+| `summary.top_file_lines` | 74142 |
 | `stage1/crates/axiomc/src/cranelift_backend.rs` | 28366 |
-| `stage1/crates/axiomc/src/hir.rs` | 6074 |
+| `stage1/crates/axiomc/src/hir.rs` | 5953 |
 | `stage1/crates/axiomc/src/project.rs` | 10812 |
 | `stage1/crates/axiomc/src/main.rs` | 10678 |
 | `stage1/crates/axiomc/src/codegen.rs` | 7804 |
@@ -142,6 +145,7 @@ matching ceiling in this table in the same PR.
 | `stage1/crates/axiomc/src/hir/diagnostics.rs` | 28 |
 | `stage1/crates/axiomc/src/hir/expressions.rs` | 205 |
 | `stage1/crates/axiomc/src/hir/generics.rs` | 4205 |
+| `stage1/crates/axiomc/src/hir/maps.rs` | 124 |
 | `stage1/crates/axiomc/src/hir/matches.rs` | 735 |
 | `stage1/crates/axiomc/src/hir/model.rs` | 607 |
 | `stage1/crates/axiomc/src/hir/ownership.rs` | 1129 |
@@ -170,8 +174,8 @@ matching ceiling in this table in the same PR.
    property checks, reachability/call-graph discovery, diagnostic recovery
    helpers, monomorphized symbol/intrinsic helpers, source-location helpers,
    return-flow analysis, const-array validation, match lowering, enum variant
-   constructor lowering, and async runtime intrinsic lowering are split;
-   continue with remaining HIR helper clusters.
+   constructor lowering, async runtime intrinsic lowering, and map intrinsic
+   lowering are split; continue with remaining HIR helper clusters.
 4. `compiler.commands` and `compiler.package_graph`: separate command envelopes
    from package loading so the snapshot bootstrap can invoke package APIs
    without Cargo assumptions.

--- a/docs/compiler-source-decomposition-plan.md
+++ b/docs/compiler-source-decomposition-plan.md
@@ -100,6 +100,9 @@ keeping async capability validation inside the `compiler.hir` boundary.
 The HIR map-intrinsic extraction then moved map lookup/key/default intrinsic
 type and ownership lowering into `stage1/crates/axiomc/src/hir/maps.rs`,
 keeping collection intrinsic validation inside the `compiler.hir` boundary.
+The HIR const-function extraction then moved const function body and expression
+validation into `stage1/crates/axiomc/src/hir/const_functions.rs`, keeping
+compile-time function restrictions inside the `compiler.hir` boundary.
 The direct-native runtime-serving stack then raised the native backend baseline
 before this ratchet merged; the ceilings below reflect that post-merge snapshot
 so future backend growth must be paid down or accompanied by an explicit
@@ -116,7 +119,7 @@ Snapshot from 2026-07-02:
 | 3 | `stage1/crates/axiomc/src/main.rs` | 10,678 | `compiler.commands` | Move command parsing, JSON envelope construction, check/build/run/test/doc/trace orchestration, and exit handling behind `docs/compiler-command-lsp-packages.md` APIs. |
 | 4 | `stage1/crates/axiomc/src/codegen.rs` | 7,804 | `compiler.backend.generated_rust`, `compiler.backend.contracts` | Isolate generated-Rust compatibility emission from backend target selection and unsupported-feature contracts. |
 | 5 | `stage1/crates/axiomc/src/syntax.rs` | 6,324 | `compiler.syntax`, `compiler.diagnostics` | Split lexer/parser, parse recovery, source spans, macros, and syntax diagnostics behind the syntax boundary. |
-| 6 | `stage1/crates/axiomc/src/hir.rs` | 5,953 | `compiler.hir` | Generic inference and monomorphization now live in `stage1/crates/axiomc/src/hir/generics.rs`; public HIR model types now live in `stage1/crates/axiomc/src/hir/model.rs`; syntax-to-HIR type/literal lowering now lives in `stage1/crates/axiomc/src/hir/types.rs`; type-name, aggregate, and trait-use definition checks now live in `stage1/crates/axiomc/src/hir/definitions.rs`; function/method signatures and trait impl signature validation now live in `stage1/crates/axiomc/src/hir/signatures.rs`; capability analysis now lives in `stage1/crates/axiomc/src/hir/capabilities.rs`; expression typing helpers now live in `stage1/crates/axiomc/src/hir/expressions.rs`; ownership and borrow-state helpers now live in `stage1/crates/axiomc/src/hir/ownership.rs`; property clause checks now live in `stage1/crates/axiomc/src/hir/properties.rs`; reachability/call-graph discovery now lives in `stage1/crates/axiomc/src/hir/reachability.rs`; diagnostic recovery helpers now live in `stage1/crates/axiomc/src/hir/diagnostics.rs`; monomorphized symbol and intrinsic helpers now live in `stage1/crates/axiomc/src/hir/symbols.rs`; source-location helpers now live in `stage1/crates/axiomc/src/hir/source_locations.rs`; return-flow analysis now lives in `stage1/crates/axiomc/src/hir/control_flow.rs`; const-array length validation now lives in `stage1/crates/axiomc/src/hir/const_arrays.rs`; match lowering now lives in `stage1/crates/axiomc/src/hir/matches.rs`; enum variant constructor helpers now live in `stage1/crates/axiomc/src/hir/variants.rs`; async runtime intrinsic lowering now lives in `stage1/crates/axiomc/src/hir/async_runtime.rs`; map intrinsic lowering now lives in `stage1/crates/axiomc/src/hir/maps.rs`; HIR boundary regression tests now live in `stage1/crates/axiomc/tests/hir_unit.rs`; continue splitting remaining HIR helper clusters behind the package APIs in `docs/compiler-hir-ownership-capability.md`. |
+| 6 | `stage1/crates/axiomc/src/hir.rs` | 5,842 | `compiler.hir` | Generic inference and monomorphization now live in `stage1/crates/axiomc/src/hir/generics.rs`; public HIR model types now live in `stage1/crates/axiomc/src/hir/model.rs`; syntax-to-HIR type/literal lowering now lives in `stage1/crates/axiomc/src/hir/types.rs`; type-name, aggregate, and trait-use definition checks now live in `stage1/crates/axiomc/src/hir/definitions.rs`; function/method signatures and trait impl signature validation now live in `stage1/crates/axiomc/src/hir/signatures.rs`; capability analysis now lives in `stage1/crates/axiomc/src/hir/capabilities.rs`; expression typing helpers now live in `stage1/crates/axiomc/src/hir/expressions.rs`; ownership and borrow-state helpers now live in `stage1/crates/axiomc/src/hir/ownership.rs`; property clause checks now live in `stage1/crates/axiomc/src/hir/properties.rs`; reachability/call-graph discovery now lives in `stage1/crates/axiomc/src/hir/reachability.rs`; diagnostic recovery helpers now live in `stage1/crates/axiomc/src/hir/diagnostics.rs`; monomorphized symbol and intrinsic helpers now live in `stage1/crates/axiomc/src/hir/symbols.rs`; source-location helpers now live in `stage1/crates/axiomc/src/hir/source_locations.rs`; return-flow analysis now lives in `stage1/crates/axiomc/src/hir/control_flow.rs`; const-array length validation now lives in `stage1/crates/axiomc/src/hir/const_arrays.rs`; const-function validation now lives in `stage1/crates/axiomc/src/hir/const_functions.rs`; match lowering now lives in `stage1/crates/axiomc/src/hir/matches.rs`; enum variant constructor helpers now live in `stage1/crates/axiomc/src/hir/variants.rs`; async runtime intrinsic lowering now lives in `stage1/crates/axiomc/src/hir/async_runtime.rs`; map intrinsic lowering now lives in `stage1/crates/axiomc/src/hir/maps.rs`; HIR boundary regression tests now live in `stage1/crates/axiomc/tests/hir_unit.rs`; continue splitting remaining HIR helper clusters behind the package APIs in `docs/compiler-hir-ownership-capability.md`. |
 | 7 | `stage1/crates/axiomc/src/hir/generics.rs` | 4,205 | `compiler.hir` | Keep generic call inference, trait-bound validation, aggregate monomorphization, and generic call rewriting isolated from the main HIR lowering facade. |
 
 ## Ratchet Ceilings
@@ -129,10 +132,10 @@ matching ceiling in this table in the same PR.
 
 | Tracked item | Ceiling |
 | --- | ---: |
-| `summary.top_file_line_share` | 0.8341 |
-| `summary.top_file_lines` | 74142 |
+| `summary.top_file_line_share` | 0.8328 |
+| `summary.top_file_lines` | 74031 |
 | `stage1/crates/axiomc/src/cranelift_backend.rs` | 28366 |
-| `stage1/crates/axiomc/src/hir.rs` | 5953 |
+| `stage1/crates/axiomc/src/hir.rs` | 5842 |
 | `stage1/crates/axiomc/src/project.rs` | 10812 |
 | `stage1/crates/axiomc/src/main.rs` | 10678 |
 | `stage1/crates/axiomc/src/codegen.rs` | 7804 |
@@ -140,6 +143,7 @@ matching ceiling in this table in the same PR.
 | `stage1/crates/axiomc/src/hir/async_runtime.rs` | 188 |
 | `stage1/crates/axiomc/src/hir/capabilities.rs` | 773 |
 | `stage1/crates/axiomc/src/hir/const_arrays.rs` | 330 |
+| `stage1/crates/axiomc/src/hir/const_functions.rs` | 117 |
 | `stage1/crates/axiomc/src/hir/control_flow.rs` | 36 |
 | `stage1/crates/axiomc/src/hir/definitions.rs` | 684 |
 | `stage1/crates/axiomc/src/hir/diagnostics.rs` | 28 |
@@ -173,9 +177,10 @@ matching ceiling in this table in the same PR.
    capability analysis, expression typing helpers, ownership/borrow helpers,
    property checks, reachability/call-graph discovery, diagnostic recovery
    helpers, monomorphized symbol/intrinsic helpers, source-location helpers,
-   return-flow analysis, const-array validation, match lowering, enum variant
-   constructor lowering, async runtime intrinsic lowering, and map intrinsic
-   lowering are split; continue with remaining HIR helper clusters.
+   return-flow analysis, const-array validation, const-function validation,
+   match lowering, enum variant constructor lowering, async runtime intrinsic
+   lowering, and map intrinsic lowering are split; continue with remaining HIR
+   helper clusters.
 4. `compiler.commands` and `compiler.package_graph`: separate command envelopes
    from package loading so the snapshot bootstrap can invoke package APIs
    without Cargo assumptions.

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -7,6 +7,7 @@ use std::collections::{HashMap, HashSet};
 mod async_runtime;
 mod capabilities;
 mod const_arrays;
+mod const_functions;
 mod control_flow;
 mod definitions;
 mod diagnostics;
@@ -38,6 +39,7 @@ use self::const_arrays::{
     declared_array_len, eval_const_int_expr, resolve_const_int_decls,
     validate_const_array_lengths_in_program,
 };
+use self::const_functions::validate_const_function_body;
 use self::definitions::{
     VariantInfo, collect_enum_definitions, collect_struct_definitions, collect_trait_definitions,
     collect_type_names, validate_recursive_type_cycles, validate_trait_bounds_in_program,
@@ -407,119 +409,6 @@ fn lower_static_decls(
         });
     }
     Ok(lowered)
-}
-
-fn validate_const_function_body(
-    function: &syntax::Function,
-    functions: &HashMap<String, FunctionSig>,
-) -> Result<(), Diagnostic> {
-    if !function.is_const {
-        return Ok(());
-    }
-    if function.is_async {
-        return Err(Diagnostic::new(
-            "type",
-            format!("const fn {:?} cannot be async", function.name),
-        )
-        .with_span(function.line, function.column));
-    }
-    if function.is_extern {
-        return Err(Diagnostic::new(
-            "type",
-            format!("const fn {:?} cannot be extern", function.name),
-        )
-        .with_span(function.line, function.column));
-    }
-    for stmt in &function.body {
-        validate_const_function_stmt(function, stmt, functions)?;
-    }
-    Ok(())
-}
-
-fn validate_const_function_stmt(
-    function: &syntax::Function,
-    stmt: &syntax::Stmt,
-    functions: &HashMap<String, FunctionSig>,
-) -> Result<(), Diagnostic> {
-    match stmt {
-        syntax::Stmt::Let { expr, .. } | syntax::Stmt::Return { expr, .. } => {
-            validate_const_function_expr(function, expr, functions)
-        }
-        syntax::Stmt::If {
-            cond,
-            then_block,
-            else_block,
-            ..
-        } => {
-            validate_const_function_expr(function, cond, functions)?;
-            for stmt in then_block {
-                validate_const_function_stmt(function, stmt, functions)?;
-            }
-            if let Some(else_block) = else_block {
-                for stmt in else_block {
-                    validate_const_function_stmt(function, stmt, functions)?;
-                }
-            }
-            Ok(())
-        }
-        _ => Err(Diagnostic::new(
-            "type",
-            format!(
-                "const fn {:?} only supports let, if/else, and return statements in stage1",
-                function.name
-            ),
-        )
-        .with_span(stmt.line(), stmt.column())),
-    }
-}
-
-fn validate_const_function_expr(
-    function: &syntax::Function,
-    expr: &syntax::Expr,
-    functions: &HashMap<String, FunctionSig>,
-) -> Result<(), Diagnostic> {
-    match expr {
-        syntax::Expr::Literal(_) | syntax::Expr::VarRef { .. } => Ok(()),
-        syntax::Expr::BinaryAdd { lhs, rhs, .. } | syntax::Expr::BinaryCompare { lhs, rhs, .. } => {
-            validate_const_function_expr(function, lhs, functions)?;
-            validate_const_function_expr(function, rhs, functions)
-        }
-        syntax::Expr::Call { name, args, .. } => {
-            let Some(signature) = functions.get(name) else {
-                return Err(const_function_call_error(function, name, expr));
-            };
-            if !signature.is_const || signature.is_extern {
-                return Err(const_function_call_error(function, name, expr));
-            }
-            for arg in args {
-                validate_const_function_expr(function, arg, functions)?;
-            }
-            Ok(())
-        }
-        _ => Err(Diagnostic::new(
-            "type",
-            format!(
-                "const fn {:?} only supports literals, variables, arithmetic/comparison expressions, and calls to other const fn in stage1",
-                function.name
-            ),
-        )
-        .with_span(expr.line(), expr.column())),
-    }
-}
-
-fn const_function_call_error(
-    function: &syntax::Function,
-    callee: &str,
-    expr: &syntax::Expr,
-) -> Diagnostic {
-    Diagnostic::new(
-        "type",
-        format!(
-            "const fn {:?} can only call other const fn; {callee:?} is a host runtime or non-const call",
-            function.name
-        ),
-    )
-    .with_span(expr.line(), expr.column())
 }
 
 fn lower_function(

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -4,6 +4,7 @@ use crate::manifest::{CapabilityConfig, CapabilityKind};
 use crate::syntax;
 use std::collections::{HashMap, HashSet};
 
+mod async_runtime;
 mod capabilities;
 mod const_arrays;
 mod control_flow;
@@ -22,6 +23,7 @@ mod symbols;
 mod types;
 mod variants;
 
+use self::async_runtime::lower_async_runtime_intrinsic;
 use self::capabilities::{
     is_stdlib_http_get_wrapper, is_stdlib_process_wrapper, net_binding_origin_from_expr,
     require_capability, stdlib_dynamic_http_socket_allowed, stdlib_dynamic_net_host_allowed,
@@ -5819,193 +5821,6 @@ fn collect_var_refs(expr: &syntax::Expr, refs: &mut HashSet<String>) {
         }
         syntax::Expr::Literal(_) => {}
     }
-}
-
-fn lower_async_runtime_intrinsic(
-    name: &str,
-    type_args: &[syntax::TypeName],
-    args: &[syntax::Expr],
-    line: usize,
-    column: usize,
-    env: &mut HashMap<String, Binding>,
-    ctx: &LowerContext<'_>,
-) -> Result<Expr, Diagnostic> {
-    require_capability(ctx.capabilities, CapabilityKind::Async, name, line, column)?;
-    if type_args.len() != 1 {
-        return Err(Diagnostic::new(
-            "type",
-            format!(
-                "{name} expects 1 explicit type argument, got {}",
-                type_args.len()
-            ),
-        )
-        .with_span(line, column));
-    }
-    let value_ty = lower_type(
-        &type_args[0],
-        ctx.structs,
-        ctx.enums,
-        ctx.aliases,
-        ctx.consts,
-        line,
-        column,
-    )?;
-    let expected_len = match name {
-        "async_channel" => 0,
-        "async_ready"
-        | "async_is_canceled"
-        | "async_spawn"
-        | "async_join"
-        | "async_cancel"
-        | "async_recv"
-        | "async_selected"
-        | "async_selected_value" => 1,
-        "async_timeout" | "async_send" | "async_select" => 2,
-        _ => unreachable!("async runtime intrinsic checked before lowering"),
-    };
-    if args.len() != expected_len {
-        return Err(Diagnostic::new(
-            "type",
-            format!(
-                "{name} expects {expected_len} arguments, got {}",
-                args.len()
-            ),
-        )
-        .with_span(line, column));
-    }
-
-    let lowered_args = match name {
-        "async_ready" => {
-            let value = lower_expr_with_expected(&args[0], Some(&value_ty), env, ctx)?;
-            if value.ty() != &value_ty {
-                return Err(Diagnostic::new(
-                    "type",
-                    format!("{name} expects value type {value_ty}, got {}", value.ty()),
-                )
-                .with_span(args[0].line(), args[0].column()));
-            }
-            move_lowered_value(&value, env)?;
-            vec![value]
-        }
-        "async_spawn" | "async_cancel" | "async_is_canceled" => {
-            let expected = Type::Task(Box::new(value_ty.clone()));
-            let task = lower_expr_with_expected(&args[0], Some(&expected), env, ctx)?;
-            if task.ty() != &expected {
-                return Err(Diagnostic::new(
-                    "type",
-                    format!("{name} expects {expected}, got {}", task.ty()),
-                )
-                .with_span(args[0].line(), args[0].column()));
-            }
-            move_lowered_value(&task, env)?;
-            vec![task]
-        }
-        "async_join" => {
-            let expected = Type::JoinHandle(Box::new(value_ty.clone()));
-            let handle = lower_expr_with_expected(&args[0], Some(&expected), env, ctx)?;
-            if handle.ty() != &expected {
-                return Err(Diagnostic::new(
-                    "type",
-                    format!("{name} expects {expected}, got {}", handle.ty()),
-                )
-                .with_span(args[0].line(), args[0].column()));
-            }
-            move_lowered_value(&handle, env)?;
-            vec![handle]
-        }
-        "async_timeout" => {
-            let expected = Type::Task(Box::new(value_ty.clone()));
-            let task = lower_expr_with_expected(&args[0], Some(&expected), env, ctx)?;
-            let ms = lower_expr_with_expected(&args[1], Some(&Type::Int), env, ctx)?;
-            if task.ty() != &expected || ms.ty() != &Type::Int {
-                return Err(Diagnostic::new(
-                    "type",
-                    format!("{name} expects Task<{value_ty}> and int arguments"),
-                )
-                .with_span(line, column));
-            }
-            move_lowered_value(&task, env)?;
-            vec![task, ms]
-        }
-        "async_channel" => Vec::new(),
-        "async_send" => {
-            let channel_ty = Type::AsyncChannel(Box::new(value_ty.clone()));
-            let channel = lower_expr_with_expected(&args[0], Some(&channel_ty), env, ctx)?;
-            let value = lower_expr_with_expected(&args[1], Some(&value_ty), env, ctx)?;
-            if channel.ty() != &channel_ty || value.ty() != &value_ty {
-                return Err(Diagnostic::new(
-                    "type",
-                    format!("{name} expects AsyncChannel<{value_ty}> and {value_ty} arguments"),
-                )
-                .with_span(line, column));
-            }
-            move_lowered_value(&channel, env)?;
-            move_lowered_value(&value, env)?;
-            vec![channel, value]
-        }
-        "async_recv" => {
-            let channel_ty = Type::AsyncChannel(Box::new(value_ty.clone()));
-            let channel = lower_expr_with_expected(&args[0], Some(&channel_ty), env, ctx)?;
-            if channel.ty() != &channel_ty {
-                return Err(Diagnostic::new(
-                    "type",
-                    format!("{name} expects {channel_ty}, got {}", channel.ty()),
-                )
-                .with_span(args[0].line(), args[0].column()));
-            }
-            move_lowered_value(&channel, env)?;
-            vec![channel]
-        }
-        "async_select" => {
-            let task_ty = Type::Task(Box::new(Type::Option(Box::new(value_ty.clone()))));
-            let left = lower_expr_with_expected(&args[0], Some(&task_ty), env, ctx)?;
-            let right = lower_expr_with_expected(&args[1], Some(&task_ty), env, ctx)?;
-            if left.ty() != &task_ty || right.ty() != &task_ty {
-                return Err(Diagnostic::new(
-                    "type",
-                    format!("{name} expects two {task_ty} arguments"),
-                )
-                .with_span(line, column));
-            }
-            move_lowered_value(&left, env)?;
-            move_lowered_value(&right, env)?;
-            vec![left, right]
-        }
-        "async_selected" | "async_selected_value" => {
-            let result_ty = Type::SelectResult(Box::new(value_ty.clone()));
-            let result = lower_expr_with_expected(&args[0], Some(&result_ty), env, ctx)?;
-            if result.ty() != &result_ty {
-                return Err(Diagnostic::new(
-                    "type",
-                    format!("{name} expects {result_ty}, got {}", result.ty()),
-                )
-                .with_span(args[0].line(), args[0].column()));
-            }
-            move_lowered_value(&result, env)?;
-            vec![result]
-        }
-        _ => unreachable!("async runtime intrinsic checked before lowering"),
-    };
-
-    let ty = match name {
-        "async_ready" | "async_cancel" | "async_join" => Type::Task(Box::new(value_ty)),
-        "async_spawn" => Type::JoinHandle(Box::new(value_ty)),
-        "async_is_canceled" => Type::Bool,
-        "async_timeout" => Type::Task(Box::new(Type::Option(Box::new(value_ty)))),
-        "async_channel" => Type::AsyncChannel(Box::new(value_ty)),
-        "async_send" => Type::Task(Box::new(Type::AsyncChannel(Box::new(value_ty)))),
-        "async_recv" => Type::Task(Box::new(Type::Option(Box::new(value_ty)))),
-        "async_select" => Type::Task(Box::new(Type::SelectResult(Box::new(value_ty)))),
-        "async_selected" => Type::Int,
-        "async_selected_value" => Type::Option(Box::new(value_ty)),
-        _ => unreachable!("async runtime intrinsic checked before lowering"),
-    };
-    Ok(Expr::Call {
-        span: SourceSpan::point(line, column),
-        name: name.to_string(),
-        args: lowered_args,
-        ty,
-    })
 }
 
 fn lower_map_lookup_intrinsic(

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -12,6 +12,7 @@ mod definitions;
 mod diagnostics;
 mod expressions;
 mod generics;
+mod maps;
 mod matches;
 mod model;
 mod ownership;
@@ -51,6 +52,7 @@ use self::expressions::{
     numeric_method_return_ty, static_bool_value,
 };
 use self::generics::monomorphize_program;
+use self::maps::lower_map_lookup_intrinsic;
 use self::matches::{
     MatchArmInput, MatchExprArmInput, lower_match_expr, lower_match_stmt, match_variants,
 };
@@ -5821,129 +5823,6 @@ fn collect_var_refs(expr: &syntax::Expr, refs: &mut HashSet<String>) {
         }
         syntax::Expr::Literal(_) => {}
     }
-}
-
-fn lower_map_lookup_intrinsic(
-    name: &str,
-    type_args: &[syntax::TypeName],
-    args: &[syntax::Expr],
-    line: usize,
-    column: usize,
-    env: &mut HashMap<String, Binding>,
-    ctx: &LowerContext<'_>,
-) -> Result<Expr, Diagnostic> {
-    if !type_args.is_empty() && type_args.len() != 2 {
-        return Err(Diagnostic::new(
-            "type",
-            format!(
-                "{name} expects 0 or 2 type arguments, got {}",
-                type_args.len()
-            ),
-        )
-        .with_span(line, column));
-    }
-    let expected_args = if matches!(name, "map_keys" | "keys") {
-        1
-    } else if name == "get_or_default" {
-        3
-    } else {
-        2
-    };
-    if args.len() != expected_args {
-        return Err(Diagnostic::new(
-            "type",
-            format!(
-                "{name} expects {expected_args} arguments, got {}",
-                args.len()
-            ),
-        )
-        .with_span(line, column));
-    }
-    let lowered_map = lower_expr(&args[0], env, ctx)?;
-    let Type::Map(key_ty, value_ty) = lowered_map.ty() else {
-        return Err(Diagnostic::new(
-            "type",
-            format!("{name} expects a map value, got {}", lowered_map.ty()),
-        )
-        .with_span(args[0].line(), args[0].column()));
-    };
-    let key_ty = (*key_ty.clone()).clone();
-    let value_ty = (*value_ty.clone()).clone();
-    if let [expected_key, expected_value] = type_args {
-        let expected_key = lower_type(
-            expected_key,
-            ctx.structs,
-            ctx.enums,
-            ctx.aliases,
-            ctx.consts,
-            line,
-            column,
-        )?;
-        let expected_value = lower_type(
-            expected_value,
-            ctx.structs,
-            ctx.enums,
-            ctx.aliases,
-            ctx.consts,
-            line,
-            column,
-        )?;
-        if expected_key != key_ty || expected_value != value_ty {
-            return Err(Diagnostic::new(
-                "type",
-                format!(
-                    "{name} type arguments expect {{{expected_key}: {expected_value}}}, got {}",
-                    lowered_map.ty()
-                ),
-            )
-            .with_span(line, column));
-        }
-    }
-    if matches!(name, "map_keys" | "keys") {
-        move_lowered_value(&lowered_map, env)?;
-        return Ok(Expr::Call {
-            span: SourceSpan::point(line, column),
-            name: name.to_string(),
-            args: vec![lowered_map],
-            ty: Type::Array(Box::new(key_ty), None),
-        });
-    }
-    let lowered_key = lower_expr_with_expected(&args[1], Some(&key_ty), env, ctx)?;
-    if lowered_key.ty() != &key_ty {
-        return Err(Diagnostic::new(
-            "type",
-            format!("{name} expects key type {key_ty}, got {}", lowered_key.ty()),
-        )
-        .with_span(args[1].line(), args[1].column()));
-    }
-    let mut lowered_args = vec![lowered_map, lowered_key];
-    if name == "get_or_default" {
-        let lowered_default = lower_expr_with_expected(&args[2], Some(&value_ty), env, ctx)?;
-        if lowered_default.ty() != &value_ty {
-            return Err(Diagnostic::new(
-                "type",
-                format!(
-                    "{name} expects default type {value_ty}, got {}",
-                    lowered_default.ty()
-                ),
-            )
-            .with_span(args[2].line(), args[2].column()));
-        }
-        move_lowered_value(&lowered_default, env)?;
-        lowered_args.push(lowered_default);
-    }
-    move_lowered_value(&lowered_args[0], env)?;
-    move_lowered_value(&lowered_args[1], env)?;
-    Ok(Expr::Call {
-        span: SourceSpan::point(line, column),
-        name: name.to_string(),
-        args: lowered_args,
-        ty: match name {
-            "map_get" | "get" => Type::Option(Box::new(value_ty)),
-            "get_or_default" => value_ty,
-            _ => Type::Bool,
-        },
-    })
 }
 
 fn lower_projection_base_expr(

--- a/stage1/crates/axiomc/src/hir/async_runtime.rs
+++ b/stage1/crates/axiomc/src/hir/async_runtime.rs
@@ -1,0 +1,188 @@
+use super::*;
+
+pub(super) fn lower_async_runtime_intrinsic(
+    name: &str,
+    type_args: &[syntax::TypeName],
+    args: &[syntax::Expr],
+    line: usize,
+    column: usize,
+    env: &mut HashMap<String, Binding>,
+    ctx: &LowerContext<'_>,
+) -> Result<Expr, Diagnostic> {
+    require_capability(ctx.capabilities, CapabilityKind::Async, name, line, column)?;
+    if type_args.len() != 1 {
+        return Err(Diagnostic::new(
+            "type",
+            format!(
+                "{name} expects 1 explicit type argument, got {}",
+                type_args.len()
+            ),
+        )
+        .with_span(line, column));
+    }
+    let value_ty = lower_type(
+        &type_args[0],
+        ctx.structs,
+        ctx.enums,
+        ctx.aliases,
+        ctx.consts,
+        line,
+        column,
+    )?;
+    let expected_len = match name {
+        "async_channel" => 0,
+        "async_ready"
+        | "async_is_canceled"
+        | "async_spawn"
+        | "async_join"
+        | "async_cancel"
+        | "async_recv"
+        | "async_selected"
+        | "async_selected_value" => 1,
+        "async_timeout" | "async_send" | "async_select" => 2,
+        _ => unreachable!("async runtime intrinsic checked before lowering"),
+    };
+    if args.len() != expected_len {
+        return Err(Diagnostic::new(
+            "type",
+            format!(
+                "{name} expects {expected_len} arguments, got {}",
+                args.len()
+            ),
+        )
+        .with_span(line, column));
+    }
+
+    let lowered_args = match name {
+        "async_ready" => {
+            let value = lower_expr_with_expected(&args[0], Some(&value_ty), env, ctx)?;
+            if value.ty() != &value_ty {
+                return Err(Diagnostic::new(
+                    "type",
+                    format!("{name} expects value type {value_ty}, got {}", value.ty()),
+                )
+                .with_span(args[0].line(), args[0].column()));
+            }
+            move_lowered_value(&value, env)?;
+            vec![value]
+        }
+        "async_spawn" | "async_cancel" | "async_is_canceled" => {
+            let expected = Type::Task(Box::new(value_ty.clone()));
+            let task = lower_expr_with_expected(&args[0], Some(&expected), env, ctx)?;
+            if task.ty() != &expected {
+                return Err(Diagnostic::new(
+                    "type",
+                    format!("{name} expects {expected}, got {}", task.ty()),
+                )
+                .with_span(args[0].line(), args[0].column()));
+            }
+            move_lowered_value(&task, env)?;
+            vec![task]
+        }
+        "async_join" => {
+            let expected = Type::JoinHandle(Box::new(value_ty.clone()));
+            let handle = lower_expr_with_expected(&args[0], Some(&expected), env, ctx)?;
+            if handle.ty() != &expected {
+                return Err(Diagnostic::new(
+                    "type",
+                    format!("{name} expects {expected}, got {}", handle.ty()),
+                )
+                .with_span(args[0].line(), args[0].column()));
+            }
+            move_lowered_value(&handle, env)?;
+            vec![handle]
+        }
+        "async_timeout" => {
+            let expected = Type::Task(Box::new(value_ty.clone()));
+            let task = lower_expr_with_expected(&args[0], Some(&expected), env, ctx)?;
+            let ms = lower_expr_with_expected(&args[1], Some(&Type::Int), env, ctx)?;
+            if task.ty() != &expected || ms.ty() != &Type::Int {
+                return Err(Diagnostic::new(
+                    "type",
+                    format!("{name} expects Task<{value_ty}> and int arguments"),
+                )
+                .with_span(line, column));
+            }
+            move_lowered_value(&task, env)?;
+            vec![task, ms]
+        }
+        "async_channel" => Vec::new(),
+        "async_send" => {
+            let channel_ty = Type::AsyncChannel(Box::new(value_ty.clone()));
+            let channel = lower_expr_with_expected(&args[0], Some(&channel_ty), env, ctx)?;
+            let value = lower_expr_with_expected(&args[1], Some(&value_ty), env, ctx)?;
+            if channel.ty() != &channel_ty || value.ty() != &value_ty {
+                return Err(Diagnostic::new(
+                    "type",
+                    format!("{name} expects AsyncChannel<{value_ty}> and {value_ty} arguments"),
+                )
+                .with_span(line, column));
+            }
+            move_lowered_value(&channel, env)?;
+            move_lowered_value(&value, env)?;
+            vec![channel, value]
+        }
+        "async_recv" => {
+            let channel_ty = Type::AsyncChannel(Box::new(value_ty.clone()));
+            let channel = lower_expr_with_expected(&args[0], Some(&channel_ty), env, ctx)?;
+            if channel.ty() != &channel_ty {
+                return Err(Diagnostic::new(
+                    "type",
+                    format!("{name} expects {channel_ty}, got {}", channel.ty()),
+                )
+                .with_span(args[0].line(), args[0].column()));
+            }
+            move_lowered_value(&channel, env)?;
+            vec![channel]
+        }
+        "async_select" => {
+            let task_ty = Type::Task(Box::new(Type::Option(Box::new(value_ty.clone()))));
+            let left = lower_expr_with_expected(&args[0], Some(&task_ty), env, ctx)?;
+            let right = lower_expr_with_expected(&args[1], Some(&task_ty), env, ctx)?;
+            if left.ty() != &task_ty || right.ty() != &task_ty {
+                return Err(Diagnostic::new(
+                    "type",
+                    format!("{name} expects two {task_ty} arguments"),
+                )
+                .with_span(line, column));
+            }
+            move_lowered_value(&left, env)?;
+            move_lowered_value(&right, env)?;
+            vec![left, right]
+        }
+        "async_selected" | "async_selected_value" => {
+            let result_ty = Type::SelectResult(Box::new(value_ty.clone()));
+            let result = lower_expr_with_expected(&args[0], Some(&result_ty), env, ctx)?;
+            if result.ty() != &result_ty {
+                return Err(Diagnostic::new(
+                    "type",
+                    format!("{name} expects {result_ty}, got {}", result.ty()),
+                )
+                .with_span(args[0].line(), args[0].column()));
+            }
+            move_lowered_value(&result, env)?;
+            vec![result]
+        }
+        _ => unreachable!("async runtime intrinsic checked before lowering"),
+    };
+
+    let ty = match name {
+        "async_ready" | "async_cancel" | "async_join" => Type::Task(Box::new(value_ty)),
+        "async_spawn" => Type::JoinHandle(Box::new(value_ty)),
+        "async_is_canceled" => Type::Bool,
+        "async_timeout" => Type::Task(Box::new(Type::Option(Box::new(value_ty)))),
+        "async_channel" => Type::AsyncChannel(Box::new(value_ty)),
+        "async_send" => Type::Task(Box::new(Type::AsyncChannel(Box::new(value_ty)))),
+        "async_recv" => Type::Task(Box::new(Type::Option(Box::new(value_ty)))),
+        "async_select" => Type::Task(Box::new(Type::SelectResult(Box::new(value_ty)))),
+        "async_selected" => Type::Int,
+        "async_selected_value" => Type::Option(Box::new(value_ty)),
+        _ => unreachable!("async runtime intrinsic checked before lowering"),
+    };
+    Ok(Expr::Call {
+        span: SourceSpan::point(line, column),
+        name: name.to_string(),
+        args: lowered_args,
+        ty,
+    })
+}

--- a/stage1/crates/axiomc/src/hir/const_functions.rs
+++ b/stage1/crates/axiomc/src/hir/const_functions.rs
@@ -1,0 +1,117 @@
+use super::signatures::FunctionSig;
+use crate::diagnostics::Diagnostic;
+use crate::syntax;
+use std::collections::HashMap;
+
+pub(super) fn validate_const_function_body(
+    function: &syntax::Function,
+    functions: &HashMap<String, FunctionSig>,
+) -> Result<(), Diagnostic> {
+    if !function.is_const {
+        return Ok(());
+    }
+    if function.is_async {
+        return Err(Diagnostic::new(
+            "type",
+            format!("const fn {:?} cannot be async", function.name),
+        )
+        .with_span(function.line, function.column));
+    }
+    if function.is_extern {
+        return Err(Diagnostic::new(
+            "type",
+            format!("const fn {:?} cannot be extern", function.name),
+        )
+        .with_span(function.line, function.column));
+    }
+    for stmt in &function.body {
+        validate_const_function_stmt(function, stmt, functions)?;
+    }
+    Ok(())
+}
+
+fn validate_const_function_stmt(
+    function: &syntax::Function,
+    stmt: &syntax::Stmt,
+    functions: &HashMap<String, FunctionSig>,
+) -> Result<(), Diagnostic> {
+    match stmt {
+        syntax::Stmt::Let { expr, .. } | syntax::Stmt::Return { expr, .. } => {
+            validate_const_function_expr(function, expr, functions)
+        }
+        syntax::Stmt::If {
+            cond,
+            then_block,
+            else_block,
+            ..
+        } => {
+            validate_const_function_expr(function, cond, functions)?;
+            for stmt in then_block {
+                validate_const_function_stmt(function, stmt, functions)?;
+            }
+            if let Some(else_block) = else_block {
+                for stmt in else_block {
+                    validate_const_function_stmt(function, stmt, functions)?;
+                }
+            }
+            Ok(())
+        }
+        _ => Err(Diagnostic::new(
+            "type",
+            format!(
+                "const fn {:?} only supports let, if/else, and return statements in stage1",
+                function.name
+            ),
+        )
+        .with_span(stmt.line(), stmt.column())),
+    }
+}
+
+fn validate_const_function_expr(
+    function: &syntax::Function,
+    expr: &syntax::Expr,
+    functions: &HashMap<String, FunctionSig>,
+) -> Result<(), Diagnostic> {
+    match expr {
+        syntax::Expr::Literal(_) | syntax::Expr::VarRef { .. } => Ok(()),
+        syntax::Expr::BinaryAdd { lhs, rhs, .. } | syntax::Expr::BinaryCompare { lhs, rhs, .. } => {
+            validate_const_function_expr(function, lhs, functions)?;
+            validate_const_function_expr(function, rhs, functions)
+        }
+        syntax::Expr::Call { name, args, .. } => {
+            let Some(signature) = functions.get(name) else {
+                return Err(const_function_call_error(function, name, expr));
+            };
+            if !signature.is_const || signature.is_extern {
+                return Err(const_function_call_error(function, name, expr));
+            }
+            for arg in args {
+                validate_const_function_expr(function, arg, functions)?;
+            }
+            Ok(())
+        }
+        _ => Err(Diagnostic::new(
+            "type",
+            format!(
+                "const fn {:?} only supports literals, variables, arithmetic/comparison expressions, and calls to other const fn in stage1",
+                function.name
+            ),
+        )
+        .with_span(expr.line(), expr.column())),
+    }
+}
+
+fn const_function_call_error(
+    function: &syntax::Function,
+    callee: &str,
+    expr: &syntax::Expr,
+) -> Diagnostic {
+    Diagnostic::new(
+        "type",
+        format!(
+            "const fn {:?} can only call other const fn; {callee:?} is a host runtime or non-const call",
+            function.name
+        ),
+    )
+    .with_span(expr.line(), expr.column())
+}

--- a/stage1/crates/axiomc/src/hir/maps.rs
+++ b/stage1/crates/axiomc/src/hir/maps.rs
@@ -1,0 +1,124 @@
+use super::*;
+
+pub(super) fn lower_map_lookup_intrinsic(
+    name: &str,
+    type_args: &[syntax::TypeName],
+    args: &[syntax::Expr],
+    line: usize,
+    column: usize,
+    env: &mut HashMap<String, Binding>,
+    ctx: &LowerContext<'_>,
+) -> Result<Expr, Diagnostic> {
+    if !type_args.is_empty() && type_args.len() != 2 {
+        return Err(Diagnostic::new(
+            "type",
+            format!(
+                "{name} expects 0 or 2 type arguments, got {}",
+                type_args.len()
+            ),
+        )
+        .with_span(line, column));
+    }
+    let expected_args = if matches!(name, "map_keys" | "keys") {
+        1
+    } else if name == "get_or_default" {
+        3
+    } else {
+        2
+    };
+    if args.len() != expected_args {
+        return Err(Diagnostic::new(
+            "type",
+            format!(
+                "{name} expects {expected_args} arguments, got {}",
+                args.len()
+            ),
+        )
+        .with_span(line, column));
+    }
+    let lowered_map = lower_expr(&args[0], env, ctx)?;
+    let Type::Map(key_ty, value_ty) = lowered_map.ty() else {
+        return Err(Diagnostic::new(
+            "type",
+            format!("{name} expects a map value, got {}", lowered_map.ty()),
+        )
+        .with_span(args[0].line(), args[0].column()));
+    };
+    let key_ty = (*key_ty.clone()).clone();
+    let value_ty = (*value_ty.clone()).clone();
+    if let [expected_key, expected_value] = type_args {
+        let expected_key = lower_type(
+            expected_key,
+            ctx.structs,
+            ctx.enums,
+            ctx.aliases,
+            ctx.consts,
+            line,
+            column,
+        )?;
+        let expected_value = lower_type(
+            expected_value,
+            ctx.structs,
+            ctx.enums,
+            ctx.aliases,
+            ctx.consts,
+            line,
+            column,
+        )?;
+        if expected_key != key_ty || expected_value != value_ty {
+            return Err(Diagnostic::new(
+                "type",
+                format!(
+                    "{name} type arguments expect {{{expected_key}: {expected_value}}}, got {}",
+                    lowered_map.ty()
+                ),
+            )
+            .with_span(line, column));
+        }
+    }
+    if matches!(name, "map_keys" | "keys") {
+        move_lowered_value(&lowered_map, env)?;
+        return Ok(Expr::Call {
+            span: SourceSpan::point(line, column),
+            name: name.to_string(),
+            args: vec![lowered_map],
+            ty: Type::Array(Box::new(key_ty), None),
+        });
+    }
+    let lowered_key = lower_expr_with_expected(&args[1], Some(&key_ty), env, ctx)?;
+    if lowered_key.ty() != &key_ty {
+        return Err(Diagnostic::new(
+            "type",
+            format!("{name} expects key type {key_ty}, got {}", lowered_key.ty()),
+        )
+        .with_span(args[1].line(), args[1].column()));
+    }
+    let mut lowered_args = vec![lowered_map, lowered_key];
+    if name == "get_or_default" {
+        let lowered_default = lower_expr_with_expected(&args[2], Some(&value_ty), env, ctx)?;
+        if lowered_default.ty() != &value_ty {
+            return Err(Diagnostic::new(
+                "type",
+                format!(
+                    "{name} expects default type {value_ty}, got {}",
+                    lowered_default.ty()
+                ),
+            )
+            .with_span(args[2].line(), args[2].column()));
+        }
+        move_lowered_value(&lowered_default, env)?;
+        lowered_args.push(lowered_default);
+    }
+    move_lowered_value(&lowered_args[0], env)?;
+    move_lowered_value(&lowered_args[1], env)?;
+    Ok(Expr::Call {
+        span: SourceSpan::point(line, column),
+        name: name.to_string(),
+        args: lowered_args,
+        ty: match name {
+            "map_get" | "get" => Type::Option(Box::new(value_ty)),
+            "get_or_default" => value_ty,
+            _ => Type::Bool,
+        },
+    })
+}


### PR DESCRIPTION
## Summary

- Move HIR async runtime intrinsic capability and type lowering into `stage1/crates/axiomc/src/hir/async_runtime.rs`.
- Keep async runtime capability validation inside the parent HIR module with `pub(super)` helper access.
- Lower the compiler-source monolith ratchet ceilings again: `hir.rs` is now 6,074 lines, top-file lines are 74,263, and top-file share is 0.8355 on this stack.

## Governing Issue

Refs #1254.

Stacked on #1345, which is stacked on #1344, #1343, #1342, #1341, #1340, and #1295. This PR should be reviewed after those base PRs.

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Commands run:

- `cargo fmt --manifest-path stage1/crates/axiomc/Cargo.toml` - passed
- `python3 scripts/ci/report-compiler-source-monoliths.py --json --check-plan --check-ratchet` - passed
- `make stage1-hir-boundary` - passed
- `make stage1-compiler-source-monoliths-test` - passed
- `make stage1-compiler-source-monoliths` - passed
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib hir::boundary_tests -- --nocapture` - passed, 25 tests
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib` - passed, 670 passed / 21 ignored
- `git diff --check` - passed
- `git diff --cached --check` - passed

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

No contributor or PR guidance files are changed.

Auto-merge is intentionally not enabled while this PR is stacked. It should become eligible after #1295, #1340, #1341, #1342, #1343, #1344, and #1345 land or after this branch is rebased onto `main`.

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Semantic node types: none.

Schemas: none.

Evidence: `docs/compiler-source-decomposition-plan.md` records the async-runtime extraction and lower ratchet ceilings.

Rust capture: satisfied. This reduces Rust-hosted HIR facade size while preserving the AxiOM `compiler.hir` boundary as the durable ownership model; it does not define async semantics in Rust-specific terms.

Agent-facing inspection impact: `make stage1-compiler-source-monoliths` reports the lower HIR facade counts on this stack.

## Flow Contract

- Owner lane: Daedalus
- Repair owner: Codex
- Autonomy class: Class 2 - Review-gated autonomous
- Risk class: Low

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is appropriate when gates pass

Blocker: #1295, #1340, #1341, #1342, #1343, #1344, and #1345 must land first, then this branch should be rebased or retargeted to `main`.

## Merge Automation

- [x] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

Auto-merge is unsafe while this PR is stacked.

## Notes

- This PR is intentionally narrow: it moves async runtime intrinsic lowering out of the HIR facade without changing HIR behavior.
