### PR TITLE
Include macro recursion limit in module parse cache key

### DIFF
--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -1546,7 +1546,7 @@ struct LoadedModule {
 
 #[derive(Default)]
 struct ModuleParseCache {
-    programs: HashMap<PathBuf, syntax::Program>,
+    programs: HashMap<(PathBuf, usize), syntax::Program>,
 }
 
 #[derive(Debug, Clone)]
@@ -4532,7 +4532,7 @@ fn parse_module_with_cache(
     macro_recursion_limit: usize,
     parse_cache: &mut ModuleParseCache,
 ) -> Result<syntax::Program, Diagnostic> {
-    let cache_key = module_parse_cache_key(module_path)?;
+    let cache_key = module_parse_cache_key(module_path, macro_recursion_limit)?;
     if let Some(program) = parse_cache.programs.get(&cache_key) {
         return Ok(program.clone());
     }
@@ -4570,12 +4570,19 @@ fn parse_module_with_cache(
     Ok(program)
 }
 
-fn module_parse_cache_key(module_path: &Path) -> Result<PathBuf, Diagnostic> {
-    if stdlib::is_stdlib_path(module_path) {
-        Ok(normalize_path(module_path))
+// The parse result depends on the macro recursion limit, so the limit is part
+// of the key: a cache hit must never return a program parsed under a
+// different limit than the caller requested.
+fn module_parse_cache_key(
+    module_path: &Path,
+    macro_recursion_limit: usize,
+) -> Result<(PathBuf, usize), Diagnostic> {
+    let path = if stdlib::is_stdlib_path(module_path) {
+        normalize_path(module_path)
     } else {
-        canonicalize_existing_path(module_path, "module path")
-    }
+        canonicalize_existing_path(module_path, "module path")?
+    };
+    Ok((path, macro_recursion_limit))
 }
 
 fn package_section<'a>(
@@ -10817,7 +10824,9 @@ out_dir = "dist"
             canonicalize_existing_path(&root, "package root").expect("canonical package root");
         let graph = load_package_graph(&package_root).expect("load graph");
         let shared_path = package_root.join("src/shared.ax");
-        let shared_key = module_parse_cache_key(&shared_path).expect("shared cache key");
+        let shared_key =
+            module_parse_cache_key(&shared_path, syntax::DEFAULT_MACRO_RECURSION_LIMIT)
+                .expect("shared cache key");
         let mut parse_cache = ModuleParseCache::default();
 
         load_modules_with_parse_cache(
@@ -10843,7 +10852,26 @@ out_dir = "dist"
         )
         .expect("load second test modules from cache");
 
-        assert!(modules.iter().any(|module| module.path == shared_key));
+        assert!(modules.iter().any(|module| module.path == shared_key.0));
+    }
+
+    #[test]
+    fn module_parse_cache_key_distinguishes_macro_recursion_limits() {
+        let dir = tempdir().unwrap_or_else(|err| panic!("tempdir: {err}"));
+        let module_path = dir.path().join("module.ax");
+        fs::write(&module_path, "fn one(): int {\nreturn 1\n}\n")
+            .unwrap_or_else(|err| panic!("write module: {err}"));
+
+        let default_key =
+            module_parse_cache_key(&module_path, syntax::DEFAULT_MACRO_RECURSION_LIMIT)
+                .expect("default-limit cache key");
+        let strict_key = module_parse_cache_key(&module_path, 1).expect("strict-limit cache key");
+
+        assert_eq!(default_key.0, strict_key.0);
+        assert_ne!(
+            default_key, strict_key,
+            "programs parsed under different macro recursion limits must not share a cache entry"
+        );
     }
 
     #[test]


### PR DESCRIPTION
    ## Summary

    - Key `ModuleParseCache` entries by `(canonical path, macro_recursion_limit)` instead of path alone in `stage1/crates/axiomc/src/project.rs`, so a cache hit can never return a program parsed under a different macro recursion limit than the caller requested.
    - Document the invariant on `module_parse_cache_key` and add a test asserting keys differ across limits for the same path.

    ## Governing Issue

    Closes #1352

    ## Validation

    - [x] Relevant local checks passed
    - [x] Required PR checks are expected to satisfy `CI Gate`
    - [x] Skipped checks are explained below

    `cargo test -p axiomc --lib -- project::tests`: 50 passed, 0 failed (includes the two parse-cache tests).

    ## Bootstrap Governance

    - [x] Changes are scoped to the linked issue
    - [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable (not applicable)
    - [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
    - [x] No real secrets, runtime auth, or machine-local env files are committed

    ## Semantic Layer Checklist

    - [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
    - [x] Schemas added/changed are listed, or this PR does not touch schemas
    - [x] Evidence added/changed is listed, or this PR does not touch evidence
    - [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
    - [x] Agent-facing inspection impact is described, or there is no inspection impact (none)

## Flow Contract

- Owner lane: compiler/runtime
- Repair owner: same lane
- Autonomy class: Class 1 - Safe autonomous
- Risk class: risk:low (behavior-preserving today; hardens a latent cache hazard)

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is appropriate when gates pass

    ## Merge Automation

    - [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

    ## Notes

    - Lane: compiler/runtime.
    - Dependencies: touches the same `project.rs` test region as #1354; if both are open when a train forms, replay #1354 before this PR.
    - Rust capture risk: none — internal cache detail.