### PR TITLE
Avoid cloning workspace manifest during lockfile validation

### DIFF
--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -1898,9 +1898,9 @@ fn validate_workspace_root_lockfile(
     graph: &PackageGraph,
     project_root: &Path,
 ) -> Result<(), Diagnostic> {
-    let manifest = graph.context(project_root)?.manifest.clone();
+    let manifest = &graph.context(project_root)?.manifest;
     if manifest.is_workspace_only() {
-        validate_lockfile(project_root, &manifest)?;
+        validate_lockfile(project_root, manifest)?;
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Borrow the workspace root manifest during lockfile validation instead of cloning it.
- Preserve the existing workspace-only validation gate and lockfile behavior while avoiding the extra manifest allocation.

## Governing Issue
Refs #1202.

## Validation
- [x] `rustfmt --edition 2024 --check stage1/crates/axiomc/src/project.rs`
- [x] `git diff --check`
- [x] `cargo test -p axiomc project::tests:: --lib`
- [x] Live GitHub PR checks are green for this PR.

Note: full `cargo fmt --check` currently reports unrelated formatting diffs in `cranelift_backend` files on `main`.

## Bootstrap Governance
No bootstrap file, workflow, CODEOWNERS, branch-protection, or repository-governance changes are included.

## Notes
- This is a scoped performance/ownership cleanup for lockfile validation.
- No migration, rollout step, or follow-up work is required for this PR.
