### PR TITLE
Avoid cloning traits during aggregate monomorphization

### DIFF
--- a/stage1/crates/axiomc/src/hir/generics.rs
+++ b/stage1/crates/axiomc/src/hir/generics.rs
@@ -1793,7 +1793,6 @@ fn monomorphize_aggregates(
             )
         })
         .collect::<Result<Vec<_>, _>>()?;
-    let traits = program.traits.clone();
     let functions = program
         .functions
         .iter()
@@ -1906,7 +1905,7 @@ fn monomorphize_aggregates(
         type_aliases,
         structs,
         enums,
-        traits,
+        traits: program.traits,
         functions,
         stmts,
     })


### PR DESCRIPTION
## Summary
- Move the aggregate monomorphization traits vector into the rebuilt program instead of cloning it.
- Preserve aggregate monomorphization behavior while removing the avoidable trait clone called out in #1202.

## Governing Issue
Refs #1202

## Validation
- [x] cargo check -p axiomc
- [x] cargo test -p axiomc --lib --no-run
- [x] git diff --check
- [x] PR_BODY="$(cat .tmp-pr-1396-body.md)" bash scripts/ci/validate-pr-description.sh

Note: `cargo fmt --check` reports unrelated formatting drift in existing cranelift backend files on `main`, so it was not used as a gating signal for this single-file change.

## Bootstrap Governance
- No bootstrap compiler artifact or generated runtime output is changed by this PR.
- The change is source-only and keeps the existing monomorphization ownership path intact.

## Notes
- Existing live PR checks are green as of the repair pass; this update only restores the required structured PR body.
