### PR TITLE
perf: hoist repeated package_root.display().to_string() in test listing/running (#1202)

### DIFF
--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -757,14 +757,15 @@ pub fn list_project_tests_with_options(
         if discovered.is_empty() {
             continue;
         }
-        packages.push(package_root.display().to_string());
+        let package_root_text = package_root.display().to_string();
+        packages.push(package_root_text.clone());
         let package_name = manifest
             .package
             .as_ref()
             .map(|package| package.name.clone());
         for test in discovered {
             tests.push(ListedTest {
-                package_root: package_root.display().to_string(),
+                package_root: package_root_text.clone(),
                 package: test.package.clone().or_else(|| package_name.clone()),
                 name: test.name,
                 kind: test.kind,
@@ -802,6 +803,7 @@ pub fn run_project_tests_with_options(
     {
         let manifest = &graph.context(&package_root)?.manifest;
         validate_lockfile(&package_root, manifest)?;
+        let package_root_text = package_root.display().to_string();
         let compile_fail_kind = expected_error_path(&package_root)
             .exists()
             .then(|| compile_fail_test_kind(options))
@@ -813,7 +815,7 @@ pub fn run_project_tests_with_options(
                 kind,
                 options.filter.as_deref(),
             ) {
-                packages.push(package_root.display().to_string());
+                packages.push(package_root_text.clone());
                 cases.push(run_compile_fail_case(
                     &package_root,
                     &graph,
@@ -836,7 +838,8 @@ pub fn run_project_tests_with_options(
         if tests.is_empty() {
             continue;
         }
-        packages.push(package_root.display().to_string());
+        let package_root_text = package_root.display().to_string();
+        packages.push(package_root_text.clone());
         for test in &tests {
             cases.push(run_test_case(
                 &package_root,

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -809,12 +809,9 @@ pub fn run_project_tests_with_options(
             .then(|| compile_fail_test_kind(options))
             .flatten();
         if let Some(kind) = compile_fail_kind {
-            if let Some(test) = compile_fail_test_target(
-                &package_root,
-                manifest,
-                kind,
-                options.filter.as_deref(),
-            ) {
+            if let Some(test) =
+                compile_fail_test_target(&package_root, manifest, kind, options.filter.as_deref())
+            {
                 packages.push(package_root_text.clone());
                 cases.push(run_compile_fail_case(
                     &package_root,
@@ -838,7 +835,6 @@ pub fn run_project_tests_with_options(
         if tests.is_empty() {
             continue;
         }
-        let package_root_text = package_root.display().to_string();
         packages.push(package_root_text.clone());
         for test in &tests {
             cases.push(run_test_case(


### PR DESCRIPTION
## Summary

- Hoists repeated `package_root.display().to_string()` work in `list_project_tests_with_options` and `run_project_tests_with_options`.
- Reuses one `package_root_text` per package where the test list/run paths need the same path string for package tracking and listed test metadata.
- Keeps behavior unchanged: emitted package-root text, discovered tests, run cases, filtering, and command APIs are unchanged.

## Governing Issue

Refs #1202.

This implements only the package-root display-string hoist from the #1202 performance sweep.

## Validation

- [x] `PR_BODY="$(cat .pr-body-1389.md)" bash scripts/ci/validate-pr-description.sh`
- [x] `rustfmt --edition 2024 --check stage1/crates/axiomc/src/project.rs`
- [x] `python3 scripts/ci/report-compiler-source-monoliths.py --json --check-plan --check-ratchet`
- [x] `bash scripts/ci/run-fast-checks.sh`
- Not run: package-wide `cargo fmt --check --manifest-path stage1/crates/axiomc/Cargo.toml` currently reports pre-existing formatting drift outside this PR's touched file.

## Bootstrap Governance

- Bootstrap surface is unchanged: no syntax, manifest, lockfile, generated artifact, or compiler contract changes.
- The change is limited to Rust-hosted command/test orchestration in `stage1/crates/axiomc/src/project.rs`.
- The PR remains review-gated under #1202 and does not claim any additional bootstrap milestone.

## Notes

- Scope guard: does not touch the other #1202 findings for lockfile sort, HIR clone avoidance, type-assignability comparison, Cranelift wrapper borrowing, expected-output reuse, project manifest borrowing, or monomorphize field moves.
- A line-count-only cleanup in the same touched region keeps `project.rs` within the current compiler-source ratchet ceiling required by Fast CI.
