### PR TITLE
Factor shared project test no-test diagnostic

### DIFF
--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -737,8 +737,7 @@ pub fn list_project_tests_with_options(
         let manifest = &graph.context(&package_root)?.manifest;
         validate_lockfile(&package_root, manifest)?;
         let expected_error = expected_error_path(&package_root);
-        let compile_fail_kind = compile_fail_test_kind(options)
-            .filter(|_| expected_error.exists());
+        let compile_fail_kind = compile_fail_test_kind(options).filter(|_| expected_error.exists());
         let discovered = if let Some(kind) = compile_fail_kind {
             compile_fail_test_target(&package_root, manifest, kind, options.filter.as_deref())
                 .into_iter()
@@ -773,14 +772,10 @@ pub fn list_project_tests_with_options(
         }
     }
     if tests.is_empty() {
-        return Err(Diagnostic::new(
-            "test",
-            "no tests discovered under src/**/*_test.ax across the workspace and no [[tests]] configured in axiom.toml",
-        )
-        .with_path(manifest_path_text));
+        return Err(no_tests_discovered_diagnostic(manifest_path_text));
     }
     Ok(TestListOutput {
-        manifest: manifest_path(&project_root).display().to_string(),
+        manifest: manifest_path_text,
         packages,
         tests,
     })
@@ -804,8 +799,7 @@ pub fn run_project_tests_with_options(
         validate_lockfile(&package_root, manifest)?;
         let package_root_text = package_root.display().to_string();
         let expected_error = expected_error_path(&package_root);
-        let compile_fail_kind = compile_fail_test_kind(options)
-            .filter(|_| expected_error.exists());
+        let compile_fail_kind = compile_fail_test_kind(options).filter(|_| expected_error.exists());
         if let Some(kind) = compile_fail_kind {
             if let Some(test) =
                 compile_fail_test_target(&package_root, manifest, kind, options.filter.as_deref())
@@ -846,11 +840,7 @@ pub fn run_project_tests_with_options(
         }
     }
     if cases.is_empty() {
-        return Err(Diagnostic::new(
-            "test",
-            "no tests discovered under src/**/*_test.ax across the workspace and no [[tests]] configured in axiom.toml",
-        )
-        .with_path(manifest_path_text));
+        return Err(no_tests_discovered_diagnostic(manifest_path_text));
     }
     let passed = cases.iter().filter(|case| case.ok).count();
     let failed = cases.len().saturating_sub(passed);
@@ -860,7 +850,7 @@ pub fn run_project_tests_with_options(
     }
     Ok(TestOutput {
         backend: options.backend,
-        manifest: manifest_path(&project_root).display().to_string(),
+        manifest: manifest_path_text,
         packages,
         cases,
         passed,
@@ -869,6 +859,14 @@ pub fn run_project_tests_with_options(
         kinds,
         duration_ms: started.elapsed().as_millis() as u64,
     })
+}
+
+fn no_tests_discovered_diagnostic(manifest_path: String) -> Diagnostic {
+    Diagnostic::new(
+        "test",
+        "no tests discovered under src/**/*_test.ax across the workspace and no [[tests]] configured in axiom.toml",
+    )
+    .with_path(manifest_path)
 }
 
 fn collect_test_targets(


### PR DESCRIPTION
## Summary

- factors the duplicated project-test "no tests discovered" diagnostic into one helper so `test --list` and `test` keep the same message/path behavior
- reuses the already-computed manifest path text in successful test list/run JSON output instead of formatting it again

## Governing Issue

Refs #1204

## Validation

- [x] Relevant local checks passed: `cargo test --manifest-path stage1/Cargo.toml -p axiomc project::tests --lib`
- [ ] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable: not applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

## Flow Contract

- Owner lane: Hephaestus
- Repair owner: Hephaestus
- Autonomy class: autonomous build/repo-ops slice
- Risk class: low

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [ ] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is appropriate when gates pass

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

## Notes

- `cargo fmt --all --manifest-path stage1/Cargo.toml --check` currently reports formatting diffs in pre-existing files outside this PR's scope; this PR ran `rustfmt --edition 2024 stage1/crates/axiomc/src/project.rs` for the touched file.
