### PR TITLE
Add run and doc command fixtures with failure envelopes

### DIFF
--- a/stage1/compiler-contracts/snapshots/command-lsp.json
+++ b/stage1/compiler-contracts/snapshots/command-lsp.json
@@ -70,6 +70,8 @@
       ],
       "stable_output": "axiom.stage1.v1",
       "fixtures": [
+        "stage1/json-fixtures/run/success.json",
+        "stage1/json-fixtures/run/failure.json",
         "stage1/compiler-contracts/snapshots/run.json"
       ]
     },
@@ -111,6 +113,8 @@
       ],
       "stable_output": "axiom.stage1.v1",
       "fixtures": [
+        "stage1/json-fixtures/doc/success.json",
+        "stage1/json-fixtures/doc/failure.json",
         "stage1/compiler-contracts/snapshots/doc-md.md"
       ]
     },

--- a/stage1/crates/axiomc/tests/json_command_fixtures.rs
+++ b/stage1/crates/axiomc/tests/json_command_fixtures.rs
@@ -143,3 +143,58 @@ fn caps_fixture_covers_unsafe_capability_state() {
     assert_eq!(env["enabled"], true);
     assert_eq!(env["unsafe_unrestricted"], true);
 }
+
+#[test]
+fn run_fixtures_cover_direct_native_success_and_runtime_failure() {
+    let validator = schema_validator();
+    let success = fixture("run", "success.json");
+    assert_matches_stage1_schema(&validator, &success);
+    assert_envelope(&success, "run", true);
+    assert_eq!(success["backend"], "cranelift");
+    assert!(success["generated_rust"].is_null());
+    assert_eq!(success["result"], "success");
+    assert_eq!(success["exit_code"], 0);
+    assert!(success["binary"].is_string());
+    assert!(success["duration_ms"].is_u64());
+    assert_eq!(success["stdout"], "hello from run\n");
+    assert_eq!(success["stderr"], "");
+
+    let failure = fixture("run", "failure.json");
+    assert_matches_stage1_schema(&validator, &failure);
+    assert_envelope(&failure, "run", false);
+    assert_eq!(failure["backend"], "cranelift");
+    assert!(failure["generated_rust"].is_null());
+    assert_eq!(failure["result"], "failure");
+    assert_eq!(failure["exit_code"], 1);
+    assert!(
+        failure["stderr"]
+            .as_str()
+            .expect("runtime stderr")
+            .contains("\"kind\":\"panic\"")
+    );
+}
+
+#[test]
+fn doc_fixtures_cover_public_api_extraction_and_missing_sources() {
+    let validator = schema_validator();
+    let success = fixture("doc", "success.json");
+    assert_matches_stage1_schema(&validator, &success);
+    assert_envelope(&success, "doc", true);
+    assert!(success["markdown"].is_string());
+    assert!(success["html"].is_string());
+    let item = &success["items"][0];
+    assert_eq!(item["kind"], "function");
+    assert_eq!(item["public"], true);
+    assert_eq!(item["signature"], "pub fn add(left: int, right: int): int {");
+
+    let failure = fixture("doc", "failure.json");
+    assert_matches_stage1_schema(&validator, &failure);
+    assert_envelope(&failure, "doc", false);
+    assert_eq!(failure["error"]["kind"], "doc");
+    assert!(
+        failure["error"]["message"]
+            .as_str()
+            .expect("doc error message")
+            .contains("no .ax files found")
+    );
+}

--- a/stage1/json-fixtures/doc/failure.json
+++ b/stage1/json-fixtures/doc/failure.json
@@ -1,0 +1,12 @@
+{
+  "command": "doc",
+  "error": {
+    "column": null,
+    "kind": "doc",
+    "line": null,
+    "message": "no .ax files found under <project>",
+    "path": null
+  },
+  "ok": false,
+  "schema_version": "axiom.stage1.v1"
+}

--- a/stage1/json-fixtures/doc/success.json
+++ b/stage1/json-fixtures/doc/success.json
@@ -1,0 +1,75 @@
+{
+  "schema_version": "axiom.stage1.v1",
+  "command": "doc",
+  "ok": true,
+  "markdown": "<project>/docs/axiom/index.md",
+  "html": "<project>/docs/axiom/index.html",
+  "functions": [
+    {
+      "file": "<project>/src/main.ax",
+      "kind": "function",
+      "public": true,
+      "signature": "pub fn add(left: int, right: int): int {",
+      "docs": [],
+      "examples": []
+    }
+  ],
+  "types": [],
+  "items": [
+    {
+      "file": "<project>/src/main.ax",
+      "kind": "function",
+      "public": true,
+      "signature": "pub fn add(left: int, right: int): int {",
+      "docs": [],
+      "examples": []
+    }
+  ],
+  "capabilities": [
+    {
+      "name": "fs",
+      "enabled": false,
+      "description": "filesystem read access"
+    },
+    {
+      "name": "fs:write",
+      "enabled": false,
+      "description": "filesystem write access"
+    },
+    {
+      "name": "net",
+      "enabled": false,
+      "description": "network access"
+    },
+    {
+      "name": "process",
+      "enabled": false,
+      "description": "child process execution"
+    },
+    {
+      "name": "env",
+      "enabled": false,
+      "description": "environment variable access"
+    },
+    {
+      "name": "clock",
+      "enabled": false,
+      "description": "wall-clock time access"
+    },
+    {
+      "name": "crypto",
+      "enabled": false,
+      "description": "hashing and cryptography primitives"
+    },
+    {
+      "name": "ffi",
+      "enabled": false,
+      "description": "foreign function interface access"
+    },
+    {
+      "name": "async",
+      "enabled": false,
+      "description": "host async runtime access"
+    }
+  ]
+}

--- a/stage1/json-fixtures/run/failure.json
+++ b/stage1/json-fixtures/run/failure.json
@@ -1,0 +1,18 @@
+{
+  "args": [],
+  "backend": "cranelift",
+  "binary": "<project>/dist/contract-run-fail-app",
+  "command": "run",
+  "duration_ms": 278,
+  "entry": "<project>/src/main.ax",
+  "exit_code": 1,
+  "generated_rust": null,
+  "manifest": "<project>/axiom.toml",
+  "ok": false,
+  "package": null,
+  "project": "<project>",
+  "result": "failure",
+  "schema_version": "axiom.stage1.v1",
+  "stderr": "{\"kind\":\"panic\",\"message\":\"run failure fixture\"}\n",
+  "stdout": ""
+}

--- a/stage1/json-fixtures/run/success.json
+++ b/stage1/json-fixtures/run/success.json
@@ -1,0 +1,18 @@
+{
+  "args": [],
+  "backend": "cranelift",
+  "binary": "<project>/dist/contract-run-ok-app",
+  "command": "run",
+  "duration_ms": 584,
+  "entry": "<project>/src/main.ax",
+  "exit_code": 0,
+  "generated_rust": null,
+  "manifest": "<project>/axiom.toml",
+  "ok": true,
+  "package": null,
+  "project": "<project>",
+  "result": "success",
+  "schema_version": "axiom.stage1.v1",
+  "stderr": "",
+  "stdout": "hello from run\n"
+}

--- a/stage1/schemas/axiom.stage1.v1.schema.json
+++ b/stage1/schemas/axiom.stage1.v1.schema.json
@@ -898,10 +898,14 @@
         "properties": {
           "command": {
             "const": "doc"
+          },
+          "ok": {
+            "const": true
           }
         },
         "required": [
-          "command"
+          "command",
+          "ok"
         ]
       },
       "then": {
@@ -955,6 +959,44 @@
             "items": {
               "$ref": "#/$defs/capability"
             }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "command": {
+            "const": "doc"
+          },
+          "ok": {
+            "const": false
+          }
+        },
+        "required": [
+          "command",
+          "ok"
+        ]
+      },
+      "then": {
+        "required": [
+          "schema_version",
+          "ok",
+          "command",
+          "error"
+        ],
+        "properties": {
+          "schema_version": {
+            "$ref": "#/$defs/schemaVersion"
+          },
+          "ok": {
+            "const": false
+          },
+          "command": {
+            "const": "doc"
+          },
+          "error": {
+            "$ref": "#/$defs/diagnostic"
           }
         }
       }


### PR DESCRIPTION
## Summary

- Add checked command fixtures for the two command-surface rows that had none: `stage1/json-fixtures/run/{success,failure}.json` (direct-native run with exit 0 vs. a structured panic envelope with exit 1) and `stage1/json-fixtures/doc/{success,failure}.json` (public-API extraction vs. missing-sources diagnostic), captured from real `axiomc run --json` / `axiomc doc --json` output and scrubbed to `<project>` placeholders like the existing build/test fixtures.
- Validate them in `stage1/crates/axiomc/tests/json_command_fixtures.rs` (schema + envelope + direct-native invariants: `backend: cranelift`, `generated_rust: null`) and cite them in the `run`/`doc` rows of `stage1/compiler-contracts/snapshots/command-lsp.json`.
- Schema delta in `stage1/schemas/axiom.stage1.v1.schema.json`: the `doc` branch previously required `ok: true` whenever `command` is `doc`, so the compiler's real doc failure envelope could never validate. The success branch is now scoped to `ok: true`, and a new failure branch requires the standard `$defs/diagnostic` error object. Success payload validation is unchanged.

## Governing Issue

Refs #1251 (issue stays open; command-surface bucket of the coverage expansion).

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Ran locally:
- `cargo test -p axiomc --test json_command_fixtures` — 5/5 pass (2 new tests)
- `cargo test -p axiomc --test json_check_fixtures --test schema_metadata` — pass
- `python3 scripts/ci/check-command-lsp-boundary.py --json` — pass
- `make rust-exit-command-surface-coverage` — `ready: true`; run and doc rows now report 3 fixtures each
- `bash scripts/ci/test-check-rust-exit-command-surface.sh` / `test-check-command-lsp-boundary.sh` — pass
- `make rust-exit-readiness` — `ready: true`
- `git diff --check` — clean

Pre-existing failures on this machine, identical on clean main (verified by stash/run/pop): 3 cases in `json_contract_snapshots` (temp-dir/sandbox path quirks) and `scripts/ci/test-check-rust-exit-readiness.sh`.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected when applicable (none needed)
- [x] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior — no semantic node changes
- [x] Schemas added/changed are listed, or this PR does not touch schemas — `axiom.stage1.v1.schema.json`: doc success branch scoped to `ok: true`; new doc failure branch requiring the existing `$defs/diagnostic`; strictly widens the schema to match already-shipped compiler behavior
- [x] Evidence added/changed is listed, or this PR does not touch evidence — 4 new command fixtures; run/doc rows in the command-lsp contract snapshot now cite success/failure fixtures
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior — no Rust-capture risk; fixtures assert `generated_rust: null` on the run path
- [x] Agent-facing inspection impact is described, or there is no inspection impact — `make rust-exit-command-surface-coverage` now reports fixtures for run/doc; doc failure envelopes are now schema-describable for agent consumers

## Flow Contract

- Owner lane: evidence/verification (Ares)
- Repair owner: author
- Autonomy class: Class 2 — Review-gated autonomous
- Risk class: low (fixtures, contract citations, one widening schema delta)

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [x] Non-author approval is present when required (pending review)
- [x] Auto-merge is appropriate when gates pass

## Merge Automation

- [x] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- Dependency note: none; independent of #1362 (already merged).
- Rust-capture-risk note: none — evidence and schema surface only; the schema delta describes existing AxiOM-neutral JSON output, not Rust implementation details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)