### PR TITLE
perf: avoid cloning functions during generic call inference (#1202)

### DIFF
--- a/stage1/crates/axiomc/src/hir/generics.rs
+++ b/stage1/crates/axiomc/src/hir/generics.rs
@@ -15,40 +15,38 @@ struct GenericInstantiation {
 const MAX_GENERIC_INSTANTIATION_EXPANSIONS: usize = 256;
 
 fn infer_generic_call_type_args(
-    program: syntax::Program,
+    mut program: syntax::Program,
     generic_functions: &HashMap<String, syntax::Function>,
 ) -> Result<syntax::Program, Diagnostic> {
-    let functions = program
-        .functions
-        .iter()
+    let original_functions = std::mem::take(&mut program.functions);
+    let original_stmts = std::mem::take(&mut program.stmts);
+
+    program.functions = original_functions
+        .into_iter()
         .map(|function| infer_generic_calls_in_function(function, generic_functions))
         .collect::<Result<Vec<_>, _>>()?;
     let mut env = HashMap::new();
-    let stmts = infer_generic_calls_in_stmts(&program.stmts, &mut env, None, generic_functions)?;
+    program.stmts =
+        infer_generic_calls_in_stmts(&original_stmts, &mut env, None, generic_functions)?;
 
-    Ok(syntax::Program {
-        functions,
-        stmts,
-        ..program
-    })
+    Ok(program)
 }
 
 fn infer_generic_calls_in_function(
-    function: &syntax::Function,
+    function: syntax::Function,
     generic_functions: &HashMap<String, syntax::Function>,
 ) -> Result<syntax::Function, Diagnostic> {
     let mut env = HashMap::new();
     for param in &function.params {
         env.insert(param.name.clone(), param.ty.clone());
     }
-    let mut inferred = function.clone();
-    inferred.body = infer_generic_calls_in_stmts(
+    let body = infer_generic_calls_in_stmts(
         &function.body,
         &mut env,
         Some(&function.return_ty),
         generic_functions,
     )?;
-    Ok(inferred)
+    Ok(syntax::Function { body, ..function })
 }
 
 fn infer_generic_calls_in_stmts(


### PR DESCRIPTION
## Summary

- Consume the owned syntax function vector inside generic call inference instead of iterating by reference and cloning each function.
- Rebuild only the inferred function body, preserving the rest of each syntax function by move.

## Governing Issue

Refs #1202

## Validation

- [x] `rustfmt --edition 2024 --check crates/axiomc/src/hir/generics.rs`
- [x] `cargo check -p axiomc`
- [x] Live PR checks currently report `CI Gate`, `Fast Checks`, `Full Lib Suite`, `Validate PR Description`, `Validate Secrets`, `Detect Relevant Changes`, and `Lockfile Integrity, Vetting, and SBOM` as successful.
- [x] PR-body repair validation: `PR_BODY="$(cat .pr-1390-body.md)" bash scripts/ci/validate-pr-description.sh`

## Bootstrap Governance

- [x] Changes are scoped to the linked issue.
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable; this PR does not change contributor or PR guidance.
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies; not changed during this body-only repair assignment.
- [x] No real secrets, runtime auth, or machine-local env files are committed.

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior.
- [x] Schemas added/changed are listed, or this PR does not touch schemas.
- [x] Evidence added/changed is listed, or this PR does not touch evidence.
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior.
- [x] Agent-facing inspection impact is described, or there is no inspection impact.

## Flow Contract

- Owner lane: daedalus
- Repair owner: daedalus
- Autonomy class: review-gated
- Risk class: low

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action.
- [x] No active blocking requested changes remain.
- [ ] Non-author approval is present when required.
- [x] Auto-merge is appropriate when gates pass.

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below; not changed during this body-only repair assignment.

## Notes

- Behavior-preserving #1202 allocation slice; generic call inference still runs the same inference pass, but no longer clones every syntax function just to overwrite the body.
- This repair only updates the PR body template structure; no branch commits or code changes are required by the current live checks.
