### PR TITLE
Wire orphaned checker self-tests into the fast lane with an orphan guard

### DIFF
--- a/scripts/ci/run-fast-checks.sh
+++ b/scripts/ci/run-fast-checks.sh
@@ -38,6 +38,19 @@ bash "$script_repo_root/scripts/ci/test-check-rust-exit-command-surface.sh"
 python3 "$script_repo_root/scripts/ci/test-pr-queue-remediation.py"
 python3 "$script_repo_root/scripts/ci/test-report-delivery-signals.py"
 python3 "$script_repo_root/scripts/ci/test-issue-pr-traceability.py"
+# Checker self-tests must run in a CI lane so their harnesses cannot rot
+# silently (#1364, #1369). test-pr-fast-ci-workflow.sh enforces that every
+# scripts/ci/test-check-*.sh stays wired here.
+bash "$script_repo_root/scripts/ci/test-check-python-exit-docs.sh"
+bash "$script_repo_root/scripts/ci/test-check-python-exit-readiness.sh"
+bash "$script_repo_root/scripts/ci/test-check-rust-exit-readiness.sh"
+bash "$script_repo_root/scripts/ci/test-check-self-hosting-language-readiness.sh"
+bash "$script_repo_root/scripts/ci/test-check-direct-native-runtime-abi.sh"
+bash "$script_repo_root/scripts/ci/test-check-package-graph-boundary.sh"
+bash "$script_repo_root/scripts/ci/test-check-diagnostics-syntax-boundary.sh"
+bash "$script_repo_root/scripts/ci/test-check-command-lsp-boundary.sh"
+bash "$script_repo_root/scripts/ci/test-check-hir-boundary.sh"
+bash "$script_repo_root/scripts/ci/test-check-mir-backend-boundary.sh"
 bash "$script_repo_root/scripts/ci/run-stdlib-property-checks.sh"
 bash "$script_repo_root/scripts/ci/run-compiler-property-checks.sh"
 

--- a/scripts/ci/test-pr-fast-ci-workflow.sh
+++ b/scripts/ci/test-pr-fast-ci-workflow.sh
@@ -175,4 +175,18 @@ if [[ -z "$proof_workload_test" ]]; then
   exit 1
 fi
 
+# Every checker self-test must be wired into the fast lane so it cannot rot
+# silently outside CI (#1364, #1369).
+orphaned_self_tests=0
+for self_test in "$repo_root"/scripts/ci/test-check-*.sh; do
+  self_test_name="$(basename "$self_test")"
+  if ! grep -qF "scripts/ci/$self_test_name" "$fast_checks_script"; then
+    echo "run-fast-checks must run scripts/ci/$self_test_name; checker self-tests outside the CI lanes rot silently" >&2
+    orphaned_self_tests=1
+  fi
+done
+if (( orphaned_self_tests )); then
+  exit 1
+fi
+
 echo "pr-fast-ci workflow validation passed"


### PR DESCRIPTION
## Summary

- Add the 10 lane-orphaned `scripts/ci/test-check-*.sh` checker self-tests to `scripts/ci/run-fast-checks.sh`, invoked via `$script_repo_root` like the self-tests already wired there, preserving the trusted-checkout pattern (base-pinned harness, PR-data cwd). The extended lane inherits them since `run-extended-validation.sh` calls the fast checks.
- Add an orphan guard to `scripts/ci/test-pr-fast-ci-workflow.sh` (already in the fast lane): it fails if any `scripts/ci/test-check-*.sh` is not referenced by `run-fast-checks.sh`, closing the class of failure behind #1364 rather than the single instance.

## Governing Issue

Closes #1369

## Validation

- [x] Relevant local checks passed
- [ ] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Local evidence: `bash scripts/ci/test-pr-fast-ci-workflow.sh` passes with the new guard; a negative test (removing one wired entry) makes the guard fail with a per-script error. All 10 newly wired self-tests were run both from the repo root and in trusted-checkout split mode (script root ≠ data-checkout cwd, matching PR fast CI); 9 pass in ~1s each and `test-check-python-exit-docs.sh` passes in ~8s with a warm cargo target. `test-check-rust-exit-readiness.sh` currently fails on `main` (#1364) until #1365 merges, so `CI Gate` on this PR is expected red until then — which is exactly the rot this wiring is meant to surface. **Blocked by #1365; land that first, then re-run checks here.**

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable (no guidance changes needed)
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

## Flow Contract

- Owner lane: evidence/verification
- Repair owner: PR author
- Autonomy class: agent-authored, operator-directed
- Risk class: low (CI lane wiring only; no checker or product code changes)

## Flow Merge Readiness

- [ ] Every blocker has a next actor and next action
- [ ] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is appropriate when gates pass

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- Sequencing: blocked by #1365 — `test-check-rust-exit-readiness.sh` is red on `main` until it merges. The red fast-checks run on this PR before that demonstrates the wiring works.
- Trusted-checkout caveat: in PR fast CI the guard and self-tests enumerate the base-pinned checkout, so a PR adding a new unwired `test-check-*.sh` is caught post-merge by extended validation on `main`, not on the PR itself. Rot is now bounded at one nightly instead of months.
- Out of scope (tracked in #1369): orphaned self-tests outside the `test-check-*.sh` family (e.g. `test-toolchain-supply-chain.sh`, `test-mutation-*.py`, `test-validate-pr-description.sh`, `scripts/debug/test-check-axiom-dwarf.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)