### PR TITLE
Remove duplicate Cranelift aggregate call arms

### DIFF
--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -2159,30 +2159,6 @@ fn lower_i64_aggregate_return_body(
             Stmt::Let {
                 name,
                 ty: Type::Enum(enum_name),
-                expr:
-                    Expr::Call {
-                        name: call_name,
-                        args,
-                        ..
-                    },
-                ..
-            } if is_i64_enum_payload_type(enum_name, static_bindings) && !seen_runtime_stmt => {
-                lowered_stmts.extend(lower_i64_enum_call_let_stmts(
-                    name,
-                    enum_name,
-                    call_name,
-                    args,
-                    &mut locals,
-                    &mut local_indexes,
-                    &mut local_conditions,
-                    helper_signatures,
-                    static_bindings,
-                )?);
-                seen_runtime_stmt = true;
-            }
-            Stmt::Let {
-                name,
-                ty: Type::Enum(enum_name),
                 expr: Expr::EnumVariant { .. },
                 ..
             } if is_i64_enum_payload_type(enum_name, static_bindings) && !seen_runtime_stmt => {
@@ -2195,33 +2171,6 @@ fn lower_i64_aggregate_return_body(
                     helper_signatures,
                     static_bindings,
                 )?;
-            }
-            Stmt::Let {
-                name,
-                ty: Type::Result(ok, err),
-                expr:
-                    Expr::Call {
-                        name: call_name,
-                        args,
-                        ..
-                    },
-                ..
-            } if is_i64_result_local_payload_type_static(ok, err, static_bindings)
-                && !seen_runtime_stmt =>
-            {
-                lowered_stmts.extend(lower_i64_result_call_let_stmts(
-                    name,
-                    ok.as_ref(),
-                    err.as_ref(),
-                    call_name,
-                    args,
-                    &mut locals,
-                    &mut local_indexes,
-                    &mut local_conditions,
-                    helper_signatures,
-                    static_bindings,
-                )?);
-                seen_runtime_stmt = true;
             }
             Stmt::Let {
                 name,


### PR DESCRIPTION
## Summary
- remove duplicated adjacent Enum/Result call-let match arms in the Cranelift aggregate return lowering path
- keep the existing surviving arms and helper calls unchanged

## Validation
- `cargo check -p axiomc` with `CARGO_TARGET_DIR=/tmp/axiomlang-daedalus-1204-check-target`
- `cargo test -p axiomc cranelift --lib` with `CARGO_TARGET_DIR=/tmp/axiomlang-daedalus-1204-target` (35 passed, 1 ignored)

Refs #1204
