### PR TITLE
Deduplicate runtime option call lowering

### DIFF
--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -2058,37 +2058,7 @@ fn lower_i64_aggregate_return_body(
                 || is_i64_known_string_option_call_let_type(inner.as_ref()))
                 && !seen_runtime_stmt =>
             {
-                if let Some(assigns) = lower_i64_env_option_call_let_stmts(
-                    name,
-                    inner.as_ref(),
-                    expr,
-                    &mut locals,
-                    &mut local_indexes,
-                    static_bindings,
-                ) {
-                    lowered_stmts.extend(assigns);
-                    seen_runtime_stmt = true;
-                } else if let Some(assigns) = lower_i64_readline_option_call_let_stmts(
-                    name,
-                    inner.as_ref(),
-                    expr,
-                    &mut locals,
-                    &mut local_indexes,
-                    static_bindings,
-                ) {
-                    lowered_stmts.extend(assigns);
-                    seen_runtime_stmt = true;
-                } else if let Some(assigns) = lower_i64_fs_read_option_call_let_stmts(
-                    name,
-                    inner.as_ref(),
-                    expr,
-                    &mut locals,
-                    &mut local_indexes,
-                    static_bindings,
-                ) {
-                    lowered_stmts.extend(assigns);
-                    seen_runtime_stmt = true;
-                } else if let Some(assigns) = lower_i64_net_option_call_let_stmts(
+                if let Some(assigns) = lower_i64_runtime_string_option_call_let_stmts(
                     name,
                     inner.as_ref(),
                     expr,
@@ -3547,37 +3517,7 @@ fn lower_i64_body(
                 || is_i64_known_string_option_call_let_type(inner.as_ref()))
                 && !seen_runtime_stmt =>
             {
-                if let Some(assigns) = lower_i64_env_option_call_let_stmts(
-                    name,
-                    inner.as_ref(),
-                    expr,
-                    &mut locals,
-                    &mut local_indexes,
-                    static_bindings,
-                ) {
-                    lowered_stmts.extend(assigns);
-                    seen_runtime_stmt = true;
-                } else if let Some(assigns) = lower_i64_readline_option_call_let_stmts(
-                    name,
-                    inner.as_ref(),
-                    expr,
-                    &mut locals,
-                    &mut local_indexes,
-                    static_bindings,
-                ) {
-                    lowered_stmts.extend(assigns);
-                    seen_runtime_stmt = true;
-                } else if let Some(assigns) = lower_i64_fs_read_option_call_let_stmts(
-                    name,
-                    inner.as_ref(),
-                    expr,
-                    &mut locals,
-                    &mut local_indexes,
-                    static_bindings,
-                ) {
-                    lowered_stmts.extend(assigns);
-                    seen_runtime_stmt = true;
-                } else if let Some(assigns) = lower_i64_net_option_call_let_stmts(
+                if let Some(assigns) = lower_i64_runtime_string_option_call_let_stmts(
                     name,
                     inner.as_ref(),
                     expr,
@@ -5203,58 +5143,7 @@ fn lower_i64_runtime_let_stmts(
         expr,
         ..
     } = stmt
-        && let Some(assigns) = lower_i64_env_option_call_let_stmts(
-            name,
-            inner.as_ref(),
-            expr,
-            locals,
-            local_indexes,
-            static_bindings,
-        )
-    {
-        return Some(assigns);
-    }
-    if let Stmt::Let {
-        name,
-        ty: Type::Option(inner),
-        expr,
-        ..
-    } = stmt
-        && let Some(assigns) = lower_i64_readline_option_call_let_stmts(
-            name,
-            inner.as_ref(),
-            expr,
-            locals,
-            local_indexes,
-            static_bindings,
-        )
-    {
-        return Some(assigns);
-    }
-    if let Stmt::Let {
-        name,
-        ty: Type::Option(inner),
-        expr,
-        ..
-    } = stmt
-        && let Some(assigns) = lower_i64_fs_read_option_call_let_stmts(
-            name,
-            inner.as_ref(),
-            expr,
-            locals,
-            local_indexes,
-            static_bindings,
-        )
-    {
-        return Some(assigns);
-    }
-    if let Stmt::Let {
-        name,
-        ty: Type::Option(inner),
-        expr,
-        ..
-    } = stmt
-        && let Some(assigns) = lower_i64_net_option_call_let_stmts(
+        && let Some(assigns) = lower_i64_runtime_string_option_call_let_stmts(
             name,
             inner.as_ref(),
             expr,
@@ -7784,6 +7673,54 @@ fn lower_i64_string_option_len_call_let_stmts(
             value: tag,
         }),
     ])
+}
+
+fn lower_i64_runtime_string_option_call_let_stmts(
+    name: &str,
+    inner: &Type,
+    expr: &Expr,
+    locals: &mut Vec<CraneliftI64Expr>,
+    local_indexes: &mut HashMap<String, usize>,
+    static_bindings: &I64StaticBindings,
+) -> Option<Vec<CraneliftI64Stmt>> {
+    if let Some(assigns) = lower_i64_env_option_call_let_stmts(
+        name,
+        inner,
+        expr,
+        locals,
+        local_indexes,
+        static_bindings,
+    ) {
+        return Some(assigns);
+    }
+    if let Some(assigns) = lower_i64_readline_option_call_let_stmts(
+        name,
+        inner,
+        expr,
+        locals,
+        local_indexes,
+        static_bindings,
+    ) {
+        return Some(assigns);
+    }
+    if let Some(assigns) = lower_i64_fs_read_option_call_let_stmts(
+        name,
+        inner,
+        expr,
+        locals,
+        local_indexes,
+        static_bindings,
+    ) {
+        return Some(assigns);
+    }
+    lower_i64_net_option_call_let_stmts(
+        name,
+        inner,
+        expr,
+        locals,
+        local_indexes,
+        static_bindings,
+    )
 }
 
 fn lower_i64_readline_option_call_let_stmts(


### PR DESCRIPTION
## Summary

- Add one shared Cranelift helper for env/readline/fs/net `Option<String>` runtime let lowering.
- Route the aggregate return, body, and runtime-let lowering paths through the shared helper.
- Preserve the existing fallback order and known-string option handling while reducing duplicated lowering code.

## Governing Issue

Refs #1204.

## Validation

- [x] `cargo check -p axiomc`
- [x] `cargo test -p axiomc --lib lower_i64_runtime`
- [x] GitHub PR Fast CI passed on head commit `2181bd6d31ffc509632861b0725c9fa2cf5ecc69`.
- [x] `PR_BODY="$(cat .tmp-pr-1391-body.md)" bash scripts/ci/validate-pr-description.sh`
- [ ] `cargo test -p axiomc --lib` was run locally but fails in this container on baseline HTTP/proof workload tests that also fail on `origin/main`.
- [ ] `cargo fmt --check` was run locally but fails with broad rustfmt drift outside this change under local rustfmt 1.9.0.

## Bootstrap Governance

- [x] Changes are scoped to the linked runtime lowering issue.
- [x] This PR does not change contributor guidance, PR templates, onboarding docs, semantic schemas, or evidence capture contracts.
- [x] No real secrets, runtime auth, or machine-local env files are committed.
- [ ] Auto-merge was not changed by this repair; the PR remains review-gated and this assignment only updates the PR body.

## Notes

- This repair updates only the PR description to satisfy the structured template contract.
- No code, branch, review, merge, or conversation-resolution changes are part of this repair.
