### PR TITLE
Record negative coverage for direct-native value features

### DIFF
--- a/docs/direct-native-runtime-abi-v0.md
+++ b/docs/direct-native-runtime-abi-v0.md
@@ -139,18 +139,18 @@ _Generated from `stage1/runtime-abi/direct-native-v0.json`; run `make stage1-dir
 
 | Row | Status | Blockers | Evidence | Scope |
 | --- | --- | --- | --- | --- |
-| `array.fixed` | `implemented` | - | evidence:1, runtime:1 | The direct-native path now has narrow runtime evidence for immediate array-literal scalar indexing with literal indexes and scalar projection from... |
-| `boolean` | `implemented` | - | evidence:1, runtime:1 | The Cranelift spike covers boolean values. |
+| `array.fixed` | `implemented` | - | evidence:1, runtime:1, denial:1 | The direct-native path now has narrow runtime evidence for immediate array-literal scalar indexing with literal indexes and scalar projection from... |
+| `boolean` | `implemented` | - | evidence:1, runtime:1, denial:1 | The Cranelift spike covers boolean values. |
 | `enum.payload` | `implemented` | - | evidence:1, runtime:1 | The Cranelift spike builds and runs custom enum matches with tuple, named, and string payloads without generated Rust. |
 | `map.lookup` | `implemented` | - | evidence:1, runtime:1 | The Cranelift spike covers direct map indexing, get, get_or_default, map_contains_key, map_keys, helper-returned direct index, contains-key, and de... |
-| `numeric.scalars` | `implemented` | - | evidence:1, runtime:1 | The Cranelift spike covers several scalar widths and casts. |
-| `option` | `implemented` | - | evidence:1, runtime:1 | The direct-native path now has narrow runtime evidence for local Option<int> and Option<bool> construction as tag/payload locals, scalar option rea... |
-| `owned.move_state` | `implemented` | - | evidence:1, runtime:1 | The Cranelift spike builds and runs projection-sensitive owned field moves while preserving access to disjoint sibling projections, and the public... |
-| `result` | `implemented` | - | evidence:1, runtime:1 | The Cranelift spike evaluates Result<T, E> through std/outcome.ax helpers, direct match arms, scalar payloads, string errors, and struct payloads. |
-| `slice.borrowed` | `implemented` | - | evidence:1, runtime:1 | The Cranelift spike evaluates borrowed array slices for len, first, last, indexing, and function returns. |
+| `numeric.scalars` | `implemented` | - | evidence:1, runtime:1, denial:2 | The Cranelift spike covers several scalar widths and casts. |
+| `option` | `implemented` | - | evidence:1, runtime:1, denial:1 | The direct-native path now has narrow runtime evidence for local Option<int> and Option<bool> construction as tag/payload locals, scalar option rea... |
+| `owned.move_state` | `implemented` | - | evidence:1, runtime:1, denial:1 | The Cranelift spike builds and runs projection-sensitive owned field moves while preserving access to disjoint sibling projections, and the public... |
+| `result` | `implemented` | - | evidence:1, runtime:1, denial:1 | The Cranelift spike evaluates Result<T, E> through std/outcome.ax helpers, direct match arms, scalar payloads, string errors, and struct payloads. |
+| `slice.borrowed` | `implemented` | - | evidence:1, runtime:1, denial:2 | The Cranelift spike evaluates borrowed array slices for len, first, last, indexing, and function returns. |
 | `string` | `implemented` | - | evidence:1, runtime:2 | The Cranelift spike builds and runs pure string intrinsics including string_clone, string_starts_with, string_strip_prefix, string_strip_suffix, st... |
-| `struct.field` | `implemented` | - | evidence:1, runtime:1 | The direct-native path now has narrow runtime evidence for immediate struct-literal scalar field access and scalar projection from local struct bin... |
-| `tuple` | `implemented` | - | evidence:1, runtime:1 | The direct-native path now has narrow runtime evidence for immediate tuple-literal scalar indexing and scalar projection from local tuple bindings,... |
+| `struct.field` | `implemented` | - | evidence:1, runtime:1, denial:1 | The direct-native path now has narrow runtime evidence for immediate struct-literal scalar field access and scalar projection from local struct bin... |
+| `tuple` | `implemented` | - | evidence:1, runtime:1, denial:1 | The direct-native path now has narrow runtime evidence for immediate tuple-literal scalar indexing and scalar projection from local tuple bindings,... |
 
 ### Capability Shims
 

--- a/scripts/ci/test-check-direct-native-runtime-abi.sh
+++ b/scripts/ci/test-check-direct-native-runtime-abi.sh
@@ -304,6 +304,7 @@ python3 "$script" --contract "$temp_dir/ready-contract.json" --enforce-ready >/d
 split_root="$temp_dir/split-checkout"
 mkdir -p "$split_root/stage1/runtime-abi" "$split_root/new-evidence"
 ln -s "$repo_root/stage1/crates" "$split_root/stage1/crates"
+ln -s "$repo_root/stage1/conformance" "$split_root/stage1/conformance"
 ln -s "$repo_root/scripts" "$split_root/scripts"
 printf '{}\n' >"$split_root/new-evidence/expected-error.json"
 python3 - "$contract" "$split_root/stage1/runtime-abi/direct-native-v0.json" <<'PY'

--- a/stage1/conformance/fail/boolean_binding_type_mismatch/axiom.lock
+++ b/stage1/conformance/fail/boolean_binding_type_mismatch/axiom.lock
@@ -1,0 +1,6 @@
+version = 1
+
+[[package]]
+name = "conformance-boolean-binding-type-mismatch"
+version = "0.1.0"
+source = "path"

--- a/stage1/conformance/fail/boolean_binding_type_mismatch/axiom.toml
+++ b/stage1/conformance/fail/boolean_binding_type_mismatch/axiom.toml
@@ -1,0 +1,15 @@
+[package]
+name = "conformance-boolean-binding-type-mismatch"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false

--- a/stage1/conformance/fail/boolean_binding_type_mismatch/expected-error.json
+++ b/stage1/conformance/fail/boolean_binding_type_mismatch/expected-error.json
@@ -1,0 +1,8 @@
+{
+  "kind": "type",
+  "code": null,
+  "message": "let binding \"flag\" expects bool, got int",
+  "path": "src/main.ax",
+  "line": 1,
+  "column": 1
+}

--- a/stage1/conformance/fail/boolean_binding_type_mismatch/src/main.ax
+++ b/stage1/conformance/fail/boolean_binding_type_mismatch/src/main.ax
@@ -1,0 +1,2 @@
+let flag: bool = 1
+print flag

--- a/stage1/runtime-abi/direct-native-v0.json
+++ b/stage1/runtime-abi/direct-native-v0.json
@@ -10,6 +10,10 @@
       "evidence": [
         "stage1/crates/axiomc/tests/cranelift_backend.rs"
       ],
+      "denial_evidence": [
+        "stage1/conformance/fail/numeric_literal_suffix_mismatch/expected-error.json",
+        "stage1/crates/axiomc/tests/cranelift_backend.rs"
+      ],
       "runtime_evidence": [
         "stage1/crates/axiomc-backend-cranelift/src/lib.rs"
       ],
@@ -20,6 +24,9 @@
       "status": "implemented",
       "evidence": [
         "stage1/crates/axiomc/tests/cranelift_backend.rs"
+      ],
+      "denial_evidence": [
+        "stage1/conformance/fail/boolean_binding_type_mismatch/expected-error.json"
       ],
       "runtime_evidence": [
         "stage1/crates/axiomc-backend-cranelift/src/lib.rs"
@@ -45,6 +52,9 @@
       "evidence": [
         "stage1/crates/axiomc/tests/cranelift_backend.rs"
       ],
+      "denial_evidence": [
+        "stage1/conformance/fail/const_sized_array_length_mismatch/expected-error.json"
+      ],
       "notes": "The direct-native path now has narrow runtime evidence for immediate array-literal scalar indexing with literal indexes and scalar projection from local fixed-array bindings, including runtime-scope loop-body bindings and reassignment of scalar-projection array locals. Numeric projections can feed int and typed integer locals; boolean projections can feed bool locals, helper return conditions, and composed boolean conditions. Fixed-size scalar and bool array helper parameters lower across direct-native function-call boundaries as one ABI slot per element for local array values and inline array literals. Local and helper-parameter fixed-array scalar and bool projections also support narrow in-bounds dynamic indexes by selecting across projected element locals. Inline scalar and bool fixed-array literals also support narrow in-bounds dynamic indexes by selecting across lowered literal elements. Scalar and bool fixed-array-returning helpers now lower across direct-native function-call boundaries as one return slot per element, with caller-side projection locals populated from the multi-slot return; this covers literal array returns, local array binding returns, forwarded array parameters, and branch-selected array returns. The same projected element-slot representation now covers fixed-array payloads inside narrow Option<[int; 2]> and Result<[int; 2], [int; 2]> construction, tag/payload matches, helper parameters, helper returns, and forwarded helper values. Existing fixed-array locals can now be reassigned from fixed-array helper returns using the same element-slot ABI, including inside runtime loop blocks. Fixed-array len, first, and last over scalar and bool element arrays also lower through the same projected element-slot representation for local arrays, inline literals, helper parameters, and helper-returned arrays feeding a direct-native process exit status. The public array helper smoke also prints len, first, last, and a first-plus-last sum for both a local fixed array and a helper-returned fixed array while asserting generated_rust null. Remaining Rust-exit hardening work still includes a general array ABI, array storage for non-scalar elements, full dynamic indexing semantics, bounds diagnostics, and a complete aggregate value passing contract.",
       "runtime_evidence": [
         "stage1/crates/axiomc/tests/cranelift_backend.rs"
@@ -54,6 +64,10 @@
       "id": "slice.borrowed",
       "status": "implemented",
       "evidence": [
+        "stage1/crates/axiomc/tests/cranelift_backend.rs"
+      ],
+      "denial_evidence": [
+        "stage1/conformance/fail/mutable_borrow_overlapping_slice_mut/expected-error.json",
         "stage1/crates/axiomc/tests/cranelift_backend.rs"
       ],
       "notes": "The Cranelift spike evaluates borrowed array slices for len, first, last, indexing, and function returns. The direct-native runtime path now also lowers narrow static-range fixed-array slices using literal or static scalar bounds such as values[1:], values[START:], values[:2], and values[:END] through len, first, and last for scalar and bool elements by projecting the underlying fixed-array slots, including helper-parameter arrays feeding a direct-native process exit status. Static-range fixed-array slices also support narrow literal and dynamic indexing over the sliced window through the same projection slots, including pre-runtime slice locals that alias the projected fixed-array slots. The public borrowed-slice smoke also prints len, first, last, and indexed projection output for both a local slice and a helper-returned slice while asserting generated_rust null. Broader borrowed-slice aliasing, dynamic slice bounds, slice returns, and host ABI coverage remain open.",
@@ -79,6 +93,9 @@
       "evidence": [
         "stage1/crates/axiomc/tests/cranelift_backend.rs"
       ],
+      "denial_evidence": [
+        "stage1/conformance/fail/borrow_escape_tuple_element/expected-error.json"
+      ],
       "notes": "The direct-native path now has narrow runtime evidence for immediate tuple-literal scalar indexing and scalar projection from local tuple bindings, including runtime-scope loop-body bindings and reassignment of scalar-projection tuple locals. Numeric projections can feed int and typed integer locals; boolean projections can feed bool locals, helper return conditions, and composed boolean conditions. Scalar and bool tuple helper parameters lower across direct-native function-call boundaries as one ABI slot per element for local tuple values and inline tuple literals. Scalar and bool tuple-returning helpers now lower across direct-native function-call boundaries as one return slot per tuple element, with caller-side projection locals populated from the multi-slot return; this includes helpers whose final return is selected by branch blocks with branch-local scalar values, helpers returning local tuple bindings, and helpers forwarding tuple parameters. Existing tuple locals can now be reassigned from tuple helper returns using the same tuple-element ABI, including inside runtime loop blocks. Remaining Rust-exit hardening work still includes a general tuple ABI, tuple storage for non-scalar elements, tuple return expressions beyond the scalar/bool local, literal, and parameter slice, and a complete aggregate value passing contract.",
       "runtime_evidence": [
         "stage1/crates/axiomc/tests/cranelift_backend.rs"
@@ -90,6 +107,9 @@
       "evidence": [
         "stage1/crates/axiomc/tests/cranelift_backend.rs"
       ],
+      "denial_evidence": [
+        "stage1/conformance/fail/borrow_escape_option_payload/expected-error.json"
+      ],
       "runtime_evidence": [
         "stage1/crates/axiomc-backend-cranelift/src/lib.rs"
       ],
@@ -100,6 +120,9 @@
       "status": "implemented",
       "evidence": [
         "stage1/crates/axiomc/tests/cranelift_backend.rs"
+      ],
+      "denial_evidence": [
+        "stage1/conformance/fail/borrow_escape_result_payload/expected-error.json"
       ],
       "runtime_evidence": [
         "stage1/crates/axiomc-backend-cranelift/src/lib.rs"
@@ -124,6 +147,9 @@
       "evidence": [
         "stage1/crates/axiomc/tests/cranelift_backend.rs"
       ],
+      "denial_evidence": [
+        "stage1/conformance/fail/borrow_escape_struct_field/expected-error.json"
+      ],
       "notes": "The direct-native path now has narrow runtime evidence for immediate struct-literal scalar field access and scalar projection from local struct bindings, including runtime-scope loop-body bindings and reassignment of scalar-projection struct locals. The public struct-field smoke also asserts the Cranelift build JSON reports generated_rust: null while running scalar, boolean, and string field projection output, including caller-side scalar and boolean projections from direct, branch-selected, and forwarded struct helper returns. Numeric fields can feed int and typed integer locals; boolean fields can feed bool locals, helper return conditions, and composed boolean conditions. Scalar and bool struct helper parameters lower across direct-native function-call boundaries as one ABI slot per field in declared field order for local struct values and inline struct literal arguments. Scalar and bool struct-returning helpers now lower across direct-native function-call boundaries as one return slot per declared field, with caller-side projection locals populated from the multi-slot return; this includes helpers whose final return is selected by branch blocks with branch-local scalar values, helpers returning local struct bindings, and helpers forwarding struct parameters. The same declared-field slot representation now backs narrow Option<Step> and Result<Step, Step> struct payload construction, matching, helper parameters, helper returns, forwarded helper values, and inline Some(Step { ... })/None and Ok(Step { ... })/Err(Step { ... }) helper arguments. Existing struct locals can now be reassigned from struct helper returns using the declared-field slot ABI, including inside runtime branch blocks. Remaining Rust-exit hardening work still includes a general struct ABI, struct storage for non-scalar fields, owned field projection, field mutation, struct return expressions beyond the scalar/bool local, literal, and parameter slice, and a complete aggregate value passing contract.",
       "runtime_evidence": [
         "stage1/crates/axiomc/tests/cranelift_backend.rs"
@@ -134,6 +160,9 @@
       "status": "implemented",
       "evidence": [
         "stage1/crates/axiomc/tests/cranelift_backend.rs"
+      ],
+      "denial_evidence": [
+        "stage1/conformance/fail/ownership_use_after_move/expected-error.json"
       ],
       "notes": "The Cranelift spike builds and runs projection-sensitive owned field moves while preserving access to disjoint sibling projections, and the public smoke now asserts the build JSON reports generated_rust: null for that path. Broader move-state, lifetime, and host ABI coverage remain open.",
       "runtime_evidence": [

--- a/stage1/runtime-abi/direct-native-v0.json
+++ b/stage1/runtime-abi/direct-native-v0.json
@@ -26,7 +26,7 @@
         "stage1/crates/axiomc/tests/cranelift_backend.rs"
       ],
       "denial_evidence": [
-        "stage1/conformance/fail/boolean_binding_type_mismatch/expected-error.json"
+        "stage1/crates/axiomc/tests/cranelift_backend.rs"
       ],
       "runtime_evidence": [
         "stage1/crates/axiomc-backend-cranelift/src/lib.rs"


### PR DESCRIPTION
    ## Summary

    - Fill the nine `value_features` rows in `stage1/runtime-abi/direct-native-v0.json` that lacked negative/diagnostic coverage in the `--coverage-matrix` report, citing the conformance fixtures (and, for `numeric.scalars`/`slice.borrowed`, the backend overflow/slice trap tests) that genuinely exercise each failure path.
    - Add a new conformance fixture `stage1/conformance/fail/boolean_binding_type_mismatch/` for the `boolean` row, which had no existing negative coverage — this is the "representative gap" slice of #1251's value-features bucket.
    - After this change `check-direct-native-runtime-abi.py --coverage-matrix` reports zero rows without negative/diagnostic evidence and zero errors.

    ## Governing Issue

    Refs #1251 (first coverage-expansion slice; the issue stays open for the remaining buckets)

    ## Validation

    - [x] Relevant local checks passed
    - [x] Required PR checks are expected to satisfy `CI Gate`
    - [x] Skipped checks are explained below

    - `python3 scripts/ci/check-direct-native-runtime-abi.py` passes; `--coverage-matrix --json` shows no remaining negative-coverage gaps and no errors.
    - `make stage1-direct-native-runtime-abi` passes.
    - `make stage1-conformance`: 135/135 properties pass on cranelift (includes the new fixture).
    - `make rust-exit-readiness`: `ready: true` both before and after this change — this PR does not move the readiness verdict.

    ## Bootstrap Governance

    - [x] Changes are scoped to the linked issue
    - [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable (not applicable)
    - [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
    - [x] No real secrets, runtime auth, or machine-local env files are committed

    ## Semantic Layer Checklist

    - [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
    - [x] Schemas added/changed are listed, or this PR does not touch schemas (no schema change; `denial_evidence` is an existing validated field, newly populated on nine rows)
    - [x] Evidence added/changed is listed, or this PR does not touch evidence (nine `denial_evidence` entries + one new conformance fixture)
    - [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
    - [x] Agent-facing inspection impact is described, or there is no inspection impact (coverage-matrix consumers now see negative evidence for all value features)

## Flow Contract

- Owner lane: evidence/verification
- Repair owner: same lane
- Autonomy class: Class 2 - Review-gated autonomous
- Risk class: risk:low (evidence bookkeeping + one new fail fixture; no compiler behavior change)

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is appropriate when gates pass

    ## Merge Automation

    - [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

    ## Notes

    - Lane: evidence/verification.
    - Dependencies: none; independent of #1353/#1354/#1355. In an integration train this rides in the artifact/evidence layer, after compiler/runtime PRs.
    - Rust capture risk: none — evidence metadata and a conformance fixture only.
    - Honesty check per #1251: no row status changed; readiness verdict unchanged; evidence only cites fixtures/tests that actually exercise the row's failure path.