### PR TITLE
Refresh command-surface report for closed doc/LSP proof

### DIFF
--- a/docs/rust-exit-readiness.md
+++ b/docs/rust-exit-readiness.md
@@ -42,9 +42,11 @@ Command-surface coverage for the official `check`, `build`, `run`, `test`,
 make rust-exit-command-surface-coverage
 ```
 
-That report currently stays `ready: false` because its `doc` and `lsp` rows
-still carry the #731 blocker; #731 itself is closed, so the row data needs a
-refresh before the report can flip.
+That report is `ready: true`: all six surfaces are implemented, and the `doc`
+and `lsp` rows record closed #731 as their ownership proof (`proof_issues`)
+instead of a live blocker. #731 stays listed in
+`docs/rust-exit-readiness.json` so `make rust-exit-readiness` keeps validating
+its CLOSED state live.
 
 The compiler rewrite also has a separate language/backend prerequisite gate:
 [`make self-hosting-language-readiness`](self-hosting-language-readiness.md).

--- a/scripts/ci/check-rust-exit-command-surface.py
+++ b/scripts/ci/check-rust-exit-command-surface.py
@@ -26,7 +26,11 @@ REQUIRED_LSP_FLOWS = (
     "shutdown",
     "exit",
 )
-DOC_LSP_BLOCKER = 731
+# Closed doc/LSP ownership proof. The issue stays listed in
+# docs/rust-exit-readiness.json so `make rust-exit-readiness` keeps validating
+# its CLOSED state live; this offline report records it as the governing proof
+# rather than a live blocker.
+DOC_LSP_PROOF_ISSUE = 731
 
 
 def load_json(path: Path) -> dict[str, Any]:
@@ -74,19 +78,19 @@ def command_row(
     if not isinstance(name, str):
         name = "<unknown>"
     fixtures = fixture_paths_exist(command.get("fixtures"), errors, f"command {name}")
-    row_blockers: list[int] = []
     status = "implemented"
     notes = "Command has a package-boundary contract and checked command fixtures."
+    proof_issues: list[int] = []
     if name == "doc":
-        status = "blocked"
-        row_blockers = [DOC_LSP_BLOCKER]
+        proof_issues = [DOC_LSP_PROOF_ISSUE]
         notes = (
-            "Documentation command contract is present, but Rust exit remains "
-            "blocked until doc/LSP ownership is AxiOM-owned."
+            "Documentation command contract is present; doc/LSP ownership "
+            f"proof #{DOC_LSP_PROOF_ISSUE} is closed and its state is "
+            "validated live by make rust-exit-readiness."
         )
-        if DOC_LSP_BLOCKER not in blockers:
+        if DOC_LSP_PROOF_ISSUE not in blockers:
             errors.append(
-                f"command doc blocker #{DOC_LSP_BLOCKER} is missing from "
+                f"command doc ownership proof #{DOC_LSP_PROOF_ISSUE} is missing from "
                 "docs/rust-exit-readiness.json"
             )
 
@@ -94,7 +98,8 @@ def command_row(
         "surface": name,
         "kind": "command",
         "status": status,
-        "blockers": row_blockers,
+        "blockers": [],
+        "proof_issues": proof_issues,
         "api": command.get("api"),
         "stable_output": command.get("stable_output"),
         "fixtures": fixtures,
@@ -116,25 +121,26 @@ def lsp_row(
     missing = sorted(set(REQUIRED_LSP_FLOWS) - set(service_map))
     if missing:
         errors.append("lsp service coverage missing flows: " + ", ".join(missing))
-    if DOC_LSP_BLOCKER not in blockers:
+    if DOC_LSP_PROOF_ISSUE not in blockers:
         errors.append(
-            f"lsp blocker #{DOC_LSP_BLOCKER} is missing from "
+            f"lsp ownership proof #{DOC_LSP_PROOF_ISSUE} is missing from "
             "docs/rust-exit-readiness.json"
         )
 
     return {
         "surface": "lsp",
         "kind": "service",
-        "status": "blocked",
-        "blockers": [DOC_LSP_BLOCKER],
+        "status": "implemented",
+        "blockers": [],
+        "proof_issues": [DOC_LSP_PROOF_ISSUE],
         "api": "compiler.services.lsp.serve_stdio",
         "stable_output": "Content-Length framed JSON-RPC 2.0",
         "flows": list(REQUIRED_LSP_FLOWS),
         "validation_command": "make stage1-command-lsp-boundary",
         "notes": (
-            "LSP protocol contract and stdio harness exist, but Rust exit "
-            "remains blocked while axiomc lsp dispatches through the "
-            "Rust-hosted stdio/message loop."
+            "LSP protocol contract, stdio harness, and compiler-service "
+            f"driver ownership are in place; ownership proof #{DOC_LSP_PROOF_ISSUE} "
+            "is closed and its state is validated live by make rust-exit-readiness."
         ),
     }
 

--- a/scripts/ci/test-check-rust-exit-command-surface.sh
+++ b/scripts/ci/test-check-rust-exit-command-surface.sh
@@ -18,22 +18,26 @@ with open(sys.argv[1], encoding="utf-8") as handle:
     report = json.load(handle)
 
 assert report["schema"] == "axiom.rust_exit.command_surface_coverage.v0"
-assert report["ready"] is False
+assert report["ready"] is True
 assert report["summary"]["surface_count"] == 6
-assert report["summary"]["implemented"] == 4
-assert report["summary"]["blocked"] == 2
-assert report["summary"]["blocked_surfaces"] == ["doc", "lsp"]
+assert report["summary"]["implemented"] == 6
+assert report["summary"]["blocked"] == 0
+assert report["summary"]["blocked_surfaces"] == []
 assert report["errors"] == []
 rows = {row["surface"]: row for row in report["rows"]}
 for surface in ("check", "build", "run", "test"):
     assert rows[surface]["status"] == "implemented"
     assert rows[surface]["fixtures"], surface
-assert rows["doc"]["blockers"] == [731]
-assert rows["lsp"]["blockers"] == [731]
+assert rows["doc"]["status"] == "implemented"
+assert rows["doc"]["blockers"] == []
+assert rows["doc"]["proof_issues"] == [731]
+assert rows["lsp"]["status"] == "implemented"
+assert rows["lsp"]["blockers"] == []
+assert rows["lsp"]["proof_issues"] == [731]
 PY
 
-if python3 "$script" --enforce-ready >"$temp_dir/enforce.out" 2>"$temp_dir/enforce.err"; then
-  echo "expected command surface readiness enforcement to fail while doc/lsp are blocked" >&2
+if ! python3 "$script" --enforce-ready >"$temp_dir/enforce.out" 2>"$temp_dir/enforce.err"; then
+  echo "expected command surface readiness enforcement to pass with doc/lsp implemented" >&2
   exit 1
 fi
 
@@ -87,7 +91,7 @@ PY
 if python3 "$script" \
   --readiness-manifest "$temp_dir/missing-731.json" \
   --json >"$temp_dir/missing-731-report.json"; then
-  echo "expected missing doc/LSP blocker to fail" >&2
+  echo "expected missing doc/LSP ownership proof to fail" >&2
   exit 1
 fi
 
@@ -98,7 +102,7 @@ import sys
 with open(sys.argv[1], encoding="utf-8") as handle:
     report = json.load(handle)
 
-assert any("blocker #731" in error for error in report["errors"])
+assert any("proof #731" in error for error in report["errors"])
 PY
 
 python3 - "$snapshot" "$temp_dir/cargo-release.json" <<'PY'


### PR DESCRIPTION
    ## Summary

    - Refresh the doc/lsp rows in `scripts/ci/check-rust-exit-command-surface.py`: closed #731 is now recorded as `proof_issues` (the ownership proof) instead of a hardcoded live blocker, flipping the offline command-surface coverage report to `ready: true`. This is the row-data refresh that `docs/rust-exit-readiness.md` explicitly queued after #1339 ("#731 itself is closed, so the row data needs a refresh before the report can flip").
    - #731 intentionally stays listed in `docs/rust-exit-readiness.json`: `make rust-exit-readiness` keeps validating its CLOSED state live, and the offline report still errors if the entry disappears from the manifest.
    - Update `scripts/ci/test-check-rust-exit-command-surface.sh` regression cases (ready/implemented counts, `--enforce-ready` now passes, missing-proof case) and the `docs/rust-exit-readiness.md` paragraph.

    ## Governing Issue

    Refs #1251 (command-surface readiness expectations bucket). Refs #1339, #731.

    ## Validation

    - [x] Relevant local checks passed
    - [x] Required PR checks are expected to satisfy `CI Gate`
    - [x] Skipped checks are explained below

    - `bash scripts/ci/test-check-rust-exit-command-surface.sh`: regression cases pass.
    - `python3 scripts/ci/check-rust-exit-command-surface.py`: reports `ready`.
    - `make rust-exit-readiness`: still `ready: true`, still validating issue #731 CLOSED live — the aggregate verdict is unchanged by this PR.
    - Local `run-fast-checks.sh` reaches the python-exit blocker GitHub lookup and fails only on this sandbox's SSL trust store; CI performs that step with a token and passed it on the other open PRs today.

    ## Bootstrap Governance

    - [x] Changes are scoped to the linked issue
    - [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable (not applicable)
    - [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
    - [x] No real secrets, runtime auth, or machine-local env files are committed

    ## Semantic Layer Checklist

    - [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
    - [x] Schemas added/changed are listed, or this PR does not touch schemas (`axiom.rust_exit.command_surface_coverage.v0` rows gain `proof_issues`; `blockers` semantics unchanged — advisory v0 report, no consumer parses these rows programmatically today)
    - [x] Evidence added/changed is listed, or this PR does not touch evidence (command-surface report now reflects the merged #731 closure)
    - [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
    - [x] Agent-facing inspection impact is described, or there is no inspection impact (`make rust-exit-command-surface-coverage` output flips from blocked to ready)

## Flow Contract

- Owner lane: evidence/verification
- Repair owner: same lane
- Autonomy class: Class 2 - Review-gated autonomous
- Risk class: risk:low (status bookkeeping aligned with already-merged #1339 docs; aggregate readiness verdict unchanged)

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is appropriate when gates pass

    ## Merge Automation

    - [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

    ## Notes

    - Lane: evidence/verification.
    - Dependencies: none on the other four open PRs; rides the artifact/evidence layer of an integration train alongside #1356.
    - Rust capture risk: none — CI reporting scripts and docs only.
    - Reviewer attention: this flips a status surface. The claim rests on #731 being CLOSED (validated live by the aggregate gate) and the merged #1339 docs stating doc/LSP ownership is implemented; nothing else changed.