### PR TITLE
Emit replayable formatter edit contracts

### DIFF
--- a/docs/compiler-source-decomposition-plan.md
+++ b/docs/compiler-source-decomposition-plan.md
@@ -170,13 +170,13 @@ value/control core is sub-partitioned by value shape.
 
 ## Current Top Files
 
-Snapshot from 2026-07-02:
+Snapshot updated 2026-07-10:
 
 | Rank | Current Rust file | Lines | Target package boundary | First extraction slice |
 | ---: | --- | ---: | --- | --- |
 | 1 | `stage1/crates/axiomc/src/cranelift_backend.rs` | 20,914 | `compiler.backend.native` | Runtime-intrinsic implementations live in `.../cranelift_backend/intrinsics.rs`, the compile-time evaluator in `.../cranelift_backend/evaluator.rs`, and the filesystem, crypto, net/http, env/process/clock, and json/serdes i64 lowering groups in `.../cranelift_backend/host_fs.rs`, `.../cranelift_backend/host_crypto.rs`, `.../cranelift_backend/host_net_http.rs`, `.../cranelift_backend/host_env_proc_clock.rs`, and `.../cranelift_backend/host_json_serdes.rs`; the remaining work is sub-partitioning the mutually-recursive value/control core by value shape. |
 | 2 | `stage1/crates/axiomc/src/project.rs` | 11,250 | `compiler.package_graph`, `compiler.commands`, `compiler.evidence` | Split manifest/workspace loading, command orchestration, provenance/debug records, and build artifact planning along package ownership. |
-| 3 | `stage1/crates/axiomc/src/main.rs` | 10,695 | `compiler.commands` | Move command parsing, JSON envelope construction, check/build/run/test/doc/trace orchestration, and exit handling behind `docs/compiler-command-lsp-packages.md` APIs. |
+| 3 | `stage1/crates/axiomc/src/main.rs` | 10,575 | `compiler.commands` | Formatter reporting and edit planning now live in `stage1/crates/axiomc/src/formatter.rs`; continue moving command parsing, JSON envelope construction, check/build/run/test/doc/trace orchestration, and exit handling behind `docs/compiler-command-lsp-packages.md` APIs. |
 | 4 | `stage1/crates/axiomc/src/codegen.rs` | 7,882 | `compiler.backend.generated_rust`, `compiler.backend.contracts` | Isolate generated-Rust compatibility emission from backend target selection and unsupported-feature contracts. |
 | 5 | `stage1/crates/axiomc/src/syntax.rs` | 6,324 | `compiler.syntax`, `compiler.diagnostics` | Split lexer/parser, parse recovery, source spans, macros, and syntax diagnostics behind the syntax boundary. |
 | 6 | `stage1/crates/axiomc/src/hir.rs` | 5,842 | `compiler.hir` | Generic inference and monomorphization now live in `stage1/crates/axiomc/src/hir/generics.rs`; public HIR model types now live in `stage1/crates/axiomc/src/hir/model.rs`; syntax-to-HIR type/literal lowering now lives in `stage1/crates/axiomc/src/hir/types.rs`; type-name, aggregate, and trait-use definition checks now live in `stage1/crates/axiomc/src/hir/definitions.rs`; function/method signatures and trait impl signature validation now live in `stage1/crates/axiomc/src/hir/signatures.rs`; capability analysis now lives in `stage1/crates/axiomc/src/hir/capabilities.rs`; expression typing helpers now live in `stage1/crates/axiomc/src/hir/expressions.rs`; ownership and borrow-state helpers now live in `stage1/crates/axiomc/src/hir/ownership.rs`; property clause checks now live in `stage1/crates/axiomc/src/hir/properties.rs`; reachability/call-graph discovery now lives in `stage1/crates/axiomc/src/hir/reachability.rs`; diagnostic recovery helpers now live in `stage1/crates/axiomc/src/hir/diagnostics.rs`; monomorphized symbol and intrinsic helpers now live in `stage1/crates/axiomc/src/hir/symbols.rs`; source-location helpers now live in `stage1/crates/axiomc/src/hir/source_locations.rs`; return-flow analysis now lives in `stage1/crates/axiomc/src/hir/control_flow.rs`; const-array length validation now lives in `stage1/crates/axiomc/src/hir/const_arrays.rs`; const-function validation now lives in `stage1/crates/axiomc/src/hir/const_functions.rs`; match lowering now lives in `stage1/crates/axiomc/src/hir/matches.rs`; enum variant constructor helpers now live in `stage1/crates/axiomc/src/hir/variants.rs`; async runtime intrinsic lowering now lives in `stage1/crates/axiomc/src/hir/async_runtime.rs`; map intrinsic lowering now lives in `stage1/crates/axiomc/src/hir/maps.rs`; HIR boundary regression tests now live in `stage1/crates/axiomc/tests/hir_unit.rs`; continue splitting remaining HIR helper clusters behind the package APIs in `docs/compiler-hir-ownership-capability.md`. |
@@ -192,8 +192,8 @@ matching ceiling in this table in the same PR.
 
 | Tracked item | Ceiling |
 | --- | ---: |
-| `summary.top_file_line_share` | 0.7373 |
-| `summary.top_file_lines` | 66561 |
+| `summary.top_file_line_share` | 0.7337 |
+| `summary.top_file_lines` | 66239 |
 | `stage1/crates/axiomc/src/cranelift_backend.rs` | 20085 |
 | `stage1/crates/axiomc/src/cranelift_backend/host_env_proc_clock.rs` | 586 |
 | `stage1/crates/axiomc/src/cranelift_backend/host_json_serdes.rs` | 258 |
@@ -204,7 +204,9 @@ matching ceiling in this table in the same PR.
 | `stage1/crates/axiomc/src/cranelift_backend/host_net_http.rs` | 1043 |
 | `stage1/crates/axiomc/src/hir.rs` | 5850 |
 | `stage1/crates/axiomc/src/project.rs` | 11396 |
-| `stage1/crates/axiomc/src/main.rs` | 10755 |
+| `stage1/crates/axiomc/src/main.rs` | 10575 |
+| `stage1/crates/axiomc/src/formatter.rs` | 219 |
+| `stage1/crates/axiomc/src/formatter_tests.rs` | 137 |
 | `stage1/crates/axiomc/src/codegen.rs` | 7919 |
 | `stage1/crates/axiomc/src/syntax.rs` | 6372 |
 | `stage1/crates/axiomc/src/hir/async_runtime.rs` | 188 |

--- a/docs/formatter-edit-contract.md
+++ b/docs/formatter-edit-contract.md
@@ -1,0 +1,30 @@
+# Formatter edit contract
+
+`axiomc fmt --json` identifies its command-specific output with
+`schema: "stage1/schemas/axiom-format-edit-v1.schema.json"`. The checked JSON
+Schema is the public contract for formatter reports and their edits.
+
+Each edit retains the bootstrap formatter's `action`, one-based `line`,
+`before`, and `after` fields for operator readability. Automation should replay
+the precise fields instead:
+
+- `start_byte` is the inclusive UTF-8 byte offset in the original file.
+- `end_byte` is the exclusive UTF-8 byte offset in the original file.
+- `replacement` is the exact text that replaces that half-open range.
+
+All offsets in a file refer to the same original source. Apply edits in
+descending `start_byte` order so earlier replacements cannot invalidate later
+offsets. Zero-width ranges are insertions and an empty replacement is a
+deletion. Offsets always fall on UTF-8 character boundaries.
+
+## Current scope and remaining formatter v1 work
+
+This contract makes the existing whitespace normalizer replayable. It covers
+tab expansion, trailing whitespace, repeated or trailing blank lines, CRLF
+normalization, and the required final newline. It does not close #1460.
+
+The remaining formatter v1 work is syntax-aware canonical layout for the full
+language, comment and macro preservation, import ordering, malformed-source
+recovery, stdin and range formatting, parse/check and semantic-digest
+preservation, complete-corpus two-pass idempotence, LSP formatting transcripts,
+and compiler-scale performance bounds.

--- a/docs/production-language-readiness.json
+++ b/docs/production-language-readiness.json
@@ -508,8 +508,8 @@
       "governingIssue": 1460,
       "blockerIssues": [1460],
       "dependencies": [],
-      "evidence": ["stage1/crates/axiomc/src/main.rs", "docs/style.md"],
-      "validatingCommand": "cargo test --manifest-path stage1/Cargo.toml -p axiomc formatter",
+      "evidence": ["stage1/crates/axiomc/src/formatter.rs", "stage1/schemas/axiom-format-edit-v1.schema.json", "docs/formatter-edit-contract.md", "docs/style.md"],
+      "validatingCommand": "cargo test --manifest-path stage1/Cargo.toml -p axiomc --bin axiomc formatter",
       "rustCaptureRisk": "low",
       "agentInspectionImpact": "Provide precise edits and unchanged semantic graph digest."
     },

--- a/docs/style.md
+++ b/docs/style.md
@@ -4,6 +4,9 @@ This document defines the canonical source style for checked-in `.ax` files.
 Use the formatter as the default enforcement path, and treat this guide as the
 readable statement of the layout it is meant to preserve.
 
+Machine consumers of `axiomc fmt --json` should use the replayable UTF-8 byte
+range contract documented in [formatter-edit-contract.md](formatter-edit-contract.md).
+
 ## Formatting
 
 Run the formatter before review:

--- a/stage1/crates/axiomc/src/formatter.rs
+++ b/stage1/crates/axiomc/src/formatter.rs
@@ -1,0 +1,219 @@
+use super::axiom_files;
+use axiomc::{diagnostics::Diagnostic, json_contract};
+use serde::Serialize;
+use std::fs;
+use std::path::Path;
+
+const FORMAT_SCHEMA_PATH: &str = "stage1/schemas/axiom-format-edit-v1.schema.json";
+
+#[derive(Debug, Clone, Serialize)]
+struct FormatEdit {
+    action: &'static str,
+    line: usize,
+    before: Option<String>,
+    after: Option<String>,
+    start_byte: usize,
+    end_byte: usize,
+    replacement: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct FormatFileReport {
+    pub(super) path: String,
+    pub(super) changed: bool,
+    edits: Vec<FormatEdit>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct FormatReport {
+    schema_version: &'static str,
+    schema: &'static str,
+    ok: bool,
+    command: &'static str,
+    check: bool,
+    pub(super) files: Vec<FormatFileReport>,
+    pub(super) changed: usize,
+}
+
+pub(super) fn format_axiom_sources(path: &Path, check: bool) -> Result<FormatReport, Diagnostic> {
+    let files = axiom_files(path)?;
+    if files.is_empty() {
+        return Err(Diagnostic::new(
+            "fmt",
+            format!("no .ax files found under {}", path.display()),
+        ));
+    }
+    let mut reports = Vec::new();
+    let mut changed = 0;
+    for file in files {
+        let original = fs::read_to_string(&file).map_err(|err| {
+            Diagnostic::new("fmt", format!("failed to read {}: {err}", file.display()))
+                .with_path(file.display().to_string())
+        })?;
+        let formatted = format_axiom_source(&original);
+        let is_changed = formatted != original;
+        let edits = format_edits(&original, &formatted);
+        if is_changed {
+            changed += 1;
+            if !check {
+                fs::write(&file, formatted).map_err(|err| {
+                    Diagnostic::new("fmt", format!("failed to write {}: {err}", file.display()))
+                        .with_path(file.display().to_string())
+                })?;
+            }
+        }
+        reports.push(FormatFileReport {
+            path: file.display().to_string(),
+            changed: is_changed,
+            edits,
+        });
+    }
+    Ok(FormatReport {
+        schema_version: json_contract::JSON_SCHEMA_VERSION,
+        schema: FORMAT_SCHEMA_PATH,
+        ok: !check || changed == 0,
+        command: "fmt",
+        check,
+        files: reports,
+        changed,
+    })
+}
+
+fn format_axiom_source(source: &str) -> String {
+    let mut lines = Vec::new();
+    let mut previous_blank = false;
+    for line in source.replace("\r\n", "\n").replace('\t', "    ").lines() {
+        let trimmed_end = line.trim_end();
+        let blank = trimmed_end.is_empty();
+        if blank && previous_blank {
+            continue;
+        }
+        lines.push(trimmed_end.to_string());
+        previous_blank = blank;
+    }
+    while lines.last().is_some_and(|line| line.is_empty()) {
+        lines.pop();
+    }
+    format!("{}\n", lines.join("\n"))
+}
+
+fn format_edits(original: &str, formatted: &str) -> Vec<FormatEdit> {
+    if original == formatted {
+        return Vec::new();
+    }
+    let lines = source_lines(original);
+    let last_content = lines
+        .iter()
+        .rposition(|line| !normalized_line(line.text).is_empty());
+    let mut expected = Vec::new();
+    let mut previous_blank = false;
+    for (index, line) in lines.iter().enumerate() {
+        let normalized = normalized_line(line.text);
+        let blank = normalized.is_empty();
+        let emit = index <= last_content.unwrap_or(0) && !(blank && previous_blank);
+        expected.push(emit.then(|| format!("{normalized}\n")));
+        if emit {
+            previous_blank = blank;
+        }
+    }
+    let rebuilt = expected.iter().flatten().cloned().collect::<String>();
+    if rebuilt != formatted && !(lines.is_empty() && formatted == "\n") {
+        return vec![precise_edit("replace_line", 1, 0, original, formatted)];
+    }
+
+    let mut edits = Vec::new();
+    for (index, (line, after)) in lines.iter().zip(&expected).enumerate() {
+        match after {
+            Some(after) if line.text != after => edits.push(precise_edit(
+                "replace_line",
+                index + 1,
+                line.start_byte,
+                line.text,
+                after,
+            )),
+            None => edits.push(precise_edit(
+                "delete_line",
+                index + 1,
+                line.start_byte,
+                line.text,
+                "",
+            )),
+            _ => {}
+        }
+    }
+    if lines.is_empty() {
+        edits.push(precise_edit("insert_line", 1, 0, "", formatted));
+    }
+    edits
+}
+
+struct SourceLine<'a> {
+    start_byte: usize,
+    text: &'a str,
+}
+
+fn source_lines(source: &str) -> Vec<SourceLine<'_>> {
+    let mut start_byte = 0;
+    source
+        .split_inclusive('\n')
+        .map(|text| {
+            let line = SourceLine { start_byte, text };
+            start_byte += text.len();
+            line
+        })
+        .collect()
+}
+
+fn normalized_line(line: &str) -> String {
+    trim_line_ending(line)
+        .replace('\t', "    ")
+        .trim_end()
+        .to_string()
+}
+
+fn precise_edit(
+    action: &'static str,
+    line: usize,
+    base: usize,
+    before: &str,
+    after: &str,
+) -> FormatEdit {
+    let prefix = common_prefix_bytes(before, after);
+    let suffix = common_suffix_bytes(&before[prefix..], &after[prefix..]);
+    FormatEdit {
+        action,
+        line,
+        before: (action != "insert_line").then(|| trim_line_ending(before).to_string()),
+        after: (action != "delete_line").then(|| trim_line_ending(after).to_string()),
+        start_byte: base + prefix,
+        end_byte: base + before.len() - suffix,
+        replacement: after[prefix..after.len() - suffix].to_string(),
+    }
+}
+
+fn common_prefix_bytes(left: &str, right: &str) -> usize {
+    left.chars()
+        .zip(right.chars())
+        .take_while(|(left, right)| left == right)
+        .map(|(character, _)| character.len_utf8())
+        .sum()
+}
+
+fn common_suffix_bytes(left: &str, right: &str) -> usize {
+    left.chars()
+        .rev()
+        .zip(right.chars().rev())
+        .take_while(|(left, right)| left == right)
+        .map(|(character, _)| character.len_utf8())
+        .sum()
+}
+
+fn trim_line_ending(line: &str) -> &str {
+    line.strip_suffix('\n')
+        .and_then(|line| line.strip_suffix('\r').or(Some(line)))
+        .unwrap_or(line)
+}
+
+#[cfg(test)]
+#[path = "formatter_tests.rs"]
+mod tests;

--- a/stage1/crates/axiomc/src/formatter_tests.rs
+++ b/stage1/crates/axiomc/src/formatter_tests.rs
@@ -1,0 +1,137 @@
+use super::*;
+
+fn replay(original: &str, edits: &[FormatEdit]) -> String {
+    let mut replayed = original.to_string();
+    for edit in edits.iter().rev() {
+        assert!(edit.start_byte <= edit.end_byte);
+        assert!(original.is_char_boundary(edit.start_byte));
+        assert!(original.is_char_boundary(edit.end_byte));
+        replayed.replace_range(edit.start_byte..edit.end_byte, &edit.replacement);
+    }
+    replayed
+}
+
+#[test]
+fn formatter_trims_whitespace_and_collapses_blank_runs() {
+    assert_eq!(
+        format_axiom_source("fn main() {   \n\tprint \"hi\"  \n\n\n}\n\n"),
+        "fn main() {\n    print \"hi\"\n\n}\n"
+    );
+}
+
+#[test]
+fn formatter_check_reports_schema_and_precise_edits_without_writing() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let source = dir.path().join("src/main.ax");
+    fs::create_dir_all(source.parent().expect("source parent")).expect("mkdir");
+    let original = "fn main() {   \n\tprint \"hi\"  \n\n\n}\n\n";
+    fs::write(&source, original).expect("write source");
+
+    let report = format_axiom_sources(dir.path(), true).expect("format report");
+
+    assert_eq!(report.schema_version, json_contract::JSON_SCHEMA_VERSION);
+    assert_eq!(report.schema, FORMAT_SCHEMA_PATH);
+    assert_eq!(report.command, "fmt");
+    assert!(!report.ok);
+    assert!(report.check);
+    assert_eq!(report.changed, 1);
+    assert_eq!(report.files.len(), 1);
+    assert!(report.files[0].changed);
+    assert_eq!(
+        replay(original, &report.files[0].edits),
+        format_axiom_source(original)
+    );
+    let schema_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..").join(
+        FORMAT_SCHEMA_PATH
+            .strip_prefix("stage1/")
+            .expect("stage1 schema path"),
+    );
+    let schema: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(schema_path).expect("read formatter schema"))
+            .expect("formatter schema JSON");
+    jsonschema::validator_for(&schema)
+        .expect("compile formatter schema")
+        .validate(&serde_json::to_value(&report).expect("serialize formatter report"))
+        .expect("formatter report matches schema");
+    assert_eq!(fs::read_to_string(&source).expect("read source"), original);
+}
+
+#[test]
+fn missing_final_newline_is_an_exact_insertion() {
+    let original = "fn main() {}";
+    let formatted = format_axiom_source(original);
+    let edits = format_edits(original, &formatted);
+
+    assert_eq!(edits.len(), 1);
+    assert_eq!(edits[0].action, "replace_line");
+    assert_eq!(edits[0].line, 1);
+    assert_eq!(edits[0].before.as_deref(), Some("fn main() {}"));
+    assert_eq!(edits[0].after.as_deref(), Some("fn main() {}"));
+    assert_eq!(edits[0].start_byte, original.len());
+    assert_eq!(edits[0].end_byte, original.len());
+    assert_eq!(edits[0].replacement, "\n");
+    assert_eq!(replay(original, &edits), formatted);
+}
+
+#[test]
+fn utf8_offsets_are_bytes_and_preserve_character_boundaries() {
+    let original = "print \"café\"   \n";
+    let formatted = format_axiom_source(original);
+    let edits = format_edits(original, &formatted);
+
+    assert_eq!(edits.len(), 1);
+    assert_eq!(edits[0].start_byte, "print \"café\"".len());
+    assert_eq!(edits[0].end_byte, "print \"café\"   ".len());
+    assert_eq!(edits[0].replacement, "");
+    assert_eq!(replay(original, &edits), formatted);
+}
+
+#[test]
+fn crlf_edits_delete_only_carriage_returns() {
+    let original = "fn main() {\r\n}\r\n";
+    let formatted = format_axiom_source(original);
+    let edits = format_edits(original, &formatted);
+
+    assert_eq!(edits.len(), 2);
+    assert!(edits.iter().all(|edit| edit.replacement.is_empty()));
+    assert!(
+        edits
+            .iter()
+            .all(|edit| edit.end_byte - edit.start_byte == 1)
+    );
+    assert_eq!(replay(original, &edits), formatted);
+}
+
+#[test]
+fn empty_source_uses_an_insert_line_edit() {
+    let formatted = format_axiom_source("");
+    let edits = format_edits("", &formatted);
+
+    assert_eq!(edits.len(), 1);
+    assert_eq!(edits[0].action, "insert_line");
+    assert_eq!(edits[0].start_byte, 0);
+    assert_eq!(edits[0].end_byte, 0);
+    assert_eq!(edits[0].replacement, "\n");
+    assert_eq!(replay("", &edits), formatted);
+}
+
+#[test]
+fn trailing_blank_lines_use_delete_line_edits() {
+    let original = "fn main() {}\n\n\n";
+    let formatted = format_axiom_source(original);
+    let edits = format_edits(original, &formatted);
+
+    assert_eq!(edits.len(), 2);
+    assert!(edits.iter().all(|edit| edit.action == "delete_line"));
+    assert_eq!(replay(original, &edits), formatted);
+}
+
+#[test]
+fn reverse_replay_handles_multiple_non_ascii_edits() {
+    let original = "print \"olá\"  \r\n\n\nprint \"fim\"   ";
+    let formatted = format_axiom_source(original);
+    let edits = format_edits(original, &formatted);
+
+    assert!(edits.len() >= 3);
+    assert_eq!(replay(original, &edits), formatted);
+}

--- a/stage1/crates/axiomc/src/main.rs
+++ b/stage1/crates/axiomc/src/main.rs
@@ -38,6 +38,10 @@ use std::path::{Component, Path, PathBuf};
 use std::process::Command as ProcessCommand;
 use std::time::Instant;
 
+mod formatter;
+
+use formatter::format_axiom_sources;
+
 #[derive(Debug, Parser)]
 #[command(name = "axiomc", about = "Axiom stage1 bootstrap compiler")]
 struct Cli {
@@ -1634,14 +1638,6 @@ fn print_json_output_or_error<T: Serialize>(command: &str, payload: &T, success_
 
 fn format_json_output<T: Serialize>(payload: &T) -> Result<String, Diagnostic> {
     json_contract::to_pretty_string(payload)
-}
-
-#[derive(Debug, Clone, Serialize)]
-struct FormatEdit {
-    action: String,
-    line: usize,
-    before: Option<String>,
-    after: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -6006,121 +6002,6 @@ fn tool_text(tool: &ToolProbe) -> String {
 }
 
 #[derive(Debug, Clone, Serialize)]
-struct FormatFileReport {
-    path: String,
-    changed: bool,
-    edits: Vec<FormatEdit>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-struct FormatReport {
-    schema_version: &'static str,
-    ok: bool,
-    command: &'static str,
-    check: bool,
-    files: Vec<FormatFileReport>,
-    changed: usize,
-}
-
-fn format_axiom_sources(path: &Path, check: bool) -> Result<FormatReport, Diagnostic> {
-    let files = axiom_files(path)?;
-    if files.is_empty() {
-        return Err(Diagnostic::new(
-            "fmt",
-            format!("no .ax files found under {}", path.display()),
-        ));
-    }
-    let mut reports = Vec::new();
-    let mut changed = 0;
-    for file in files {
-        let original = fs::read_to_string(&file).map_err(|err| {
-            Diagnostic::new("fmt", format!("failed to read {}: {err}", file.display()))
-                .with_path(file.display().to_string())
-        })?;
-        let formatted = format_axiom_source(&original);
-        let is_changed = formatted != original;
-        let edits = format_edits(&original, &formatted);
-        if is_changed {
-            changed += 1;
-            if !check {
-                fs::write(&file, formatted).map_err(|err| {
-                    Diagnostic::new("fmt", format!("failed to write {}: {err}", file.display()))
-                        .with_path(file.display().to_string())
-                })?;
-            }
-        }
-        reports.push(FormatFileReport {
-            path: file.display().to_string(),
-            changed: is_changed,
-            edits,
-        });
-    }
-    Ok(FormatReport {
-        schema_version: json_contract::JSON_SCHEMA_VERSION,
-        ok: !check || changed == 0,
-        command: "fmt",
-        check,
-        files: reports,
-        changed,
-    })
-}
-
-fn format_axiom_source(source: &str) -> String {
-    let mut lines = Vec::new();
-    let mut previous_blank = false;
-    for line in source.replace("\r\n", "\n").replace('\t', "    ").lines() {
-        let trimmed_end = line.trim_end();
-        let blank = trimmed_end.is_empty();
-        if blank && previous_blank {
-            continue;
-        }
-        lines.push(trimmed_end.to_string());
-        previous_blank = blank;
-    }
-    while lines.last().is_some_and(|line| line.is_empty()) {
-        lines.pop();
-    }
-    format!("{}\n", lines.join("\n"))
-}
-
-fn format_edits(original: &str, formatted: &str) -> Vec<FormatEdit> {
-    let original_lines: Vec<&str> = original.split_inclusive('\n').collect();
-    let formatted_lines: Vec<&str> = formatted.split_inclusive('\n').collect();
-    let max_len = original_lines.len().max(formatted_lines.len());
-    let mut edits = Vec::new();
-    for index in 0..max_len {
-        match (original_lines.get(index), formatted_lines.get(index)) {
-            (Some(before), Some(after)) if before != after => edits.push(FormatEdit {
-                action: String::from("replace_line"),
-                line: index + 1,
-                before: Some(trim_line_ending(before).to_string()),
-                after: Some(trim_line_ending(after).to_string()),
-            }),
-            (Some(before), None) => edits.push(FormatEdit {
-                action: String::from("delete_line"),
-                line: index + 1,
-                before: Some(trim_line_ending(before).to_string()),
-                after: None,
-            }),
-            (None, Some(after)) => edits.push(FormatEdit {
-                action: String::from("insert_line"),
-                line: index + 1,
-                before: None,
-                after: Some(trim_line_ending(after).to_string()),
-            }),
-            _ => {}
-        }
-    }
-    edits
-}
-
-fn trim_line_ending(line: &str) -> &str {
-    line.strip_suffix('\n')
-        .and_then(|line| line.strip_suffix('\r').or(Some(line)))
-        .unwrap_or(line)
-}
-
-#[derive(Debug, Clone, Serialize)]
 struct DocOutput {
     schema_version: &'static str,
     command: &'static str,
@@ -10348,65 +10229,6 @@ print serve("127.0.0.1:0", selected_route, 1)
                 && artifact.path.ends_with("dist/runbook.md")
                 && artifact.status == "generated"
         }));
-    }
-
-    #[test]
-    fn formatter_trims_whitespace_and_collapses_blank_runs() {
-        assert_eq!(
-            format_axiom_source("fn main() {   \n\tprint \"hi\"  \n\n\n}\n\n"),
-            "fn main() {\n    print \"hi\"\n\n}\n"
-        );
-    }
-
-    #[test]
-    fn formatter_check_reports_json_planning_edits_without_writing() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let source = dir.path().join("src/main.ax");
-        fs::create_dir_all(source.parent().expect("source parent")).expect("mkdir");
-        fs::write(&source, "fn main() {   \n\tprint \"hi\"  \n\n\n}\n\n").expect("write source");
-
-        let report = format_axiom_sources(dir.path(), true).expect("format report");
-
-        assert_eq!(report.schema_version, json_contract::JSON_SCHEMA_VERSION);
-        assert_eq!(report.command, "fmt");
-        assert!(report.check);
-        assert_eq!(report.changed, 1);
-        assert_eq!(report.files.len(), 1);
-        assert!(report.files[0].changed);
-        assert!(
-            report.files[0]
-                .edits
-                .iter()
-                .any(|edit| edit.action == "replace_line" && edit.line == 1)
-        );
-        assert_eq!(
-            fs::read_to_string(&source).expect("read source"),
-            "fn main() {   \n\tprint \"hi\"  \n\n\n}\n\n"
-        );
-    }
-
-    #[test]
-    fn formatter_check_reports_missing_final_newline_edit() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let source = dir.path().join("src/main.ax");
-        fs::create_dir_all(source.parent().expect("source parent")).expect("mkdir");
-        fs::write(&source, "fn main() {}").expect("write source");
-
-        let report = format_axiom_sources(dir.path(), true).expect("format report");
-
-        assert_eq!(report.changed, 1);
-        assert_eq!(report.files.len(), 1);
-        assert_eq!(report.files[0].edits.len(), 1);
-        assert_eq!(report.files[0].edits[0].action, "replace_line");
-        assert_eq!(report.files[0].edits[0].line, 1);
-        assert_eq!(
-            report.files[0].edits[0].before.as_deref(),
-            Some("fn main() {}")
-        );
-        assert_eq!(
-            report.files[0].edits[0].after.as_deref(),
-            Some("fn main() {}")
-        );
     }
 
     #[test]

--- a/stage1/crates/axiomc/tests/json_command_fixtures.rs
+++ b/stage1/crates/axiomc/tests/json_command_fixtures.rs
@@ -43,6 +43,35 @@ fn assert_envelope(payload: &Value, command: &str, ok: bool) {
 }
 
 #[test]
+fn fmt_fixture_covers_replayable_byte_edits() {
+    let stage1_validator = schema_validator();
+    let payload = fixture("fmt", "changes.json");
+    assert_matches_stage1_schema(&stage1_validator, &payload);
+    assert_envelope(&payload, "fmt", false);
+
+    let schema_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("schemas")
+        .join("axiom-format-edit-v1.schema.json");
+    let schema: Value =
+        serde_json::from_str(&fs::read_to_string(schema_path).expect("read formatter edit schema"))
+            .expect("formatter edit schema is valid JSON");
+    jsonschema::validator_for(&schema)
+        .expect("compile formatter edit schema")
+        .validate(&payload)
+        .expect("fmt fixture matches formatter edit schema");
+
+    let edits = payload["files"][0]["edits"]
+        .as_array()
+        .expect("formatter fixture edits");
+    assert_eq!(edits[0]["start_byte"], 11);
+    assert_eq!(edits[0]["end_byte"], 14);
+    assert_eq!(edits[1]["start_byte"], edits[1]["end_byte"]);
+    assert_eq!(edits[1]["replacement"], "\n");
+}
+
+#[test]
 fn build_fixtures_cover_direct_native_target_and_no_fallback_failure() {
     let validator = schema_validator();
     let success = fixture("build", "success.json");

--- a/stage1/crates/axiomc/tests/schema_metadata.rs
+++ b/stage1/crates/axiomc/tests/schema_metadata.rs
@@ -16,6 +16,80 @@ fn compile_validator(schema: &Value) -> Validator {
 }
 
 #[test]
+fn formatter_edit_v1_schema_metadata_is_current() {
+    let schema: Value = serde_json::from_str(
+        &fs::read_to_string(schema_dir().join("axiom-format-edit-v1.schema.json"))
+            .expect("read formatter edit schema"),
+    )
+    .expect("formatter edit schema is valid JSON");
+
+    assert_eq!(
+        schema["$id"],
+        "https://axiom.omt.global/schemas/axiom-format-edit-v1.schema.json"
+    );
+    assert_eq!(schema["title"], "Axiom formatter edit report v1");
+    assert_eq!(
+        schema["properties"]["schema_version"]["const"],
+        json_contract::JSON_SCHEMA_VERSION
+    );
+    assert_eq!(schema["properties"]["command"]["const"], "fmt");
+    let edit = &schema["$defs"]["edit"];
+    for field in [
+        "action",
+        "line",
+        "before",
+        "after",
+        "start_byte",
+        "end_byte",
+        "replacement",
+    ] {
+        assert!(
+            edit["required"]
+                .as_array()
+                .expect("formatter edit required fields")
+                .iter()
+                .any(|required| required == field),
+            "formatter edit schema requires {field}"
+        );
+    }
+
+    let validator = compile_validator(&schema);
+    let valid_edit = serde_json::json!({
+        "schema_version": json_contract::JSON_SCHEMA_VERSION,
+        "schema": "stage1/schemas/axiom-format-edit-v1.schema.json",
+        "ok": false,
+        "command": "fmt",
+        "check": true,
+        "files": [{
+            "path": "src/main.ax",
+            "changed": true,
+            "edits": [{
+                "action": "replace_line",
+                "line": 1,
+                "before": "print 1",
+                "after": "print 1",
+                "start_byte": 7,
+                "end_byte": 7,
+                "replacement": "\n"
+            }]
+        }],
+        "changed": 1
+    });
+    assert!(validator.is_valid(&valid_edit));
+
+    let mut missing_replacement = valid_edit.clone();
+    missing_replacement["files"][0]["edits"][0]
+        .as_object_mut()
+        .expect("formatter edit object")
+        .remove("replacement");
+    assert!(!validator.is_valid(&missing_replacement));
+
+    let mut negative_offset = valid_edit;
+    negative_offset["files"][0]["edits"][0]["start_byte"] = serde_json::json!(-1);
+    assert!(!validator.is_valid(&negative_offset));
+}
+
+#[test]
 fn editor_metadata_schemas_are_parseable_and_current() {
     let compiler_schema: Value = serde_json::from_str(
         &fs::read_to_string(schema_dir().join("axiom.stage1.v1.schema.json"))

--- a/stage1/json-fixtures/fmt/changes.json
+++ b/stage1/json-fixtures/fmt/changes.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": "axiom.stage1.v1",
+  "schema": "stage1/schemas/axiom-format-edit-v1.schema.json",
+  "ok": false,
+  "command": "fmt",
+  "check": true,
+  "files": [
+    {
+      "path": "<project>/src/main.ax",
+      "changed": true,
+      "edits": [
+        {
+          "action": "replace_line",
+          "line": 1,
+          "before": "fn main() {   ",
+          "after": "fn main() {",
+          "start_byte": 11,
+          "end_byte": 14,
+          "replacement": ""
+        },
+        {
+          "action": "replace_line",
+          "line": 2,
+          "before": "}",
+          "after": "}",
+          "start_byte": 16,
+          "end_byte": 16,
+          "replacement": "\n"
+        }
+      ]
+    }
+  ],
+  "changed": 1
+}

--- a/stage1/schemas/axiom-format-edit-v1.schema.json
+++ b/stage1/schemas/axiom-format-edit-v1.schema.json
@@ -1,0 +1,126 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axiom.omt.global/schemas/axiom-format-edit-v1.schema.json",
+  "title": "Axiom formatter edit report v1",
+  "description": "Replayable UTF-8 byte edits emitted by axiomc fmt --json.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "schema",
+    "ok",
+    "command",
+    "check",
+    "files",
+    "changed"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "axiom.stage1.v1"
+    },
+    "schema": {
+      "const": "stage1/schemas/axiom-format-edit-v1.schema.json"
+    },
+    "ok": {
+      "type": "boolean"
+    },
+    "command": {
+      "const": "fmt"
+    },
+    "check": {
+      "type": "boolean"
+    },
+    "files": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/fileReport"
+      }
+    },
+    "changed": {
+      "type": "integer",
+      "minimum": 0
+    }
+  },
+  "$defs": {
+    "fileReport": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "changed",
+        "edits"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "changed": {
+          "type": "boolean"
+        },
+        "edits": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/edit"
+          }
+        }
+      }
+    },
+    "edit": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "action",
+        "line",
+        "before",
+        "after",
+        "start_byte",
+        "end_byte",
+        "replacement"
+      ],
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "replace_line",
+            "delete_line",
+            "insert_line"
+          ]
+        },
+        "line": {
+          "description": "One-based source line associated with the legacy action metadata.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "before": {
+          "description": "Legacy source-line text without its line ending, or null for insertions.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "after": {
+          "description": "Legacy formatted-line text without its line ending, or null for deletions.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "start_byte": {
+          "description": "Inclusive UTF-8 byte offset in the original file.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "end_byte": {
+          "description": "Exclusive UTF-8 byte offset in the original file.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "replacement": {
+          "description": "Exact UTF-8 text replacing the half-open original byte range.",
+          "type": "string"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- emit formatter changes as replayable UTF-8 byte-range replacements while preserving the existing human-readable fields
- publish the `axiom.format_edit.v1` schema, deterministic JSON fixture, and formatter edit contract
- extract formatter implementation/tests from `main.rs` and ratchet the reduced compiler source ceilings

## Governing Issue

Advances #1460

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Commands run:

- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --bin axiomc formatter`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test schema_metadata`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test json_command_fixtures`
- `python3 scripts/ci/report-compiler-source-monoliths.py --json --check-plan --check-ratchet`
- `python3 scripts/ci/check-production-language-readiness.py --json --validate-only`
- `git diff --check`

The readiness validator is structurally valid and exits successfully; the aggregate remains intentionally `ready: false` while unrelated production-readiness rows are open.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

No contributor or bootstrap guidance changes are required. Auto-merge is intentionally deferred until independent review is present.

## Semantic Layer Checklist

- [x] Semantic node types added/changed are listed, or this PR does not touch semantic-layer behavior
- [x] Schemas added/changed are listed, or this PR does not touch schemas
- [x] Evidence added/changed is listed, or this PR does not touch evidence
- [x] Rust capture check is satisfied, or this PR is backend-only and marks backend-specific behavior
- [x] Agent-facing inspection impact is described, or there is no inspection impact

No semantic node types change. The PR adds `axiom-format-edit-v1.schema.json` plus the `fmt/changes.json` fixture. Rust implementation code is extracted without changing formatter policy. Agent-facing consumers can now apply exact byte-range replacements and validate the payload without parsing descriptive text.

## Flow Contract

- Owner lane: artifact generation
- Repair owner: PR author
- Autonomy class: review-gated
- Risk class: medium

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is appropriate when gates pass

Next actor: an independent reviewer should validate the new edit contract and replay semantics.

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

Auto-merge is unsafe until the required non-author approval is recorded.

## Notes

- This advances the broader formatter production-qualification issue; it does not claim the remaining idempotence, corpus, and qualification work is complete.
