### PR TITLE
Consolidate runtime string option length lowering

### DIFF
--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -7546,56 +7546,19 @@ fn lower_i64_runtime_string_option_call_let_stmts(
     local_indexes: &mut HashMap<String, usize>,
     static_bindings: &I64StaticBindings,
 ) -> Option<Vec<CraneliftI64Stmt>> {
-    if let Some(assigns) = lower_i64_env_option_call_let_stmts(
-        name,
-        inner,
-        expr,
-        locals,
-        local_indexes,
-        static_bindings,
-    ) {
-        return Some(assigns);
-    }
-    if let Some(assigns) = lower_i64_readline_option_call_let_stmts(
-        name,
-        inner,
-        expr,
-        locals,
-        local_indexes,
-        static_bindings,
-    ) {
-        return Some(assigns);
-    }
-    if let Some(assigns) = lower_i64_fs_read_option_call_let_stmts(
-        name,
-        inner,
-        expr,
-        locals,
-        local_indexes,
-        static_bindings,
-    ) {
-        return Some(assigns);
-    }
-    lower_i64_net_option_call_let_stmts(
-        name,
-        inner,
-        expr,
-        locals,
-        local_indexes,
-        static_bindings,
-    )
-}
-
-fn lower_i64_readline_option_call_let_stmts(
-    name: &str,
-    inner: &Type,
-    expr: &Expr,
-    locals: &mut Vec<CraneliftI64Expr>,
-    local_indexes: &mut HashMap<String, usize>,
-    static_bindings: &I64StaticBindings,
-) -> Option<Vec<CraneliftI64Stmt>> {
     if !matches!(inner, Type::String | Type::Str) {
         return None;
+    }
+    let payload_len = lower_i64_runtime_string_option_len_expr(expr, static_bindings)?;
+    lower_i64_string_option_len_call_let_stmts(name, payload_len, locals, local_indexes)
+}
+
+fn lower_i64_runtime_string_option_len_expr(
+    expr: &Expr,
+    static_bindings: &I64StaticBindings,
+) -> Option<CraneliftI64Expr> {
+    if let Some(key) = i64_env_get_key(expr, static_bindings) {
+        return i64_env_len_expr(&key, static_bindings);
     }
     let Expr::Call {
         name: call_name,
@@ -7605,13 +7568,16 @@ fn lower_i64_readline_option_call_let_stmts(
     else {
         return None;
     };
-    if !is_i64_io_readline_name(call_name, static_bindings) || !args.is_empty() {
-        return None;
+    if is_i64_io_readline_name(call_name, static_bindings) && args.is_empty() {
+        return Some(CraneliftI64Expr::StdinLineLen {
+            max_bytes: I64_STDIN_BUFFER_BYTES,
+        });
     }
-    let line_len = CraneliftI64Expr::StdinLineLen {
-        max_bytes: I64_STDIN_BUFFER_BYTES,
-    };
-    lower_i64_string_option_len_call_let_stmts(name, line_len, locals, local_indexes)
+    if let Some(path) = i64_fs_read_path(expr, static_bindings) {
+        return i64_fs_read_file_len_expr(&path.candidate, path.requested_len, static_bindings);
+    }
+    let host = i64_net_resolve_host(expr, static_bindings)?;
+    i64_net_resolve_len_expr(&host, static_bindings)
 }
 
 fn lower_i64_result_literal_let_stmts(

--- a/stage1/crates/axiomc/src/cranelift_backend/host_env_proc_clock.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend/host_env_proc_clock.rs
@@ -217,21 +217,6 @@ pub(crate) fn i64_env_option_expr_uses_payload_len_only(expr: &Expr, binding: &s
 /// Resolve the per-element local slots backing an array, slice, or mutable
 /// slice binding so runtime-index writes can target them. Mirrors the element
 /// resolution used by the dynamic-index read paths.
-pub(crate) fn lower_i64_env_option_call_let_stmts(
-    name: &str,
-    inner: &Type,
-    expr: &Expr,
-    locals: &mut Vec<CraneliftI64Expr>,
-    local_indexes: &mut HashMap<String, usize>,
-    static_bindings: &I64StaticBindings,
-) -> Option<Vec<CraneliftI64Stmt>> {
-    if !matches!(inner, Type::String | Type::Str) {
-        return None;
-    }
-    let key = i64_env_get_key(expr, static_bindings)?;
-    let env_len = i64_env_len_expr(&key, static_bindings)?;
-    lower_i64_string_option_len_call_let_stmts(name, env_len, locals, local_indexes)
-}
 pub(crate) fn lower_i64_env_option_match_value_expr(
     expr: &Expr,
     local_indexes: &HashMap<String, usize>,

--- a/stage1/crates/axiomc/src/cranelift_backend/host_fs.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend/host_fs.rs
@@ -12,22 +12,6 @@ pub(crate) struct I64FsReadPath {
     pub(crate) requested_len: usize,
 }
 
-pub(crate) fn lower_i64_fs_read_option_call_let_stmts(
-    name: &str,
-    inner: &Type,
-    expr: &Expr,
-    locals: &mut Vec<CraneliftI64Expr>,
-    local_indexes: &mut HashMap<String, usize>,
-    static_bindings: &I64StaticBindings,
-) -> Option<Vec<CraneliftI64Stmt>> {
-    if !matches!(inner, Type::String | Type::Str) {
-        return None;
-    }
-    let path = i64_fs_read_path(expr, static_bindings)?;
-    let file_len = i64_fs_read_file_len_expr(&path.candidate, path.requested_len, static_bindings)?;
-    lower_i64_string_option_len_call_let_stmts(name, file_len, locals, local_indexes)
-}
-
 pub(crate) fn i64_fs_read_path(expr: &Expr, static_bindings: &I64StaticBindings) -> Option<I64FsReadPath> {
     if static_bindings.has_fs_write_calls {
         return None;

--- a/stage1/crates/axiomc/src/cranelift_backend/host_net_http.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend/host_net_http.rs
@@ -90,21 +90,6 @@ pub(crate) fn i64_http_non_loopback_bind_diag(
     Some(String::from(HTTP_NON_LOOPBACK_BIND_DIAG))
 }
 
-pub(crate) fn lower_i64_net_option_call_let_stmts(
-    name: &str,
-    inner: &Type,
-    expr: &Expr,
-    locals: &mut Vec<CraneliftI64Expr>,
-    local_indexes: &mut HashMap<String, usize>,
-    static_bindings: &I64StaticBindings,
-) -> Option<Vec<CraneliftI64Stmt>> {
-    if !matches!(inner, Type::String | Type::Str) {
-        return None;
-    }
-    let host = i64_net_resolve_host(expr, static_bindings)?;
-    let net_len = i64_net_resolve_len_expr(&host, static_bindings)?;
-    lower_i64_string_option_len_call_let_stmts(name, net_len, locals, local_indexes)
-}
 
 pub(crate) fn lower_i64_net_option_match_value_expr(
     expr: &Expr,


### PR DESCRIPTION
## Summary
- centralize runtime Option<String> payload-length resolution for env/readline/fs/net calls
- reuse the existing slot/tag assignment helper after one shared type gate
- remove now-redundant per-host option-call let wrappers

Refs #1204.

## Validation
- git diff --check
- CARGO_TARGET_DIR=/tmp/axiomlang-hephaestus-target cargo check --manifest-path stage1/Cargo.toml -p axiomc

## Notes
- Broader `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend -- --nocapture` currently fails in this node run with existing native-smoke failures, including env payload/nested enum negative tests and HTTP/fs runtime smoke cases.