### PR TITLE
Avoid boxed type clone churn in HIR lowering

### DIFF
--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -1610,7 +1610,7 @@ fn lower_expr_with_expected_inner(
         syntax::Expr::Deref { expr, line, column } => {
             let lowered = lower_expr(expr, env, ctx)?;
             let inner_ty = match lowered.ty() {
-                Type::MutRef(inner_ty) => (*inner_ty.clone()).clone(),
+                Type::MutRef(inner_ty) => inner_ty.as_ref().clone(),
                 ty => {
                     return Err(Diagnostic::new(
                         "type",
@@ -4206,7 +4206,7 @@ fn lower_expr_with_expected_inner(
                 let element_ty = match lowered.ty() {
                     Type::Array(element_ty, _)
                     | Type::Slice(element_ty)
-                    | Type::MutSlice(element_ty) => (*element_ty.clone()).clone(),
+                    | Type::MutSlice(element_ty) => element_ty.as_ref().clone(),
                     _ => {
                         return Err(Diagnostic::new(
                             "type",
@@ -5330,7 +5330,7 @@ fn lower_expr_with_expected_inner(
             let element_ty = match lowered_base.ty() {
                 Type::Array(element_ty, _)
                 | Type::Slice(element_ty)
-                | Type::MutSlice(element_ty) => (*element_ty.clone()).clone(),
+                | Type::MutSlice(element_ty) => element_ty.as_ref().clone(),
                 _ => {
                     return Err(Diagnostic::new(
                         "type",
@@ -5417,7 +5417,7 @@ fn lower_expr_with_expected_inner(
                         )
                         .with_span(*line, *column));
                     }
-                    let element_ty = (*element_ty.clone()).clone();
+                    let element_ty = element_ty.as_ref().clone();
                     if !element_ty.is_copy() {
                         move_lowered_owner_value(&lowered_base, env)?;
                     }
@@ -5431,7 +5431,7 @@ fn lower_expr_with_expected_inner(
                         )
                         .with_span(*line, *column));
                     }
-                    let element_ty = (*element_ty.clone()).clone();
+                    let element_ty = element_ty.as_ref().clone();
                     if !element_ty.is_copy() {
                         return Err(Diagnostic::new(
                             "type",
@@ -5455,7 +5455,7 @@ fn lower_expr_with_expected_inner(
                         )
                         .with_span(*line, *column));
                     }
-                    let value_ty = (*value_ty.clone()).clone();
+                    let value_ty = value_ty.as_ref().clone();
                     if !value_ty.is_copy() {
                         move_lowered_owner_value(&lowered_base, env)?;
                     }

--- a/stage1/crates/axiomc/src/hir/maps.rs
+++ b/stage1/crates/axiomc/src/hir/maps.rs
@@ -44,8 +44,8 @@ pub(super) fn lower_map_lookup_intrinsic(
         )
         .with_span(args[0].line(), args[0].column()));
     };
-    let key_ty = (*key_ty.clone()).clone();
-    let value_ty = (*value_ty.clone()).clone();
+    let key_ty = key_ty.as_ref().clone();
+    let value_ty = value_ty.as_ref().clone();
     if let [expected_key, expected_value] = type_args {
         let expected_key = lower_type(
             expected_key,

--- a/stage1/crates/axiomc/src/hir/matches.rs
+++ b/stage1/crates/axiomc/src/hir/matches.rs
@@ -707,7 +707,7 @@ pub(super) fn match_variants(
             vec![
                 EnumVariantDef {
                     name: String::from("Some"),
-                    payload_tys: vec![(*inner.clone()).clone()],
+                    payload_tys: vec![inner.as_ref().clone()],
                     payload_names: Vec::new(),
                 },
                 EnumVariantDef {
@@ -722,12 +722,12 @@ pub(super) fn match_variants(
             vec![
                 EnumVariantDef {
                     name: String::from("Ok"),
-                    payload_tys: vec![(*ok.clone()).clone()],
+                    payload_tys: vec![ok.as_ref().clone()],
                     payload_names: Vec::new(),
                 },
                 EnumVariantDef {
                     name: String::from("Err"),
-                    payload_tys: vec![(*err.clone()).clone()],
+                    payload_tys: vec![err.as_ref().clone()],
                     payload_names: Vec::new(),
                 },
             ],


### PR DESCRIPTION
## Summary
- replace boxed-type clone-then-deref patterns in HIR lowering with direct inner `Type` clones
- apply the same cleanup to implicit match variant payloads and map lookup type extraction

## Verification
- `CARGO_TARGET_DIR=/openclaw-data/src/_worktrees/hephaestus/target-1202-clone-1783611412 cargo check --manifest-path stage1/Cargo.toml -p axiomc --lib` ✅
- `git diff --check` ✅
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc` ❌ existing `crates/axiomc/tests/hir_unit.rs` compile errors for undeclared HIR types (`Stmt`, `Expr`, `LogicOp`, borrow region types)
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib` ❌ 691 passed / 4 failed / 21 ignored; failures are HTTP/proof workload runtime readiness/cranelift spike errors (`http_server_accept failed`, `Connection refused`, `proof_http_service` exit mismatch)

Refs #1202
