### PR TITLE
Avoid cloning generic trait-bound lookup keys

### DIFF
--- a/stage1/crates/axiomc/src/hir/generics.rs
+++ b/stage1/crates/axiomc/src/hir/generics.rs
@@ -1522,7 +1522,12 @@ fn validate_type_param_trait_bounds(
             ));
         };
         for trait_name in &bound.traits {
-            if !trait_impls.contains(&(trait_name.clone(), type_name.clone())) {
+            if !trait_impls
+                .iter()
+                .any(|(implemented_trait, implemented_type)| {
+                    implemented_trait == trait_name && implemented_type == &type_name
+                })
+            {
                 return Err(trait_bound_not_satisfied(
                     type_arg, trait_name, line, column,
                 ));


### PR DESCRIPTION
## Summary
- Avoid allocating cloned `(trait, type)` lookup keys while validating generic trait bounds.
- Keep the existing trait-bound diagnostics and monomorphization behavior unchanged.

## Governing Issue
- Refs #1202.

## Validation
- [x] `cargo check --manifest-path stage1/Cargo.toml -p axiomc`
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc trait_bound --lib`
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc generics --lib`
- [x] GitHub PR Fast CI: Validate PR Description, Fast Checks, Full Lib Suite, and CI Gate passed on head `dc55e4e6de3a25d156e6f86ccb2b238d64e18d59`.

## Bootstrap Governance
- PR factory repair: body updated in place for structured template compliance.
- No branch replacement, PR replacement, approval, or merge performed.

## Notes
- Full `cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib` previously exceeded the node timeout.
- `cargo fmt --manifest-path stage1/Cargo.toml --all -- --check` previously reported pre-existing formatting drift in backend files outside this PR.
