### PR TITLE
Extract HIR const function validation

### DIFF
--- a/docs/compiler-source-decomposition-plan.md
+++ b/docs/compiler-source-decomposition-plan.md
@@ -100,6 +100,9 @@ keeping async capability validation inside the `compiler.hir` boundary.
 The HIR map-intrinsic extraction then moved map lookup/key/default intrinsic
 type and ownership lowering into `stage1/crates/axiomc/src/hir/maps.rs`,
 keeping collection intrinsic validation inside the `compiler.hir` boundary.
+The HIR const-function extraction then moved const function body and expression
+validation into `stage1/crates/axiomc/src/hir/const_functions.rs`, keeping
+compile-time function restrictions inside the `compiler.hir` boundary.
 The direct-native runtime-serving stack then raised the native backend baseline
 before this ratchet merged; the ceilings below reflect that post-merge snapshot
 so future backend growth must be paid down or accompanied by an explicit
@@ -116,7 +119,7 @@ Snapshot from 2026-07-02:
 | 3 | `stage1/crates/axiomc/src/main.rs` | 10,678 | `compiler.commands` | Move command parsing, JSON envelope construction, check/build/run/test/doc/trace orchestration, and exit handling behind `docs/compiler-command-lsp-packages.md` APIs. |
 | 4 | `stage1/crates/axiomc/src/codegen.rs` | 7,804 | `compiler.backend.generated_rust`, `compiler.backend.contracts` | Isolate generated-Rust compatibility emission from backend target selection and unsupported-feature contracts. |
 | 5 | `stage1/crates/axiomc/src/syntax.rs` | 6,324 | `compiler.syntax`, `compiler.diagnostics` | Split lexer/parser, parse recovery, source spans, macros, and syntax diagnostics behind the syntax boundary. |
-| 6 | `stage1/crates/axiomc/src/hir.rs` | 5,953 | `compiler.hir` | Generic inference and monomorphization now live in `stage1/crates/axiomc/src/hir/generics.rs`; public HIR model types now live in `stage1/crates/axiomc/src/hir/model.rs`; syntax-to-HIR type/literal lowering now lives in `stage1/crates/axiomc/src/hir/types.rs`; type-name, aggregate, and trait-use definition checks now live in `stage1/crates/axiomc/src/hir/definitions.rs`; function/method signatures and trait impl signature validation now live in `stage1/crates/axiomc/src/hir/signatures.rs`; capability analysis now lives in `stage1/crates/axiomc/src/hir/capabilities.rs`; expression typing helpers now live in `stage1/crates/axiomc/src/hir/expressions.rs`; ownership and borrow-state helpers now live in `stage1/crates/axiomc/src/hir/ownership.rs`; property clause checks now live in `stage1/crates/axiomc/src/hir/properties.rs`; reachability/call-graph discovery now lives in `stage1/crates/axiomc/src/hir/reachability.rs`; diagnostic recovery helpers now live in `stage1/crates/axiomc/src/hir/diagnostics.rs`; monomorphized symbol and intrinsic helpers now live in `stage1/crates/axiomc/src/hir/symbols.rs`; source-location helpers now live in `stage1/crates/axiomc/src/hir/source_locations.rs`; return-flow analysis now lives in `stage1/crates/axiomc/src/hir/control_flow.rs`; const-array length validation now lives in `stage1/crates/axiomc/src/hir/const_arrays.rs`; match lowering now lives in `stage1/crates/axiomc/src/hir/matches.rs`; enum variant constructor helpers now live in `stage1/crates/axiomc/src/hir/variants.rs`; async runtime intrinsic lowering now lives in `stage1/crates/axiomc/src/hir/async_runtime.rs`; map intrinsic lowering now lives in `stage1/crates/axiomc/src/hir/maps.rs`; HIR boundary regression tests now live in `stage1/crates/axiomc/tests/hir_unit.rs`; continue splitting remaining HIR helper clusters behind the package APIs in `docs/compiler-hir-ownership-capability.md`. |
+| 6 | `stage1/crates/axiomc/src/hir.rs` | 5,842 | `compiler.hir` | Generic inference and monomorphization now live in `stage1/crates/axiomc/src/hir/generics.rs`; public HIR model types now live in `stage1/crates/axiomc/src/hir/model.rs`; syntax-to-HIR type/literal lowering now lives in `stage1/crates/axiomc/src/hir/types.rs`; type-name, aggregate, and trait-use definition checks now live in `stage1/crates/axiomc/src/hir/definitions.rs`; function/method signatures and trait impl signature validation now live in `stage1/crates/axiomc/src/hir/signatures.rs`; capability analysis now lives in `stage1/crates/axiomc/src/hir/capabilities.rs`; expression typing helpers now live in `stage1/crates/axiomc/src/hir/expressions.rs`; ownership and borrow-state helpers now live in `stage1/crates/axiomc/src/hir/ownership.rs`; property clause checks now live in `stage1/crates/axiomc/src/hir/properties.rs`; reachability/call-graph discovery now lives in `stage1/crates/axiomc/src/hir/reachability.rs`; diagnostic recovery helpers now live in `stage1/crates/axiomc/src/hir/diagnostics.rs`; monomorphized symbol and intrinsic helpers now live in `stage1/crates/axiomc/src/hir/symbols.rs`; source-location helpers now live in `stage1/crates/axiomc/src/hir/source_locations.rs`; return-flow analysis now lives in `stage1/crates/axiomc/src/hir/control_flow.rs`; const-array length validation now lives in `stage1/crates/axiomc/src/hir/const_arrays.rs`; const-function validation now lives in `stage1/crates/axiomc/src/hir/const_functions.rs`; match lowering now lives in `stage1/crates/axiomc/src/hir/matches.rs`; enum variant constructor helpers now live in `stage1/crates/axiomc/src/hir/variants.rs`; async runtime intrinsic lowering now lives in `stage1/crates/axiomc/src/hir/async_runtime.rs`; map intrinsic lowering now lives in `stage1/crates/axiomc/src/hir/maps.rs`; HIR boundary regression tests now live in `stage1/crates/axiomc/tests/hir_unit.rs`; continue splitting remaining HIR helper clusters behind the package APIs in `docs/compiler-hir-ownership-capability.md`. |
 | 7 | `stage1/crates/axiomc/src/hir/generics.rs` | 4,205 | `compiler.hir` | Keep generic call inference, trait-bound validation, aggregate monomorphization, and generic call rewriting isolated from the main HIR lowering facade. |
 
 ## Ratchet Ceilings
@@ -129,10 +132,10 @@ matching ceiling in this table in the same PR.
 
 | Tracked item | Ceiling |
 | --- | ---: |
-| `summary.top_file_line_share` | 0.8341 |
-| `summary.top_file_lines` | 74142 |
+| `summary.top_file_line_share` | 0.8328 |
+| `summary.top_file_lines` | 74031 |
 | `stage1/crates/axiomc/src/cranelift_backend.rs` | 28366 |
-| `stage1/crates/axiomc/src/hir.rs` | 5953 |
+| `stage1/crates/axiomc/src/hir.rs` | 5842 |
 | `stage1/crates/axiomc/src/project.rs` | 10812 |
 | `stage1/crates/axiomc/src/main.rs` | 10678 |
 | `stage1/crates/axiomc/src/codegen.rs` | 7804 |
@@ -140,6 +143,7 @@ matching ceiling in this table in the same PR.
 | `stage1/crates/axiomc/src/hir/async_runtime.rs` | 188 |
 | `stage1/crates/axiomc/src/hir/capabilities.rs` | 773 |
 | `stage1/crates/axiomc/src/hir/const_arrays.rs` | 330 |
+| `stage1/crates/axiomc/src/hir/const_functions.rs` | 117 |
 | `stage1/crates/axiomc/src/hir/control_flow.rs` | 36 |
 | `stage1/crates/axiomc/src/hir/definitions.rs` | 684 |
 | `stage1/crates/axiomc/src/hir/diagnostics.rs` | 28 |
@@ -173,9 +177,10 @@ matching ceiling in this table in the same PR.
    capability analysis, expression typing helpers, ownership/borrow helpers,
    property checks, reachability/call-graph discovery, diagnostic recovery
    helpers, monomorphized symbol/intrinsic helpers, source-location helpers,
-   return-flow analysis, const-array validation, match lowering, enum variant
-   constructor lowering, async runtime intrinsic lowering, and map intrinsic
-   lowering are split; continue with remaining HIR helper clusters.
+   return-flow analysis, const-array validation, const-function validation,
+   match lowering, enum variant constructor lowering, async runtime intrinsic
+   lowering, and map intrinsic lowering are split; continue with remaining HIR
+   helper clusters.
 4. `compiler.commands` and `compiler.package_graph`: separate command envelopes
    from package loading so the snapshot bootstrap can invoke package APIs
    without Cargo assumptions.

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -7,6 +7,7 @@ use std::collections::{HashMap, HashSet};
 mod async_runtime;
 mod capabilities;
 mod const_arrays;
+mod const_functions;
 mod control_flow;
 mod definitions;
 mod diagnostics;
@@ -38,6 +39,7 @@ use self::const_arrays::{
     declared_array_len, eval_const_int_expr, resolve_const_int_decls,
     validate_const_array_lengths_in_program,
 };
+use self::const_functions::validate_const_function_body;
 use self::definitions::{
     VariantInfo, collect_enum_definitions, collect_struct_definitions, collect_trait_definitions,
     collect_type_names, validate_recursive_type_cycles, validate_trait_bounds_in_program,
@@ -407,119 +409,6 @@ fn lower_static_decls(
         });
     }
     Ok(lowered)
-}
-
-fn validate_const_function_body(
-    function: &syntax::Function,
-    functions: &HashMap<String, FunctionSig>,
-) -> Result<(), Diagnostic> {
-    if !function.is_const {
-        return Ok(());
-    }
-    if function.is_async {
-        return Err(Diagnostic::new(
-            "type",
-            format!("const fn {:?} cannot be async", function.name),
-        )
-        .with_span(function.line, function.column));
-    }
-    if function.is_extern {
-        return Err(Diagnostic::new(
-            "type",
-            format!("const fn {:?} cannot be extern", function.name),
-        )
-        .with_span(function.line, function.column));
-    }
-    for stmt in &function.body {
-        validate_const_function_stmt(function, stmt, functions)?;
-    }
-    Ok(())
-}
-
-fn validate_const_function_stmt(
-    function: &syntax::Function,
-    stmt: &syntax::Stmt,
-    functions: &HashMap<String, FunctionSig>,
-) -> Result<(), Diagnostic> {
-    match stmt {
-        syntax::Stmt::Let { expr, .. } | syntax::Stmt::Return { expr, .. } => {
-            validate_const_function_expr(function, expr, functions)
-        }
-        syntax::Stmt::If {
-            cond,
-            then_block,
-            else_block,
-            ..
-        } => {
-            validate_const_function_expr(function, cond, functions)?;
-            for stmt in then_block {
-                validate_const_function_stmt(function, stmt, functions)?;
-            }
-            if let Some(else_block) = else_block {
-                for stmt in else_block {
-                    validate_const_function_stmt(function, stmt, functions)?;
-                }
-            }
-            Ok(())
-        }
-        _ => Err(Diagnostic::new(
-            "type",
-            format!(
-                "const fn {:?} only supports let, if/else, and return statements in stage1",
-                function.name
-            ),
-        )
-        .with_span(stmt.line(), stmt.column())),
-    }
-}
-
-fn validate_const_function_expr(
-    function: &syntax::Function,
-    expr: &syntax::Expr,
-    functions: &HashMap<String, FunctionSig>,
-) -> Result<(), Diagnostic> {
-    match expr {
-        syntax::Expr::Literal(_) | syntax::Expr::VarRef { .. } => Ok(()),
-        syntax::Expr::BinaryAdd { lhs, rhs, .. } | syntax::Expr::BinaryCompare { lhs, rhs, .. } => {
-            validate_const_function_expr(function, lhs, functions)?;
-            validate_const_function_expr(function, rhs, functions)
-        }
-        syntax::Expr::Call { name, args, .. } => {
-            let Some(signature) = functions.get(name) else {
-                return Err(const_function_call_error(function, name, expr));
-            };
-            if !signature.is_const || signature.is_extern {
-                return Err(const_function_call_error(function, name, expr));
-            }
-            for arg in args {
-                validate_const_function_expr(function, arg, functions)?;
-            }
-            Ok(())
-        }
-        _ => Err(Diagnostic::new(
-            "type",
-            format!(
-                "const fn {:?} only supports literals, variables, arithmetic/comparison expressions, and calls to other const fn in stage1",
-                function.name
-            ),
-        )
-        .with_span(expr.line(), expr.column())),
-    }
-}
-
-fn const_function_call_error(
-    function: &syntax::Function,
-    callee: &str,
-    expr: &syntax::Expr,
-) -> Diagnostic {
-    Diagnostic::new(
-        "type",
-        format!(
-            "const fn {:?} can only call other const fn; {callee:?} is a host runtime or non-const call",
-            function.name
-        ),
-    )
-    .with_span(expr.line(), expr.column())
 }
 
 fn lower_function(

--- a/stage1/crates/axiomc/src/hir/const_functions.rs
+++ b/stage1/crates/axiomc/src/hir/const_functions.rs
@@ -1,0 +1,117 @@
+use super::signatures::FunctionSig;
+use crate::diagnostics::Diagnostic;
+use crate::syntax;
+use std::collections::HashMap;
+
+pub(super) fn validate_const_function_body(
+    function: &syntax::Function,
+    functions: &HashMap<String, FunctionSig>,
+) -> Result<(), Diagnostic> {
+    if !function.is_const {
+        return Ok(());
+    }
+    if function.is_async {
+        return Err(Diagnostic::new(
+            "type",
+            format!("const fn {:?} cannot be async", function.name),
+        )
+        .with_span(function.line, function.column));
+    }
+    if function.is_extern {
+        return Err(Diagnostic::new(
+            "type",
+            format!("const fn {:?} cannot be extern", function.name),
+        )
+        .with_span(function.line, function.column));
+    }
+    for stmt in &function.body {
+        validate_const_function_stmt(function, stmt, functions)?;
+    }
+    Ok(())
+}
+
+fn validate_const_function_stmt(
+    function: &syntax::Function,
+    stmt: &syntax::Stmt,
+    functions: &HashMap<String, FunctionSig>,
+) -> Result<(), Diagnostic> {
+    match stmt {
+        syntax::Stmt::Let { expr, .. } | syntax::Stmt::Return { expr, .. } => {
+            validate_const_function_expr(function, expr, functions)
+        }
+        syntax::Stmt::If {
+            cond,
+            then_block,
+            else_block,
+            ..
+        } => {
+            validate_const_function_expr(function, cond, functions)?;
+            for stmt in then_block {
+                validate_const_function_stmt(function, stmt, functions)?;
+            }
+            if let Some(else_block) = else_block {
+                for stmt in else_block {
+                    validate_const_function_stmt(function, stmt, functions)?;
+                }
+            }
+            Ok(())
+        }
+        _ => Err(Diagnostic::new(
+            "type",
+            format!(
+                "const fn {:?} only supports let, if/else, and return statements in stage1",
+                function.name
+            ),
+        )
+        .with_span(stmt.line(), stmt.column())),
+    }
+}
+
+fn validate_const_function_expr(
+    function: &syntax::Function,
+    expr: &syntax::Expr,
+    functions: &HashMap<String, FunctionSig>,
+) -> Result<(), Diagnostic> {
+    match expr {
+        syntax::Expr::Literal(_) | syntax::Expr::VarRef { .. } => Ok(()),
+        syntax::Expr::BinaryAdd { lhs, rhs, .. } | syntax::Expr::BinaryCompare { lhs, rhs, .. } => {
+            validate_const_function_expr(function, lhs, functions)?;
+            validate_const_function_expr(function, rhs, functions)
+        }
+        syntax::Expr::Call { name, args, .. } => {
+            let Some(signature) = functions.get(name) else {
+                return Err(const_function_call_error(function, name, expr));
+            };
+            if !signature.is_const || signature.is_extern {
+                return Err(const_function_call_error(function, name, expr));
+            }
+            for arg in args {
+                validate_const_function_expr(function, arg, functions)?;
+            }
+            Ok(())
+        }
+        _ => Err(Diagnostic::new(
+            "type",
+            format!(
+                "const fn {:?} only supports literals, variables, arithmetic/comparison expressions, and calls to other const fn in stage1",
+                function.name
+            ),
+        )
+        .with_span(expr.line(), expr.column())),
+    }
+}
+
+fn const_function_call_error(
+    function: &syntax::Function,
+    callee: &str,
+    expr: &syntax::Expr,
+) -> Diagnostic {
+    Diagnostic::new(
+        "type",
+        format!(
+            "const fn {:?} can only call other const fn; {callee:?} is a host runtime or non-const call",
+            function.name
+        ),
+    )
+    .with_span(expr.line(), expr.column())
+}


### PR DESCRIPTION
## Summary

- Move HIR const-function body/statement/expression validation from `hir.rs` into `stage1/crates/axiomc/src/hir/const_functions.rs`.
- Lower the compiler source monolith ratchets after shrinking `hir.rs` from 5,953 to 5,842 lines and top-seven source lines from 74,142 to 74,031.
- Record the new `compiler.hir` const-function validation module in the decomposition plan.

## Governing Issue

Refs #1254

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Commands run:

```bash
cargo fmt --manifest-path stage1/crates/axiomc/Cargo.toml --check
python3 scripts/ci/report-compiler-source-monoliths.py --json --check-plan --check-ratchet
make stage1-compiler-source-monoliths-test
make stage1-hir-boundary
make stage1-compiler-source-monoliths
cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib hir::boundary_tests -- --nocapture
cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib
git diff --check
git diff --cached --check
```

Result: all passed. The full `axiomc` lib suite reported 670 passed, 0 failed, 21 ignored.

Skipped checks: none locally.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

Guidance files are not applicable; this is a compiler source decomposition slice. Auto-merge should wait for the stacked base PRs and required non-author review.

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

Semantic node types added/changed: none. This moves existing HIR const-function validation into a smaller Rust module.

Schemas added/changed: none.

Evidence added/changed: compiler source monolith ratchets updated in `docs/compiler-source-decomposition-plan.md`.

Rust capture risk: reduced. The PR removes another helper cluster from the `hir.rs` facade without defining the semantic contract by Rust helper layout.

Agent-facing inspection impact: the decomposition plan now identifies `stage1/crates/axiomc/src/hir/const_functions.rs` as the host location for `compiler.hir` const-function validation.

## Flow Contract

- Owner lane: Daedalus
- Repair owner: Codex
- Autonomy class: Class 2 - Review-gated autonomous
- Risk class: Low

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is appropriate when gates pass

Current next actor: reviewer for non-author approval after stacked checks pass.

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

Auto-merge is not enabled by this agent. This PR is stacked on `codex/hir-map-lookup-split`, so it should merge after its base chain is green and approved.

## Notes

- Stacked on #1347.
