### PR TITLE
Replace rg with grep in the python-exit readiness checker

### DIFF
--- a/scripts/ci/check-python-exit-readiness.sh
+++ b/scripts/ci/check-python-exit-readiness.sh
@@ -116,11 +116,12 @@ for path in README.md docs scripts; do
   fi
 done
 
-if [[ "${#doc_search_paths[@]}" -gt 0 ]] && rg -n "$legacy_invocation" "${doc_search_paths[@]}" \
-  --glob '*.md' \
-  --glob '*.sh' \
-  --glob '!docs/python-exit-parity-gate.md' \
-  --glob '!docs/python-exit-vm-disposition.md' >/dev/null; then
+if [[ "${#doc_search_paths[@]}" -gt 0 ]] && grep -rnF \
+  --include='*.md' \
+  --include='*.sh' \
+  --exclude='python-exit-parity-gate.md' \
+  --exclude='python-exit-vm-disposition.md' \
+  -e "$legacy_invocation" -- "${doc_search_paths[@]}" >/dev/null; then
   add_check "no_user_facing_python_cli" "fail" "user-facing docs still instruct users to run $legacy_invocation"
 else
   add_check "no_user_facing_python_cli" "pass" "user-facing docs do not instruct users to run $legacy_invocation"
@@ -133,7 +134,7 @@ for path in .github scripts Makefile project.bootstrap.yaml; do
   fi
 done
 
-if [[ "${#ci_search_paths[@]}" -gt 0 ]] && rg -n --hidden "$python_unittest" "${ci_search_paths[@]}" >/dev/null; then
+if [[ "${#ci_search_paths[@]}" -gt 0 ]] && grep -rnF -e "$python_unittest" -- "${ci_search_paths[@]}" >/dev/null; then
   add_check "no_python_unittest_ci_gate" "fail" "CI still uses Python unittest as a language/runtime correctness gate"
 else
   add_check "no_python_unittest_ci_gate" "pass" "CI does not use Python unittest as a language/runtime correctness gate"

--- a/scripts/ci/test-check-python-exit-readiness.sh
+++ b/scripts/ci/test-check-python-exit-readiness.sh
@@ -68,6 +68,20 @@ assert_success all_closed \
     --issue-state-file "$all_closed" \
     --require-issue-states
 
+fake_bin="$tmpdir/fake-bin"
+mkdir -p "$fake_bin"
+cat > "$fake_bin/rg" <<'FAKE_RG'
+#!/usr/bin/env bash
+exit 0
+FAKE_RG
+chmod +x "$fake_bin/rg"
+
+assert_success no_rg_dependency \
+  env PATH="$fake_bin:$PATH" \
+  bash scripts/ci/check-python-exit-readiness.sh --json \
+    --issue-state-file "$all_closed" \
+    --require-issue-states
+
 assert_failure_contains one_open "issue #268 is OPEN" \
   bash scripts/ci/check-python-exit-readiness.sh --json \
     --issue-state-file "$one_open" \


### PR DESCRIPTION
    ## Summary

    - Replace the two `rg` invocations in `scripts/ci/check-python-exit-readiness.sh` (the `no_user_facing_python_cli` and `no_python_unittest_ci_gate` checks) with `grep -rnF` equivalents. On runners without ripgrep (ubuntu GitHub runners), `rg` failed as command-not-found inside the guarded `[[ ... ]] && rg ...` conditions, so both checks silently reported pass — a silent false-negative in the same class #1371 fixed loudly in `test-check-rust-exit-readiness.sh`.
    - `--include`/`--exclude` reproduce the rg `--glob` filters for the doc check; plain recursive grep covers `--hidden` because grep does not skip dotfiles. Both search patterns are literal strings, so `-F` matching is exact.
    - Add a regression case to `scripts/ci/test-check-python-exit-readiness.sh` that runs the checker with a stubbed always-matching `rg` on PATH: any reintroduced rg dependency flips the checks to fail and trips the fast lane. Verified the stub makes the pre-fix script fail.
    - Audited `scripts/`, `.github/`, and the Makefile for other rg/fd/bat-style tool assumptions: these two sites were the only remaining ones, so no additional fail-closed `command -v` guards are needed (`gh` is already guarded).

    ## Governing Issue

    Closes #1372

    ## Validation

    - [x] Relevant local checks passed (`bash scripts/ci/check-python-exit-readiness.sh` → ready; `bash scripts/ci/test-check-python-exit-readiness.sh` → all regression cases pass, including the new no-rg case)
    - [x] Required PR checks are expected to satisfy `CI Gate`
    - [x] Skipped checks are explained below

    ## Bootstrap Governance

    - [x] Changes are scoped to the linked issue
    - [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable (not applicable — CI script fix only)
    - [x] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
    - [x] No real secrets, runtime auth, or machine-local env files are committed

    ## Semantic Layer Checklist

    - [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
    - [x] Schemas added/changed are listed, or this PR does not touch schemas
    - [x] Evidence added/changed is listed, or this PR does not touch evidence
    - [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior (no Rust capture risk — shell-only CI tooling)
    - [x] Agent-facing inspection impact is described, or there is no inspection impact

## Flow Contract

- Owner lane: evidence/verification
- Repair owner: author (john.m.teneyck / agent lane)
- Autonomy class: Class 2 - Review-gated autonomous
- Risk class: low (CI checker portability; no compiler/runtime/schema changes; no dependency on other open PRs)

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] Auto-merge is appropriate when gates pass

    ## Merge Automation

    - [x] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

    ## Notes

    - Follow-up to #1364 / #1371 (rust-exit self-test rg regression). This checker's failure mode was quieter: instead of failing the lane, missing `rg` made the legacy-invocation checks pass unconditionally.
    - The new self-test stub asserts behavior (checker output unaffected by a hostile `rg` on PATH) rather than linting the script text, so it survives refactors.
