### PR TITLE
Add stdlib string facade

### DIFF
--- a/stage1/crates/axiomc/src/stdlib.rs
+++ b/stage1/crates/axiomc/src/stdlib.rs
@@ -323,6 +323,19 @@ pub fn get_or_default<K, V>(values: {K: V}, key: K, default: V): V {\nmatch map_
 pub fn keys<K, V>(values: {K: V}): [K] {\nreturn map_keys<K, V>(values)\n}\n",
     ),
     (
+        "string.ax",
+        "pub fn from_int(value: int): string {\nreturn int_to_string(value)\n}\n\
+pub fn clone_text(value: string): string {\nreturn string_clone(value)\n}\n\
+pub fn contains(text: string, needle: string): bool {\nreturn string_contains(text, needle)\n}\n\
+pub fn starts_with(text: string, prefix: string): bool {\nreturn string_starts_with(text, prefix)\n}\n\
+pub fn strip_prefix(text: string, prefix: string): Option<string> {\nreturn string_strip_prefix(text, prefix)\n}\n\
+pub fn strip_suffix(text: string, suffix: string): Option<string> {\nreturn string_strip_suffix(text, suffix)\n}\n\
+pub fn trim(text: string): string {\nreturn string_trim(text)\n}\n\
+pub fn trim_start(text: string): string {\nreturn string_trim_start(text)\n}\n\
+pub fn line_at(text: string, index: int): Option<string> {\nreturn string_line_at(text, index)\n}\n\
+pub fn byte_at(text: string, index: int): Option<int> {\nreturn string_byte_at(text, index)\n}\n",
+    ),
+    (
         "string_builder.ax",
         "pub struct StringBuilder {\nvalue: string\n}\n\
 pub fn builder(): StringBuilder {\nreturn StringBuilder { value: \"\" }\n}\n\

--- a/stage1/crates/axiomc/tests/lib_unit.rs
+++ b/stage1/crates/axiomc/tests/lib_unit.rs
@@ -7767,6 +7767,53 @@ fn stage1_project_imports_synthetic_stdlib_collections_module() {
 }
 
 #[test]
+fn stage1_project_imports_synthetic_stdlib_string_module() {
+    let dir = tempdir().expect("tempdir");
+    let project = dir.path().join("stdlib-string-app");
+    create_project(&project, Some("stdlib-string-app")).expect("create project");
+    fs::write(
+        project.join("axiom.toml"),
+        render_manifest_with_capabilities(
+            "stdlib-string-app",
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+        ),
+    )
+    .expect("write manifest");
+    let manifest = load_manifest(&project).expect("load manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        render_lockfile_for_project(&project, &manifest).expect("lockfile"),
+    )
+    .expect("write lockfile");
+    let source = "import \"std/string.ax\"\nprint from_int(42)\nprint clone_text(\"agent\")\nprint contains(\"compiler\", \"pile\")\nprint starts_with(\"compiler\", \"com\")\nmatch strip_prefix(\"compiler\", \"com\") {\nSome(value) {\nprint value\n}\nNone {\nprint \"none\"\n}\n}\nmatch strip_suffix(\"compiler\", \"ler\") {\nSome(value) {\nprint value\n}\nNone {\nprint \"none\"\n}\n}\nprint trim(\"  spaced  \")\nprint trim_start(\"  left\")\nmatch line_at(\"first\\nsecond\", 1) {\nSome(value) {\nprint value\n}\nNone {\nprint \"none\"\n}\n}\nmatch byte_at(\"AZ\", 1) {\nSome(value) {\nprint value\n}\nNone {\nprint 0\n}\n}\n";
+    fs::write(project.join("src/main.ax"), source).expect("write source");
+    fs::write(project.join("src/main_test.ax"), source).expect("write test");
+    fs::write(
+        project.join("src/main_test.stdout"),
+        "42\nagent\ntrue\ntrue\npiler\ncompi\nspaced\nleft\nsecond\n90\n",
+    )
+    .expect("write golden");
+
+    let built = build_project(&project).expect("build project");
+    let output = compiled_binary_command(&built.binary)
+        .output()
+        .expect("run compiled binary");
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "42\nagent\ntrue\ntrue\npiler\ncompi\nspaced\nleft\nsecond\n90\n"
+    );
+
+    let tests = run_project_tests(&project).expect("run tests");
+    assert_eq!(tests.passed, 1);
+    assert_eq!(tests.failed, 0);
+}
+
+#[test]
 fn stage1_project_imports_synthetic_stdlib_string_builder_module() {
     let dir = tempdir().expect("tempdir");
     let project = dir.path().join("stdlib-string-builder-app");


### PR DESCRIPTION
## Summary
- add a synthetic `std/string.ax` facade over existing string and int-to-string intrinsics
- cover importing the module, generated-Rust build/run, and manifest test execution

## Validation
- `CARGO_TARGET_DIR=/tmp/axiomlang-daedalus-target2 cargo test --manifest-path stage1/Cargo.toml -p axiomc stage1_project_imports_synthetic_stdlib_string_module --lib -- --nocapture`
- `git diff --check`

Refs #1366.