### PR TITLE
ci: route PR fast checks to shell-safe runners

### DIFF
--- a/.github/workflows/pr-fast-ci.yml
+++ b/.github/workflows/pr-fast-ci.yml
@@ -24,7 +24,7 @@ defaults:
 jobs:
   changes:
     name: Detect Relevant Changes
-    runs-on: ubuntu-latest
+    runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
     outputs:
       app: ${{ steps.filter.outputs.app }}
       ci: ${{ steps.filter.outputs.ci }}
@@ -60,7 +60,7 @@ jobs:
 
   fast-checks:
     name: Fast Checks
-    runs-on: ubuntu-latest
+    runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
     timeout-minutes: 45
     needs: changes
     if: >-
@@ -158,7 +158,7 @@ jobs:
 
   full-lib-suite:
     name: Full Lib Suite
-    runs-on: ubuntu-latest
+    runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
     timeout-minutes: 45
     needs: changes
     if: >-
@@ -180,7 +180,7 @@ jobs:
 
   validate-pr-description:
     name: Validate PR Description
-    runs-on: ubuntu-latest
+    runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
     timeout-minutes: 5
     if: >-
       github.event.pull_request.draft == false &&
@@ -276,7 +276,7 @@ jobs:
 
   validate-secrets:
     name: Validate Secrets
-    runs-on: ubuntu-latest
+    runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
     timeout-minutes: 10
     if: >-
       github.event.pull_request.draft == false &&
@@ -295,7 +295,7 @@ jobs:
 
   ci-gate:
     name: CI Gate
-    runs-on: ubuntu-latest
+    runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
     if: always()
     needs:
       - changes


### PR DESCRIPTION
## Summary
- Route bootstrap-managed PR Fast CI shell-safe jobs to the OMT self-hosted shell runner pool.
- Keep the existing trusted-script and fork-guard workflow structure unchanged.

## Governing Issue
No issue is linked; this is Workboard card 9625fd72-bb21-4be1-966e-546ad781309a for bootstrap manifest and runner-policy drift reconciliation.

## Validation
- [x] Parsed `.github/workflows/pr-fast-ci.yml` as YAML with the bootstrap toolchain YAML parser.
- [x] Confirmed `ci.runnerPolicy: hybrid-safe` in `project.bootstrap.yaml`.
- [x] Confirmed all 6 PR Fast CI `runs-on` entries now use `['self-hosted', 'linux', 'shell-only', 'public']` and no `runs-on: ubuntu-latest` entries remain in that workflow.

## Bootstrap Governance
- [x] Change is limited to bootstrap-managed runner-policy drift in `.github/workflows/pr-fast-ci.yml`.
- [x] No real secrets, runtime auth, or machine-local env files are committed.
- [x] Full bootstrap apply was intentionally not used because the current generated plan includes broad unrelated managed-file drift; this PR is the smallest runner-policy repair slice.

## Merge Automation
- Auto-merge is enabled with `gh pr merge --auto --squash`; merge remains gated on CI and required review.

## Notes
- `OMT-Global/apw-cli` already has live `pr-fast-ci.yml` shell-safe runner labels on `main`; no APW PR was needed.
