### PR TITLE
Extract json/serdes i64 lowering into host_json_serdes.rs (#1254)

### DIFF
--- a/docs/compiler-source-decomposition-plan.md
+++ b/docs/compiler-source-decomposition-plan.md
@@ -174,7 +174,7 @@ Snapshot from 2026-07-02:
 
 | Rank | Current Rust file | Lines | Target package boundary | First extraction slice |
 | ---: | --- | ---: | --- | --- |
-| 1 | `stage1/crates/axiomc/src/cranelift_backend.rs` | 20,914 | `compiler.backend.native` | Runtime-intrinsic implementations live in `.../cranelift_backend/intrinsics.rs`, the compile-time evaluator in `.../cranelift_backend/evaluator.rs`, and the filesystem, crypto, and net/http i64 lowering groups in `.../cranelift_backend/host_fs.rs`, `.../cranelift_backend/host_crypto.rs`, and `.../cranelift_backend/host_net_http.rs`; continue splitting the remaining i64 runtime lowering (`lower_i64_*`) by host-capability group (env/process/clock, json/serdes) before sub-partitioning the mutually-recursive value/control core by value shape. |
+| 1 | `stage1/crates/axiomc/src/cranelift_backend.rs` | 20,914 | `compiler.backend.native` | Runtime-intrinsic implementations live in `.../cranelift_backend/intrinsics.rs`, the compile-time evaluator in `.../cranelift_backend/evaluator.rs`, and the filesystem, crypto, net/http, env/process/clock, and json/serdes i64 lowering groups in `.../cranelift_backend/host_fs.rs`, `.../cranelift_backend/host_crypto.rs`, `.../cranelift_backend/host_net_http.rs`, `.../cranelift_backend/host_env_proc_clock.rs`, and `.../cranelift_backend/host_json_serdes.rs`; the remaining work is sub-partitioning the mutually-recursive value/control core by value shape. |
 | 2 | `stage1/crates/axiomc/src/project.rs` | 11,250 | `compiler.package_graph`, `compiler.commands`, `compiler.evidence` | Split manifest/workspace loading, command orchestration, provenance/debug records, and build artifact planning along package ownership. |
 | 3 | `stage1/crates/axiomc/src/main.rs` | 10,695 | `compiler.commands` | Move command parsing, JSON envelope construction, check/build/run/test/doc/trace orchestration, and exit handling behind `docs/compiler-command-lsp-packages.md` APIs. |
 | 4 | `stage1/crates/axiomc/src/codegen.rs` | 7,882 | `compiler.backend.generated_rust`, `compiler.backend.contracts` | Isolate generated-Rust compatibility emission from backend target selection and unsupported-feature contracts. |
@@ -192,10 +192,11 @@ matching ceiling in this table in the same PR.
 
 | Tracked item | Ceiling |
 | --- | ---: |
-| `summary.top_file_line_share` | 0.7401 |
-| `summary.top_file_lines` | 66814 |
-| `stage1/crates/axiomc/src/cranelift_backend.rs` | 20338 |
+| `summary.top_file_line_share` | 0.7373 |
+| `summary.top_file_lines` | 66561 |
+| `stage1/crates/axiomc/src/cranelift_backend.rs` | 20085 |
 | `stage1/crates/axiomc/src/cranelift_backend/host_env_proc_clock.rs` | 586 |
+| `stage1/crates/axiomc/src/cranelift_backend/host_json_serdes.rs` | 258 |
 | `stage1/crates/axiomc/src/cranelift_backend/intrinsics.rs` | 917 |
 | `stage1/crates/axiomc/src/cranelift_backend/evaluator.rs` | 4128 |
 | `stage1/crates/axiomc/src/cranelift_backend/host_fs.rs` | 984 |
@@ -267,8 +268,8 @@ Slice status (update as PRs land):
 - filesystem -> `host_fs.rs` — #1379, merged
 - crypto -> `host_crypto.rs` — #1380, merged
 - net/http -> `host_net_http.rs` — #1381, in review (do not redo)
-- **env/process/clock -> `host_env_proc_clock.rs` — NEXT (not started)**
-- **json/serdes -> `host_json_serdes.rs` — after env/process/clock**
+- env/process/clock -> `host_env_proc_clock.rs` — #1383, merged
+- json/serdes -> `host_json_serdes.rs` — #1254/#1384, in review (do not redo)
 
 After these host families are out, sub-partition the mutually-recursive
 value/control core by value shape.

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -36,6 +36,8 @@ mod host_net_http;
 pub(crate) use host_net_http::*;
 mod host_env_proc_clock;
 pub(crate) use host_env_proc_clock::*;
+mod host_json_serdes;
+pub(crate) use host_json_serdes::*;
 
 const SPIKE_PACKAGE_ROOT_BINDING: &str = "$axiom_package_root";
 const SPIKE_FS_ROOT_BINDING: &str = "$axiom_fs_root";
@@ -7191,70 +7193,6 @@ fn lower_i64_print_bool_line_stmts(
 const HTTP_NON_LOOPBACK_BIND_DIAG: &str =
     "{\"kind\":\"net\",\"message\":\"http server bind address must resolve only to loopback\"}";
 
-fn lower_i64_json_stringify_string_line_stmts(
-    expr: &Expr,
-    stream: OutputStream,
-    local_indexes: &HashMap<String, usize>,
-    local_conditions: &HashMap<String, CraneliftI64Condition>,
-    helper_signatures: &HashMap<&str, I64HelperSignature>,
-    static_bindings: &I64StaticBindings,
-) -> Option<Vec<CraneliftI64Stmt>> {
-    lower_i64_json_stringify_string_line_stmts_with_written(
-        expr,
-        stream,
-        local_indexes,
-        local_conditions,
-        helper_signatures,
-        static_bindings,
-    )
-    .map(|(stmts, _)| stmts)
-}
-
-fn lower_i64_json_stringify_string_line_stmts_with_written(
-    expr: &Expr,
-    stream: OutputStream,
-    local_indexes: &HashMap<String, usize>,
-    local_conditions: &HashMap<String, CraneliftI64Condition>,
-    helper_signatures: &HashMap<&str, I64HelperSignature>,
-    static_bindings: &I64StaticBindings,
-) -> Option<(Vec<CraneliftI64Stmt>, CraneliftI64Expr)> {
-    let Expr::Call { name, args, .. } = expr else {
-        return None;
-    };
-    if !is_i64_json_stringify_string_name(name, static_bindings) {
-        return None;
-    }
-    let [value] = args.as_slice() else {
-        return None;
-    };
-    let mut stmts = lower_i64_log_json_string_value_stmts(
-        value,
-        stream,
-        local_indexes,
-        local_conditions,
-        helper_signatures,
-        static_bindings,
-    )?;
-    stmts.push(CraneliftI64Stmt::WriteLine {
-        stream,
-        text: String::new(),
-    });
-    Some((
-        stmts,
-        CraneliftI64Expr::Binary {
-            op: CraneliftI64BinaryOp::Add,
-            lhs: Box::new(lower_i64_json_escaped_string_len_expr(
-                value,
-                local_indexes,
-                local_conditions,
-                helper_signatures,
-                static_bindings,
-            )?),
-            rhs: Box::new(CraneliftI64Expr::Literal(1)),
-        },
-    ))
-}
-
 fn lower_i64_dynamic_known_string_line_stmts(
     expr: &Expr,
     stream: OutputStream,
@@ -7811,7 +7749,6 @@ fn lower_i64_known_string_option_call_let_stmts(
         .insert(name.to_string(), value);
     Some(Vec::new())
 }
-
 
 fn lower_i64_string_option_len_call_let_stmts(
     name: &str,
@@ -10376,7 +10313,6 @@ fn lower_i64_fs_read_some_arm_expr(
         static_bindings,
     )
 }
-
 
 pub(crate) struct I64NetResolveHost {
     host: String,
@@ -14798,10 +14734,6 @@ fn i64_string_len_key(name: &str) -> String {
     format!("{name}$len")
 }
 
-fn i64_json_safe_string_len_key(name: &str) -> String {
-    format!("{name}$json_safe_len")
-}
-
 fn i64_option_tag_key(name: &str) -> String {
     format!("{name}?tag")
 }
@@ -15125,7 +15057,6 @@ fn lower_i64_array_literal_projection_index_expr(
     }
     Some(result)
 }
-
 
 fn i64_audited_ffi_expr(
     intrinsic: &str,
@@ -15610,55 +15541,6 @@ fn is_i64_encoding_path_join_segment_name(name: &str, static_bindings: &I64Stati
     name == "encoding_path_join_segment"
         || static_bindings
             .encoding_path_join_segment_wrappers
-            .contains(name)
-}
-
-fn is_i64_std_json_wrapper(function: &Function, source_name: &str) -> bool {
-    function.path == "<stdlib>/json.ax" && function.source_name == source_name
-}
-
-fn is_i64_json_parse_int_name(name: &str, static_bindings: &I64StaticBindings) -> bool {
-    name == "json_parse_int" || static_bindings.json_parse_int_wrappers.contains(name)
-}
-
-fn is_i64_json_parse_bool_name(name: &str, static_bindings: &I64StaticBindings) -> bool {
-    name == "json_parse_bool" || static_bindings.json_parse_bool_wrappers.contains(name)
-}
-
-fn is_i64_json_parse_string_name(name: &str, static_bindings: &I64StaticBindings) -> bool {
-    name == "json_parse_string" || static_bindings.json_parse_string_wrappers.contains(name)
-}
-
-fn is_i64_json_parse_field_int_name(name: &str, static_bindings: &I64StaticBindings) -> bool {
-    name == "json_parse_field_int" || static_bindings.json_parse_field_int_wrappers.contains(name)
-}
-
-fn is_i64_json_parse_field_bool_name(name: &str, static_bindings: &I64StaticBindings) -> bool {
-    name == "json_parse_field_bool"
-        || static_bindings
-            .json_parse_field_bool_wrappers
-            .contains(name)
-}
-
-fn is_i64_json_parse_field_string_name(name: &str, static_bindings: &I64StaticBindings) -> bool {
-    name == "json_parse_field_string"
-        || static_bindings
-            .json_parse_field_string_wrappers
-            .contains(name)
-}
-
-fn is_i64_json_stringify_int_name(name: &str, static_bindings: &I64StaticBindings) -> bool {
-    name == "json_stringify_int" || static_bindings.json_stringify_int_wrappers.contains(name)
-}
-
-fn is_i64_json_stringify_bool_name(name: &str, static_bindings: &I64StaticBindings) -> bool {
-    name == "json_stringify_bool" || static_bindings.json_stringify_bool_wrappers.contains(name)
-}
-
-fn is_i64_json_stringify_string_name(name: &str, static_bindings: &I64StaticBindings) -> bool {
-    name == "json_stringify_string"
-        || static_bindings
-            .json_stringify_string_wrappers
             .contains(name)
 }
 
@@ -16417,59 +16299,6 @@ fn lower_i64_string_len_expr(
     }
 }
 
-fn lower_i64_json_escaped_string_len_expr(
-    expr: &Expr,
-    local_indexes: &HashMap<String, usize>,
-    local_conditions: &HashMap<String, CraneliftI64Condition>,
-    helper_signatures: &HashMap<&str, I64HelperSignature>,
-    static_bindings: &I64StaticBindings,
-) -> Option<CraneliftI64Expr> {
-    if let Some(value) = i64_string_text(expr, static_bindings) {
-        return Some(CraneliftI64Expr::Literal(
-            json_escape_string(&value).len() as i64
-        ));
-    }
-    if let Expr::Call { name, args, .. } = expr {
-        if is_i64_json_stringify_string_name(name, static_bindings) {
-            let [text] = args.as_slice() else {
-                return None;
-            };
-            return Some(CraneliftI64Expr::Binary {
-                op: CraneliftI64BinaryOp::Add,
-                lhs: Box::new(lower_i64_json_safe_string_len_expr(
-                    text,
-                    local_indexes,
-                    local_conditions,
-                    helper_signatures,
-                    static_bindings,
-                )?),
-                rhs: Box::new(CraneliftI64Expr::Literal(4)),
-            });
-        }
-    }
-    lower_i64_map_key_array_string_index_mapped_i64_expr(
-        expr,
-        local_indexes,
-        local_conditions,
-        helper_signatures,
-        static_bindings,
-        |value| json_escape_string(value).len() as i64,
-    )
-    .or_else(|| {
-        Some(CraneliftI64Expr::Binary {
-            op: CraneliftI64BinaryOp::Add,
-            lhs: Box::new(lower_i64_json_safe_string_len_expr(
-                expr,
-                local_indexes,
-                local_conditions,
-                helper_signatures,
-                static_bindings,
-            )?),
-            rhs: Box::new(CraneliftI64Expr::Literal(2)),
-        })
-    })
-}
-
 fn lower_i64_map_key_array_string_index_len_expr(
     base: &Expr,
     index: &Expr,
@@ -16526,88 +16355,6 @@ fn lower_i64_map_key_array_string_index_len_expr(
         };
     }
     Some(result)
-}
-
-fn lower_i64_json_safe_string_len_expr(
-    expr: &Expr,
-    local_indexes: &HashMap<String, usize>,
-    local_conditions: &HashMap<String, CraneliftI64Condition>,
-    helper_signatures: &HashMap<&str, I64HelperSignature>,
-    static_bindings: &I64StaticBindings,
-) -> Option<CraneliftI64Expr> {
-    match expr {
-        Expr::Call { name, args, .. } if is_i64_json_stringify_int_name(name, static_bindings) => {
-            let [value] = args.as_slice() else {
-                return None;
-            };
-            let value = lower_i64_expr(
-                value,
-                local_indexes,
-                local_conditions,
-                helper_signatures,
-                static_bindings,
-            )?;
-            Some(i64_decimal_string_len_expr(value))
-        }
-        Expr::Call { name, args, .. } if is_i64_json_stringify_bool_name(name, static_bindings) => {
-            let [value] = args.as_slice() else {
-                return None;
-            };
-            Some(CraneliftI64Expr::Select {
-                cond: Box::new(lower_i64_condition(
-                    value,
-                    local_indexes,
-                    local_conditions,
-                    helper_signatures,
-                    static_bindings,
-                )?),
-                then_result: Box::new(CraneliftI64Expr::Literal(4)),
-                else_result: Box::new(CraneliftI64Expr::Literal(5)),
-            })
-        }
-        Expr::VarRef {
-            name,
-            ty: Type::String | Type::Str,
-        } => {
-            if let Some(local) = local_indexes.get(i64_json_safe_string_len_key(name).as_str()) {
-                return Some(CraneliftI64Expr::Local(*local));
-            }
-            if let Some(local) = local_indexes.get(i64_printable_i64_string_key(name).as_str()) {
-                return Some(i64_decimal_string_len_expr(CraneliftI64Expr::Local(*local)));
-            }
-            local_conditions
-                .get(i64_printable_bool_string_key(name).as_str())
-                .cloned()
-                .map(|cond| CraneliftI64Expr::Select {
-                    cond: Box::new(cond),
-                    then_result: Box::new(CraneliftI64Expr::Literal(4)),
-                    else_result: Box::new(CraneliftI64Expr::Literal(5)),
-                })
-        }
-        Expr::BinaryAdd {
-            op: ArithmeticOp::Add,
-            lhs,
-            rhs,
-            ty: Type::String | Type::Str,
-        } => Some(CraneliftI64Expr::Binary {
-            op: CraneliftI64BinaryOp::Add,
-            lhs: Box::new(lower_i64_json_safe_string_len_expr(
-                lhs,
-                local_indexes,
-                local_conditions,
-                helper_signatures,
-                static_bindings,
-            )?),
-            rhs: Box::new(lower_i64_json_safe_string_len_expr(
-                rhs,
-                local_indexes,
-                local_conditions,
-                helper_signatures,
-                static_bindings,
-            )?),
-        }),
-        _ => None,
-    }
 }
 
 fn i64_decimal_string_len_expr(value: CraneliftI64Expr) -> CraneliftI64Expr {

--- a/stage1/crates/axiomc/src/cranelift_backend/host_json_serdes.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend/host_json_serdes.rs
@@ -1,0 +1,258 @@
+//! JSON / serdes i64-lowering support for the native Cranelift backend.
+//!
+//! Extracted from `cranelift_backend.rs` under issue #1254.  All functions are
+//! `pub(crate)` because they are called back into from sibling modules (evaluator,
+//! host_* peers) through the parent's `use super::*` re-export.
+
+use super::*;
+pub(crate) fn i64_json_safe_string_len_key(name: &str) -> String {
+    format!("{name}$json_safe_len")
+}
+
+pub(crate) fn is_i64_std_json_wrapper(function: &Function, source_name: &str) -> bool {
+    function.path == "<stdlib>/json.ax" && function.source_name == source_name
+}
+
+pub(crate) fn is_i64_json_parse_int_name(name: &str, static_bindings: &I64StaticBindings) -> bool {
+    name == "json_parse_int" || static_bindings.json_parse_int_wrappers.contains(name)
+}
+
+pub(crate) fn is_i64_json_parse_bool_name(name: &str, static_bindings: &I64StaticBindings) -> bool {
+    name == "json_parse_bool" || static_bindings.json_parse_bool_wrappers.contains(name)
+}
+
+pub(crate) fn is_i64_json_parse_string_name(name: &str, static_bindings: &I64StaticBindings) -> bool {
+    name == "json_parse_string" || static_bindings.json_parse_string_wrappers.contains(name)
+}
+
+pub(crate) fn is_i64_json_parse_field_int_name(name: &str, static_bindings: &I64StaticBindings) -> bool {
+    name == "json_parse_field_int" || static_bindings.json_parse_field_int_wrappers.contains(name)
+}
+
+pub(crate) fn is_i64_json_parse_field_bool_name(name: &str, static_bindings: &I64StaticBindings) -> bool {
+    name == "json_parse_field_bool"
+        || static_bindings
+            .json_parse_field_bool_wrappers
+            .contains(name)
+}
+
+pub(crate) fn is_i64_json_parse_field_string_name(name: &str, static_bindings: &I64StaticBindings) -> bool {
+    name == "json_parse_field_string"
+        || static_bindings
+            .json_parse_field_string_wrappers
+            .contains(name)
+}
+
+pub(crate) fn is_i64_json_stringify_int_name(name: &str, static_bindings: &I64StaticBindings) -> bool {
+    name == "json_stringify_int" || static_bindings.json_stringify_int_wrappers.contains(name)
+}
+
+pub(crate) fn is_i64_json_stringify_bool_name(name: &str, static_bindings: &I64StaticBindings) -> bool {
+    name == "json_stringify_bool" || static_bindings.json_stringify_bool_wrappers.contains(name)
+}
+
+pub(crate) fn is_i64_json_stringify_string_name(name: &str, static_bindings: &I64StaticBindings) -> bool {
+    name == "json_stringify_string"
+        || static_bindings
+            .json_stringify_string_wrappers
+            .contains(name)
+}
+
+pub(crate) fn lower_i64_json_stringify_string_line_stmts(
+    expr: &Expr,
+    stream: OutputStream,
+    local_indexes: &HashMap<String, usize>,
+    local_conditions: &HashMap<String, CraneliftI64Condition>,
+    helper_signatures: &HashMap<&str, I64HelperSignature>,
+    static_bindings: &I64StaticBindings,
+) -> Option<Vec<CraneliftI64Stmt>> {
+    lower_i64_json_stringify_string_line_stmts_with_written(
+        expr,
+        stream,
+        local_indexes,
+        local_conditions,
+        helper_signatures,
+        static_bindings,
+    )
+    .map(|(stmts, _)| stmts)
+}
+
+pub(crate) fn lower_i64_json_stringify_string_line_stmts_with_written(
+    expr: &Expr,
+    stream: OutputStream,
+    local_indexes: &HashMap<String, usize>,
+    local_conditions: &HashMap<String, CraneliftI64Condition>,
+    helper_signatures: &HashMap<&str, I64HelperSignature>,
+    static_bindings: &I64StaticBindings,
+) -> Option<(Vec<CraneliftI64Stmt>, CraneliftI64Expr)> {
+    let Expr::Call { name, args, .. } = expr else {
+        return None;
+    };
+    if !is_i64_json_stringify_string_name(name, static_bindings) {
+        return None;
+    }
+    let [value] = args.as_slice() else {
+        return None;
+    };
+    let mut stmts = lower_i64_log_json_string_value_stmts(
+        value,
+        stream,
+        local_indexes,
+        local_conditions,
+        helper_signatures,
+        static_bindings,
+    )?;
+    stmts.push(CraneliftI64Stmt::WriteLine {
+        stream,
+        text: String::new(),
+    });
+    Some((
+        stmts,
+        CraneliftI64Expr::Binary {
+            op: CraneliftI64BinaryOp::Add,
+            lhs: Box::new(lower_i64_json_escaped_string_len_expr(
+                value,
+                local_indexes,
+                local_conditions,
+                helper_signatures,
+                static_bindings,
+            )?),
+            rhs: Box::new(CraneliftI64Expr::Literal(1)),
+        },
+    ))
+}
+
+pub(crate) fn lower_i64_json_escaped_string_len_expr(
+    expr: &Expr,
+    local_indexes: &HashMap<String, usize>,
+    local_conditions: &HashMap<String, CraneliftI64Condition>,
+    helper_signatures: &HashMap<&str, I64HelperSignature>,
+    static_bindings: &I64StaticBindings,
+) -> Option<CraneliftI64Expr> {
+    if let Some(value) = i64_string_text(expr, static_bindings) {
+        return Some(CraneliftI64Expr::Literal(
+            json_escape_string(&value).len() as i64
+        ));
+    }
+    if let Expr::Call { name, args, .. } = expr {
+        if is_i64_json_stringify_string_name(name, static_bindings) {
+            let [text] = args.as_slice() else {
+                return None;
+            };
+            return Some(CraneliftI64Expr::Binary {
+                op: CraneliftI64BinaryOp::Add,
+                lhs: Box::new(lower_i64_json_safe_string_len_expr(
+                    text,
+                    local_indexes,
+                    local_conditions,
+                    helper_signatures,
+                    static_bindings,
+                )?),
+                rhs: Box::new(CraneliftI64Expr::Literal(4)),
+            });
+        }
+    }
+    lower_i64_map_key_array_string_index_mapped_i64_expr(
+        expr,
+        local_indexes,
+        local_conditions,
+        helper_signatures,
+        static_bindings,
+        |value| json_escape_string(value).len() as i64,
+    )
+    .or_else(|| {
+        Some(CraneliftI64Expr::Binary {
+            op: CraneliftI64BinaryOp::Add,
+            lhs: Box::new(lower_i64_json_safe_string_len_expr(
+                expr,
+                local_indexes,
+                local_conditions,
+                helper_signatures,
+                static_bindings,
+            )?),
+            rhs: Box::new(CraneliftI64Expr::Literal(2)),
+        })
+    })
+}
+
+pub(crate) fn lower_i64_json_safe_string_len_expr(
+    expr: &Expr,
+    local_indexes: &HashMap<String, usize>,
+    local_conditions: &HashMap<String, CraneliftI64Condition>,
+    helper_signatures: &HashMap<&str, I64HelperSignature>,
+    static_bindings: &I64StaticBindings,
+) -> Option<CraneliftI64Expr> {
+    match expr {
+        Expr::Call { name, args, .. } if is_i64_json_stringify_int_name(name, static_bindings) => {
+            let [value] = args.as_slice() else {
+                return None;
+            };
+            let value = lower_i64_expr(
+                value,
+                local_indexes,
+                local_conditions,
+                helper_signatures,
+                static_bindings,
+            )?;
+            Some(i64_decimal_string_len_expr(value))
+        }
+        Expr::Call { name, args, .. } if is_i64_json_stringify_bool_name(name, static_bindings) => {
+            let [value] = args.as_slice() else {
+                return None;
+            };
+            Some(CraneliftI64Expr::Select {
+                cond: Box::new(lower_i64_condition(
+                    value,
+                    local_indexes,
+                    local_conditions,
+                    helper_signatures,
+                    static_bindings,
+                )?),
+                then_result: Box::new(CraneliftI64Expr::Literal(4)),
+                else_result: Box::new(CraneliftI64Expr::Literal(5)),
+            })
+        }
+        Expr::VarRef {
+            name,
+            ty: Type::String | Type::Str,
+        } => {
+            if let Some(local) = local_indexes.get(i64_json_safe_string_len_key(name).as_str()) {
+                return Some(CraneliftI64Expr::Local(*local));
+            }
+            if let Some(local) = local_indexes.get(i64_printable_i64_string_key(name).as_str()) {
+                return Some(i64_decimal_string_len_expr(CraneliftI64Expr::Local(*local)));
+            }
+            local_conditions
+                .get(i64_printable_bool_string_key(name).as_str())
+                .cloned()
+                .map(|cond| CraneliftI64Expr::Select {
+                    cond: Box::new(cond),
+                    then_result: Box::new(CraneliftI64Expr::Literal(4)),
+                    else_result: Box::new(CraneliftI64Expr::Literal(5)),
+                })
+        }
+        Expr::BinaryAdd {
+            op: ArithmeticOp::Add,
+            lhs,
+            rhs,
+            ty: Type::String | Type::Str,
+        } => Some(CraneliftI64Expr::Binary {
+            op: CraneliftI64BinaryOp::Add,
+            lhs: Box::new(lower_i64_json_safe_string_len_expr(
+                lhs,
+                local_indexes,
+                local_conditions,
+                helper_signatures,
+                static_bindings,
+            )?),
+            rhs: Box::new(lower_i64_json_safe_string_len_expr(
+                rhs,
+                local_indexes,
+                local_conditions,
+                helper_signatures,
+                static_bindings,
+            )?),
+        }),
+        _ => None,
+    }
+}


### PR DESCRIPTION
## Summary

Follows the #1383 pure-function move pattern: the new child module `stage1/crates/axiomc/src/cranelift_backend/host_json_serdes.rs` starts with `use super::*;`, and the parent adds `mod host_json_serdes;` + `pub(crate) use host_json_serdes::*;` next to the existing `host_*` wiring.

This extracts the focused json/serdes i64-lowering slice (definitions only; call sites stay in the parent and resolve through the re-export):

- predicates: `is_i64_std_json_wrapper`, `is_i64_json_parse_*_name`, `is_i64_json_stringify_*_name`
- helpers: `i64_json_safe_string_len_key`, `lower_i64_json_escaped_string_len_expr`, `lower_i64_json_safe_string_len_expr`
- lowerers: `lower_i64_json_stringify_string_line_stmts`, `lower_i64_json_stringify_string_line_stmts_with_written`

Kept in the parent (reachable from the child via `use super::*`): `I64StaticBindings` fields/population, `json_serdes_*` runtime helpers, panic/logging (`lower_i64_log_json_*`), and the recursive `lower_i64_expr`/`lower_i64_condition` hub.

## Verification

- `cargo build -p axiomc` — warning-clean (0 warnings).
- Monolith plan/ratchet gate (`scripts/ci/report-compiler-source-monoliths.py --check-ratchet`) — passed.
- Narrower json/serdes test `cranelift_backend_builds_json_serdes_binary` — 1 passed, 0 failed.

## Docs

`docs/compiler-source-decomposition-plan.md` ratchet update (#1382): added the `host_json_serdes.rs` ceiling and lowered the `cranelift_backend.rs`, `summary.top_file_lines`, and `summary.top_file_line_share` ceilings; marked the json/serdes slice.

Closes the json/serdes slice of #1254 (after #1381 net/http, #1382 doc recipe, #1383 env/process/clock). Do not redo net/http or env/process/clock.

🤖 Generated with [OpenClaw](https://openclaw.ai)