### PR TITLE
perf: hoist repeated package_root.display().to_string() in test listing/running (#1202)

### DIFF
--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -757,14 +757,15 @@ pub fn list_project_tests_with_options(
         if discovered.is_empty() {
             continue;
         }
-        packages.push(package_root.display().to_string());
+        let package_root_text = package_root.display().to_string();
+        packages.push(package_root_text.clone());
         let package_name = manifest
             .package
             .as_ref()
             .map(|package| package.name.clone());
         for test in discovered {
             tests.push(ListedTest {
-                package_root: package_root.display().to_string(),
+                package_root: package_root_text.clone(),
                 package: test.package.clone().or_else(|| package_name.clone()),
                 name: test.name,
                 kind: test.kind,
@@ -802,6 +803,7 @@ pub fn run_project_tests_with_options(
     {
         let manifest = &graph.context(&package_root)?.manifest;
         validate_lockfile(&package_root, manifest)?;
+        let package_root_text = package_root.display().to_string();
         let compile_fail_kind = expected_error_path(&package_root)
             .exists()
             .then(|| compile_fail_test_kind(options))
@@ -813,7 +815,7 @@ pub fn run_project_tests_with_options(
                 kind,
                 options.filter.as_deref(),
             ) {
-                packages.push(package_root.display().to_string());
+                packages.push(package_root_text.clone());
                 cases.push(run_compile_fail_case(
                     &package_root,
                     &graph,
@@ -836,7 +838,7 @@ pub fn run_project_tests_with_options(
         if tests.is_empty() {
             continue;
         }
-        packages.push(package_root.display().to_string());
+        packages.push(package_root_text.clone());
         for test in &tests {
             cases.push(run_test_case(
                 &package_root,


### PR DESCRIPTION
## Slice

Implements one behavior-preserving, review-gated finding from axiomlang#1202:
**"Hoist repeated `package_root.display().to_string()` calls in test listing/running code."**

### Change
In `stage1/crates/axiomc/src/project.rs`, the functions `list_project_tests_with_options`
and `run_project_tests_with_options` recomputed `package_root.display().to_string()` on
every loop iteration — and in the `list` path, once **per discovered test** inside the
inner `for test in discovered` loop.

The call is now computed once per iteration into a local `package_root_text` and that
`String` is cloned where needed (`packages.push(...)` and the per-test `ListedTest` field
in the list path; both `packages.push(...)` branches in the run path).

### Why safe
- **Behavior-preserving**: identical output (`package_root` path text is unchanged); only
  the allocation is hoisted out of the hot loop.
- **Localized**: limited to `stage1/crates/axiomc/src/project.rs`; no signature, API, or
  public-behavior change.
- Verified with the focused tests:
  - `list_project_tests_reports_stable_names_paths_and_package_membership` — passed
  - `run_project_tests_executes_manifest_cases` — passed

### Scope guard
Does not touch any other #1202 finding (lockfile sort #1320, HIR program clone avoidance
#1321, type_assignable_to direct compare #1322, Cranelift helper wrapper-set borrowing
#1323, expected-output reuse #1324, project manifest borrowing #1325, nor the monomorphize
field move). No conflicting open PR: the only open PR (#1387) addresses a different #1202
slice (`infer_generic_call_type_args` move-instead-of-clone) and does not touch
`project.rs`.

Refs #1202.
