### PR TITLE
Avoid repeated expected-error path construction

### DIFF
--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -736,10 +736,9 @@ pub fn list_project_tests_with_options(
     {
         let manifest = &graph.context(&package_root)?.manifest;
         validate_lockfile(&package_root, manifest)?;
-        let compile_fail_kind = expected_error_path(&package_root)
-            .exists()
-            .then(|| compile_fail_test_kind(options))
-            .flatten();
+        let expected_error = expected_error_path(&package_root);
+        let compile_fail_kind = compile_fail_test_kind(options)
+            .filter(|_| expected_error.exists());
         let discovered = if let Some(kind) = compile_fail_kind {
             compile_fail_test_target(&package_root, manifest, kind, options.filter.as_deref())
                 .into_iter()
@@ -804,10 +803,9 @@ pub fn run_project_tests_with_options(
         let manifest = &graph.context(&package_root)?.manifest;
         validate_lockfile(&package_root, manifest)?;
         let package_root_text = package_root.display().to_string();
-        let compile_fail_kind = expected_error_path(&package_root)
-            .exists()
-            .then(|| compile_fail_test_kind(options))
-            .flatten();
+        let expected_error = expected_error_path(&package_root);
+        let compile_fail_kind = compile_fail_test_kind(options)
+            .filter(|_| expected_error.exists());
         if let Some(kind) = compile_fail_kind {
             if let Some(test) =
                 compile_fail_test_target(&package_root, manifest, kind, options.filter.as_deref())


### PR DESCRIPTION
## Summary
- Hoist expected-error path construction in both test listing and test running loops.
- Keep compile-fail kind detection behavior unchanged while avoiding duplicate `PathBuf` construction at the call site.

## Governing Issue
- Refs #1202.

## Validation
- [x] cargo check -p axiomc
- [x] cargo test -p axiomc --lib compile_fail_package_list_and_run_agree_across_modes
- [x] PR_BODY="$(cat .tmp-pr-1394-body.md)" bash scripts/ci/validate-pr-description.sh

## Bootstrap Governance
- No bootstrap-governance behavior or documentation changes are included in this scoped compiler test-path cleanup.
- The PR preserves the existing compile-fail discovery and run-mode contract while reducing repeated expected-error path construction.

## Notes
- `cargo fmt --all --check` was not used as proof for this PR because it currently reports unrelated rustfmt drift in `cranelift_backend` files on `main`.
- Standalone rustfmt on `project.rs` cannot infer the crate's Rust 2024 edition for existing let-chain syntax.
