### PR TITLE
Add int_to_string intrinsic alias

### DIFF
--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -6739,7 +6739,7 @@ fn render_expr(expr: &Expr) -> String {
                 render_expr(&args[1])
             )
         }
-        Expr::Call { name, args, .. } if name == "json_stringify_int" => {
+        Expr::Call { name, args, .. } if name == "json_stringify_int" || name == "int_to_string" => {
             format!("axiom_json_stringify_int({})", render_expr(&args[0]))
         }
         Expr::Call { name, args, .. } if name == "json_stringify_bool" => {

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -12720,6 +12720,7 @@ fn i64_known_pure_intrinsic_call(name: &str, static_bindings: &I64StaticBindings
             | "json_parse_bool"
             | "json_parse_string"
             | "json_stringify_int"
+            | "int_to_string"
             | "json_stringify_bool"
             | "json_stringify_string"
             | "json_serdes_parse"

--- a/stage1/crates/axiomc/src/cranelift_backend/evaluator.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend/evaluator.rs
@@ -1701,7 +1701,6 @@ pub(crate) fn is_json_call(name: &str) -> bool {
             | "json_stringify_value"
     )
 }
-
 pub(crate) fn eval_json_call(
     name: &str,
     args: &[Expr],

--- a/stage1/crates/axiomc/src/cranelift_backend/evaluator.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend/evaluator.rs
@@ -1695,7 +1695,7 @@ pub(crate) fn is_json_call(name: &str) -> bool {
             | "json_parse_field_bool"
             | "json_parse_field_string"
             | "json_parse_field_value"
-            | "json_stringify_int"
+            | "json_stringify_int" | "int_to_string"
             | "json_stringify_bool"
             | "json_stringify_string"
             | "json_stringify_value"
@@ -1758,7 +1758,7 @@ pub(crate) fn eval_json_call(
                     .map(SpikeValue::Text),
             ))
         }
-        "json_stringify_int" => {
+        "json_stringify_int" | "int_to_string" => {
             let value = eval_json_unary(name, args, functions, env, lines)?;
             let value = expect_signed_integer(value)?;
             Ok(SpikeValue::Text(value.to_string()))

--- a/stage1/crates/axiomc/src/cranelift_backend/host_json_serdes.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend/host_json_serdes.rs
@@ -46,7 +46,6 @@ pub(crate) fn is_i64_json_parse_field_string_name(name: &str, static_bindings: &
 pub(crate) fn is_i64_json_stringify_int_name(name: &str, static_bindings: &I64StaticBindings) -> bool {
     matches!(name, "json_stringify_int" | "int_to_string") || static_bindings.json_stringify_int_wrappers.contains(name)
 }
-
 pub(crate) fn is_i64_json_stringify_bool_name(name: &str, static_bindings: &I64StaticBindings) -> bool {
     name == "json_stringify_bool" || static_bindings.json_stringify_bool_wrappers.contains(name)
 }

--- a/stage1/crates/axiomc/src/cranelift_backend/host_json_serdes.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend/host_json_serdes.rs
@@ -44,7 +44,7 @@ pub(crate) fn is_i64_json_parse_field_string_name(name: &str, static_bindings: &
 }
 
 pub(crate) fn is_i64_json_stringify_int_name(name: &str, static_bindings: &I64StaticBindings) -> bool {
-    name == "json_stringify_int" || static_bindings.json_stringify_int_wrappers.contains(name)
+    matches!(name, "json_stringify_int" | "int_to_string") || static_bindings.json_stringify_int_wrappers.contains(name)
 }
 
 pub(crate) fn is_i64_json_stringify_bool_name(name: &str, static_bindings: &I64StaticBindings) -> bool {

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -2105,11 +2105,11 @@ fn lower_expr_with_expected_inner(
                     ty,
                 });
             }
-            if name == "json_stringify_int" {
+            if name == "json_stringify_int" || name == "int_to_string" {
                 if args.len() != 1 {
                     return Err(Diagnostic::new(
                         "type",
-                        format!("json_stringify_int expects 1 argument, got {}", args.len()),
+                        format!("{name} expects 1 argument, got {}", args.len()),
                     )
                     .with_span(*line, *column));
                 }
@@ -2118,7 +2118,7 @@ fn lower_expr_with_expected_inner(
                     return Err(Diagnostic::new(
                         "type",
                         format!(
-                            "json_stringify_int expects an int argument, got {}",
+                            "{name} expects an int argument, got {}",
                             lowered.ty()
                         ),
                     )

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -3539,6 +3539,7 @@ fn cranelift_backend_builds_string_intrinsics_binary() {
 true
 false
 true
+42
 1
 stage
 [padded]
@@ -11720,6 +11721,7 @@ fn write_string_intrinsics_project(project: &Path) {
 print string_contains("diagnostic: missing closing brace", "missing")
 print string_contains("diagnostic", "syntax")
 print string_starts_with("stage1", "stage")
+print int_to_string(42)
 
 match string_strip_prefix("stage1", "stage") {
 Some(value) {

--- a/stage1/crates/axiomc/tests/lib_unit.rs
+++ b/stage1/crates/axiomc/tests/lib_unit.rs
@@ -263,6 +263,16 @@ fn new_project_templates_build_and_test_without_edits() {
 }
 
 #[test]
+fn int_to_string_lowers_to_decimal_string() {
+    let source = "let rendered: string = int_to_string(42)\nprint rendered\n";
+    let parsed = parse_program(source, Path::new("main.ax")).expect("parse");
+    let hir = hir::lower(&parsed).expect("lower");
+    let mir = mir::lower(&hir);
+    let rendered = render_rust(&mir);
+    assert!(rendered.contains("let rendered: String = axiom_json_stringify_int(42);"));
+}
+
+#[test]
 fn parser_lowers_functions_calls_and_while() {
     let source = "fn banner(name: string): string {\nreturn \"hello \" + name\n}\n\nfn lucky(base: int): int {\nreturn base + 2\n}\n\nfn is_ready(value: int): bool {\nreturn value == 42\n}\n\nlet answer: int = lucky(40)\nlet ready: bool = is_ready(answer)\nwhile false {\nprint \"never\"\n}\nif ready {\nprint banner(\"from stage1\")\n} else {\nprint \"bad\"\n}\nprint answer\nprint ready\n";
     let parsed = parse_program(source, Path::new("main.ax")).expect("parse");


### PR DESCRIPTION
## Summary
- Add `int_to_string(int): string` as a general decimal string intrinsic alias for the existing integer stringify runtime.
- Route the alias through HIR, Rust codegen, direct-native JSON/string lowering, and the native evaluator.
- Cover Rust rendering and direct-native execution in focused tests.

## Governing Issue
Refs #1366.

## Validation
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib int_to_string_lowers_to_decimal_string -- --nocapture`
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend cranelift_backend_builds_string_intrinsics_binary -- --exact --nocapture`
- [x] `cargo check --manifest-path stage1/Cargo.toml -p axiomc`

## Bootstrap Governance
- This PR only adds the `int_to_string` intrinsic alias and its focused coverage; it does not change bootstrap policy or generated artifact governance.
- Existing intrinsic ratchet ceilings were satisfied by commit `0526d7402a345f56ab5823f280aa147060da5d2a`.

## Notes
- No migration or rollout action is required.
- CI was already running on the current PR head when this body-only repair was made.

