### PR TITLE
Align compile-fail discovery between test --list and test

### DIFF
--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -736,17 +736,14 @@ pub fn list_project_tests_with_options(
     {
         let manifest = &graph.context(&package_root)?.manifest;
         validate_lockfile(&package_root, manifest)?;
-        let discovered = if expected_error_path(&package_root).exists() && !options.conformance {
-            Vec::new()
-        } else if expected_error_path(&package_root).exists() {
-            compile_fail_test_target(
-                &package_root,
-                &manifest,
-                TestKind::Property,
-                options.filter.as_deref(),
-            )
-            .into_iter()
-            .collect()
+        let compile_fail_kind = expected_error_path(&package_root)
+            .exists()
+            .then(|| compile_fail_test_kind(options))
+            .flatten();
+        let discovered = if let Some(kind) = compile_fail_kind {
+            compile_fail_test_target(&package_root, manifest, kind, options.filter.as_deref())
+                .into_iter()
+                .collect()
         } else {
             collect_test_targets(
                 &package_root,
@@ -805,17 +802,15 @@ pub fn run_project_tests_with_options(
     {
         let manifest = &graph.context(&package_root)?.manifest;
         validate_lockfile(&package_root, manifest)?;
-        if expected_error_path(&package_root).exists()
-            && (!options.properties_only || options.conformance)
-        {
+        let compile_fail_kind = expected_error_path(&package_root)
+            .exists()
+            .then(|| compile_fail_test_kind(options))
+            .flatten();
+        if let Some(kind) = compile_fail_kind {
             if let Some(test) = compile_fail_test_target(
                 &package_root,
                 manifest,
-                if options.conformance {
-                    TestKind::Property
-                } else {
-                    TestKind::Unit
-                },
+                kind,
                 options.filter.as_deref(),
             ) {
                 packages.push(package_root.display().to_string());
@@ -941,6 +936,20 @@ fn collect_test_targets(
         tests.retain(|test| test_matches_filter(test, filter));
     }
     Ok(tests)
+}
+
+/// Shared gating for compile-fail packages so `test --list` and `test` agree:
+/// conformance runs treat the case as a property, default runs treat it as a
+/// unit test, and properties-only runs skip the synthesized case entirely
+/// (falling back to regular target discovery).
+fn compile_fail_test_kind(options: &TestOptions) -> Option<TestKind> {
+    if options.conformance {
+        Some(TestKind::Property)
+    } else if options.properties_only {
+        None
+    } else {
+        Some(TestKind::Unit)
+    }
 }
 
 fn compile_fail_test_target(
@@ -10671,6 +10680,115 @@ return async_serve_route(1, "/", "ok", 1)
             .expect("unfiltered package-less compile-fail target");
         assert_eq!(fallback_target.name, root.display().to_string());
         assert_eq!(fallback_target.package, None);
+    }
+
+    #[test]
+    fn compile_fail_kind_gating_is_shared_between_list_and_run() {
+        let default_options = TestOptions::default();
+        assert_eq!(
+            compile_fail_test_kind(&default_options),
+            Some(TestKind::Unit)
+        );
+
+        let properties_only = TestOptions {
+            properties_only: true,
+            ..TestOptions::default()
+        };
+        assert_eq!(compile_fail_test_kind(&properties_only), None);
+
+        let conformance = TestOptions {
+            properties_only: true,
+            conformance: true,
+            ..TestOptions::default()
+        };
+        assert_eq!(
+            compile_fail_test_kind(&conformance),
+            Some(TestKind::Property)
+        );
+    }
+
+    #[test]
+    fn compile_fail_package_list_and_run_agree_across_modes() {
+        let dir = tempdir().unwrap_or_else(|err| panic!("tempdir: {err}"));
+        let root = dir.path().join("compile-fail-agreement");
+        fs::create_dir_all(root.join("src")).unwrap_or_else(|err| panic!("create src: {err}"));
+        fs::write(
+            root.join("axiom.toml"),
+            r#"[package]
+name = "compile-fail-agreement"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+"#,
+        )
+        .unwrap_or_else(|err| panic!("write manifest: {err}"));
+        fs::write(root.join("src/main.ax"), "let count: int = \"seven\"\n")
+            .unwrap_or_else(|err| panic!("write entry: {err}"));
+        fs::write(
+            root.join("expected-error.json"),
+            r#"{
+  "kind": "type",
+  "code": null,
+  "message": "let binding \"count\" expects int, got string",
+  "path": "src/main.ax",
+  "line": 1,
+  "column": 1
+}
+"#,
+        )
+        .unwrap_or_else(|err| panic!("write expected error: {err}"));
+        let manifest = load_manifest(&root).unwrap_or_else(|err| panic!("load manifest: {err:?}"));
+        fs::write(
+            root.join("axiom.lock"),
+            crate::lockfile::render_lockfile_for_project(&root, &manifest)
+                .unwrap_or_else(|err| panic!("render lockfile: {err:?}")),
+        )
+        .unwrap_or_else(|err| panic!("write lockfile: {err}"));
+
+        // Default mode: run executes the compile-fail case as a unit test, so
+        // list must show the same case with the same kind.
+        let default_options = TestOptions::default();
+        let listed = list_project_tests_with_options(&root, &default_options)
+            .unwrap_or_else(|err| panic!("list default: {err:?}"));
+        assert_eq!(listed.tests.len(), 1);
+        assert_eq!(listed.tests[0].name, "compile-fail-agreement");
+        assert_eq!(listed.tests[0].kind, TestKind::Unit);
+        let run = run_project_tests_with_options(&root, &default_options)
+            .unwrap_or_else(|err| panic!("run default: {err:?}"));
+        assert_eq!(run.cases.len(), 1);
+        assert_eq!(run.cases[0].name, listed.tests[0].name);
+        assert_eq!(run.cases[0].kind, listed.tests[0].kind);
+        assert!(run.cases[0].ok, "expected-error fixture should match");
+
+        // Conformance mode: both surfaces report the case as a property.
+        let conformance_options = TestOptions {
+            conformance: true,
+            ..TestOptions::default()
+        };
+        let listed = list_project_tests_with_options(&root, &conformance_options)
+            .unwrap_or_else(|err| panic!("list conformance: {err:?}"));
+        assert_eq!(listed.tests.len(), 1);
+        assert_eq!(listed.tests[0].kind, TestKind::Property);
+        let run = run_project_tests_with_options(&root, &conformance_options)
+            .unwrap_or_else(|err| panic!("run conformance: {err:?}"));
+        assert_eq!(run.cases.len(), 1);
+        assert_eq!(run.cases[0].kind, TestKind::Property);
+
+        // Properties-only mode: neither surface synthesizes the compile-fail
+        // case, and regular discovery finds nothing else in this package.
+        let properties_only_options = TestOptions {
+            properties_only: true,
+            ..TestOptions::default()
+        };
+        let list_error = list_project_tests_with_options(&root, &properties_only_options)
+            .expect_err("properties-only list should discover no tests");
+        assert_eq!(list_error.kind, "test");
+        let run_error = run_project_tests_with_options(&root, &properties_only_options)
+            .expect_err("properties-only run should discover no tests");
+        assert_eq!(run_error.kind, "test");
+        assert_eq!(run_error.message, list_error.message);
     }
 
     #[test]


### PR DESCRIPTION
    ## Summary

    - Add `compile_fail_test_kind` as the single gating/kind decision for compile-fail packages and use it from both `list_project_tests_with_options` and `run_project_tests_with_options` in `stage1/crates/axiomc/src/project.rs`.
    - Behavior fix: a default `test --list` now shows the compile-fail case (as `unit`) that a default `test` already executes; previously the listing omitted it entirely and only showed it (as `property`) under `--conformance`. Properties-only mode now falls through to regular discovery on both surfaces instead of list-only skipping.
    - Add a unit test for the shared gating and an integration regression test asserting list/run agreement in default, conformance, and properties-only modes.

    ## Governing Issue

    Closes #1351

    ## Validation

    - [x] Relevant local checks passed
    - [x] Required PR checks are expected to satisfy `CI Gate`
    - [x] Skipped checks are explained below

    `cargo test -p axiomc --lib compile_fail`: 4 passed.
    `cargo test -p axiomc --lib project`: 353 passed, 1 failed — `build_project_wasm_alias_emits_wasm_artifact` fails for a missing `wasm32-wasip1` rustup target in this environment and fails identically on unmodified `origin/main`; unrelated to this change.

    ## Bootstrap Governance

    - [x] Changes are scoped to the linked issue
    - [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable (not applicable)
    - [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
    - [x] No real secrets, runtime auth, or machine-local env files are committed

    ## Semantic Layer Checklist

    - [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior (no node changes)
    - [x] Schemas added/changed are listed, or this PR does not touch schemas (JSON shape of `test --list` is unchanged; only which cases appear and their kind)
    - [x] Evidence added/changed is listed, or this PR does not touch evidence
    - [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
    - [x] Agent-facing inspection impact is described, or there is no inspection impact (agents consuming `test --list` JSON now see the compile-fail case a default `test` will execute)

## Flow Contract

- Owner lane: compiler/runtime
- Repair owner: same lane
- Autonomy class: Class 2 - Review-gated autonomous
- Risk class: risk:low (test-discovery surface only)

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is appropriate when gates pass

    ## Merge Automation

    - [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

    ## Notes

    - Lane: compiler/runtime.
    - Dependencies: none; textually independent of #1353 (different files). Both touch the post-#1340 layout, so they should ride the same integration train if one forms.
    - Rust capture risk: low — discovery policy only, no semantic contract change.
    - Behavior change is intentional and user-visible in `test --list` output for compile-fail packages; documented in the linked issue.