### PR TITLE
docs: clarify shipped self-hosting gap rows

### DIFF
--- a/docs/self-hosting-language-gaps.md
+++ b/docs/self-hosting-language-gaps.md
@@ -3,9 +3,10 @@
 Seed checklist for the self-hosting language-readiness surface, produced by the
 compiler.diagnostics feasibility spike under
 [#1253](https://github.com/OMT-Global/axiomlang/issues/1253). Each entry is a
-language or backend feature the spike needed (or had to design around) that the
-stage1 AxiOM surface does not provide today. Every gap below was reproduced
-against the current compiler; the quoted text is the verbatim diagnostic.
+language or backend feature the spike needed, had to design around, or has since
+unblocked for the stage1 AxiOM surface. The shipped rows preserve the original
+spike diagnostic as historical evidence; the open rows still describe current
+compiler gaps.
 
 The spike itself lives at `stage1/selfhost/compiler-diagnostics-spike` and is
 validated by `scripts/ci/run-self-hosting-spike-parity.sh`. It proves the


### PR DESCRIPTION
## Summary
- Clarifies that `docs/self-hosting-language-gaps.md` now contains both still-open compiler gaps and rows for features that have since shipped.
- Preserves the original compiler.diagnostics spike diagnostics as historical evidence for shipped rows while keeping open rows scoped to current stage1 gaps.

## Governing Issue
Refs #1366.

## Validation
- [x] `git diff --check`
- [x] `PR_BODY="$(cat pr-1407-body.md)" bash scripts/ci/validate-pr-description.sh`

## Bootstrap Governance
Docs-only clarification. This PR does not change bootstrap compiler behavior, generated artifacts, runtime semantics, or migration ordering.

## Notes
- PR Fast CI is already green on the current head.
- No code or line-neutral CI repair was required for this body-only repair.
