### PR TITLE
Emit complete canonical Intent IR

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Axiom
 
-<!-- capability-ledger:v1 commands=29 stdlib_modules=34 stdlib_functions=299 capabilities=9 backend=cranelift -->
+<!-- capability-ledger:v1 commands=30 stdlib_modules=34 stdlib_functions=299 capabilities=9 backend=cranelift -->
 
 Axiom is an agent-native typed intent and semantic construction system. It
 defines what must be true, which effects are allowed, what evidence proves a

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Axiom
 
-<!-- capability-ledger:v1 commands=28 stdlib_modules=34 stdlib_functions=299 capabilities=9 backend=cranelift -->
+<!-- capability-ledger:v1 commands=29 stdlib_modules=34 stdlib_functions=299 capabilities=9 backend=cranelift -->
 
 Axiom is an agent-native typed intent and semantic construction system. It
 defines what must be true, which effects are allowed, what evidence proves a

--- a/docs/agent-task-contract-v0.md
+++ b/docs/agent-task-contract-v0.md
@@ -1,0 +1,92 @@
+# Agent Task Contract v0
+
+Agent Task Contract v0 is the read-only authority boundary between an approved
+issue or specification and an executor. It compiles an explicitly approved,
+machine-readable task specification into a deterministic
+`axiom.agent_task.v0` contract. It does not edit files, invoke a model, run a
+declared command, create a branch, publish a commit, or mutate delivery state.
+
+## Command
+
+```bash
+axiomc task-contract <spec.json> --project <path> --json
+```
+
+The specification and the resulting contract are validated against:
+
+- `stage1/schemas/axiom-agent-task-spec-v0.schema.json`
+- `stage1/schemas/axiom-agent-task-v0.schema.json`
+
+Paths in successful output are normalized relative to the project root and use
+`/` separators. Output ordering and generated identifiers are stable, so two
+invocations over identical bytes and project state produce identical bytes.
+
+## Authority Is Data, Not An Inference
+
+The input must carry an immutable authority record identifying the repository,
+governing issue, source revision and digest, and the explicit approval state,
+approver, and approval method. The compiler rejects unapproved, ambiguous, or
+internally inconsistent authority. It never treats free-form issue prose,
+repository access, an agent assignment, or a prior approval as permission.
+
+The compiler also never infers permission to widen:
+
+- allowed files or semantic nodes;
+- commands or capabilities;
+- credential or environment access;
+- time, token, retry, or cost budgets; or
+- commit, push, pull-request, review, merge, release, or deployment mutations.
+
+Unknown fields fail schema validation. Conflicting required and forbidden
+commands or capabilities, missing scope, contradictory acceptance criteria,
+unsupported irreversible actions, invalid dependency graphs, and delivery
+permissions above the approved autonomy class fail closed.
+
+## Contract Sections
+
+Every successful contract preserves the approved specification's:
+
+- objective and immutable authority;
+- task kind (`feature` or `repair`);
+- affected semantic node ids and allowed project-relative files;
+- required and forbidden capabilities and commands;
+- acceptance criteria and required evidence;
+- dependency and precondition graph;
+- autonomy and risk classification;
+- time, token, retry, and cost budgets;
+- rollback checkpoints and rollback commands;
+- success, stop, and escalation conditions; and
+- explicit delivery permissions.
+
+The delivery object records hard denials for self-approval, force-push,
+protected-branch direct push, and irreversible actions. Those fields are always
+`false` in v0 and cannot be overridden by a higher autonomy class.
+
+Lists are normalized and deduplicated only where order has no semantic meaning.
+Acceptance and evidence order are preserved because they can define execution
+order. Normalization may make authority narrower or reject it; it cannot make
+authority broader.
+
+## Feature And Repair Fixtures
+
+The checked-in feature specification authorizes a bounded documentation and
+source change, local validation, and review-gated pull-request delivery. Its
+expected contract proves deterministic normalization and project-relative
+paths.
+
+The checked-in repair specification carries a Repair Plan v0 task as a
+constrained subtype. Its diagnostic trigger, target node, allowed files, and
+required evidence are preserved losslessly. Repair compatibility does not grant
+execution: the task contract remains read-only and supplies authority to the
+separately governed executor.
+
+## Failure Contract
+
+Invalid specifications exit non-zero. JSON mode returns a deterministic error
+envelope and no executable contract. Validation tests cover missing or
+ambiguous authority, missing scope, conflicts, irreversible actions, scope
+widening, invalid or unbounded budgets, unresolved dependencies, and delivery
+permissions that exceed the autonomy class.
+
+These are contract errors, not warnings. An executor must not attempt to repair
+or fill in a rejected specification.

--- a/docs/autonomous-agent-roadmap.md
+++ b/docs/autonomous-agent-roadmap.md
@@ -56,6 +56,10 @@ must identify their omissions explicitly.
 Compile an approved issue or specification into a task contract containing
 scope, allowed files, required and forbidden capabilities, evidence, budgets,
 dependencies, rollback, delivery permissions, and stop/escalation conditions.
+The executable contract and its fail-closed boundary are defined in
+[Agent Task Contract v0](agent-task-contract-v0.md). Authority includes the
+approved source revision and digest; it is preserved rather than reconstructed
+from issue prose.
 
 ### A2: Transactional containment — #1420
 

--- a/docs/autonomous-agent-roadmap.md
+++ b/docs/autonomous-agent-roadmap.md
@@ -66,12 +66,16 @@ from issue prose.
 Execute from an exact base SHA in an isolated branch/worktree. Enforce path,
 command, network, credential, and external-mutation policy; preserve user-owned
 dirty work; checkpoint changes; and support crash-safe rollback.
+The normative policy, audit, and recovery rules are defined in
+[Transactional Workspace v0](transactional-workspace-v0.md).
 
 ### A3: Impact-aware proof — #1421
 
 Map before/after Intent IR and semantic drift to required positive, negative,
 schema, artifact, security, and performance evidence. Unknown impact broadens
 the suite or blocks execution; it never silently reduces validation.
+The versioned plan, evidence-result, and exact-head verdict contracts are
+defined in [Verification Planner v0](verification-planner-v0.md).
 
 ### A4: Bounded execution — #1422
 

--- a/docs/book.md
+++ b/docs/book.md
@@ -1,6 +1,6 @@
 # The Axiom Book
 
-<!-- capability-ledger:v1 commands=29 stdlib_modules=34 stdlib_functions=299 capabilities=9 backend=cranelift -->
+<!-- capability-ledger:v1 commands=30 stdlib_modules=34 stdlib_functions=299 capabilities=9 backend=cranelift -->
 
 This book is the tutorial path for the Rust-only stage1 toolchain. It teaches
 the current supported Axiom surface from first package to agent-oriented

--- a/docs/book.md
+++ b/docs/book.md
@@ -1,6 +1,6 @@
 # The Axiom Book
 
-<!-- capability-ledger:v1 commands=28 stdlib_modules=34 stdlib_functions=299 capabilities=9 backend=cranelift -->
+<!-- capability-ledger:v1 commands=29 stdlib_modules=34 stdlib_functions=299 capabilities=9 backend=cranelift -->
 
 This book is the tutorial path for the Rust-only stage1 toolchain. It teaches
 the current supported Axiom surface from first package to agent-oriented

--- a/docs/bootstrap/versioning.md
+++ b/docs/bootstrap/versioning.md
@@ -1,6 +1,6 @@
 # Release Versioning
 
-<!-- capability-ledger:v1 commands=28 stdlib_modules=34 stdlib_functions=299 capabilities=9 backend=cranelift -->
+<!-- capability-ledger:v1 commands=29 stdlib_modules=34 stdlib_functions=299 capabilities=9 backend=cranelift -->
 
 This bootstrap standardizes on Semantic Versioning with immutable exact tags and automatically promoted compatibility aliases.
 

--- a/docs/bootstrap/versioning.md
+++ b/docs/bootstrap/versioning.md
@@ -1,6 +1,6 @@
 # Release Versioning
 
-<!-- capability-ledger:v1 commands=29 stdlib_modules=34 stdlib_functions=299 capabilities=9 backend=cranelift -->
+<!-- capability-ledger:v1 commands=30 stdlib_modules=34 stdlib_functions=299 capabilities=9 backend=cranelift -->
 
 This bootstrap standardizes on Semantic Versioning with immutable exact tags and automatically promoted compatibility aliases.
 

--- a/docs/intent-ir-v0.md
+++ b/docs/intent-ir-v0.md
@@ -12,11 +12,11 @@ Intent IR is not the AST, HIR, or MIR:
 - Intent IR is the durable semantic contract agents inspect, transform,
   validate, repair, and trace across generated artifacts.
 
-The stage1 compiler does not emit full Intent IR yet. This v0 document and
-schema define the first stable shape; complete real-package emission is tracked
-by [#1418](https://github.com/OMT-Global/axiomlang/issues/1418) so inspection,
-verification, repair, artifact planning, and autonomous execution can consume
-one canonical graph.
+The stage1 compiler emits Intent IR for real packages and workspaces with
+`axiomc inspect intent <path> --json`. The emitted document is the canonical
+semantic input for inspection, semantic diff, verification, repair planning,
+and artifact planning. Consumers should not reconstruct competing partial
+graphs from compiler implementation details.
 
 ## Envelope
 
@@ -25,8 +25,14 @@ Every Intent IR document uses:
 - `schema_version`: `axiom.intent_ir.v0`
 - `graph_id`: stable graph identifier
 - `package`: root package node id
+- `provenance`: deterministic source inputs and their digests
 - `nodes`: semantic graph nodes
 - `edges`: semantic graph relationships
+- `diagnostics`: explicit, node-linked completeness diagnostics
+
+Arrays and object members use deterministic ordering. The command does not add
+timestamps or machine-specific absolute paths, so repeated runs over unchanged
+inputs are byte-stable.
 
 ## Node Types
 
@@ -78,6 +84,41 @@ axiom://package/<package-name>/artifact/<artifact-name>
 axiom://package/<package-name>/evidence/<evidence-name>
 ```
 
+IDs describe Axiom concepts. Compiler-host names such as Rust structs, Cargo
+packages, backend implementation types, and code-generator internals are not
+part of this contract.
+
+## Provenance and diagnostics
+
+`provenance.source_digest` is a digest of the normalized semantic inputs.
+`provenance.inputs` records each package-relative source input, its owning
+package node, and its digest. `path_policy` is fixed to `package_relative` so
+documents do not capture checkout or machine paths.
+
+Diagnostics make incomplete semantic coverage visible. An unsupported or
+partially represented node family produces a stable diagnostic code instead of
+being silently omitted. Every diagnostic has at least one `node_ids` entry;
+optional `node_kind` and `source_span` fields narrow the affected contract.
+An empty diagnostics array means the emitter found no known completeness gap.
+
+Every artifact is itself an `Artifact` node and must have a `generated_from` or
+`implements` edge to the semantic node it traces to. The same node identity is
+used by artifact inspection and planning.
+
+## CLI
+
+Emit a graph for a package or workspace:
+
+```bash
+axiomc inspect intent stage1/examples/agent_native_authorize --json
+axiomc inspect intent stage1/examples/workspace --json
+```
+
+The first command exercises capabilities, effects, axioms, evidence, and
+artifacts. The workspace fixture exercises package dependencies and modules
+across multiple member packages. Both outputs validate against
+`stage1/schemas/axiom-intent-ir-v0.schema.json`.
+
 ## V0 Fixture
 
 The smoke fixture lives at:
@@ -87,20 +128,20 @@ stage1/examples/intent_ir_smoke/intent-ir.json
 ```
 
 It includes one package, one module, one function, one manifest capability, one
-effect edge, one evidence placeholder, and one artifact placeholder. It is
-validated by `stage1/schemas/axiom-intent-ir-v0.schema.json`.
+effect edge, one evidence placeholder, one artifact placeholder, deterministic
+input provenance, and an empty completeness diagnostic set. It is validated by
+`stage1/schemas/axiom-intent-ir-v0.schema.json`.
 
 ## Boundaries
 
-Intent IR v0 does not require:
+Intent IR remains distinct from:
 
-- parser integration
 - proof solving
 - code generation from Intent IR
 - runtime execution
 
-Those behaviors should be added by later issues after the schema and smoke
-fixture are stable.
+Those systems may consume or contribute nodes and evidence without defining the
+graph contract.
 
 ## Related Schemas
 

--- a/docs/performance-benchmarks.md
+++ b/docs/performance-benchmarks.md
@@ -1,6 +1,6 @@
 # Performance Benchmarks
 
-<!-- capability-ledger:v1 commands=28 stdlib_modules=34 stdlib_functions=299 capabilities=9 backend=cranelift -->
+<!-- capability-ledger:v1 commands=29 stdlib_modules=34 stdlib_functions=299 capabilities=9 backend=cranelift -->
 
 The first benchmark harness is `axiomc bench`. It discovers `*_bench.ax` files,
 runs warmup iterations, runs measured iterations, and emits median and p95 wall

--- a/docs/performance-benchmarks.md
+++ b/docs/performance-benchmarks.md
@@ -1,6 +1,6 @@
 # Performance Benchmarks
 
-<!-- capability-ledger:v1 commands=29 stdlib_modules=34 stdlib_functions=299 capabilities=9 backend=cranelift -->
+<!-- capability-ledger:v1 commands=30 stdlib_modules=34 stdlib_functions=299 capabilities=9 backend=cranelift -->
 
 The first benchmark harness is `axiomc bench`. It discovers `*_bench.ax` files,
 runs warmup iterations, runs measured iterations, and emits median and p95 wall

--- a/docs/production-language-roadmap.md
+++ b/docs/production-language-roadmap.md
@@ -15,7 +15,7 @@ This track complements, but does not replace:
 
 - [self-hosting](rust-exit-readiness.md), governed by #721;
 - [unattended agent coding](autonomous-agent-roadmap.md), governed by #1417;
-- complete real-package Intent IR, governed by #1418.
+- canonical real-package and workspace Intent IR, governed by #1418.
 
 ## Critical Runtime Correction
 

--- a/docs/repair-executor-v0.md
+++ b/docs/repair-executor-v0.md
@@ -34,6 +34,13 @@ Merge-capable delivery remains a separate Class 3 decision under #1423.
 
 ## Inputs
 
+The general executor work in #1422 must consume an approved
+[`axiom.agent_task.v0`](agent-task-contract-v0.md) contract. A repair execution
+embeds the Repair Plan v0 task described below as a constrained subtype. A
+repair plan alone is diagnostic evidence, not execution authority; the task
+contract supplies the immutable approval, budgets, capability and command
+boundaries, terminal conditions, and delivery permissions.
+
 The executor input is a Repair Plan v0 JSON report:
 
 ```bash

--- a/docs/repair-plan-v0.md
+++ b/docs/repair-plan-v0.md
@@ -40,3 +40,15 @@ V0 covers:
 
 Future versions can attach capability, effect, axiom, evidence, and artifact
 node ids once those semantic graph surfaces are fully merged.
+
+## Agent Task Contract Compatibility
+
+[Agent Task Contract v0](agent-task-contract-v0.md) can represent a Repair Plan
+v0 task as a constrained `repair` task. The conversion preserves the repair
+task id, reason, target node, diagnostics, allowed files, and required evidence.
+It may add narrower authority, budgets, rollback, terminal conditions, and
+delivery denials supplied by an explicitly approved specification, but it may
+not widen the repair plan's file or evidence boundary.
+
+Repair Plan v0 remains a diagnostic-driven planning API. It is not itself proof
+of approval and does not grant execution or delivery permission.

--- a/docs/roadmap-agent-native-ledger.md
+++ b/docs/roadmap-agent-native-ledger.md
@@ -40,7 +40,7 @@ canonical issue has already shipped or has an active PR.
 |---|---:|---|---|---|
 | Vision and Rust boundary | #774 | #775, #789 | shipped | Keep new semantics Axiom-neutral and preserve the anti-capture checks. |
 | Roadmap and execution contract | #776 | #788 | shipped | GitHub issues remain the execution source of record; keep this ledger aligned with live issue state. |
-| Intent IR v0 schema | #777 | #778, #779, #781, #785, #787 | shipped foundation | The schema and smoke fixture are stable; complete real-package emission is now #1418. |
+| Intent IR v0 schema | #777 | #778, #779, #781, #785, #787 | shipped foundation | The schema, smoke fixture, and #1418 real-package emitter define one contract. |
 | Inspection, capabilities, effects, and axioms | #778 | #779, #780, #781 | shipped | Extend existing versioned envelopes and fixtures rather than creating parallel inspection graphs. |
 | Evidence, artifacts, repair plans, and provenance | #782 | #783, #784, #785 | shipped | These remain read-only/verification foundations; bounded execution is #1422. |
 | Backend target interface | #786 | #777, #783 | shipped | New targets must declare a v0 contract before implementation. |
@@ -57,7 +57,7 @@ The complete roadmap is [Autonomous Agent Execution Roadmap](autonomous-agent-ro
 | Family | Canonical issue | Disposition | Agent instruction |
 |---|---:|---|---|
 | Unattended coding umbrella | #1417 | needs human approval for policy transitions | Compose child gates; do not infer delivery permission from feature completeness. |
-| Complete Intent IR emission | #1418 | ready for planning | Emit one deterministic real-package graph consumed by planning, verification, repair, and artifacts. |
+| Complete Intent IR emission | #1418 | implemented; review-gated | Preserve deterministic package/workspace emission, provenance, traceable diagnostics, and the shared consumer contract. |
 | Typed task contract | #1419 | ready for planning | Compile approved issues/specs into bounded authority, evidence, budgets, rollback, and stop conditions. |
 | Transactional workspace | #1420 | ready for planning | Isolate work, enforce file/command/capability policy, preserve dirty user state, and prove rollback. |
 | Verification planner | #1421 | ready for planning | Map semantic drift to exact-head positive, negative, schema, artifact, security, and performance evidence. |

--- a/docs/roadmap-agent-native-ledger.md
+++ b/docs/roadmap-agent-native-ledger.md
@@ -58,7 +58,7 @@ The complete roadmap is [Autonomous Agent Execution Roadmap](autonomous-agent-ro
 |---|---:|---|---|
 | Unattended coding umbrella | #1417 | needs human approval for policy transitions | Compose child gates; do not infer delivery permission from feature completeness. |
 | Complete Intent IR emission | #1418 | implemented; review-gated | Preserve deterministic package/workspace emission, provenance, traceable diagnostics, and the shared consumer contract. |
-| Typed task contract | #1419 | ready for planning | Compile approved issues/specs into bounded authority, evidence, budgets, rollback, and stop conditions. |
+| Typed task contract | #1419 | implemented; review-gated | Preserve approved source authority and compile strict feature/repair specs into deterministic bounded contracts; rejected or ambiguous authority fails closed. |
 | Transactional workspace | #1420 | ready for planning | Isolate work, enforce file/command/capability policy, preserve dirty user state, and prove rollback. |
 | Verification planner | #1421 | ready for planning | Map semantic drift to exact-head positive, negative, schema, artifact, security, and performance evidence. |
 | Bounded executor | #1422 | ready after #1419-#1421 | Implement dry-run, deterministic repair, assisted proposals, budgets, retries, and auditable terminal states. |

--- a/docs/roadmap-agent-native-ledger.md
+++ b/docs/roadmap-agent-native-ledger.md
@@ -59,8 +59,8 @@ The complete roadmap is [Autonomous Agent Execution Roadmap](autonomous-agent-ro
 | Unattended coding umbrella | #1417 | needs human approval for policy transitions | Compose child gates; do not infer delivery permission from feature completeness. |
 | Complete Intent IR emission | #1418 | implemented; review-gated | Preserve deterministic package/workspace emission, provenance, traceable diagnostics, and the shared consumer contract. |
 | Typed task contract | #1419 | implemented; review-gated | Preserve approved source authority and compile strict feature/repair specs into deterministic bounded contracts; rejected or ambiguous authority fails closed. |
-| Transactional workspace | #1420 | ready for planning | Isolate work, enforce file/command/capability policy, preserve dirty user state, and prove rollback. |
-| Verification planner | #1421 | ready for planning | Map semantic drift to exact-head positive, negative, schema, artifact, security, and performance evidence. |
+| Transactional workspace | #1420 | implemented; review-gated | Preserve the strict execution policy, isolated exact-SHA workspace, dirty-source boundary, deterministic audit, and crash-safe rollback contract. |
+| Verification planner | #1421 | implemented; review-gated | Preserve deterministic semantic-impact mapping, conservative unknown-impact coverage, strict evidence schemas, and exact-head terminal verdicts. |
 | Bounded executor | #1422 | ready after #1419-#1421 | Implement dry-run, deterministic repair, assisted proposals, budgets, retries, and auditable terminal states. |
 | Delivery controller | #1423 | human approval required before merge-capable code | Require independent review; prohibit self-approval, force-push, and policy bypass. |
 | Autonomy evaluation | #1424 | ready for planning | Gate promotion on correctness, containment, recovery, escalation, time, and cost, including tasks that must stop. |

--- a/docs/roadmap-status.md
+++ b/docs/roadmap-status.md
@@ -34,7 +34,8 @@ define completion.
   readiness is red, and no genesis snapshot is pinned.
 - Semantic inspection, evidence, verification, repair planning, provenance,
   semantic diff, decisions, target contracts, and artifact generators are
-  shipped foundations. Full real-package Intent IR emission remains open.
+  shipped foundations. Real-package and workspace Intent IR emission is
+  available through `axiomc inspect intent <path> --json`.
 
 ## Active Roadmap Families
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -58,8 +58,9 @@ implementation surfaces; see
   compiler-workload gaps (#1425-#1427), migrate compiler source packages in
   AxiOM (#1468-#1475 and #1478-#1479), prove the Cargo-free snapshot chain
   (#1428), and reserve the final #721 decision for the exact release candidate.
-- Emit complete Intent IR for real packages (#1418) so the semantic APIs share
-  one canonical graph rather than partial, command-specific views.
+- Use complete Intent IR emission for real packages and workspaces (#1418) so
+  semantic APIs share one canonical graph rather than partial,
+  command-specific views.
 - Advance the [Autonomous Agent Execution Roadmap](autonomous-agent-roadmap.md)
   (#1417 and #1419-#1424) from typed authority through transactional execution,
   impact-aware evidence, independent review, delivery, and recovery.

--- a/docs/stage1-agent-grade-compiler.md
+++ b/docs/stage1-agent-grade-compiler.md
@@ -1,6 +1,6 @@
 # Stage1 Agent-Grade Compiler Plan
 
-<!-- capability-ledger:v1 commands=29 stdlib_modules=34 stdlib_functions=299 capabilities=9 backend=cranelift -->
+<!-- capability-ledger:v1 commands=30 stdlib_modules=34 stdlib_functions=299 capabilities=9 backend=cranelift -->
 
 This doc is the implementation spec for turning `stage1/` into Axiom's first
 workable compiler for agent use. `docs/stage1.md` stays as the shorter status

--- a/docs/stage1-agent-grade-compiler.md
+++ b/docs/stage1-agent-grade-compiler.md
@@ -1,6 +1,6 @@
 # Stage1 Agent-Grade Compiler Plan
 
-<!-- capability-ledger:v1 commands=28 stdlib_modules=34 stdlib_functions=299 capabilities=9 backend=cranelift -->
+<!-- capability-ledger:v1 commands=29 stdlib_modules=34 stdlib_functions=299 capabilities=9 backend=cranelift -->
 
 This doc is the implementation spec for turning `stage1/` into Axiom's first
 workable compiler for agent use. `docs/stage1.md` stays as the shorter status

--- a/docs/stage1-language-issue-disposition.md
+++ b/docs/stage1-language-issue-disposition.md
@@ -1,6 +1,6 @@
 # Stage1 Language Issue Disposition
 
-<!-- capability-ledger:v1 commands=29 stdlib_modules=34 stdlib_functions=299 capabilities=9 backend=cranelift -->
+<!-- capability-ledger:v1 commands=30 stdlib_modules=34 stdlib_functions=299 capabilities=9 backend=cranelift -->
 
 This document records the historical disposition for the broad Phase A language
 issues opened as #216 through #225. It is an evidence guide, not current live

--- a/docs/stage1-language-issue-disposition.md
+++ b/docs/stage1-language-issue-disposition.md
@@ -1,6 +1,6 @@
 # Stage1 Language Issue Disposition
 
-<!-- capability-ledger:v1 commands=28 stdlib_modules=34 stdlib_functions=299 capabilities=9 backend=cranelift -->
+<!-- capability-ledger:v1 commands=29 stdlib_modules=34 stdlib_functions=299 capabilities=9 backend=cranelift -->
 
 This document records the historical disposition for the broad Phase A language
 issues opened as #216 through #225. It is an evidence guide, not current live

--- a/docs/stage1-stdlib-status.md
+++ b/docs/stage1-stdlib-status.md
@@ -1,6 +1,6 @@
 # Stage1 stdlib status
 
-<!-- capability-ledger:v1 commands=28 stdlib_modules=34 stdlib_functions=299 capabilities=9 backend=cranelift -->
+<!-- capability-ledger:v1 commands=29 stdlib_modules=34 stdlib_functions=299 capabilities=9 backend=cranelift -->
 
 This page maps historical phase-c roadmap issues to the current compiler-owned
 stdlib inventory. Issue numbers are historical evidence, not live issue-state

--- a/docs/stage1-stdlib-status.md
+++ b/docs/stage1-stdlib-status.md
@@ -1,6 +1,6 @@
 # Stage1 stdlib status
 
-<!-- capability-ledger:v1 commands=29 stdlib_modules=34 stdlib_functions=299 capabilities=9 backend=cranelift -->
+<!-- capability-ledger:v1 commands=30 stdlib_modules=34 stdlib_functions=299 capabilities=9 backend=cranelift -->
 
 This page maps historical phase-c roadmap issues to the current compiler-owned
 stdlib inventory. Issue numbers are historical evidence, not live issue-state

--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -1,6 +1,6 @@
 # Stage1 bootstrap
 
-<!-- capability-ledger:v1 commands=28 stdlib_modules=34 stdlib_functions=299 capabilities=9 backend=cranelift -->
+<!-- capability-ledger:v1 commands=29 stdlib_modules=34 stdlib_functions=299 capabilities=9 backend=cranelift -->
 
 The Rust bootstrap compiler in `stage1/` is the supported Axiom toolchain.
 The Python `stage0` interpreter, bytecode compiler, bytecode format, bytecode

--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -1,6 +1,6 @@
 # Stage1 bootstrap
 
-<!-- capability-ledger:v1 commands=29 stdlib_modules=34 stdlib_functions=299 capabilities=9 backend=cranelift -->
+<!-- capability-ledger:v1 commands=30 stdlib_modules=34 stdlib_functions=299 capabilities=9 backend=cranelift -->
 
 The Rust bootstrap compiler in `stage1/` is the supported Axiom toolchain.
 The Python `stage0` interpreter, bytecode compiler, bytecode format, bytecode

--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -152,6 +152,11 @@ The checked-in compiler JSON schema is
 The first agent-facing Intent IR / semantic graph schema is
 `stage1/schemas/axiom-intent-ir-v0.schema.json`; see
 [intent-ir-v0.md](intent-ir-v0.md).
+`axiomc inspect intent <path> --json` emits that canonical, deterministic
+package or workspace graph with package-relative provenance and explicit
+node-linked completeness diagnostics. Its output is the dedicated
+`axiom.intent_ir.v0` document rather than the shared command envelope described
+below.
 Successful payloads always include `ok` and `command`; project-scoped payloads
 also include `project`.
 `axiomc run --json` captures the selected backend, native binary exit code,

--- a/docs/transactional-workspace-v0.md
+++ b/docs/transactional-workspace-v0.md
@@ -1,0 +1,78 @@
+# Transactional Workspace v0
+
+Transactional Workspace v0 is the containment boundary between an approved
+`axiom.agent_task.v0` contract and a future bounded executor. Every transaction
+starts from an exact base commit in a transaction-owned branch and worktree;
+the convenience API may use a detached transaction worktree. The
+source checkout is evidence, not scratch space: pre-existing user changes are
+never copied, overwritten, cleaned, reset, staged, or committed.
+
+The two machine-readable contracts are:
+
+- `axiom.execution_policy.v0`, the immutable authority compiled before any
+  workspace mutation; and
+- `axiom.execution_transaction.v0`, the durable transaction state and audit
+  journal used for inspection, recovery, and rollback.
+
+Their schemas and representative fixtures live under `stage1/schemas` and
+`stage1/json-fixtures/execution-transaction`.
+
+## Prepare Before Mutation
+
+Preparation resolves the requested base revision to a full SHA, creates the
+requested transaction-owned branch (or an explicitly detached worktree),
+and records the initial checkpoint. A transaction must reject a reused or dirty
+isolated worktree. An executor must canonicalize the worktree root and the
+nearest existing ancestor of every requested path before granting access.
+
+Paths are project-relative authority. Absolute paths, `..` traversal, NULs,
+duplicate separators, and canonical paths outside the isolated root fail
+closed. Symlinks are never followed for authority decisions. The same check
+applies to reads, writes, chmod, rename source and destination, and deletion.
+Protected paths cannot be edited in v0.
+
+## Capabilities And External Effects
+
+Portable v0 does not execute external commands. It records every request as a
+denial even when a program name appears in the policy, because a program-name
+allowlist cannot contain its filesystem, subprocess, environment, credential,
+or network effects. A future executor may consume the schema's argument-vector,
+capability, host, and broker-reference bounds only after it supplies a verified
+OS sandbox backend. Until then commands, network, ambient credentials, and
+external mutations fail closed and no secret value enters process context.
+
+Protected-branch pushes, force-pushes, self-approval, and policy edits are hard
+denials. Delivery mutations require both task authority and a separately
+authorized pre-delivery checkpoint. Local rollback does not infer authority to
+revert a delivered commit or other external state.
+
+## Checkpoint, Abort, And Recovery
+
+A durable exact-base checkpoint is recorded before mutation, and a pending
+effect marker is persisted before every write, delete, rename, or chmod. The
+journal assigns monotonically increasing sequence numbers and is persisted
+atomically before the corresponding effect. On a local failure, rollback
+restores the isolated workspace to its exact-base checkpoint,
+removes only transaction-owned untracked files, and verifies that the source
+checkout fingerprint is unchanged.
+
+After interruption, an inspector validates the state SHA-256, transaction
+identity, exact base/HEAD relationship, worktree identity, and journal sequence.
+Resume is allowed only when no filesystem effect was pending at interruption.
+Otherwise the only local action is rollback. Delivered changes require a
+separately authorized revert path and are never silently reset.
+
+## Deterministic Audit
+
+The audit records the exact base SHA and policy digest, ordered checkpoints,
+canonical reads and writes with content digests, command argument vectors,
+capabilities and network hosts, exit codes, output digests, artifacts, rollback
+result, and recovery state. Stable identifiers derive from approved inputs;
+timestamps, hostnames, absolute machine paths, raw command output, environment
+contents, credential material, and secret values are excluded. Identical
+approved inputs and observations serialize to identical JSON bytes.
+
+The security test matrix covers traversal, symlink escape, out-of-scope chmod,
+rename and deletion, command and network escalation, ambient credentials,
+protected delivery operations, dirty-source preservation, failure rollback,
+and interrupted transaction recovery. These are rejection tests, not warnings.

--- a/docs/verification-planner-v0.md
+++ b/docs/verification-planner-v0.md
@@ -1,0 +1,91 @@
+# Verification Planner v0
+
+Verification Planner v0 deterministically maps the semantic impact between two
+complete Intent IR snapshots to the evidence required for one exact delivered
+head. It is a read-only planning and evaluation surface: it does not run tests,
+edit a checkout, grant capabilities, waive evidence, or deliver a change.
+
+## Contract
+
+The planner consumes before and after `axiom.intent_ir.v0` documents plus the
+established `axiom.semantic_diff.v0` report and the source and delivered commit
+SHAs. The CLI recomputes graph changes and rejects a diff that omits or invents
+node or edge drift. It emits `axiom.verification_plan.v0`, whose
+bindings retain both graph IDs, both snapshot digests, and both commit SHAs.
+Every semantic change records its stable ID, change kind, semantic node kind,
+semantic ID, package-relative source path when known, and classified impact.
+
+Evidence requirements use these closed categories:
+
+- `positive` proves intended behavior;
+- `denial` proves prohibited capability or effect paths remain denied;
+- `regression` protects public and dependency-facing behavior;
+- `schema` validates changed machine-readable contracts;
+- `artifact` detects generated-output drift;
+- `security` exercises security-sensitive boundaries;
+- `performance` compares a performance-sensitive change with its baseline.
+
+A changed capability, effect, axiom, dependency, public contract, schema, or
+artifact target always produces required evidence. A localized implementation
+change produces positive evidence. An impact the planner cannot classify is
+reported in `coverage.unknown_impacts` and receives the conservative evidence
+suite; uncertainty can broaden or block a plan but cannot reduce it. Plans with
+semantic changes but no evidence requirements are invalid; identical snapshots
+may produce an explicitly empty plan.
+
+The machine-readable contracts are:
+
+- `stage1/schemas/axiom-verification-plan-v0.schema.json`
+- `stage1/schemas/axiom-verification-results-v0.schema.json`
+- `stage1/schemas/axiom-verification-verdict-v0.schema.json`
+
+All three reject undeclared fields. IDs and requirement order are derived from
+canonical semantic input, so identical inputs and SHA bindings serialize to
+identical bytes.
+
+```bash
+axiomc verification-plan before.json after.json \
+  --diff semantic-diff.json --project . \
+  --source-head <source-sha> --delivered-head <current-head> --json
+```
+
+The CLI resolves `--project` HEAD independently and rejects a stale or invented
+`--delivered-head`. Library callers must supply an independently observed head
+from their delivery controller; repeating an untrusted result field is not a
+freshness proof.
+
+## Exact-head evaluation
+
+An evidence producer returns an `axiom.verification_results.v0` envelope. The
+envelope and each result repeat the plan digest, source head SHA, and delivered
+head SHA. Evaluation rejects stale or cross-plan evidence, duplicate evidence
+IDs, unknown IDs, and a caller-provided delivered SHA that differs from the
+plan. Evidence digests bind the observed result without embedding logs or
+secrets in the contract.
+
+`axiom.verification_verdict.v0` is terminally successful only when all of the
+following hold:
+
+1. every planned requirement has exactly one result;
+2. every result is schema-valid and bound to the plan and exact heads;
+3. no unplanned or duplicate evidence result is present;
+4. every required result is `passed`.
+
+The verdict exposes deterministic `missing`, `duplicate`, `invalid`, and
+`failed` requirement-ID lists. A non-empty list makes the verdict rejected.
+Neither evaluator nor schema treats an absent result as success.
+
+## Fixture and quality surface
+
+`stage1/json-fixtures/verification-planner` covers localized implementation,
+public API, capability escalation, schema, generated-artifact, performance, and
+unknown-impact changes. The unknown fixture is adversarial: it proves that an
+unmapped node kind broadens evidence instead of silently producing a smaller
+suite. Mapping and adversarial tests form the initial quality measurement; the
+same fixture dimensions feed the autonomy evaluation suite governed by #1417
+and #1424.
+
+This planner composes the complete Intent IR from #1418, the bounded task
+contract from #1419, and the transactional boundary from #1420. The bounded
+executor in #1422 may run only the evidence a valid plan requires and must use
+the exact-head verdict as its terminal verification gate.

--- a/scripts/ci/check-capability-ledger.py
+++ b/scripts/ci/check-capability-ledger.py
@@ -41,6 +41,7 @@ COMMAND_TIERS = {
     "caps": "static_spike",
     "repair-plan": "static_spike",
     "task-contract": "static_spike",
+    "verification-plan": "static_spike",
     "evidence": "static_spike",
     "verify": "static_spike",
     "semantic-diff": "static_spike",

--- a/scripts/ci/check-capability-ledger.py
+++ b/scripts/ci/check-capability-ledger.py
@@ -40,6 +40,7 @@ COMMAND_TIERS = {
     "test": "static_spike",
     "caps": "static_spike",
     "repair-plan": "static_spike",
+    "task-contract": "static_spike",
     "evidence": "static_spike",
     "verify": "static_spike",
     "semantic-diff": "static_spike",

--- a/stage1/compiler-contracts/snapshots/capability-ledger.json
+++ b/stage1/compiler-contracts/snapshots/capability-ledger.json
@@ -240,6 +240,12 @@
     },
     {
       "evidenceTier": "static_spike",
+      "name": "verification-plan",
+      "source": "stage1/crates/axiomc/src/main.rs",
+      "status": "implemented"
+    },
+    {
+      "evidenceTier": "static_spike",
       "name": "verify",
       "source": "stage1/crates/axiomc/src/main.rs",
       "status": "implemented"
@@ -894,6 +900,18 @@
     },
     {
       "evidenceTier": "static_spike",
+      "name": "https://axiom.omt.global/schemas/axiom-execution-policy-v0.schema.json",
+      "source": "stage1/schemas/axiom-execution-policy-v0.schema.json",
+      "status": "checked"
+    },
+    {
+      "evidenceTier": "static_spike",
+      "name": "https://axiom.omt.global/schemas/axiom-execution-transaction-v0.schema.json",
+      "source": "stage1/schemas/axiom-execution-transaction-v0.schema.json",
+      "status": "checked"
+    },
+    {
+      "evidenceTier": "static_spike",
       "name": "https://axiom.omt.global/schemas/axiom-format-edit-v1.schema.json",
       "source": "stage1/schemas/axiom-format-edit-v1.schema.json",
       "status": "checked"
@@ -962,6 +980,24 @@
       "evidenceTier": "static_spike",
       "name": "https://axiom-lang.dev/schemas/axiom-trace-v0.schema.json",
       "source": "stage1/schemas/axiom-trace-v0.schema.json",
+      "status": "checked"
+    },
+    {
+      "evidenceTier": "static_spike",
+      "name": "https://axiom.omt.global/schemas/axiom-verification-plan-v0.schema.json",
+      "source": "stage1/schemas/axiom-verification-plan-v0.schema.json",
+      "status": "checked"
+    },
+    {
+      "evidenceTier": "static_spike",
+      "name": "https://axiom.omt.global/schemas/axiom-verification-results-v0.schema.json",
+      "source": "stage1/schemas/axiom-verification-results-v0.schema.json",
+      "status": "checked"
+    },
+    {
+      "evidenceTier": "static_spike",
+      "name": "https://axiom.omt.global/schemas/axiom-verification-verdict-v0.schema.json",
+      "source": "stage1/schemas/axiom-verification-verdict-v0.schema.json",
       "status": "checked"
     },
     {
@@ -1667,16 +1703,16 @@
   ],
   "summary": {
     "capabilities": 9,
-    "commands": 29,
+    "commands": 30,
     "evidenceTiers": {
       "direct_runtime": 2,
       "production_qualified": 0,
       "scaffold": 5,
-      "static_spike": 187,
+      "static_spike": 193,
       "unsupported": 5
     },
     "runtimeAbiRows": 34,
-    "schemas": 30,
+    "schemas": 35,
     "stdlibFunctions": 299,
     "stdlibModules": 34,
     "supportedNativeBackend": "cranelift"

--- a/stage1/compiler-contracts/snapshots/capability-ledger.json
+++ b/stage1/compiler-contracts/snapshots/capability-ledger.json
@@ -222,6 +222,12 @@
     },
     {
       "evidenceTier": "static_spike",
+      "name": "task-contract",
+      "source": "stage1/crates/axiomc/src/main.rs",
+      "status": "implemented"
+    },
+    {
+      "evidenceTier": "static_spike",
       "name": "test",
       "source": "stage1/crates/axiomc/src/main.rs",
       "status": "implemented"
@@ -832,6 +838,18 @@
   ],
   "schemaVersion": "axiom.capability_ledger.v1",
   "schemas": [
+    {
+      "evidenceTier": "static_spike",
+      "name": "https://axiom.omt.global/schemas/axiom-agent-task-spec-v0.schema.json",
+      "source": "stage1/schemas/axiom-agent-task-spec-v0.schema.json",
+      "status": "checked"
+    },
+    {
+      "evidenceTier": "static_spike",
+      "name": "https://axiom.omt.global/schemas/axiom-agent-task-v0.schema.json",
+      "source": "stage1/schemas/axiom-agent-task-v0.schema.json",
+      "status": "checked"
+    },
     {
       "evidenceTier": "static_spike",
       "name": "https://axiomlang.dev/schemas/axiom-artifacts-v0.schema.json",
@@ -1643,16 +1661,16 @@
   ],
   "summary": {
     "capabilities": 9,
-    "commands": 28,
+    "commands": 29,
     "evidenceTiers": {
       "direct_runtime": 2,
       "production_qualified": 0,
       "scaffold": 5,
-      "static_spike": 183,
+      "static_spike": 186,
       "unsupported": 5
     },
     "runtimeAbiRows": 34,
-    "schemas": 27,
+    "schemas": 29,
     "stdlibFunctions": 299,
     "stdlibModules": 34,
     "supportedNativeBackend": "cranelift"

--- a/stage1/crates/axiomc/src/agent_task.rs
+++ b/stage1/crates/axiomc/src/agent_task.rs
@@ -1,0 +1,1282 @@
+//! Fail-closed compilation of approved specifications into bounded agent tasks.
+
+use crate::diagnostics::Diagnostic;
+use crate::intent_ir::{IntentIrDocument, emit_intent_ir};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+pub const SOURCE_SCHEMA_VERSION: &str = "axiom.agent_task.spec.v0";
+pub const TASK_SCHEMA_VERSION: &str = "axiom.agent_task.v0";
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct AgentTaskSource {
+    pub schema_version: String,
+    pub task: AgentTaskSpec,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct AgentTaskSpec {
+    pub id: String,
+    pub kind: TaskKind,
+    pub objective: String,
+    pub authority: Authority,
+    pub scope: Scope,
+    pub capabilities: PermissionSet,
+    pub commands: PermissionSet,
+    pub acceptance_criteria: Vec<AcceptanceCriterion>,
+    pub required_evidence: Vec<EvidenceRequirement>,
+    pub dependencies: Vec<TaskDependency>,
+    pub autonomy: Autonomy,
+    pub budgets: Budgets,
+    pub rollback: RollbackPlan,
+    pub terminal_conditions: TerminalConditions,
+    pub delivery_permissions: DeliveryPermissions,
+    #[serde(default)]
+    #[serde(rename = "repair")]
+    pub repair_plan: Option<RepairPlan>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskKind {
+    Feature,
+    Migration,
+    Refactor,
+    Operational,
+    Repair,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct Authority {
+    pub governing_issue: String,
+    pub repository: String,
+    pub issue: u64,
+    pub source_revision: String,
+    pub source_digest: String,
+    pub approval: Approval,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthorityStatus {
+    Approved,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct Approval {
+    pub state: AuthorityStatus,
+    pub approver: String,
+    pub method: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct Scope {
+    pub affected_semantic_nodes: Vec<String>,
+    pub allowed_files: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub denied_files: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct PermissionSet {
+    pub required: Vec<String>,
+    pub forbidden: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct AcceptanceCriterion {
+    pub id: String,
+    pub requirement: String,
+    pub expected: AcceptanceExpectation,
+    pub evidence_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AcceptanceExpectation {
+    Pass,
+    Fail,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct EvidenceRequirement {
+    pub id: String,
+    pub kind: EvidenceKind,
+    pub command: String,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceKind {
+    UnitTest,
+    PropertyTest,
+    ConformanceFixture,
+    CapabilityDenialTest,
+    GoldenOutput,
+    SchemaValidation,
+    SecurityFixture,
+    BenchmarkBaseline,
+    ManualReview,
+    RiskNote,
+    CiStatus,
+    ReviewState,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct TaskDependency {
+    pub id: String,
+    pub status: DependencyStatus,
+    pub depends_on: Vec<String>,
+    pub precondition: String,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DependencyStatus {
+    Satisfied,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct Autonomy {
+    pub class: u8,
+    pub risk: RiskClass,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RiskClass {
+    Low,
+    Medium,
+    High,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct Budgets {
+    pub time_seconds: u64,
+    pub tokens: u64,
+    pub retries: u32,
+    pub cost_usd_micros: u64,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RollbackPlan {
+    pub checkpoint: String,
+    pub commands: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct TerminalConditions {
+    pub success: Vec<String>,
+    pub stop: Vec<String>,
+    pub escalation: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct DeliveryPermissions {
+    pub commit: bool,
+    pub push: bool,
+    pub pull_request: bool,
+    pub review: bool,
+    pub merge: bool,
+    pub deploy: bool,
+    pub approve_own_pull_request: bool,
+    pub force_push: bool,
+    pub direct_push_protected: bool,
+    pub irreversible_actions: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RepairPlan {
+    pub id: String,
+    pub reason: String,
+    pub target_node: String,
+    pub allowed_files: Vec<String>,
+    pub required_evidence: Vec<EvidenceKind>,
+    pub diagnostics: Vec<RepairDiagnostic>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RepairDiagnostic {
+    pub kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub help: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub column: Option<u64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub related: Vec<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repair: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct AgentTaskContract {
+    pub schema_version: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub contract_digest: String,
+    pub id: String,
+    #[serde(rename = "kind")]
+    pub task_kind: TaskKind,
+    pub objective: String,
+    pub authority: Authority,
+    pub scope: Scope,
+    pub capabilities: PermissionSet,
+    pub commands: PermissionSet,
+    pub acceptance_criteria: Vec<AcceptanceCriterion>,
+    pub required_evidence: Vec<EvidenceRequirement>,
+    pub dependencies: Vec<TaskDependency>,
+    pub autonomy: Autonomy,
+    pub budgets: Budgets,
+    pub rollback: RollbackPlan,
+    pub terminal_conditions: TerminalConditions,
+    pub delivery_permissions: DeliveryPermissions,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "repair")]
+    pub repair_plan: Option<RepairPlan>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct AgentTaskReport {
+    pub schema_version: String,
+    pub ok: bool,
+    pub command: String,
+    pub project: String,
+    pub contract: AgentTaskContract,
+}
+
+pub fn compile_task_contract(
+    project: &Path,
+    source_path: &Path,
+) -> Result<AgentTaskReport, Diagnostic> {
+    let content = fs::read_to_string(source_path).map_err(|error| {
+        task_error(
+            "agent_task_source_read",
+            format!("failed to read {}: {error}", source_path.display()),
+        )
+    })?;
+    let source: AgentTaskSource = serde_json::from_str(&content).map_err(|error| {
+        task_error(
+            "agent_task_source_invalid",
+            format!("invalid task source {}: {error}", source_path.display()),
+        )
+    })?;
+    require(
+        source.schema_version == SOURCE_SCHEMA_VERSION,
+        "agent_task_schema",
+        "unsupported task source schema",
+    )?;
+    validate_project_paths(project, &source.task)?;
+    let intent = emit_intent_ir(project)?;
+    let contract = compile_approved_task(source.task, &intent)?;
+    Ok(AgentTaskReport {
+        schema_version: TASK_SCHEMA_VERSION.into(),
+        ok: true,
+        command: "task-contract".into(),
+        project: ".".into(),
+        contract,
+    })
+}
+
+pub fn compile_approved_task(
+    mut source: AgentTaskSpec,
+    intent: &IntentIrDocument,
+) -> Result<AgentTaskContract, Diagnostic> {
+    validate(&source, intent)?;
+    canonicalize(&mut source);
+    let mut contract = AgentTaskContract {
+        schema_version: TASK_SCHEMA_VERSION.into(),
+        contract_digest: String::new(),
+        id: source.id,
+        task_kind: source.kind,
+        objective: source.objective,
+        authority: source.authority,
+        scope: source.scope,
+        capabilities: source.capabilities,
+        commands: source.commands,
+        acceptance_criteria: source.acceptance_criteria,
+        required_evidence: source.required_evidence,
+        dependencies: source.dependencies,
+        autonomy: source.autonomy,
+        budgets: source.budgets,
+        rollback: source.rollback,
+        terminal_conditions: source.terminal_conditions,
+        delivery_permissions: source.delivery_permissions,
+        repair_plan: source.repair_plan,
+    };
+    let canonical = serde_json::to_vec(&contract)
+        .map_err(|error| task_error("agent_task_digest", error.to_string()))?;
+    contract.contract_digest = format!("sha256:{}", stable_digest(&canonical));
+    Ok(contract)
+}
+
+fn validate(source: &AgentTaskSpec, intent: &IntentIrDocument) -> Result<(), Diagnostic> {
+    nonempty(&source.id, "task ID")?;
+    require(
+        source.id.chars().enumerate().all(|(i, c)| {
+            c.is_ascii_lowercase() || c.is_ascii_digit() || (i > 0 && matches!(c, '.' | '_' | '-'))
+        }),
+        "agent_task_id",
+        "task ID must be canonical lowercase ASCII",
+    )?;
+    nonempty(&source.objective, "objective")?;
+    nonempty(&source.authority.governing_issue, "governing issue")?;
+    nonempty(&source.authority.repository, "authority repository")?;
+    require(
+        source.authority.issue > 0,
+        "agent_task_authority",
+        "authority issue must be positive",
+    )?;
+    nonempty(
+        &source.authority.source_revision,
+        "authority source revision",
+    )?;
+    nonempty(&source.authority.source_digest, "authority source digest")?;
+    nonempty(&source.authority.approval.approver, "approver")?;
+    nonempty(&source.authority.approval.method, "approval method")?;
+    let expected_issue = format!(
+        "https://github.com/{}/issues/{}",
+        source.authority.repository, source.authority.issue
+    );
+    require(
+        source.authority.governing_issue == expected_issue,
+        "agent_task_authority",
+        "governing issue, repository, and issue number do not agree",
+    )?;
+    require(
+        source
+            .authority
+            .repository
+            .split_once('/')
+            .is_some_and(|(owner, repo)| {
+                !owner.is_empty() && !repo.is_empty() && !repo.contains('/')
+            }),
+        "agent_task_authority",
+        "repository must be owner/name",
+    )?;
+    require(
+        source.authority.source_revision.len() == 40
+            && source
+                .authority
+                .source_revision
+                .bytes()
+                .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase()),
+        "agent_task_authority",
+        "source revision must be a full lowercase commit SHA",
+    )?;
+    require(
+        source
+            .authority
+            .source_digest
+            .strip_prefix("sha256:")
+            .is_some_and(|digest| {
+                digest.len() == 64
+                    && digest
+                        .bytes()
+                        .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+            }),
+        "agent_task_authority",
+        "source digest must be lowercase SHA-256",
+    )?;
+    require(
+        matches!(
+            source.authority.approval.method.as_str(),
+            "issue_label" | "issue_comment" | "signed_spec" | "maintainer_review"
+        ),
+        "agent_task_authority",
+        "unsupported approval method",
+    )?;
+    require(
+        !source.scope.affected_semantic_nodes.is_empty(),
+        "agent_task_scope",
+        "semantic node scope is required",
+    )?;
+    require(
+        !source.scope.allowed_files.is_empty(),
+        "agent_task_scope",
+        "allowed file scope is required",
+    )?;
+    for node in &source.scope.affected_semantic_nodes {
+        nonempty(node, "semantic node")?;
+        require(
+            intent.contains_node(node),
+            "agent_task_scope",
+            &format!("semantic node `{node}` is not in canonical Intent IR"),
+        )?;
+    }
+    validate_paths(&source.scope.allowed_files)?;
+    validate_paths(&source.scope.denied_files)?;
+    disjoint(
+        &source.scope.allowed_files,
+        &source.scope.denied_files,
+        "file scope",
+    )?;
+    validate_permissions(&source.capabilities, "capability")?;
+    validate_permissions(&source.commands, "command")?;
+    validate_support_commands(source)?;
+    validate_acceptance(source)?;
+    validate_dependencies(&source.dependencies)?;
+    require(
+        (1..=3).contains(&source.autonomy.class),
+        "agent_task_autonomy",
+        "autonomy class must be between 1 and 3",
+    )?;
+    require(
+        source.budgets.time_seconds > 0 && source.budgets.tokens > 0,
+        "agent_task_budget",
+        "time and token budgets must be positive",
+    )?;
+    require(
+        source.budgets.time_seconds <= 86_400
+            && source.budgets.tokens <= 10_000_000
+            && source.budgets.retries <= 20
+            && source.budgets.cost_usd_micros <= 1_000_000_000,
+        "agent_task_budget",
+        "budget exceeds the supported bound",
+    )?;
+    nonempty(&source.rollback.checkpoint, "rollback checkpoint")?;
+    nonempty_list(&source.rollback.commands, "rollback commands")?;
+    nonempty_list(&source.terminal_conditions.success, "success conditions")?;
+    nonempty_list(&source.terminal_conditions.stop, "stop conditions")?;
+    nonempty_list(
+        &source.terminal_conditions.escalation,
+        "escalation conditions",
+    )?;
+    let delivery = &source.delivery_permissions;
+    require(
+        !delivery.approve_own_pull_request,
+        "agent_task_delivery",
+        "self-approval is always denied",
+    )?;
+    require(
+        !delivery.force_push,
+        "agent_task_delivery",
+        "force push is always denied",
+    )?;
+    require(
+        !delivery.direct_push_protected,
+        "agent_task_delivery",
+        "direct protected-branch push is always denied",
+    )?;
+    require(
+        !delivery.irreversible_actions,
+        "agent_task_irreversible",
+        "irreversible actions are unsupported",
+    )?;
+    let remote_or_privileged = delivery.push
+        || delivery.pull_request
+        || delivery.review
+        || delivery.merge
+        || delivery.deploy;
+    require(
+        source.autonomy.class != 0 || (!delivery.commit && !remote_or_privileged),
+        "agent_task_delivery",
+        "class 0 tasks cannot mutate or deliver",
+    )?;
+    require(
+        source.autonomy.class != 1 || !remote_or_privileged,
+        "agent_task_delivery",
+        "class 1 tasks are local-only",
+    )?;
+    require(
+        source.autonomy.class != 2 || (!delivery.review && !delivery.merge && !delivery.deploy),
+        "agent_task_delivery",
+        "class 2 tasks cannot review, merge, or deploy",
+    )?;
+    match (&source.kind, &source.repair_plan) {
+        (TaskKind::Repair, Some(repair)) => validate_repair(repair, source)?,
+        (TaskKind::Repair, None) => {
+            return Err(task_error(
+                "agent_task_repair",
+                "repair task must embed its repair plan",
+            ));
+        }
+        (_, Some(_)) => {
+            return Err(task_error(
+                "agent_task_repair",
+                "only repair tasks may embed a repair plan",
+            ));
+        }
+        (_, None) => {}
+    }
+    Ok(())
+}
+
+fn validate_acceptance(source: &AgentTaskSpec) -> Result<(), Diagnostic> {
+    require(
+        !source.acceptance_criteria.is_empty(),
+        "agent_task_acceptance",
+        "acceptance criteria are required",
+    )?;
+    require(
+        !source.required_evidence.is_empty(),
+        "agent_task_evidence",
+        "required evidence is missing",
+    )?;
+    let evidence: BTreeSet<_> = source
+        .required_evidence
+        .iter()
+        .map(|item| item.id.as_str())
+        .collect();
+    require(
+        evidence.len() == source.required_evidence.len(),
+        "agent_task_evidence",
+        "evidence IDs must be unique",
+    )?;
+    let mut expectations = BTreeMap::new();
+    let mut ids = BTreeSet::new();
+    for criterion in &source.acceptance_criteria {
+        nonempty(&criterion.id, "acceptance ID")?;
+        nonempty(&criterion.requirement, "acceptance requirement")?;
+        require(
+            ids.insert(criterion.id.as_str()),
+            "agent_task_acceptance",
+            "acceptance IDs must be unique",
+        )?;
+        if expectations
+            .insert(criterion.requirement.trim(), criterion.expected)
+            .is_some_and(|old| old != criterion.expected)
+        {
+            return Err(task_error(
+                "agent_task_acceptance_conflict",
+                format!(
+                    "conflicting acceptance criterion `{}`",
+                    criterion.requirement
+                ),
+            ));
+        }
+        require(
+            !criterion.evidence_refs.is_empty(),
+            "agent_task_evidence",
+            "each acceptance criterion requires evidence",
+        )?;
+        for reference in &criterion.evidence_refs {
+            require(
+                evidence.contains(reference.as_str()),
+                "agent_task_evidence",
+                &format!("dangling evidence reference `{reference}`"),
+            )?;
+        }
+    }
+    for item in &source.required_evidence {
+        nonempty(&item.id, "evidence ID")?;
+        nonempty(&item.command, "evidence command")?;
+    }
+    Ok(())
+}
+
+fn validate_dependencies(items: &[TaskDependency]) -> Result<(), Diagnostic> {
+    let ids: BTreeSet<_> = items.iter().map(|item| item.id.as_str()).collect();
+    require(
+        ids.len() == items.len(),
+        "agent_task_dependency",
+        "dependency IDs must be unique",
+    )?;
+    for item in items {
+        nonempty(&item.id, "dependency ID")?;
+        if !item.precondition.is_empty() {
+            nonempty(&item.precondition, "dependency precondition")?;
+        }
+        for dep in &item.depends_on {
+            require(
+                dep != &item.id && ids.contains(dep.as_str()),
+                "agent_task_dependency",
+                &format!("dangling or self dependency `{dep}`"),
+            )?;
+        }
+    }
+    fn visit<'a>(
+        id: &'a str,
+        map: &BTreeMap<&'a str, &'a TaskDependency>,
+        visiting: &mut BTreeSet<&'a str>,
+        done: &mut BTreeSet<&'a str>,
+    ) -> bool {
+        if done.contains(id) {
+            return false;
+        }
+        if !visiting.insert(id) {
+            return true;
+        }
+        let cycle = map[id]
+            .depends_on
+            .iter()
+            .any(|next| visit(next, map, visiting, done));
+        visiting.remove(id);
+        done.insert(id);
+        cycle
+    }
+    let map: BTreeMap<_, _> = items.iter().map(|item| (item.id.as_str(), item)).collect();
+    let mut visiting = BTreeSet::new();
+    let mut done = BTreeSet::new();
+    for id in ids {
+        require(
+            !visit(id, &map, &mut visiting, &mut done),
+            "agent_task_dependency_cycle",
+            "dependency graph contains a cycle",
+        )?;
+    }
+    Ok(())
+}
+
+fn validate_repair(repair: &RepairPlan, source: &AgentTaskSpec) -> Result<(), Diagnostic> {
+    require(
+        matches!(source.kind, TaskKind::Repair),
+        "agent_task_repair",
+        "embedded repair plan requires repair task kind",
+    )?;
+    nonempty(&repair.id, "repair ID")?;
+    nonempty(&repair.reason, "repair reason")?;
+    require(
+        source
+            .scope
+            .affected_semantic_nodes
+            .contains(&repair.target_node),
+        "agent_task_repair_widening",
+        "repair target widens semantic node scope",
+    )?;
+    nonempty_list(&repair.allowed_files, "repair files")?;
+    require(
+        !repair.required_evidence.is_empty(),
+        "agent_task_repair",
+        "repair evidence is required",
+    )?;
+    require(
+        !repair.diagnostics.is_empty(),
+        "agent_task_repair",
+        "repair diagnostics are required",
+    )?;
+    validate_paths(&repair.allowed_files)?;
+    let files: BTreeSet<_> = source.scope.allowed_files.iter().collect();
+    let evidence: BTreeSet<_> = source
+        .required_evidence
+        .iter()
+        .map(|item| item.kind)
+        .collect();
+    require(
+        repair.allowed_files.iter().all(|path| files.contains(path)),
+        "agent_task_repair_widening",
+        "repair plan widens allowed files",
+    )?;
+    require(
+        repair
+            .required_evidence
+            .iter()
+            .all(|kind| evidence.contains(kind)),
+        "agent_task_repair_widening",
+        "repair plan widens required evidence",
+    )
+}
+
+fn validate_paths(paths: &[String]) -> Result<(), Diagnostic> {
+    for path in paths {
+        nonempty(path, "file path")?;
+        let value = Path::new(path);
+        require(
+            !value.is_absolute()
+                && !path.contains('*')
+                && !path.contains('?')
+                && !path.ends_with('/'),
+            "agent_task_path",
+            &format!("path `{path}` must be an exact package-relative file"),
+        )?;
+        require(
+            value
+                .components()
+                .all(|part| matches!(part, Component::Normal(_))),
+            "agent_task_path",
+            &format!("path `{path}` is not normalized"),
+        )?;
+    }
+    Ok(())
+}
+
+fn validate_permissions(set: &PermissionSet, label: &str) -> Result<(), Diagnostic> {
+    for value in &set.required {
+        nonempty(value, label)?;
+    }
+    for value in &set.forbidden {
+        nonempty(value, label)?;
+    }
+    disjoint(&set.required, &set.forbidden, label)
+}
+
+fn validate_support_commands(source: &AgentTaskSpec) -> Result<(), Diagnostic> {
+    for (kind, command) in source
+        .required_evidence
+        .iter()
+        .map(|item| ("evidence", item.command.as_str()))
+        .chain(
+            source
+                .rollback
+                .commands
+                .iter()
+                .map(|command| ("rollback", command.as_str())),
+        )
+    {
+        require(
+            !source
+                .commands
+                .forbidden
+                .iter()
+                .any(|denied| command_invokes(command, denied)),
+            "agent_task_forbidden_command",
+            &format!("{kind} command `{command}` invokes a forbidden command"),
+        )?;
+        require(
+            !source
+                .capabilities
+                .forbidden
+                .iter()
+                .any(|denied| command_mentions_capability(command, denied)),
+            "agent_task_forbidden_capability",
+            &format!("{kind} command `{command}` requests a forbidden capability"),
+        )?;
+    }
+    Ok(())
+}
+
+fn command_invokes(command: &str, denied: &str) -> bool {
+    let command = command.trim();
+    let denied = denied.trim();
+    command == denied
+        || command
+            .strip_prefix(denied)
+            .is_some_and(|rest| rest.chars().next().is_some_and(char::is_whitespace))
+}
+
+fn command_mentions_capability(command: &str, denied: &str) -> bool {
+    command
+        .split(|c: char| c.is_whitespace() || matches!(c, '=' | ',' | ':' | '"' | '\''))
+        .any(|token| token == denied)
+}
+
+fn validate_project_paths(project: &Path, source: &AgentTaskSpec) -> Result<(), Diagnostic> {
+    let root = project.canonicalize().map_err(|error| {
+        task_error(
+            "agent_task_project_path",
+            format!(
+                "failed to canonicalize project {}: {error}",
+                project.display()
+            ),
+        )
+    })?;
+    require(
+        root.is_dir(),
+        "agent_task_project_path",
+        "task project root must be a directory",
+    )?;
+    for path in source.scope.allowed_files.iter().chain(
+        source
+            .repair_plan
+            .iter()
+            .flat_map(|repair| &repair.allowed_files),
+    ) {
+        validate_path_boundary(&root, path)?;
+    }
+    Ok(())
+}
+
+fn validate_path_boundary(root: &Path, relative: &str) -> Result<(), Diagnostic> {
+    let mut candidate = root.join(relative);
+    let mut unresolved = Vec::new();
+    while !candidate.exists() {
+        let name = candidate.file_name().ok_or_else(|| {
+            task_error(
+                "agent_task_path",
+                format!("path `{relative}` has no existing parent"),
+            )
+        })?;
+        unresolved.push(name.to_owned());
+        candidate = candidate.parent().map(Path::to_owned).ok_or_else(|| {
+            task_error(
+                "agent_task_path",
+                format!("path `{relative}` has no existing parent"),
+            )
+        })?;
+    }
+    let resolved = candidate.canonicalize().map_err(|error| {
+        task_error(
+            "agent_task_path",
+            format!("failed to resolve scope path `{relative}`: {error}"),
+        )
+    })?;
+    require(
+        resolved.starts_with(root),
+        "agent_task_path_escape",
+        &format!("scope path `{relative}` escapes the canonical project root"),
+    )?;
+    // Reconstructing the unresolved suffix documents that validation is against
+    // the nearest existing parent, including a symlink at any existing prefix.
+    let _bounded: PathBuf = unresolved
+        .iter()
+        .rev()
+        .fold(resolved, |path, component| path.join(component));
+    Ok(())
+}
+
+fn disjoint(left: &[String], right: &[String], label: &str) -> Result<(), Diagnostic> {
+    let denied: BTreeSet<_> = right.iter().collect();
+    require(
+        !left.iter().any(|item| denied.contains(item)),
+        "agent_task_permission_conflict",
+        &format!("{label} allow and deny sets overlap"),
+    )
+}
+
+fn canonicalize(source: &mut AgentTaskSpec) {
+    fn sort(values: &mut Vec<String>) {
+        values.sort();
+        values.dedup();
+    }
+    sort(&mut source.scope.affected_semantic_nodes);
+    sort(&mut source.scope.allowed_files);
+    sort(&mut source.scope.denied_files);
+    sort(&mut source.capabilities.required);
+    sort(&mut source.capabilities.forbidden);
+    sort(&mut source.commands.required);
+    sort(&mut source.commands.forbidden);
+    source.acceptance_criteria.sort_by(|a, b| a.id.cmp(&b.id));
+    for item in &mut source.acceptance_criteria {
+        sort(&mut item.evidence_refs);
+    }
+    source.required_evidence.sort_by(|a, b| a.id.cmp(&b.id));
+    source.dependencies.sort_by(|a, b| a.id.cmp(&b.id));
+    for item in &mut source.dependencies {
+        sort(&mut item.depends_on);
+    }
+    sort(&mut source.rollback.commands);
+    sort(&mut source.terminal_conditions.success);
+    sort(&mut source.terminal_conditions.stop);
+    sort(&mut source.terminal_conditions.escalation);
+    if let Some(repair) = &mut source.repair_plan {
+        sort(&mut repair.allowed_files);
+        repair.required_evidence.sort();
+        repair.required_evidence.dedup();
+    }
+}
+
+fn nonempty(value: &str, label: &str) -> Result<(), Diagnostic> {
+    require(
+        !value.trim().is_empty(),
+        "agent_task_missing",
+        &format!("{label} must not be empty"),
+    )
+}
+fn nonempty_list(values: &[String], label: &str) -> Result<(), Diagnostic> {
+    require(
+        !values.is_empty(),
+        "agent_task_missing",
+        &format!("{label} are required"),
+    )?;
+    for value in values {
+        nonempty(value, label)?;
+    }
+    Ok(())
+}
+fn require(condition: bool, code: &str, message: &str) -> Result<(), Diagnostic> {
+    if condition {
+        Ok(())
+    } else {
+        Err(task_error(code, message))
+    }
+}
+fn task_error(code: &str, message: impl Into<String>) -> Diagnostic {
+    Diagnostic::new("agent_task", message).with_code(code)
+}
+
+fn stable_digest(bytes: &[u8]) -> String {
+    const K: [u32; 64] = [
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4,
+        0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe,
+        0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f,
+        0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+        0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc,
+        0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+        0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116,
+        0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7,
+        0xc67178f2,
+    ];
+    let bit_len = (bytes.len() as u64).wrapping_mul(8);
+    let mut message = bytes.to_vec();
+    message.push(0x80);
+    while message.len() % 64 != 56 {
+        message.push(0);
+    }
+    message.extend_from_slice(&bit_len.to_be_bytes());
+    let mut h = [
+        0x6a09e667u32,
+        0xbb67ae85,
+        0x3c6ef372,
+        0xa54ff53a,
+        0x510e527f,
+        0x9b05688c,
+        0x1f83d9ab,
+        0x5be0cd19,
+    ];
+    for block in message.chunks_exact(64) {
+        let mut w = [0u32; 64];
+        for (index, word) in block.chunks_exact(4).enumerate() {
+            w[index] = u32::from_be_bytes(word.try_into().expect("four-byte SHA word"));
+        }
+        for i in 16..64 {
+            let s0 = w[i - 15].rotate_right(7) ^ w[i - 15].rotate_right(18) ^ (w[i - 15] >> 3);
+            let s1 = w[i - 2].rotate_right(17) ^ w[i - 2].rotate_right(19) ^ (w[i - 2] >> 10);
+            w[i] = w[i - 16]
+                .wrapping_add(s0)
+                .wrapping_add(w[i - 7])
+                .wrapping_add(s1);
+        }
+        let [mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut hh] = h;
+        for i in 0..64 {
+            let s1 = e.rotate_right(6) ^ e.rotate_right(11) ^ e.rotate_right(25);
+            let ch = (e & f) ^ (!e & g);
+            let t1 = hh
+                .wrapping_add(s1)
+                .wrapping_add(ch)
+                .wrapping_add(K[i])
+                .wrapping_add(w[i]);
+            let s0 = a.rotate_right(2) ^ a.rotate_right(13) ^ a.rotate_right(22);
+            let maj = (a & b) ^ (a & c) ^ (b & c);
+            let t2 = s0.wrapping_add(maj);
+            hh = g;
+            g = f;
+            f = e;
+            e = d.wrapping_add(t1);
+            d = c;
+            c = b;
+            b = a;
+            a = t1.wrapping_add(t2);
+        }
+        for (state, value) in h.iter_mut().zip([a, b, c, d, e, f, g, hh]) {
+            *state = state.wrapping_add(value);
+        }
+    }
+    h.iter().map(|word| format!("{word:08x}")).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::intent_ir::{IntentIrNode, IntentIrProvenance};
+    use serde_json::Map;
+
+    fn intent() -> IntentIrDocument {
+        IntentIrDocument {
+            schema_version: "axiom.intent_ir.v0".into(),
+            graph_id: "g".into(),
+            package: "pkg".into(),
+            provenance: IntentIrProvenance::default(),
+            diagnostics: vec![],
+            nodes: vec![IntentIrNode {
+                id: "pkg::main".into(),
+                kind: "Module".into(),
+                name: "main".into(),
+                description: None,
+                source_span: None,
+                metadata: Map::new(),
+            }],
+            edges: vec![],
+        }
+    }
+    fn source() -> AgentTaskSpec {
+        serde_json::from_value(serde_json::json!({
+        "id":"task-1419", "kind":"feature", "objective": "Implement feature",
+        "authority": {"governing_issue":"https://github.com/OMT-Global/axiomlang/issues/1419","repository":"OMT-Global/axiomlang","issue":1419,"source_revision":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","source_digest":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","approval":{"state":"approved","approver":"Pheidon","method":"maintainer_review"}},
+        "scope":{"affected_semantic_nodes":["pkg::main"],"allowed_files":["src/main.ax"],"denied_files":["secrets.env"]},
+        "capabilities":{"required":["filesystem.write"],"forbidden":["credentials.read"]},
+        "commands":{"required":["axiomc check"],"forbidden":["git push --force"]},
+        "acceptance_criteria":[{"id":"a","requirement":"checks pass","expected":"pass","evidence_refs":["e"]}],
+        "required_evidence":[{"id":"e","kind":"unit_test","command":"axiomc check"}],
+        "dependencies":[{"id":"spec","status":"satisfied","depends_on":[],"precondition":"accepted"}],
+        "autonomy":{"class":2,"risk":"medium"}, "budgets":{"time_seconds":3600,"tokens":10000,"retries":3,"cost_usd_micros":1000},
+        "rollback":{"checkpoint":"before edit","commands":["git revert HEAD"]},
+        "terminal_conditions":{"success":["criteria pass"],"stop":["budget exhausted"],"escalation":["scope change"]},
+        "delivery_permissions":{"commit":true,"push":true,"pull_request":true,"review":false,"merge":false,"deploy":false,"approve_own_pull_request":false,"force_push":false,"direct_push_protected":false,"irreversible_actions":false}
+    })).unwrap()
+    }
+
+    #[test]
+    fn compiles_deterministically() {
+        let a = compile_approved_task(source(), &intent()).unwrap();
+        let b = compile_approved_task(source(), &intent()).unwrap();
+        assert_eq!(
+            serde_json::to_string(&a).unwrap(),
+            serde_json::to_string(&b).unwrap()
+        );
+        assert_eq!(a.id, "task-1419");
+    }
+    #[test]
+    fn contract_digest_uses_sha256() {
+        assert_eq!(
+            stable_digest(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+        assert!(
+            compile_approved_task(source(), &intent())
+                .unwrap()
+                .contract_digest
+                .starts_with("sha256:")
+        );
+    }
+    #[test]
+    fn rejects_ambiguous_authority_and_unknown_nodes() {
+        let mut s = source();
+        s.authority.approval.approver.clear();
+        assert_eq!(
+            compile_approved_task(s, &intent())
+                .unwrap_err()
+                .code
+                .as_deref(),
+            Some("agent_task_missing")
+        );
+        let mut s = source();
+        s.scope.affected_semantic_nodes[0] = "missing".into();
+        assert_eq!(
+            compile_approved_task(s, &intent())
+                .unwrap_err()
+                .code
+                .as_deref(),
+            Some("agent_task_scope")
+        );
+    }
+    #[test]
+    fn rejects_scope_and_acceptance_conflicts() {
+        let mut s = source();
+        s.scope.denied_files.push("src/main.ax".into());
+        assert_eq!(
+            compile_approved_task(s, &intent())
+                .unwrap_err()
+                .code
+                .as_deref(),
+            Some("agent_task_permission_conflict")
+        );
+        let mut s = source();
+        let mut other = s.acceptance_criteria[0].clone();
+        other.id = "b".into();
+        other.expected = AcceptanceExpectation::Fail;
+        s.acceptance_criteria.push(other);
+        assert_eq!(
+            compile_approved_task(s, &intent())
+                .unwrap_err()
+                .code
+                .as_deref(),
+            Some("agent_task_acceptance_conflict")
+        );
+    }
+    #[test]
+    fn rejects_dangling_and_cyclic_dependencies() {
+        let mut s = source();
+        s.dependencies[0].depends_on.push("missing".into());
+        assert_eq!(
+            compile_approved_task(s, &intent())
+                .unwrap_err()
+                .code
+                .as_deref(),
+            Some("agent_task_dependency")
+        );
+        let mut s = source();
+        s.dependencies.push(TaskDependency {
+            id: "other".into(),
+            status: DependencyStatus::Satisfied,
+            depends_on: vec!["spec".into()],
+            precondition: "ready".into(),
+        });
+        s.dependencies[0].depends_on.push("other".into());
+        assert_eq!(
+            compile_approved_task(s, &intent())
+                .unwrap_err()
+                .code
+                .as_deref(),
+            Some("agent_task_dependency_cycle")
+        );
+    }
+    #[test]
+    fn denies_unsafe_delivery_and_irreversible_work() {
+        let mut s = source();
+        s.delivery_permissions.force_push = true;
+        assert_eq!(
+            compile_approved_task(s, &intent())
+                .unwrap_err()
+                .code
+                .as_deref(),
+            Some("agent_task_delivery")
+        );
+        s = source();
+        s.delivery_permissions.irreversible_actions = true;
+        assert_eq!(
+            compile_approved_task(s, &intent())
+                .unwrap_err()
+                .code
+                .as_deref(),
+            Some("agent_task_irreversible")
+        );
+    }
+    #[test]
+    fn repair_plan_cannot_widen_task() {
+        let mut s = source();
+        s.kind = TaskKind::Repair;
+        s.repair_plan = Some(RepairPlan {
+            id: "repair-1".into(),
+            reason: "diagnostic".into(),
+            target_node: "pkg::main".into(),
+            allowed_files: vec!["other.ax".into()],
+            required_evidence: vec![EvidenceKind::UnitTest],
+            diagnostics: vec![RepairDiagnostic {
+                kind: "type".into(), code: None, message: "bad".into(), help: None,
+                path: None, line: None, column: None, related: vec![], repair: None,
+            }],
+        });
+        assert_eq!(
+            compile_approved_task(s, &intent())
+                .unwrap_err()
+                .code
+                .as_deref(),
+            Some("agent_task_repair_widening")
+        );
+    }
+
+    #[test]
+    fn compiles_public_feature_and_repair_fixtures() {
+        let stage1 = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let project = stage1.join("examples/agent_native_authorize");
+        for fixture in ["feature-approved.spec.json", "repair-approved.spec.json"] {
+            let report = compile_task_contract(
+                &project,
+                &stage1.join("json-fixtures/task-contract").join(fixture),
+            )
+            .unwrap_or_else(|error| panic!("compile {fixture}: {error:?}"));
+            assert!(report.ok);
+            assert_eq!(report.project, ".");
+            assert!(report.contract.contract_digest.starts_with("sha256:"));
+        }
+    }
+
+    #[test]
+    fn evidence_and_rollback_cannot_bypass_denials() {
+        let mut task = source();
+        task.commands.forbidden.push("curl".into());
+        task.required_evidence[0].command = "curl https://example.invalid".into();
+        assert_eq!(
+            compile_approved_task(task, &intent())
+                .unwrap_err()
+                .code
+                .as_deref(),
+            Some("agent_task_forbidden_command")
+        );
+
+        let mut task = source();
+        task.commands.forbidden.push("git reset".into());
+        task.rollback.commands = vec!["git reset --hard HEAD".into()];
+        assert_eq!(
+            compile_approved_task(task, &intent())
+                .unwrap_err()
+                .code
+                .as_deref(),
+            Some("agent_task_forbidden_command")
+        );
+
+        let mut task = source();
+        task.capabilities.forbidden.push("credentials.read".into());
+        task.required_evidence[0].command = "axiomc check --capability credentials.read".into();
+        assert_eq!(
+            compile_approved_task(task, &intent())
+                .unwrap_err()
+                .code
+                .as_deref(),
+            Some("agent_task_forbidden_capability")
+        );
+    }
+
+    #[test]
+    fn serde_requirements_match_schema_and_preserve_diagnostics() {
+        let mut value = serde_json::to_value(AgentTaskSource {
+            schema_version: SOURCE_SCHEMA_VERSION.into(),
+            task: source(),
+        })
+        .unwrap();
+        value["task"]["commands"]
+            .as_object_mut()
+            .unwrap()
+            .remove("forbidden");
+        assert!(serde_json::from_value::<AgentTaskSource>(value).is_err());
+
+        let mut value = serde_json::to_value(AgentTaskSource {
+            schema_version: SOURCE_SCHEMA_VERSION.into(),
+            task: source(),
+        })
+        .unwrap();
+        value["task"]["dependencies"][0]
+            .as_object_mut()
+            .unwrap()
+            .remove("precondition");
+        value["task"]["repair"] = serde_json::json!({
+            "id":"repair-1", "reason":"legacy", "target_node":"pkg::main",
+            "allowed_files":["src/main.ax"], "required_evidence":["unit_test"],
+            "diagnostics":["opaque legacy repair diagnostic"]
+        });
+        value["task"]["kind"] = "repair".into();
+        assert!(serde_json::from_value::<AgentTaskSource>(value).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn project_paths_reject_existing_and_parent_symlink_escapes() {
+        use std::os::unix::fs::symlink;
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        fs::create_dir(root.path().join("src")).unwrap();
+        fs::write(root.path().join("src/main.ax"), "fn main() {}\n").unwrap();
+        fs::write(outside.path().join("escaped.ax"), "fn escaped() {}\n").unwrap();
+
+        let mut task = source();
+        validate_project_paths(root.path(), &task).unwrap();
+
+        symlink(
+            outside.path().join("escaped.ax"),
+            root.path().join("src/link.ax"),
+        )
+        .unwrap();
+        task.scope.allowed_files = vec!["src/link.ax".into()];
+        assert_eq!(
+            validate_project_paths(root.path(), &task)
+                .unwrap_err()
+                .code
+                .as_deref(),
+            Some("agent_task_path_escape")
+        );
+
+        symlink(outside.path(), root.path().join("external")).unwrap();
+        task.scope.allowed_files = vec!["external/new/nested.ax".into()];
+        assert_eq!(
+            validate_project_paths(root.path(), &task)
+                .unwrap_err()
+                .code
+                .as_deref(),
+            Some("agent_task_path_escape")
+        );
+    }
+}

--- a/stage1/crates/axiomc/src/agent_task_cli.rs
+++ b/stage1/crates/axiomc/src/agent_task_cli.rs
@@ -1,0 +1,21 @@
+use std::path::Path;
+
+pub(super) fn run(project: &Path, spec: &Path, json: bool) -> i32 {
+    match axiomc::agent_task::compile_task_contract(project, spec) {
+        Ok(report) => {
+            if json {
+                super::print_json("task-contract", &report)
+            } else {
+                println!(
+                    "task={} kind={:?} scope_nodes={} allowed_files={}",
+                    report.contract.id,
+                    report.contract.task_kind,
+                    report.contract.scope.affected_semantic_nodes.len(),
+                    report.contract.scope.allowed_files.len()
+                );
+                0
+            }
+        }
+        Err(error) => super::print_error("task-contract", error, json),
+    }
+}

--- a/stage1/crates/axiomc/src/intent_ir.rs
+++ b/stage1/crates/axiomc/src/intent_ir.rs
@@ -328,7 +328,7 @@ fn emit_program(package: &str, module: &str, path: &str, program: &Program, grap
             &declaration.name,
             declaration.line,
             declaration.column,
-            Map::new(),
+            object([("visibility", json!(declaration.visibility))]),
         );
     }
     for declaration in &program.structs {
@@ -345,6 +345,7 @@ fn emit_program(package: &str, module: &str, path: &str, program: &Program, grap
             object([
                 ("shape", json!("struct")),
                 ("fields", json!(declaration.fields)),
+                ("visibility", json!(declaration.visibility)),
             ]),
         );
     }
@@ -362,6 +363,7 @@ fn emit_program(package: &str, module: &str, path: &str, program: &Program, grap
             object([
                 ("shape", json!("enum")),
                 ("variants", json!(declaration.variants)),
+                ("visibility", json!(declaration.visibility)),
             ]),
         );
     }
@@ -379,6 +381,7 @@ fn emit_program(package: &str, module: &str, path: &str, program: &Program, grap
             object([
                 ("shape", json!("trait")),
                 ("methods", json!(declaration.methods)),
+                ("visibility", json!(declaration.visibility)),
             ]),
         );
     }
@@ -398,6 +401,7 @@ fn emit_program(package: &str, module: &str, path: &str, program: &Program, grap
                 ("return_type", json!(function.return_ty)),
                 ("async", json!(function.is_async)),
                 ("property", json!(function.is_property)),
+                ("visibility", json!(function.visibility)),
             ]),
         );
     }

--- a/stage1/crates/axiomc/src/intent_ir.rs
+++ b/stage1/crates/axiomc/src/intent_ir.rs
@@ -1,0 +1,864 @@
+//! Canonical, Axiom-neutral Intent IR emission.
+//!
+//! IDs describe Axiom packages and declarations. They deliberately do not
+//! expose implementation backend, build-tool, or host-language terminology.
+
+use crate::diagnostics::Diagnostic;
+use crate::manifest::{CapabilityKind, Manifest, load_manifest};
+use crate::syntax::{Program, parse_program};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value, json};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+pub const SCHEMA_VERSION: &str = "axiom.intent_ir.v0";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IntentIrDocument {
+    pub schema_version: String,
+    #[serde(default)]
+    pub graph_id: String,
+    #[serde(default)]
+    pub package: String,
+    #[serde(default)]
+    pub provenance: IntentIrProvenance,
+    #[serde(default)]
+    pub diagnostics: Vec<IntentIrDiagnostic>,
+    pub nodes: Vec<IntentIrNode>,
+    pub edges: Vec<IntentIrEdge>,
+}
+
+impl IntentIrDocument {
+    pub fn contains_node(&self, id: &str) -> bool {
+        self.nodes.binary_search_by(|node| node.id.as_str().cmp(id)).is_ok()
+    }
+
+    pub fn node_id(&self, kind: &str, name: &str) -> Option<&str> {
+        self.nodes
+            .iter()
+            .find(|node| node.kind == kind && node.name == name)
+            .map(|node| node.id.as_str())
+    }
+
+    pub fn node_id_for_source(&self, kind: &str, path: &str) -> Option<&str> {
+        let path = normalize_text_path(path);
+        self.nodes
+            .iter()
+            .find(|node| {
+                node.kind == kind
+                    && node.source_span.as_ref().is_some_and(|span| {
+                        span.path == path || path.ends_with(&format!("/{}", span.path))
+                    })
+            })
+            .map(|node| node.id.as_str())
+    }
+
+    pub fn semantic_target_for_source(&self, path: &str) -> &str {
+        self.node_id_for_source("Module", path)
+            .unwrap_or(&self.package)
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct IntentIrProvenance {
+    pub producer: String,
+    pub source_digest: String,
+    pub path_policy: String,
+    pub inputs: Vec<IntentIrInput>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct IntentIrInput {
+    pub package: String,
+    pub path: String,
+    pub digest: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct IntentIrDiagnostic {
+    pub code: String,
+    pub severity: String,
+    pub message: String,
+    pub node_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IntentIrNode {
+    pub id: String,
+    pub kind: String,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_span: Option<SourceSpan>,
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
+    pub metadata: Map<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SourceSpan {
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub column: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IntentIrEdge {
+    pub from: String,
+    pub kind: String,
+    pub to: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
+    pub metadata: Map<String, Value>,
+}
+
+#[derive(Default)]
+struct Graph {
+    nodes: BTreeMap<String, IntentIrNode>,
+    edges: BTreeMap<(String, String, String), IntentIrEdge>,
+    diagnostics: Vec<IntentIrDiagnostic>,
+    inputs: Vec<IntentIrInput>,
+}
+
+impl Graph {
+    fn node(&mut self, node: IntentIrNode) {
+        self.nodes.insert(node.id.clone(), node);
+    }
+
+    fn edge(&mut self, from: &str, kind: &str, to: &str) {
+        let key = (from.to_owned(), kind.to_owned(), to.to_owned());
+        self.edges.entry(key).or_insert_with(|| IntentIrEdge {
+            from: from.to_owned(),
+            kind: kind.to_owned(),
+            to: to.to_owned(),
+            description: None,
+            metadata: Map::new(),
+        });
+    }
+
+    fn diagnostic(&mut self, code: &str, message: impl Into<String>, semantic_node: &str) {
+        self.diagnostics.push(IntentIrDiagnostic {
+            code: code.to_owned(),
+            severity: "warning".to_owned(),
+            message: message.into(),
+            node_ids: vec![semantic_node.to_owned()],
+        });
+    }
+
+    fn input(&mut self, package: &str, path: String, bytes: &[u8]) {
+        self.inputs.push(IntentIrInput {
+            package: package.to_owned(),
+            path,
+            digest: stable_digest(bytes),
+        });
+    }
+}
+
+/// Emits one deterministic graph for the package or workspace at `root`.
+pub fn emit_intent_ir(root: &Path) -> Result<IntentIrDocument, Diagnostic> {
+    let root = root
+        .canonicalize()
+        .map_err(|error| io_error("intent_ir_root", root, error))?;
+    let root_manifest = load_manifest(&root)?;
+    let root_name = package_name(&root_manifest, &root);
+    let root_id = package_id(&root_name);
+    let mut graph = Graph::default();
+    let mut packages = vec![root.clone()];
+    if let Some(workspace) = &root_manifest.workspace {
+        for member in &workspace.members {
+            packages.push(root.join(member));
+        }
+    }
+    packages.sort_by_key(|path| normalized_relative(&root, path));
+    packages.dedup();
+    for package_root in packages {
+        match load_manifest(&package_root) {
+            Ok(manifest) => emit_package(&root, &package_root, &manifest, &mut graph)?,
+            Err(error) => graph.diagnostic(
+                "intent_ir_incomplete_package",
+                format!("workspace package could not be loaded: {error}"),
+                &root_id,
+            ),
+        }
+    }
+    graph.diagnostics.sort();
+    graph.diagnostics.dedup();
+    graph.inputs.sort();
+    graph.inputs.dedup();
+    let source_digest = stable_digest(
+        graph
+            .inputs
+            .iter()
+            .flat_map(|input| input.digest.bytes())
+            .collect::<Vec<_>>()
+            .as_slice(),
+    );
+    Ok(IntentIrDocument {
+        schema_version: SCHEMA_VERSION.to_owned(),
+        graph_id: format!("axiom://graph/{}", segment(&root_name)),
+        package: root_id,
+        provenance: IntentIrProvenance {
+            producer: "axiomc".to_owned(),
+            source_digest,
+            path_policy: "package_relative".to_owned(),
+            inputs: graph.inputs,
+        },
+        diagnostics: graph.diagnostics,
+        nodes: graph.nodes.into_values().collect(),
+        edges: graph.edges.into_values().collect(),
+    })
+}
+
+fn emit_package(
+    workspace_root: &Path,
+    package_root: &Path,
+    manifest: &Manifest,
+    graph: &mut Graph,
+) -> Result<(), Diagnostic> {
+    let name = package_name(manifest, package_root);
+    let package = package_id(&name);
+    let mut metadata = Map::new();
+    metadata.insert(
+        "path".into(),
+        json!(normalized_relative(workspace_root, package_root)),
+    );
+    if let Some(section) = &manifest.package {
+        metadata.insert("version".into(), json!(section.version));
+    }
+    graph.node(node(&package, "Package", &name, None, metadata));
+    let manifest_path = package_root.join(crate::manifest::MANIFEST_FILENAME);
+    if let Ok(bytes) = fs::read(&manifest_path) {
+        graph.input(
+            &package,
+            normalized_relative(workspace_root, &manifest_path),
+            &bytes,
+        );
+    }
+
+    for (alias, dependency) in &manifest.dependencies {
+        let id = child_id(&package, "dependency", alias);
+        graph.node(node(
+            &id,
+            "Dependency",
+            alias,
+            None,
+            object([
+                ("path", json!(normalize_text_path(&dependency.path))),
+                ("version", json!(dependency.version)),
+            ]),
+        ));
+        graph.edge(&package, "depends_on", &id);
+    }
+
+    for kind in crate::manifest::KNOWN_CAPABILITIES {
+        if manifest.capabilities.enabled(kind) {
+            emit_manifest_capability(manifest, kind, &package, graph);
+        }
+    }
+
+    let files = axiom_files(package_root)?;
+    if files.is_empty() {
+        graph.diagnostic(
+            "intent_ir_no_sources",
+            "package contains no Axiom source files",
+            &package,
+        );
+    }
+    for file in files {
+        let relative = normalized_relative(workspace_root, &file);
+        let module_name = module_name(package_root, &file);
+        let module = child_id(&package, "module", &module_name);
+        graph.node(node(
+            &module,
+            "Module",
+            &module_name,
+            Some(SourceSpan {
+                path: relative.clone(),
+                line: None,
+                column: None,
+            }),
+            Map::new(),
+        ));
+        graph.edge(&package, "declares", &module);
+        let source =
+            fs::read_to_string(&file).map_err(|error| io_error("intent_ir_read", &file, error))?;
+        graph.input(&package, relative.clone(), source.as_bytes());
+        match parse_program(&source, &file) {
+            Ok(program) => emit_program(&package, &module, &relative, &program, graph),
+            Err(error) => graph.diagnostic(
+                "intent_ir_incomplete_module",
+                format!("module could not be parsed: {error}"),
+                &module,
+            ),
+        }
+    }
+
+    emit_artifacts(package_root, workspace_root, manifest, &package, graph)?;
+    emit_decisions(package_root, workspace_root, &package, graph)?;
+    Ok(())
+}
+
+fn emit_program(package: &str, module: &str, path: &str, program: &Program, graph: &mut Graph) {
+    for import in &program.imports {
+        let target = child_id(package, "module", &import.path.replace("::", "/"));
+        if !graph.nodes.contains_key(&target) {
+            graph.node(node(
+                &target,
+                "Module",
+                &import.path,
+                None,
+                object([("resolution", json!("referenced"))]),
+            ));
+            graph.edge(package, "declares", &target);
+        }
+        graph.edge(module, "uses", &target);
+    }
+    for declaration in &program.type_aliases {
+        emit_decl(
+            graph,
+            package,
+            module,
+            path,
+            "Type",
+            "type",
+            &declaration.name,
+            declaration.line,
+            declaration.column,
+            Map::new(),
+        );
+    }
+    for declaration in &program.structs {
+        emit_decl(
+            graph,
+            package,
+            module,
+            path,
+            "Type",
+            "type",
+            &declaration.name,
+            declaration.line,
+            declaration.column,
+            object([
+                ("shape", json!("struct")),
+                ("fields", json!(declaration.fields)),
+            ]),
+        );
+    }
+    for declaration in &program.enums {
+        emit_decl(
+            graph,
+            package,
+            module,
+            path,
+            "Type",
+            "type",
+            &declaration.name,
+            declaration.line,
+            declaration.column,
+            object([
+                ("shape", json!("enum")),
+                ("variants", json!(declaration.variants)),
+            ]),
+        );
+    }
+    for declaration in &program.traits {
+        emit_decl(
+            graph,
+            package,
+            module,
+            path,
+            "Type",
+            "type",
+            &declaration.name,
+            declaration.line,
+            declaration.column,
+            object([
+                ("shape", json!("trait")),
+                ("methods", json!(declaration.methods)),
+            ]),
+        );
+    }
+    for function in &program.functions {
+        emit_decl(
+            graph,
+            package,
+            module,
+            path,
+            "Function",
+            "function",
+            &function.name,
+            function.line,
+            function.column,
+            object([
+                ("parameters", json!(function.params)),
+                ("return_type", json!(function.return_ty)),
+                ("async", json!(function.is_async)),
+                ("property", json!(function.is_property)),
+            ]),
+        );
+    }
+    for axiom in &program.axioms {
+        let mut metadata = object([
+            ("scope", json!(axiom.scope)),
+            ("severity", json!(axiom.severity)),
+            ("assertion", json!(axiom.assertion)),
+        ]);
+        if let Some(description) = &axiom.description {
+            metadata.insert("description".into(), json!(description));
+        }
+        emit_decl(
+            graph,
+            package,
+            module,
+            path,
+            "Axiom",
+            "axiom",
+            &axiom.name,
+            axiom.line,
+            axiom.column,
+            metadata,
+        );
+    }
+    for evidence in &program.evidence {
+        emit_decl(
+            graph,
+            package,
+            module,
+            path,
+            "Evidence",
+            "evidence",
+            &evidence.name,
+            evidence.line,
+            evidence.column,
+            object([("description", json!(evidence.description))]),
+        );
+    }
+    for capability in &program.semantic_capabilities {
+        let id = emit_decl(
+            graph,
+            package,
+            module,
+            path,
+            "Capability",
+            "capability",
+            &capability.name,
+            capability.line,
+            capability.column,
+            object([("inputs", json!(capability.inputs))]),
+        );
+        for effect in &capability.effects {
+            let effect_name = format!("{}:{}", effect.kind, effect.target);
+            let effect_id = child_id(&id, "effect", &effect_name);
+            graph.node(node(
+                &effect_id,
+                "Effect",
+                &effect_name,
+                Some(span(path, effect.line, effect.column)),
+                object([
+                    ("effect_kind", json!(effect.kind)),
+                    ("target", json!(effect.target)),
+                ]),
+            ));
+            graph.edge(&id, "allows_effect", &effect_id);
+        }
+        for reference in &capability.preserves {
+            let referenced = ensure_reference(graph, module, "Axiom", "axiom", &reference.name);
+            graph.edge(&id, "preserves", &referenced);
+        }
+        for reference in &capability.evidence {
+            let referenced =
+                ensure_reference(graph, module, "Evidence", "evidence", &reference.name);
+            graph.edge(&id, "verified_by", &referenced);
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn emit_decl(
+    graph: &mut Graph,
+    _package: &str,
+    module: &str,
+    path: &str,
+    kind: &str,
+    family: &str,
+    name: &str,
+    line: usize,
+    column: usize,
+    metadata: Map<String, Value>,
+) -> String {
+    let id = child_id(module, family, name);
+    graph.node(node(
+        &id,
+        kind,
+        name,
+        Some(span(path, line, column)),
+        metadata,
+    ));
+    graph.edge(module, "declares", &id);
+    id
+}
+
+fn ensure_reference(
+    graph: &mut Graph,
+    module: &str,
+    kind: &str,
+    family: &str,
+    name: &str,
+) -> String {
+    let id = child_id(module, family, name);
+    if !graph.nodes.contains_key(&id) {
+        graph.node(node(
+            &id,
+            kind,
+            name,
+            None,
+            object([("resolution", json!("referenced"))]),
+        ));
+        graph.edge(module, "declares", &id);
+    }
+    id
+}
+
+fn emit_manifest_capability(
+    manifest: &Manifest,
+    kind: CapabilityKind,
+    package: &str,
+    graph: &mut Graph,
+) {
+    let name = kind.name();
+    let capability = child_id(package, "capability", name);
+    graph.node(node(&capability, "Capability", name, None, Map::new()));
+    graph.edge(package, "requires", &capability);
+    let targets: Vec<String> = match kind {
+        CapabilityKind::Fs | CapabilityKind::FsWrite => {
+            manifest.capabilities.fs_root.iter().cloned().collect()
+        }
+        CapabilityKind::Net => manifest.capabilities.net_hosts.clone(),
+        CapabilityKind::Process => Vec::new(),
+        CapabilityKind::Env => manifest.capabilities.env_vars.clone(),
+        _ => Vec::new(),
+    };
+    let targets = if targets.is_empty() {
+        vec!["unrestricted".to_owned()]
+    } else {
+        targets
+    };
+    for target in targets {
+        let surface_name = format!("{name}:{target}");
+        let surface = child_id(package, "runtime-surface", &surface_name);
+        graph.node(node(
+            &surface,
+            "RuntimeSurface",
+            &surface_name,
+            None,
+            object([("capability", json!(name)), ("target", json!(target))]),
+        ));
+        graph.edge(&capability, "uses", &surface);
+    }
+}
+
+fn emit_artifacts(
+    package_root: &Path,
+    workspace_root: &Path,
+    manifest: &Manifest,
+    package: &str,
+    graph: &mut Graph,
+) -> Result<(), Diagnostic> {
+    let out = package_root.join(&manifest.build.out_dir);
+    let planned_path = normalize_text_path(&format!(
+        "{}/{}",
+        manifest.build.out_dir,
+        package.rsplit('/').next().unwrap_or("package")
+    ));
+    let planned = child_id(package, "artifact", &planned_path);
+    graph.node(node(
+        &planned,
+        "Artifact",
+        &planned_path,
+        None,
+        object([
+            ("state", json!("planned")),
+            ("provenance_node", json!(package)),
+        ]),
+    ));
+    graph.edge(&planned, "generated_from", package);
+    if out.is_dir() {
+        for path in regular_files(&out)? {
+            let relative = normalized_relative(workspace_root, &path);
+            let bytes =
+                fs::read(&path).map_err(|error| io_error("intent_ir_read", &path, error))?;
+            graph.input(package, relative.clone(), &bytes);
+            let artifact = child_id(package, "artifact", &relative);
+            graph.node(node(
+                &artifact,
+                "Artifact",
+                &relative,
+                Some(SourceSpan {
+                    path: relative.clone(),
+                    line: None,
+                    column: None,
+                }),
+                object([
+                    ("state", json!("materialized")),
+                    ("provenance_node", json!(package)),
+                ]),
+            ));
+            graph.edge(&artifact, "generated_from", package);
+        }
+    }
+    Ok(())
+}
+
+fn emit_decisions(
+    package_root: &Path,
+    workspace_root: &Path,
+    package: &str,
+    graph: &mut Graph,
+) -> Result<(), Diagnostic> {
+    let mut paths = Vec::new();
+    for directory in [package_root.join("decisions"), package_root.join(".axiom/decisions")] {
+        if directory.is_dir() {
+            paths.extend(regular_files(&directory)?);
+        }
+    }
+    paths.sort();
+    paths.dedup();
+    for path in paths {
+        let relative = normalized_relative(workspace_root, &path);
+        let bytes = fs::read(&path).map_err(|error| io_error("intent_ir_read", &path, error))?;
+        graph.input(package, relative.clone(), &bytes);
+        let value: Value = match serde_json::from_slice(&bytes).ok() {
+            Some(value) => value,
+            None => {
+                graph.diagnostic(
+                    "intent_ir_incomplete_decision",
+                    format!("decision record is not valid JSON: {relative}"),
+                    package,
+                );
+                continue;
+            }
+        };
+        let name = value
+            .get("id")
+            .or_else(|| value.get("name"))
+            .and_then(Value::as_str)
+            .unwrap_or(&relative)
+            .to_owned();
+        let id = child_id(package, "decision", &name);
+        graph.node(node(
+            &id,
+            "Decision",
+            &name,
+            Some(SourceSpan {
+                path: relative,
+                line: None,
+                column: None,
+            }),
+            object([("record", value)]),
+        ));
+        graph.edge(package, "declares", &id);
+    }
+    Ok(())
+}
+
+fn node(
+    id: &str,
+    kind: &str,
+    name: &str,
+    source_span: Option<SourceSpan>,
+    metadata: Map<String, Value>,
+) -> IntentIrNode {
+    IntentIrNode {
+        id: id.to_owned(),
+        kind: kind.to_owned(),
+        name: name.to_owned(),
+        description: None,
+        source_span,
+        metadata,
+    }
+}
+
+fn span(path: &str, line: usize, column: usize) -> SourceSpan {
+    SourceSpan {
+        path: path.to_owned(),
+        line: Some(line.max(1)),
+        column: Some(column.max(1)),
+    }
+}
+fn package_id(name: &str) -> String {
+    format!("axiom://package/{}", segment(name))
+}
+fn child_id(package: &str, family: &str, name: &str) -> String {
+    format!("{package}/{family}/{}", segment(name))
+}
+
+fn segment(value: &str) -> String {
+    let mut result = String::new();
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || b"._~-".contains(&byte) {
+            result.push(byte as char);
+        } else {
+            result.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    if result.is_empty() {
+        "unnamed".to_owned()
+    } else {
+        result
+    }
+}
+
+fn package_name(manifest: &Manifest, root: &Path) -> String {
+    manifest
+        .package
+        .as_ref()
+        .map(|package| package.name.clone())
+        .or_else(|| {
+            root.file_name()
+                .and_then(|name| name.to_str())
+                .map(str::to_owned)
+        })
+        .unwrap_or_else(|| "package".into())
+}
+
+fn module_name(root: &Path, file: &Path) -> String {
+    let relative = file.strip_prefix(root).unwrap_or(file);
+    let without_extension = relative.with_extension("");
+    normalize_path(&without_extension)
+}
+
+fn normalize_text_path(value: &str) -> String {
+    value
+        .split(['/', '\\'])
+        .filter(|segment| !segment.is_empty() && *segment != ".")
+        .collect::<Vec<_>>()
+        .join("/")
+}
+fn normalized_relative(root: &Path, path: &Path) -> String {
+    normalize_path(path.strip_prefix(root).unwrap_or(path))
+}
+fn normalize_path(path: &Path) -> String {
+    path.components()
+        .filter_map(|component| match component {
+            Component::Normal(value) => Some(value.to_string_lossy().into_owned()),
+            Component::ParentDir => Some("..".into()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn axiom_files(root: &Path) -> Result<Vec<PathBuf>, Diagnostic> {
+    let mut pending = vec![root.to_owned()];
+    let mut files = Vec::new();
+    while let Some(directory) = pending.pop() {
+        let entries = fs::read_dir(&directory)
+            .map_err(|error| io_error("intent_ir_read_dir", &directory, error))?;
+        for entry in entries {
+            let entry = entry
+                .map_err(|error| io_error("intent_ir_read_dir", &directory, error))?;
+            let path = entry.path();
+            if path.is_dir() {
+                let skipped = matches!(
+                    path.file_name().and_then(|value| value.to_str()),
+                    Some(".git" | "target")
+                );
+                let nested_package = path != root
+                    && path.join(crate::manifest::MANIFEST_FILENAME).is_file();
+                if !skipped && !nested_package {
+                    pending.push(path);
+                }
+            } else if path.extension().and_then(|extension| extension.to_str()) == Some("ax") {
+                files.push(path);
+            }
+        }
+    }
+    files.sort_by_key(|path| normalize_path(path));
+    Ok(files)
+}
+
+fn regular_files(root: &Path) -> Result<Vec<PathBuf>, Diagnostic> {
+    let mut pending = vec![root.to_owned()];
+    let mut files = Vec::new();
+    while let Some(directory) = pending.pop() {
+        let entries = fs::read_dir(&directory)
+            .map_err(|error| io_error("intent_ir_read_dir", &directory, error))?;
+        for entry in entries {
+            let entry = entry.map_err(|error| io_error("intent_ir_read_dir", &directory, error))?;
+            let path = entry.path();
+            if path.is_dir() {
+                if !matches!(
+                    path.file_name().and_then(|value| value.to_str()),
+                    Some(".git" | "target")
+                ) {
+                    pending.push(path);
+                }
+            } else if path.is_file() {
+                files.push(path);
+            }
+        }
+    }
+    files.sort_by_key(|path| normalize_path(path));
+    Ok(files)
+}
+
+fn object<const N: usize>(entries: [(&str, Value); N]) -> Map<String, Value> {
+    entries
+        .into_iter()
+        .map(|(key, value)| (key.to_owned(), value))
+        .collect()
+}
+
+// A small deterministic content digest for graph identity. This is provenance,
+// not an authenticity primitive; release attestations provide cryptographic
+// integrity. Four independently seeded FNV-1a lanes avoid platform hash state.
+fn stable_digest(bytes: &[u8]) -> String {
+    const SEEDS: [u64; 4] = [
+        0xcbf29ce484222325,
+        0x84222325cbf29ce4,
+        0x9e3779b185ebca87,
+        0x517cc1b727220a95,
+    ];
+    SEEDS
+        .iter()
+        .map(|seed| {
+            let mut hash = *seed;
+            for byte in bytes {
+                hash = (hash ^ u64::from(*byte)).wrapping_mul(0x100000001b3);
+            }
+            format!("{hash:016x}")
+        })
+        .collect()
+}
+
+fn io_error(code: &'static str, path: &Path, error: std::io::Error) -> Diagnostic {
+    Diagnostic::new("intent_ir", format!("{}: {error}", path.display()))
+        .with_code(code)
+        .with_path(path.display().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn segments_are_stable_and_schema_safe() {
+        assert_eq!(segment("api/main value"), "api%2Fmain%20value");
+        assert_eq!(
+            child_id("axiom://package/demo", "function", "main"),
+            "axiom://package/demo/function/main"
+        );
+    }
+
+    #[test]
+    fn path_normalization_is_posix() {
+        assert_eq!(
+            normalize_text_path(r"src\\nested\\main.ax"),
+            "src/nested/main.ax"
+        );
+    }
+}

--- a/stage1/crates/axiomc/src/intent_ir_cli.rs
+++ b/stage1/crates/axiomc/src/intent_ir_cli.rs
@@ -1,0 +1,21 @@
+use std::path::Path;
+
+pub(super) fn run(path: &Path, json: bool) -> i32 {
+    match axiomc::intent_ir::emit_intent_ir(path) {
+        Ok(document) => {
+            if json {
+                super::print_json("inspect intent", &document)
+            } else {
+                println!(
+                    "graph={} nodes={} edges={} diagnostics={}",
+                    document.graph_id,
+                    document.nodes.len(),
+                    document.edges.len(),
+                    document.diagnostics.len()
+                );
+                0
+            }
+        }
+        Err(error) => super::print_error("inspect intent", error, json),
+    }
+}

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -19,5 +19,5 @@ pub mod new_project;
 pub mod project;
 pub mod registry;
 pub mod stdlib;
-pub mod syntax;
+pub mod syntax; pub mod transactional_workspace; pub mod verification_planner;
 #[cfg(test)] #[path = "../tests/lib_unit.rs"] mod tests;

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod agent_task;
 pub(crate) mod borrowck;
 #[path = "project/build_contract.rs"]
 pub mod build_contract;
@@ -19,5 +20,4 @@ pub mod project;
 pub mod registry;
 pub mod stdlib;
 pub mod syntax;
-#[cfg(test)] #[path = "../tests/lib_unit.rs"]
-mod tests;
+#[cfg(test)] #[path = "../tests/lib_unit.rs"] mod tests;

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -8,6 +8,7 @@ pub mod diagnostic_catalog;
 pub mod diagnostics;
 pub mod doctor;
 pub mod hir;
+pub mod intent_ir;
 pub mod json_contract;
 pub mod lockfile;
 pub mod lsp;
@@ -18,6 +19,5 @@ pub mod project;
 pub mod registry;
 pub mod stdlib;
 pub mod syntax;
-#[cfg(test)]
-#[path = "../tests/lib_unit.rs"]
+#[cfg(test)] #[path = "../tests/lib_unit.rs"]
 mod tests;

--- a/stage1/crates/axiomc/src/main.rs
+++ b/stage1/crates/axiomc/src/main.rs
@@ -42,6 +42,7 @@ use std::time::Instant;
 mod formatter;
 mod intent_ir_cli;
 mod agent_task_cli;
+mod verification_planner_cli;
 
 #[derive(Debug, Parser)]
 #[command(name = "axiomc", about = "Axiom stage1 bootstrap compiler")]
@@ -200,13 +201,9 @@ enum Command {
         json: bool,
     },
     /// Diff two Intent IR snapshots for product-facing semantic drift.
-    SemanticDiff {
-        old: PathBuf,
-        new: PathBuf,
-        /// Emit an axiom.stage1.v1 JSON envelope for agent/tool consumption.
-        #[arg(long)]
-        json: bool,
-    },
+    SemanticDiff { old: PathBuf, new: PathBuf, #[arg(long)] json: bool },
+    /// Map semantic impact to exact-head evidence, or evaluate a result set.
+    VerificationPlan { before: PathBuf, after: PathBuf, #[arg(long)] diff: PathBuf, #[arg(long, default_value = ".")] project: PathBuf, #[arg(long)] source_head: String, #[arg(long)] delivered_head: String, #[arg(long)] results: Option<PathBuf>, #[arg(long)] json: bool },
     /// Inspect project metadata for agent tooling.
     Inspect {
         #[command(subcommand)]
@@ -914,6 +911,7 @@ fn main() {
             }
             Err(error) => print_error("semantic-diff", error, json),
         },
+        Command::VerificationPlan { before, after, diff, project, source_head, delivered_head, results, json } => verification_planner_cli::run(&before, &after, &diff, &project, &source_head, &delivered_head, results.as_deref(), json),
         Command::Inspect { command } => match command {
             InspectCommand::Intent { path, json } => intent_ir_cli::run(&path, json),
             InspectCommand::Symbols { path, json } => match inspect_symbols(&path) {

--- a/stage1/crates/axiomc/src/main.rs
+++ b/stage1/crates/axiomc/src/main.rs
@@ -41,6 +41,7 @@ use std::time::Instant;
 
 mod formatter;
 mod intent_ir_cli;
+mod agent_task_cli;
 
 #[derive(Debug, Parser)]
 #[command(name = "axiomc", about = "Axiom stage1 bootstrap compiler")]
@@ -182,6 +183,8 @@ enum Command {
         #[arg(long)]
         json: bool,
     },
+    /// Compile an approved specification into a bounded, read-only task contract.
+    TaskContract { spec: PathBuf, #[arg(long, default_value = ".")] project: PathBuf, #[arg(long)] json: bool },
     /// Emit semantic evidence requirements and observed test evidence.
     Evidence {
         path: PathBuf,
@@ -849,6 +852,7 @@ fn main() {
             }
             Err(error) => print_error("repair-plan", error, json),
         },
+        Command::TaskContract { spec, project, json } => agent_task_cli::run(&project, &spec, json),
         Command::Evidence { path, json } => match evidence_report(&path) {
             Ok(report) => {
                 if json {

--- a/stage1/crates/axiomc/src/main.rs
+++ b/stage1/crates/axiomc/src/main.rs
@@ -4,6 +4,7 @@ use axiomc::diagnostic_catalog::{DiagnosticCodeInfo, diagnostic_code_info};
 use axiomc::diagnostics::Diagnostic;
 use axiomc::doctor::{doctor_report, doctor_text};
 use axiomc::json_contract;
+use axiomc::intent_ir::{IntentIrDocument, emit_intent_ir};
 use axiomc::lockfile::{expected_lockfile_for_project, validate_lockfile};
 use axiomc::lsp;
 use axiomc::manifest::{
@@ -39,8 +40,7 @@ use std::path::{Component, Path, PathBuf};
 use std::time::Instant;
 
 mod formatter;
-
-use formatter::format_axiom_sources;
+mod intent_ir_cli;
 
 #[derive(Debug, Parser)]
 #[command(name = "axiomc", about = "Axiom stage1 bootstrap compiler")]
@@ -347,6 +347,12 @@ enum CapsCommand {
 
 #[derive(Debug, Subcommand)]
 enum InspectCommand {
+    /// Emit canonical Intent IR for a package or workspace.
+    Intent {
+        path: PathBuf,
+        #[arg(long)]
+        json: bool,
+    },
     /// Emit exported functions, types, consts, imports, and capability use.
     Symbols {
         path: PathBuf,
@@ -905,6 +911,7 @@ fn main() {
             Err(error) => print_error("semantic-diff", error, json),
         },
         Command::Inspect { command } => match command {
+            InspectCommand::Intent { path, json } => intent_ir_cli::run(&path, json),
             InspectCommand::Symbols { path, json } => match inspect_symbols(&path) {
                 Ok(report) => {
                     if json {
@@ -1084,7 +1091,7 @@ fn main() {
                 if report.ok { 0 } else { 1 }
             }
         }
-        Command::Fmt { path, check, json } => match format_axiom_sources(&path, check) {
+        Command::Fmt { path, check, json } => match formatter::format_axiom_sources(&path, check) {
             Ok(report) => {
                 let serialization_error = if json {
                     match json_contract::to_pretty_string(&report) {
@@ -1689,20 +1696,22 @@ struct SymbolSpan {
 }
 
 fn repair_plan(path: &Path) -> Result<RepairPlanReport, Diagnostic> {
+    let intent = emit_intent_ir(path)?;
+    let package_target = intent.package.clone();
     let mut tasks = Vec::new();
     match check_project_with_options(path, &CheckOptions::default()) {
         Ok(output) => {
             if !repair_tests_discoverable(path)? {
                 tasks.push(missing_evidence_task(
                     "repair-001",
-                    package_node_for_path(path),
+                    package_target.clone(),
                     repair_allowed_files(path)?,
                 ));
             }
             for warning in output.warnings {
                 tasks.push(diagnostic_repair_task(
                     tasks.len() + 1,
-                    package_node_for_path(path),
+                    package_target.clone(),
                     Diagnostic::new("warning", warning).normalized_for_json(),
                 ));
             }
@@ -1710,7 +1719,11 @@ fn repair_plan(path: &Path) -> Result<RepairPlanReport, Diagnostic> {
         Err(error) => {
             tasks.push(diagnostic_repair_task(
                 tasks.len() + 1,
-                package_node_for_path(path),
+                error
+                    .path
+                    .as_deref()
+                    .map(|source| intent.semantic_target_for_source(source).to_owned())
+                    .unwrap_or(package_target),
                 error.normalized_for_json(),
             ));
         }
@@ -1734,17 +1747,7 @@ fn diagnostic_repair_task(
         .as_ref()
         .map(|path| vec![path.clone()])
         .unwrap_or_default();
-    let target_node = diagnostic
-        .path
-        .as_ref()
-        .map(|path| {
-            format!(
-                "{}/diagnostic/{}",
-                package_node_component(path),
-                repair_component(diagnostic.code.as_deref().unwrap_or(&diagnostic.kind))
-            )
-        })
-        .unwrap_or(fallback_target);
+    let target_node = fallback_target;
     RepairTask {
         id: format!("repair-{index:03}"),
         reason: diagnostic
@@ -1814,6 +1817,7 @@ struct EvidenceItem {
 }
 
 fn evidence_report(project: &Path) -> Result<EvidenceReport, Diagnostic> {
+    let intent = emit_intent_ir(project)?;
     let manifest = load_manifest(project)?;
     let package_name = manifest
         .package
@@ -1821,7 +1825,7 @@ fn evidence_report(project: &Path) -> Result<EvidenceReport, Diagnostic> {
         .map(|package| package.name.clone())
         .unwrap_or_else(|| String::from("workspace"));
     let package_component = evidence_id_component(&package_name);
-    let package_target = format!("axiom://package/{package_component}");
+    let package_target = intent.package.clone();
     let mut evidence = Vec::new();
     if evidence_tests_discoverable(project, &manifest)? {
         let test_output = run_project_tests_with_options(
@@ -1937,10 +1941,6 @@ fn package_node_for_path(path: &Path) -> String {
                 .to_string()
         });
     format!("axiom://package/{}", repair_component(&name))
-}
-
-fn package_node_component(path: &str) -> String {
-    format!("axiom://package/{}", repair_component(path))
 }
 
 fn repair_component(value: &str) -> String {
@@ -2073,13 +2073,14 @@ struct VerificationTargetContract {
 }
 
 fn verify_project(project: &Path) -> Result<VerificationReport, Diagnostic> {
+    let intent = emit_intent_ir(project)?;
     let manifest = load_manifest(project)?;
     let package = manifest
         .package
         .as_ref()
         .map(|package| package.name.clone())
         .unwrap_or_else(|| String::from("workspace"));
-    let declarations = collect_semantic_declarations(project)?;
+    let declarations = collect_semantic_declarations(project, &intent)?;
     let evidence = evidence_report(project)?;
     let targets = load_target_contracts(project)?;
     let observed_by_name = observed_evidence_by_name(&evidence.evidence);
@@ -2124,7 +2125,10 @@ fn verify_project(project: &Path) -> Result<VerificationReport, Diagnostic> {
         }
 
         for evidence_name in required {
-            let semantic_node = semantic_node_id("evidence", &evidence_name);
+            let semantic_node = intent
+                .node_id("Evidence", &evidence_name)
+                .unwrap_or(&intent.package)
+                .to_owned();
             edges.push(VerificationEdge {
                 from: axiom.id.clone(),
                 kind: "verified_by",
@@ -2297,7 +2301,10 @@ fn verify_project(project: &Path) -> Result<VerificationReport, Diagnostic> {
     })
 }
 
-fn collect_semantic_declarations(project: &Path) -> Result<SemanticDeclarations, Diagnostic> {
+fn collect_semantic_declarations(
+    project: &Path,
+    intent: &IntentIrDocument,
+) -> Result<SemanticDeclarations, Diagnostic> {
     let mut axioms = Vec::new();
     let mut capabilities = Vec::new();
     let mut evidence = Vec::new();
@@ -2311,7 +2318,10 @@ fn collect_semantic_declarations(project: &Path) -> Result<SemanticDeclarations,
         })?;
         let program = parse_program(&source, &file)?;
         axioms.extend(program.axioms.iter().map(|axiom| DeclaredAxiom {
-            id: semantic_node_id("axiom", &axiom.name),
+            id: intent
+                .node_id("Axiom", &axiom.name)
+                .unwrap_or(&intent.package)
+                .to_owned(),
             name: axiom.name.clone(),
         }));
         capabilities.extend(program.semantic_capabilities.iter().map(|capability| {
@@ -2435,30 +2445,8 @@ struct SemanticChange {
     description: String,
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq)]
-struct IntentIrSnapshot {
-    schema_version: String,
-    nodes: Vec<IntentIrNode>,
-    edges: Vec<IntentIrEdge>,
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
-struct IntentIrNode {
-    id: String,
-    kind: String,
-    name: String,
-    #[serde(flatten)]
-    extra: BTreeMap<String, serde_json::Value>,
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
-struct IntentIrEdge {
-    from: String,
-    kind: String,
-    to: String,
-    #[serde(flatten)]
-    extra: BTreeMap<String, serde_json::Value>,
-}
+type IntentIrSnapshot = IntentIrDocument;
+type IntentIrEdge = axiomc::intent_ir::IntentIrEdge;
 
 fn semantic_diff_report(old: &Path, new: &Path) -> Result<SemanticDiffReport, Diagnostic> {
     let old_snapshot = read_intent_ir_snapshot(old)?;
@@ -7387,8 +7375,9 @@ struct ArtifactNode {
 }
 
 fn inspect_artifacts(project: &Path) -> Result<InspectArtifactsReport, Diagnostic> {
+    let intent = emit_intent_ir(project)?;
     let manifest = load_manifest(project)?;
-    let package_id = package_node_for_path(project);
+    let package_id = intent.package.clone();
     let mut artifacts = Vec::new();
     push_artifact(
         &mut artifacts,

--- a/stage1/crates/axiomc/src/transactional_workspace.rs
+++ b/stage1/crates/axiomc/src/transactional_workspace.rs
@@ -1,0 +1,1137 @@
+//! Durable, fail-closed workspace transactions for unattended agents.
+//!
+//! A transaction owns a detached Git worktree at an exact commit. All file
+//! mutations are built-ins so their canonical targets can be checked before
+//! use. External commands and network remain unavailable until a caller has
+//! independently established a verified sandbox.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::{Component, Path, PathBuf};
+use std::process::Command;
+
+const STATE_FILE: &str = ".axiom-transaction.json";
+const AUDIT_SCHEMA: &str = "axiom.transactional_workspace.v0";
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkspacePolicy {
+    pub allowed_read_paths: BTreeSet<String>,
+    pub allowed_write_paths: BTreeSet<String>,
+    pub allowed_commands: BTreeSet<String>,
+    pub allow_network: bool,
+    pub verified_sandbox: bool,
+}
+
+impl Default for WorkspacePolicy {
+    fn default() -> Self {
+        Self {
+            allowed_read_paths: BTreeSet::new(),
+            allowed_write_paths: BTreeSet::new(),
+            allowed_commands: BTreeSet::new(),
+            allow_network: false,
+            verified_sandbox: false,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AuditEvent {
+    pub sequence: u64,
+    pub operation: String,
+    pub subject: String,
+    pub result: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TransactionState {
+    pub schema_version: String,
+    pub base_sha: String,
+    pub source_checkout: String,
+    pub worktree: String,
+    pub policy: WorkspacePolicy,
+    pub phase: TransactionPhase,
+    pub checkpoint_tree: String,
+    pub events: Vec<AuditEvent>,
+    pub artifacts: BTreeSet<String>,
+    pub rollback_result: Option<String>,
+    pub checksum: String,
+    pub transaction_id: String,
+    pub task_contract_digest: String,
+    pub policy_digest: String,
+    pub branch: String,
+    pub pending_effect: Option<String>,
+    pub workspace_fingerprint: String,
+    pub source_fingerprint: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExecutionTransactionAudit {
+    pub schema_version: String,
+    pub transaction_id: String,
+    pub task_contract_digest: String,
+    pub policy_digest: String,
+    pub base_sha: String,
+    pub branch: String,
+    pub status: String,
+    pub checkpoints: Vec<AuditCheckpoint>,
+    pub reads: Vec<FileObservation>,
+    pub writes: Vec<AuditWrite>,
+    pub commands: Vec<AuditCommand>,
+    pub artifacts: Vec<AuditArtifact>,
+    pub rollback: RollbackAudit,
+    pub recovery: RecoveryAudit,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AuditCheckpoint {
+    pub sequence: u64,
+    pub kind: String,
+    pub tree_sha: String,
+    pub created_before: String,
+}
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FileObservation {
+    pub sequence: u64,
+    pub path: String,
+    pub digest: String,
+}
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AuditWrite {
+    pub sequence: u64,
+    pub operation: String,
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub destination: Option<String>,
+    pub before_digest: Option<String>,
+    pub after_digest: Option<String>,
+}
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AuditCommand {
+    pub sequence: u64,
+    pub argv: Vec<String>,
+    pub capabilities: Vec<String>,
+    pub network_hosts: Vec<String>,
+    pub outcome: String,
+    pub exit_code: i32,
+    pub stdout_digest: String,
+    pub stderr_digest: String,
+}
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AuditArtifact {
+    pub sequence: u64,
+    pub path: String,
+    pub digest: String,
+    pub kind: String,
+}
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RollbackAudit {
+    pub attempted: bool,
+    pub result: String,
+    pub restored_checkpoint: Option<u64>,
+    pub source_checkout_untouched: bool,
+}
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RecoveryAudit {
+    pub resumable: bool,
+    pub rollback_safe: bool,
+    pub next_sequence: u64,
+    pub journal_digest: String,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TransactionPhase {
+    Active,
+    Interrupted,
+    Committed,
+    Aborted,
+}
+
+#[derive(Debug)]
+pub struct TransactionalWorkspace {
+    state_path: PathBuf,
+    state: TransactionState,
+}
+
+impl TransactionalWorkspace {
+    /// Create a detached, tool-owned worktree at `base_sha` without changing
+    /// the source checkout's index, branch, or working files.
+    pub fn create(
+        source_checkout: &Path,
+        worktree: &Path,
+        base_sha: &str,
+        policy: WorkspacePolicy,
+    ) -> Result<Self, String> {
+        let policy_bytes = serde_json::to_vec(&policy).map_err(|e| e.to_string())?;
+        let policy_digest = sha256_digest(&policy_bytes);
+        Self::create_for_task(
+            source_checkout,
+            worktree,
+            base_sha,
+            policy,
+            &sha256_digest(b"unspecified-task"),
+            &policy_digest,
+            "detached",
+        )
+    }
+
+    pub fn create_for_task(
+        source_checkout: &Path,
+        worktree: &Path,
+        base_sha: &str,
+        policy: WorkspacePolicy,
+        task_contract_digest: &str,
+        policy_digest: &str,
+        branch: &str,
+    ) -> Result<Self, String> {
+        validate_sha(base_sha)?;
+        validate_policy(&policy)?;
+        validate_digest(task_contract_digest)?;
+        validate_digest(policy_digest)?;
+        if branch.trim().is_empty() {
+            return Err("branch must not be empty".into());
+        }
+        let source = source_checkout
+            .canonicalize()
+            .map_err(|e| format!("cannot canonicalize source checkout: {e}"))?;
+        if !worktree.is_absolute() || worktree.starts_with(&source) {
+            return Err("transaction worktree must be an absolute sibling outside the source checkout".into());
+        }
+        if worktree.exists() {
+            return Err("transaction worktree already exists".into());
+        }
+        let verified = git(
+            &source,
+            &["rev-parse", "--verify", &format!("{base_sha}^{{commit}}")],
+        )?;
+        let exact_sha = verified.trim();
+        if exact_sha != base_sha {
+            return Err("base SHA must be the exact full commit SHA".into());
+        }
+        let worktree_text = worktree
+            .to_str()
+            .ok_or_else(|| "worktree path is not UTF-8".to_string())?;
+        if branch == "detached" {
+            git(
+                &source,
+                &["worktree", "add", "--detach", worktree_text, exact_sha],
+            )?;
+        } else {
+            if branch.starts_with('-')
+                || branch.contains("..")
+                || branch.contains(char::is_whitespace)
+            {
+                return Err("invalid transaction-owned branch name".into());
+            }
+            git(
+                &source,
+                &["worktree", "add", "-b", branch, worktree_text, exact_sha],
+            )?;
+        }
+        let canonical_worktree = worktree
+            .canonicalize()
+            .map_err(|e| format!("cannot canonicalize transaction worktree: {e}"))?;
+        let checkpoint_tree = git(&canonical_worktree, &["rev-parse", "HEAD^{tree}"])?
+            .trim()
+            .to_string();
+        let txn_digest = sha256_digest(
+            format!("{exact_sha}\0{task_contract_digest}\0{policy_digest}\0{branch}").as_bytes(),
+        );
+        let workspace_fingerprint = checkout_fingerprint(&canonical_worktree, &policy)?;
+        let source_fingerprint = source_fingerprint(&source)?;
+        let mut this = Self {
+            state_path: canonical_worktree.join(STATE_FILE),
+            state: TransactionState {
+                schema_version: AUDIT_SCHEMA.into(),
+                base_sha: exact_sha.into(),
+                source_checkout: normalized(&source),
+                worktree: normalized(&canonical_worktree),
+                policy,
+                phase: TransactionPhase::Active,
+                checkpoint_tree,
+                events: Vec::new(),
+                artifacts: BTreeSet::new(),
+                rollback_result: None,
+                checksum: String::new(),
+                transaction_id: format!("txn-{}", &txn_digest[7..23]),
+                task_contract_digest: task_contract_digest.into(),
+                policy_digest: policy_digest.into(),
+                branch: branch.into(),
+                pending_effect: None,
+                workspace_fingerprint,
+                source_fingerprint,
+            },
+        };
+        this.record("checkpoint", exact_sha, "created")?;
+        Ok(this)
+    }
+
+    /// Open and verify an interrupted or active transaction. Corrupt or
+    /// partially written state is rejected instead of guessed at.
+    pub fn recover(worktree: &Path) -> Result<Self, String> {
+        let root = worktree
+            .canonicalize()
+            .map_err(|e| format!("cannot canonicalize worktree: {e}"))?;
+        let state_path = root.join(STATE_FILE);
+        let bytes =
+            fs::read(&state_path).map_err(|e| format!("cannot read transaction state: {e}"))?;
+        let state: TransactionState = serde_json::from_slice(&bytes)
+            .map_err(|e| format!("invalid transaction state: {e}"))?;
+        let expected = state_checksum(&state)?;
+        if state.checksum != expected {
+            return Err("transaction state checksum mismatch".into());
+        }
+        if state.worktree != normalized(&root) {
+            return Err("transaction state belongs to another worktree".into());
+        }
+        let observed_head = git(&root, &["rev-parse", "HEAD"])?;
+        if observed_head.trim() != state.base_sha && state.phase != TransactionPhase::Committed {
+            return Err("transaction HEAD no longer matches its exact base SHA".into());
+        }
+        if state.events.iter().enumerate().any(|(index, event)| event.sequence != index as u64) {
+            return Err("transaction journal sequence is corrupt".into());
+        }
+        if state.pending_effect.is_none()
+            && checkout_fingerprint(&root, &state.policy)? != state.workspace_fingerprint
+        {
+            return Err("transaction worktree does not match its durable journal".into());
+        }
+        Ok(Self { state_path, state })
+    }
+
+    pub fn state(&self) -> &TransactionState {
+        &self.state
+    }
+
+    pub fn mark_interrupted(&mut self) -> Result<(), String> {
+        self.require_active()?;
+        self.state.phase = TransactionPhase::Interrupted;
+        self.record("lifecycle", "transaction", "interrupted")
+    }
+
+    pub fn resume(&mut self) -> Result<(), String> {
+        if self.state.phase != TransactionPhase::Interrupted {
+            return Err("only an interrupted transaction may be resumed".into());
+        }
+        if self.state.pending_effect.is_some() {
+            return Err("an interrupted filesystem effect is ambiguous; rollback is required".into());
+        }
+        if checkout_fingerprint(&self.root(), &self.state.policy)? != self.state.workspace_fingerprint {
+            return Err("transaction worktree changed after its last durable event".into());
+        }
+        self.state.phase = TransactionPhase::Active;
+        self.record("lifecycle", "transaction", "resumed")
+    }
+
+    pub fn read(&mut self, path: &str) -> Result<Vec<u8>, String> {
+        self.require_active()?;
+        let target = self.authorize_existing(path, &self.state.policy.allowed_read_paths)?;
+        let result = fs::read(&target).map_err(|e| format!("read failed: {e}"));
+        let audit_result = result
+            .as_ref()
+            .map(|bytes| sha256_digest(bytes))
+            .unwrap_or_else(|_| "failed".into());
+        self.record("read", path, &audit_result)?;
+        result
+    }
+
+    pub fn write(&mut self, path: &str, bytes: &[u8]) -> Result<(), String> {
+        self.require_active()?;
+        let target = self.authorize_write(path)?;
+        let before = file_digest(&target)?;
+        self.record("checkpoint", path, "before_write")?;
+        self.begin_effect(&format!("write:{path}"))?;
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+        }
+        atomic_write(&target, bytes)?;
+        self.finish_effect(
+            "write",
+            path,
+            &format!("{}|{}", optional_digest(&before), sha256_digest(bytes)),
+        )
+    }
+
+    pub fn delete(&mut self, path: &str) -> Result<(), String> {
+        self.require_active()?;
+        let target = self.authorize_existing(path, &self.state.policy.allowed_write_paths)?;
+        let before = file_digest(&target)?;
+        self.record("checkpoint", path, "before_delete")?;
+        self.begin_effect(&format!("delete:{path}"))?;
+        if target.is_dir() {
+            fs::remove_dir(&target)
+        } else {
+            fs::remove_file(&target)
+        }
+        .map_err(|e| format!("delete failed: {e}"))?;
+        self.finish_effect("delete", path, &format!("{}|-", optional_digest(&before)))
+    }
+
+    pub fn rename(&mut self, from: &str, to: &str) -> Result<(), String> {
+        self.require_active()?;
+        let source = self.authorize_existing(from, &self.state.policy.allowed_write_paths)?;
+        let target = self.authorize_write(to)?;
+        let before = file_digest(&source)?;
+        self.record("checkpoint", &format!("{from}->{to}"), "before_rename")?;
+        self.begin_effect(&format!("rename:{from}->{to}"))?;
+        fs::rename(source, target).map_err(|e| format!("rename failed: {e}"))?;
+        self.finish_effect(
+            "rename",
+            &format!("{from}->{to}"),
+            &format!("{}|{}", optional_digest(&before), optional_digest(&before)),
+        )
+    }
+
+    #[cfg(unix)]
+    pub fn chmod(&mut self, path: &str, mode: u32) -> Result<(), String> {
+        use std::os::unix::fs::PermissionsExt;
+        self.require_active()?;
+        if mode & !0o777 != 0 {
+            return Err("special permission bits are forbidden".into());
+        }
+        let target = self.authorize_existing(path, &self.state.policy.allowed_write_paths)?;
+        let digest = file_digest(&target)?;
+        self.record("checkpoint", path, "before_chmod")?;
+        self.begin_effect(&format!("chmod:{path}"))?;
+        fs::set_permissions(target, fs::Permissions::from_mode(mode))
+            .map_err(|e| format!("chmod failed: {e}"))?;
+        self.finish_effect(
+            "chmod",
+            path,
+            &format!("{}|{}", optional_digest(&digest), optional_digest(&digest)),
+        )
+    }
+
+    /// Validate authority for an external command. Execution is deliberately
+    /// separate so callers cannot confuse an allowlist entry with isolation.
+    pub fn authorize_external(&mut self, program: &str, network: bool) -> Result<(), String> {
+        self.require_active()?;
+        let _ = network;
+        self.record("command", program, "denied")?;
+        Err("portable v0 denies external commands and network; a verified sandbox executor is required".into())
+    }
+
+    pub fn record_artifact(&mut self, path: &str) -> Result<(), String> {
+        let target = self.authorize_existing(path, &self.state.policy.allowed_read_paths)?;
+        let digest = file_digest(&target)?.ok_or_else(|| "artifact is not a file".to_string())?;
+        self.state.artifacts.insert(path.into());
+        self.record("artifact", path, &digest)
+    }
+
+    /// Restore tracked content to the exact base commit and remove only
+    /// untracked files inside the isolated worktree. The source checkout is
+    /// never addressed by these commands.
+    pub fn abort(&mut self) -> Result<(), String> {
+        if matches!(
+            self.state.phase,
+            TransactionPhase::Committed | TransactionPhase::Aborted
+        ) {
+            return Err("transaction is already terminal".into());
+        }
+        let root = PathBuf::from(&self.state.worktree);
+        git(&root, &["reset", "--hard", &self.state.base_sha])?;
+        git(&root, &["clean", "-fd", "--exclude", STATE_FILE])?;
+        self.state.phase = TransactionPhase::Aborted;
+        self.state.rollback_result = Some("restored_to_base_sha".into());
+        self.state.pending_effect = None;
+        self.state.workspace_fingerprint = checkout_fingerprint(&root, &self.state.policy)?;
+        self.record("rollback", &self.state.base_sha.clone(), "succeeded")
+    }
+
+    pub fn commit_local(&mut self) -> Result<(), String> {
+        self.require_active()?;
+        self.record("checkpoint", "delivery", "before_local_commit")?;
+        self.state.phase = TransactionPhase::Committed;
+        self.record("lifecycle", "transaction", "committed")
+    }
+
+    /// Operations which alter protected history or governance can never be
+    /// granted by this Class-2 primitive.
+    pub fn reject_delivery_operation(operation: &str) -> Result<(), String> {
+        match operation {
+            "force_push" | "push_protected_branch" | "self_approve" | "edit_policy" => Err(
+                format!("delivery operation {operation} requires separate Class-3 authority"),
+            ),
+            _ => Ok(()),
+        }
+    }
+
+    pub fn execution_audit(&self) -> ExecutionTransactionAudit {
+        let digest = |value: &str| sha256_digest(value.as_bytes());
+        let checkpoints = self
+            .state
+            .events
+            .iter()
+            .filter(|e| e.operation == "checkpoint")
+            .map(|e| AuditCheckpoint {
+                sequence: e.sequence,
+                kind: if e.result == "created" {
+                    "initial".into()
+                } else if e.subject == "delivery" {
+                    "before_delivery".into()
+                } else {
+                    "before_write".into()
+                },
+                tree_sha: self.state.checkpoint_tree.clone(),
+                created_before: e.subject.clone(),
+            })
+            .collect();
+        let reads = self
+            .state
+            .events
+            .iter()
+            .filter(|e| e.operation == "read" && e.result.starts_with("sha256:"))
+            .map(|e| FileObservation {
+                sequence: e.sequence,
+                path: e.subject.clone(),
+                digest: e.result.clone(),
+            })
+            .collect();
+        let writes = self
+            .state
+            .events
+            .iter()
+            .filter(|e| {
+                matches!(
+                    e.operation.as_str(),
+                    "write" | "delete" | "rename" | "chmod"
+                )
+            })
+            .map(|e| {
+                let (path, destination) = if e.operation == "rename" {
+                    let mut split = e.subject.splitn(2, "->");
+                    (
+                        split.next().unwrap_or("").into(),
+                        split.next().map(str::to_string),
+                    )
+                } else {
+                    (e.subject.clone(), None)
+                };
+                let mut digests = e.result.splitn(2, '|');
+                let before_digest = parse_optional_digest(digests.next());
+                let after_digest = parse_optional_digest(digests.next());
+                AuditWrite {
+                    sequence: e.sequence,
+                    operation: if e.operation == "write" && before_digest.is_none() {
+                        "create".into()
+                    } else if e.operation == "write" {
+                        "modify".into()
+                    } else {
+                        e.operation.clone()
+                    },
+                    path,
+                    destination,
+                    before_digest,
+                    after_digest,
+                }
+            })
+            .collect();
+        let commands = self
+            .state
+            .events
+            .iter()
+            .filter(|e| e.operation == "command")
+            .map(|e| AuditCommand {
+                sequence: e.sequence,
+                argv: vec![e.subject.clone()],
+                capabilities: vec![],
+                network_hosts: vec![],
+                outcome: "denied".into(),
+                exit_code: 126,
+                stdout_digest: digest(""),
+                stderr_digest: digest(""),
+            })
+            .collect();
+        let artifacts = self
+            .state
+            .artifacts
+            .iter()
+            .enumerate()
+            .map(|(i, path)| AuditArtifact {
+                sequence: self.state.events.len() as u64 + i as u64,
+                path: path.clone(),
+                digest: self
+                    .state
+                    .events
+                    .iter()
+                    .rev()
+                    .find(|event| event.operation == "artifact" && event.subject == *path)
+                    .map(|event| event.result.clone())
+                    .unwrap_or_else(|| digest(path)),
+                kind: "file".into(),
+            })
+            .collect();
+        let attempted = self.state.rollback_result.is_some();
+        let rollback = RollbackAudit {
+            attempted,
+            result: if attempted {
+                "succeeded".into()
+            } else {
+                "not_required".into()
+            },
+            restored_checkpoint: attempted.then_some(0),
+            source_checkout_untouched: source_fingerprint(Path::new(&self.state.source_checkout))
+                .is_ok_and(|fingerprint| fingerprint == self.state.source_fingerprint),
+        };
+        let status = match self.state.phase {
+            TransactionPhase::Active => "running",
+            TransactionPhase::Interrupted => "interrupted",
+            TransactionPhase::Committed => "succeeded",
+            TransactionPhase::Aborted => "rolled_back",
+        }
+        .into();
+        let journal = serde_json::to_vec(&self.state.events).unwrap_or_default();
+        let workspace_matches = checkout_fingerprint(&self.root(), &self.state.policy)
+            .is_ok_and(|fingerprint| fingerprint == self.state.workspace_fingerprint);
+        ExecutionTransactionAudit {
+            schema_version: "axiom.execution_transaction.v0".into(),
+            transaction_id: self.state.transaction_id.clone(),
+            task_contract_digest: self.state.task_contract_digest.clone(),
+            policy_digest: self.state.policy_digest.clone(),
+            base_sha: self.state.base_sha.clone(),
+            branch: self.state.branch.clone(),
+            status,
+            checkpoints,
+            reads,
+            writes,
+            commands,
+            artifacts,
+            rollback,
+            recovery: RecoveryAudit {
+                resumable: matches!(self.state.phase, TransactionPhase::Active | TransactionPhase::Interrupted)
+                    && self.state.pending_effect.is_none()
+                    && workspace_matches,
+                rollback_safe: !matches!(self.state.phase, TransactionPhase::Committed),
+                next_sequence: self.state.events.len() as u64,
+                journal_digest: sha256_digest(&journal),
+            },
+        }
+    }
+
+    pub fn deterministic_audit_json(&self) -> Result<String, String> {
+        serde_json::to_string_pretty(&self.execution_audit()).map_err(|e| e.to_string())
+    }
+
+    fn require_active(&self) -> Result<(), String> {
+        if self.state.phase == TransactionPhase::Active {
+            Ok(())
+        } else {
+            Err("transaction is not active".into())
+        }
+    }
+
+    fn root(&self) -> PathBuf {
+        PathBuf::from(&self.state.worktree)
+    }
+
+    fn authorize_write(&self, path: &str) -> Result<PathBuf, String> {
+        validate_relative(path)?;
+        if !self.state.policy.allowed_write_paths.contains(path) {
+            return Err("write path is outside task scope".into());
+        }
+        canonical_target(&self.root(), path)
+    }
+
+    fn authorize_existing(
+        &self,
+        path: &str,
+        allowed: &BTreeSet<String>,
+    ) -> Result<PathBuf, String> {
+        validate_relative(path)?;
+        if !allowed.contains(path) {
+            return Err("path is outside task scope".into());
+        }
+        let target = canonical_target(&self.root(), path)?;
+        target
+            .canonicalize()
+            .map_err(|e| format!("path does not exist: {e}"))
+            .and_then(|p| {
+                if p.starts_with(self.root()) {
+                    Ok(p)
+                } else {
+                    Err("symlink escapes transaction worktree".into())
+                }
+            })
+    }
+
+    fn record(&mut self, operation: &str, subject: &str, result: &str) -> Result<(), String> {
+        self.state.events.push(AuditEvent {
+            sequence: self.state.events.len() as u64,
+            operation: operation.into(),
+            subject: redact(subject),
+            result: redact(result),
+        });
+        persist(&self.state_path, &mut self.state)
+    }
+
+    fn begin_effect(&mut self, effect: &str) -> Result<(), String> {
+        if self.state.pending_effect.is_some() {
+            return Err("another filesystem effect is pending".into());
+        }
+        self.state.pending_effect = Some(effect.into());
+        persist(&self.state_path, &mut self.state)
+    }
+
+    fn finish_effect(&mut self, operation: &str, subject: &str, result: &str) -> Result<(), String> {
+        self.record(operation, subject, result)?;
+        self.state.pending_effect = None;
+        self.state.workspace_fingerprint = checkout_fingerprint(&self.root(), &self.state.policy)?;
+        persist(&self.state_path, &mut self.state)
+    }
+}
+
+fn validate_policy(policy: &WorkspacePolicy) -> Result<(), String> {
+    for path in policy
+        .allowed_read_paths
+        .iter()
+        .chain(&policy.allowed_write_paths)
+    {
+        validate_relative(path)?;
+    }
+    for command in &policy.allowed_commands {
+        if command.contains('/') || command.trim().is_empty() {
+            return Err("commands must be canonical program names".into());
+        }
+    }
+    Ok(())
+}
+
+fn validate_sha(sha: &str) -> Result<(), String> {
+    if sha.len() == 40 && sha.bytes().all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase()) {
+        Ok(())
+    } else {
+        Err("base SHA must be a full 40-character hexadecimal commit id".into())
+    }
+}
+
+fn validate_digest(digest: &str) -> Result<(), String> {
+    if digest.len() == 71
+        && digest.starts_with("sha256:")
+        && digest[7..]
+            .bytes()
+            .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+    {
+        Ok(())
+    } else {
+        Err("digest must use sha256:<64 lowercase hex> form".into())
+    }
+}
+
+fn sha256_digest(bytes: &[u8]) -> String {
+    const K: [u32; 64] = [
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4,
+        0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe,
+        0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f,
+        0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+        0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc,
+        0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+        0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116,
+        0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7,
+        0xc67178f2,
+    ];
+    let mut message = bytes.to_vec();
+    let bit_len = (message.len() as u64).wrapping_mul(8);
+    message.push(0x80);
+    while message.len() % 64 != 56 {
+        message.push(0);
+    }
+    message.extend_from_slice(&bit_len.to_be_bytes());
+    let mut h = [
+        0x6a09e667u32,
+        0xbb67ae85,
+        0x3c6ef372,
+        0xa54ff53a,
+        0x510e527f,
+        0x9b05688c,
+        0x1f83d9ab,
+        0x5be0cd19,
+    ];
+    for block in message.chunks_exact(64) {
+        let mut w = [0u32; 64];
+        for (i, word) in block.chunks_exact(4).enumerate() {
+            w[i] = u32::from_be_bytes(word.try_into().expect("SHA word"));
+        }
+        for i in 16..64 {
+            let s0 = w[i - 15].rotate_right(7) ^ w[i - 15].rotate_right(18) ^ (w[i - 15] >> 3);
+            let s1 = w[i - 2].rotate_right(17) ^ w[i - 2].rotate_right(19) ^ (w[i - 2] >> 10);
+            w[i] = w[i - 16]
+                .wrapping_add(s0)
+                .wrapping_add(w[i - 7])
+                .wrapping_add(s1);
+        }
+        let [mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut hh] = h;
+        for i in 0..64 {
+            let s1 = e.rotate_right(6) ^ e.rotate_right(11) ^ e.rotate_right(25);
+            let ch = (e & f) ^ (!e & g);
+            let t1 = hh
+                .wrapping_add(s1)
+                .wrapping_add(ch)
+                .wrapping_add(K[i])
+                .wrapping_add(w[i]);
+            let s0 = a.rotate_right(2) ^ a.rotate_right(13) ^ a.rotate_right(22);
+            let maj = (a & b) ^ (a & c) ^ (b & c);
+            let t2 = s0.wrapping_add(maj);
+            hh = g;
+            g = f;
+            f = e;
+            e = d.wrapping_add(t1);
+            d = c;
+            c = b;
+            b = a;
+            a = t1.wrapping_add(t2);
+        }
+        for (state, value) in h.iter_mut().zip([a, b, c, d, e, f, g, hh]) {
+            *state = state.wrapping_add(value);
+        }
+    }
+    format!(
+        "sha256:{}",
+        h.iter()
+            .map(|word| format!("{word:08x}"))
+            .collect::<String>()
+    )
+}
+
+fn validate_relative(path: &str) -> Result<(), String> {
+    let p = Path::new(path);
+    if path.is_empty()
+        || p.is_absolute()
+        || p.components().any(|c| !matches!(c, Component::Normal(_)))
+    {
+        return Err("path must be a normalized relative path without traversal".into());
+    }
+    if path == STATE_FILE || path.starts_with(".git") || path.starts_with(".codex/policies/") {
+        return Err("protected transaction or policy path".into());
+    }
+    Ok(())
+}
+
+fn canonical_target(root: &Path, relative: &str) -> Result<PathBuf, String> {
+    let target = root.join(relative);
+    let mut ancestor = target.as_path();
+    while !ancestor.exists() {
+        ancestor = ancestor
+            .parent()
+            .ok_or_else(|| "invalid target".to_string())?;
+    }
+    let canonical = ancestor
+        .canonicalize()
+        .map_err(|e| format!("cannot canonicalize target ancestor: {e}"))?;
+    if !canonical.starts_with(root) {
+        return Err("path or symlink escapes transaction worktree".into());
+    }
+    Ok(target)
+}
+
+fn file_digest(path: &Path) -> Result<Option<String>, String> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    if !path.is_file() {
+        return Ok(None);
+    }
+    fs::read(path)
+        .map(|bytes| Some(sha256_digest(&bytes)))
+        .map_err(|e| format!("cannot hash {}: {e}", path.display()))
+}
+
+fn checkout_fingerprint(root: &Path, _policy: &WorkspacePolicy) -> Result<String, String> {
+    let head = git(root, &["rev-parse", "HEAD"])?;
+    Ok(sha256_digest(
+        format!("{}\0{}", head.trim(), tree_fingerprint(root)?).as_bytes(),
+    ))
+}
+
+fn source_fingerprint(root: &Path) -> Result<String, String> {
+    let head = git(root, &["rev-parse", "HEAD"])?;
+    Ok(sha256_digest(
+        format!("{}\0{}", head.trim(), tree_fingerprint(root)?).as_bytes(),
+    ))
+}
+
+fn tree_fingerprint(root: &Path) -> Result<String, String> {
+    fn visit(root: &Path, path: &Path, rows: &mut Vec<String>) -> Result<(), String> {
+        let mut entries = fs::read_dir(path)
+            .map_err(|e| format!("cannot inspect {}: {e}", path.display()))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| e.to_string())?;
+        entries.sort_by_key(|entry| entry.file_name());
+        for entry in entries {
+            let child = entry.path();
+            let relative = child.strip_prefix(root).map_err(|e| e.to_string())?;
+            if relative == Path::new(".git") || relative == Path::new(STATE_FILE) {
+                continue;
+            }
+            let metadata = fs::symlink_metadata(&child).map_err(|e| e.to_string())?;
+            let mode = metadata_mode(&metadata);
+            if metadata.file_type().is_symlink() {
+                let target = fs::read_link(&child).map_err(|e| e.to_string())?;
+                rows.push(format!("L\0{}\0{mode:o}\0{}", normalized(relative), normalized(&target)));
+            } else if metadata.is_dir() {
+                rows.push(format!("D\0{}\0{mode:o}", normalized(relative)));
+                visit(root, &child, rows)?;
+            } else if metadata.is_file() {
+                let digest = sha256_digest(&fs::read(&child).map_err(|e| e.to_string())?);
+                rows.push(format!("F\0{}\0{mode:o}\0{digest}", normalized(relative)));
+            } else {
+                return Err(format!("unsupported filesystem object {}", child.display()));
+            }
+        }
+        Ok(())
+    }
+    let mut rows = Vec::new();
+    visit(root, root, &mut rows)?;
+    Ok(sha256_digest(rows.join("\n").as_bytes()))
+}
+
+#[cfg(unix)]
+fn metadata_mode(metadata: &fs::Metadata) -> u32 {
+    use std::os::unix::fs::MetadataExt;
+    metadata.mode()
+}
+
+#[cfg(not(unix))]
+fn metadata_mode(metadata: &fs::Metadata) -> u32 {
+    u32::from(metadata.permissions().readonly())
+}
+
+fn optional_digest(digest: &Option<String>) -> &str {
+    digest.as_deref().unwrap_or("-")
+}
+
+fn parse_optional_digest(value: Option<&str>) -> Option<String> {
+    value.filter(|value| *value != "-").map(str::to_owned)
+}
+
+fn git(dir: &Path, args: &[&str]) -> Result<String, String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .map_err(|e| format!("cannot execute git: {e}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "git operation failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    String::from_utf8(output.stdout).map_err(|e| format!("git output is not UTF-8: {e}"))
+}
+
+fn persist(path: &Path, state: &mut TransactionState) -> Result<(), String> {
+    state.checksum.clear();
+    state.checksum = state_checksum(state)?;
+    let bytes = serde_json::to_vec_pretty(state).map_err(|e| e.to_string())?;
+    atomic_write(path, &bytes)
+}
+
+fn state_checksum(state: &TransactionState) -> Result<String, String> {
+    let mut copy = state.clone();
+    copy.checksum.clear();
+    let bytes = serde_json::to_vec(&copy).map_err(|e| e.to_string())?;
+    Ok(sha256_digest(&bytes))
+}
+
+fn atomic_write(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| "state path has no parent".to_string())?;
+    fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    let tmp = parent.join(format!(
+        ".{}.tmp",
+        path.file_name()
+            .and_then(|v| v.to_str())
+            .unwrap_or("transaction")
+    ));
+    let mut file = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(&tmp)
+        .map_err(|e| e.to_string())?;
+    file.write_all(bytes).map_err(|e| e.to_string())?;
+    file.sync_all().map_err(|e| e.to_string())?;
+    fs::rename(&tmp, path).map_err(|e| e.to_string())?;
+    File::open(parent)
+        .and_then(|f| f.sync_all())
+        .map_err(|e| e.to_string())
+}
+
+fn normalized(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+fn redact(value: &str) -> String {
+    let lower = value.to_ascii_lowercase();
+    if lower.starts_with("secret://")
+        || lower.starts_with("secret-ref:")
+        || lower.contains("credential=")
+        || lower.contains("token=")
+        || lower.contains("password=")
+        || lower.contains("authorization:")
+        || lower.contains(&["github_", "pat_"].concat())
+        || lower.contains(&["gh", "p_"].concat())
+        || lower.contains("bearer ")
+    {
+        "[secret-reference-redacted]".into()
+    } else {
+        value.into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn fixture() -> (TempDir, PathBuf, String) {
+        let dir = TempDir::new().unwrap();
+        let source = dir.path().join("source");
+        fs::create_dir(&source).unwrap();
+        git(&source, &["init", "-q"]).unwrap();
+        git(
+            &source,
+            &["config", "user.email", "test@example.invalid"],
+        )
+        .unwrap();
+        git(&source, &["config", "user.name", "Test"]).unwrap();
+        fs::write(source.join("allowed.txt"), b"original").unwrap();
+        fs::write(source.join("outside.txt"), b"owned").unwrap();
+        git(&source, &["add", "allowed.txt", "outside.txt"]).unwrap();
+        git(
+            &source,
+            &["-c", "commit.gpgsign=false", "commit", "-qm", "base"],
+        )
+        .unwrap();
+        let sha = git(&source, &["rev-parse", "HEAD"])
+            .unwrap()
+            .trim()
+            .into();
+        (dir, source, sha)
+    }
+
+    fn policy() -> WorkspacePolicy {
+        WorkspacePolicy {
+            allowed_read_paths: BTreeSet::from(["allowed.txt".into()]),
+            allowed_write_paths: BTreeSet::from(["allowed.txt".into(), "new.txt".into()]),
+            ..WorkspacePolicy::default()
+        }
+    }
+
+    #[test]
+    fn isolated_abort_preserves_dirty_source() {
+        let (repo, source, sha) = fixture();
+        fs::write(source.join("outside.txt"), b"user dirty").unwrap();
+        let worktree = repo.path().join("txn");
+        let mut txn =
+            TransactionalWorkspace::create(&source, &worktree, &sha, policy()).unwrap();
+        txn.write("allowed.txt", b"changed").unwrap();
+        txn.write("new.txt", b"new").unwrap();
+        txn.abort().unwrap();
+        assert_eq!(fs::read(worktree.join("allowed.txt")).unwrap(), b"original");
+        assert!(!worktree.join("new.txt").exists());
+        assert_eq!(
+            fs::read(source.join("outside.txt")).unwrap(),
+            b"user dirty"
+        );
+    }
+
+    #[test]
+    fn traversal_and_unapproved_commands_fail_closed() {
+        let (repo, source, sha) = fixture();
+        let worktree = repo.path().join("txn");
+        let mut txn =
+            TransactionalWorkspace::create(&source, &worktree, &sha, policy()).unwrap();
+        assert!(txn.write("../outside.txt", b"bad").is_err());
+        assert!(txn.write("outside.txt", b"bad").is_err());
+        assert!(txn.authorize_external("sh", false).is_err());
+        assert!(txn.authorize_external("curl", true).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_escape_fails_closed() {
+        use std::os::unix::fs::symlink;
+        let (repo, source, sha) = fixture();
+        let worktree = repo.path().join("txn");
+        let mut scoped = policy();
+        scoped.allowed_write_paths.insert("link/stolen.txt".into());
+        let mut txn = TransactionalWorkspace::create(&source, &worktree, &sha, scoped).unwrap();
+        symlink(&source, worktree.join("link")).unwrap();
+        assert!(txn.write("link/stolen.txt", b"bad").is_err());
+    }
+
+    #[test]
+    fn crash_recovery_verifies_state_and_can_resume() {
+        let (repo, source, sha) = fixture();
+        let worktree = repo.path().join("txn");
+        let mut txn =
+            TransactionalWorkspace::create(&source, &worktree, &sha, policy()).unwrap();
+        txn.mark_interrupted().unwrap();
+        drop(txn);
+        let mut recovered = TransactionalWorkspace::recover(&worktree).unwrap();
+        assert_eq!(recovered.state().phase, TransactionPhase::Interrupted);
+        recovered.resume().unwrap();
+        recovered.write("new.txt", b"resumed").unwrap();
+    }
+
+    #[test]
+    fn crash_during_effect_requires_rollback() {
+        let (repo, source, sha) = fixture();
+        let worktree = repo.path().join("txn");
+        let mut txn =
+            TransactionalWorkspace::create(&source, &worktree, &sha, policy()).unwrap();
+        txn.state.pending_effect = Some("write:allowed.txt".into());
+        txn.state.phase = TransactionPhase::Interrupted;
+        persist(&txn.state_path, &mut txn.state).unwrap();
+        drop(txn);
+        let mut recovered = TransactionalWorkspace::recover(&worktree).unwrap();
+        assert!(!recovered.execution_audit().recovery.resumable);
+        assert!(recovered.resume().is_err());
+        recovered.abort().unwrap();
+        assert_eq!(recovered.state.phase, TransactionPhase::Aborted);
+    }
+
+    #[test]
+    fn recovery_rejects_unjournaled_workspace_mutation() {
+        let (repo, source, sha) = fixture();
+        let worktree = repo.path().join("txn");
+        let mut txn =
+            TransactionalWorkspace::create(&source, &worktree, &sha, policy()).unwrap();
+        txn.mark_interrupted().unwrap();
+        drop(txn);
+        fs::write(worktree.join("allowed.txt"), b"unjournaled").unwrap();
+        assert!(TransactionalWorkspace::recover(&worktree).is_err());
+    }
+
+    #[test]
+    fn audit_is_deterministic_and_redacts_secret_references() {
+        let (repo, source, sha) = fixture();
+        let worktree = repo.path().join("txn");
+        let mut txn =
+            TransactionalWorkspace::create(&source, &worktree, &sha, policy()).unwrap();
+        assert!(txn
+            .authorize_external("secret://broker/key", false)
+            .is_err());
+        let first = txn.deterministic_audit_json().unwrap();
+        let second = txn.deterministic_audit_json().unwrap();
+        assert_eq!(first, second);
+        assert!(!first.contains("broker/key"));
+        assert!(first.contains("[secret-reference-redacted]"));
+    }
+
+    #[test]
+    fn class_three_delivery_mutations_are_rejected() {
+        for op in [
+            "force_push",
+            "push_protected_branch",
+            "self_approve",
+            "edit_policy",
+        ] {
+            assert!(TransactionalWorkspace::reject_delivery_operation(op).is_err());
+        }
+    }
+}

--- a/stage1/crates/axiomc/src/verification_planner.rs
+++ b/stage1/crates/axiomc/src/verification_planner.rs
@@ -1,0 +1,1276 @@
+//! Deterministic, fail-closed evidence planning from canonical Intent IR changes.
+
+use crate::intent_ir::{IntentIrDocument, IntentIrEdge, IntentIrNode};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Component, Path};
+
+pub const PLAN_SCHEMA_VERSION: &str = "axiom.verification_plan.v0";
+pub const RESULTS_SCHEMA_VERSION: &str = "axiom.verification_results.v0";
+pub const VERDICT_SCHEMA_VERSION: &str = "axiom.verification_verdict.v0";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct SemanticDiffContract {
+    pub schema_version: String,
+    pub ok: bool,
+    pub command: String,
+    pub old: String,
+    pub new: String,
+    pub summary: SemanticDiffSummary,
+    pub changes: Vec<SemanticDiffChange>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct SemanticDiffSummary {
+    pub breaking: usize,
+    pub additive: usize,
+    pub informational: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(deny_unknown_fields)]
+pub struct SemanticDiffChange {
+    pub change: String,
+    pub severity: String,
+    pub node_kind: String,
+    pub node_id: String,
+    pub edge_kind: Option<String>,
+    pub edge_from: Option<String>,
+    pub edge_to: Option<String>,
+    pub description: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct VerificationPlan {
+    pub schema_version: String,
+    pub plan_digest: String,
+    pub bindings: PlanBindings,
+    pub changes: Vec<SemanticChange>,
+    pub requirements: Vec<EvidenceRequirement>,
+    pub coverage: Coverage,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct PlanBindings {
+    pub before_graph_id: String,
+    pub after_graph_id: String,
+    pub before_snapshot_digest: String,
+    pub after_snapshot_digest: String,
+    pub source_head_sha: String,
+    pub delivered_head_sha: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(deny_unknown_fields)]
+pub struct SemanticChange {
+    pub id: String,
+    pub change_kind: ChangeKind,
+    pub node_kind: String,
+    pub semantic_id: String,
+    pub source_path: Option<String>,
+    pub impact: Vec<EvidenceKind>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum ChangeKind {
+    Added,
+    Removed,
+    Modified,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceKind {
+    Positive,
+    Denial,
+    Regression,
+    Schema,
+    Artifact,
+    Security,
+    Performance,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct EvidenceRequirement {
+    pub id: String,
+    pub kind: EvidenceKind,
+    pub reason: String,
+    pub semantic_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct Coverage {
+    pub confidence: CoverageConfidence,
+    pub complete: bool,
+    pub explanation: String,
+    pub unknown_impacts: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CoverageConfidence {
+    Complete,
+    Conservative,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct VerificationResults {
+    pub schema_version: String,
+    pub plan_digest: String,
+    pub source_head_sha: String,
+    pub delivered_head_sha: String,
+    pub results: Vec<EvidenceResult>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct EvidenceResult {
+    pub id: String,
+    pub plan_digest: String,
+    pub source_head_sha: String,
+    pub delivered_head_sha: String,
+    pub status: EvidenceStatus,
+    pub evidence_digest: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceStatus {
+    Passed,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct VerificationVerdict {
+    pub schema_version: String,
+    pub plan_digest: String,
+    pub status: VerdictStatus,
+    pub source_head_sha: String,
+    pub delivered_head_sha: String,
+    pub missing: Vec<String>,
+    pub duplicate: Vec<String>,
+    pub invalid: Vec<String>,
+    pub failed: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum VerdictStatus {
+    Passed,
+    Failed,
+}
+
+/// Computes a stable verification plan. Unknown semantic surfaces deliberately
+/// request every evidence family rather than guessing a narrower suite.
+pub fn plan_verification(
+    before: &IntentIrDocument,
+    after: &IntentIrDocument,
+    source_head_sha: &str,
+    delivered_head_sha: &str,
+) -> Result<VerificationPlan, String> {
+    validate_document(before, "before")?;
+    validate_document(after, "after")?;
+    validate_sha(source_head_sha)?;
+    validate_sha(delivered_head_sha)?;
+
+    let mut unknown = BTreeSet::new();
+    let mut changes = node_changes(before, after, &mut unknown);
+    changes.extend(edge_changes(before, after, &mut unknown));
+    let source_changes = source_changes(before, after, &mut unknown);
+    if source_changes.is_empty()
+        && before.provenance.source_digest != after.provenance.source_digest
+    {
+        unknown.insert("provenance:unmapped_source_digest".into());
+        changes.push(SemanticChange {
+            id: "source:modified:unmapped-provenance".into(),
+            change_kind: ChangeKind::Modified,
+            node_kind: "SourceInput".into(),
+            semantic_id: "source:unmapped-provenance".into(),
+            source_path: None,
+            impact: all_evidence(),
+        });
+    }
+    changes.extend(source_changes);
+    if !before.diagnostics.is_empty() || !after.diagnostics.is_empty() {
+        unknown.insert("intent_ir:incomplete_diagnostics".into());
+        changes.push(SemanticChange {
+            id: "diagnostic:incomplete-intent-ir".into(),
+            change_kind: ChangeKind::Modified,
+            node_kind: "IntentDiagnostic".into(),
+            semantic_id: after.package.clone(),
+            source_path: None,
+            impact: all_evidence(),
+        });
+    }
+    if before.graph_id != after.graph_id
+        || before.package != after.package
+        || before.provenance.producer != after.provenance.producer
+        || before.provenance.path_policy != after.provenance.path_policy
+    {
+        unknown.insert("intent_ir:top_level_contract_change".into());
+        changes.push(SemanticChange {
+            id: "snapshot:modified:top-level-contract".into(),
+            change_kind: ChangeKind::Modified,
+            node_kind: "IntentSnapshot".into(),
+            semantic_id: after.package.clone(),
+            source_path: None,
+            impact: all_evidence(),
+        });
+    }
+    if changes.is_empty() && before != after {
+        unknown.insert("intent_ir:unmapped_snapshot_change".into());
+        changes.push(SemanticChange {
+            id: "snapshot:modified:unmapped".into(),
+            change_kind: ChangeKind::Modified,
+            node_kind: "IntentSnapshot".into(),
+            semantic_id: after.package.clone(),
+            source_path: None,
+            impact: all_evidence(),
+        });
+    }
+    changes.sort();
+    changes.dedup();
+
+    let mut by_kind: BTreeMap<EvidenceKind, BTreeSet<String>> = BTreeMap::new();
+    for change in &changes {
+        for kind in &change.impact {
+            by_kind
+                .entry(*kind)
+                .or_default()
+                .insert(change.semantic_id.clone());
+        }
+    }
+    let requirements = by_kind
+        .into_iter()
+        .map(|(kind, semantic_ids)| EvidenceRequirement {
+            id: format!("evidence-{}", kind_name(kind)),
+            kind,
+            reason: requirement_reason(kind).into(),
+            semantic_ids: semantic_ids.into_iter().collect(),
+        })
+        .collect();
+    let unknown_impacts: Vec<_> = unknown.into_iter().collect();
+    let conservative = !unknown_impacts.is_empty();
+    let mut plan = VerificationPlan {
+        schema_version: PLAN_SCHEMA_VERSION.into(),
+        plan_digest: String::new(),
+        bindings: PlanBindings {
+            before_graph_id: before.graph_id.clone(),
+            after_graph_id: after.graph_id.clone(),
+            before_snapshot_digest: snapshot_digest(before)?,
+            after_snapshot_digest: snapshot_digest(after)?,
+            source_head_sha: source_head_sha.into(),
+            delivered_head_sha: delivered_head_sha.into(),
+        },
+        changes,
+        requirements,
+        coverage: Coverage {
+            confidence: if conservative {
+                CoverageConfidence::Conservative
+            } else {
+                CoverageConfidence::Complete
+            },
+            complete: !conservative,
+            explanation: if conservative {
+                "Unknown semantic impact broadened the plan to every evidence family.".into()
+            } else {
+                "Every changed semantic surface mapped to an explicit evidence family.".into()
+            },
+            unknown_impacts,
+        },
+    };
+    let bytes = serde_json::to_vec(&plan).map_err(|error| error.to_string())?;
+    plan.plan_digest = sha256_digest(&bytes);
+    Ok(plan)
+}
+
+/// Plans verification only after the established semantic-diff contract is
+/// proven to describe the same node and edge changes as the supplied graphs.
+pub fn plan_verification_with_diff(
+    before: &IntentIrDocument,
+    after: &IntentIrDocument,
+    diff: &SemanticDiffContract,
+    source_head_sha: &str,
+    delivered_head_sha: &str,
+) -> Result<VerificationPlan, String> {
+    validate_semantic_diff(before, after, diff)?;
+    plan_verification(before, after, source_head_sha, delivered_head_sha)
+}
+
+/// Fails closed unless every planned item has exactly one valid, passing result
+/// bound to the plan and both exact commit heads.
+pub fn evaluate_verification(
+    plan: &VerificationPlan,
+    results: &VerificationResults,
+    exact_delivered_head_sha: &str,
+) -> VerificationVerdict {
+    let mut invalid = BTreeSet::new();
+    if validate_sha(exact_delivered_head_sha).is_err() {
+        invalid.insert("delivered_head_sha:invalid".into());
+    }
+    if !plan_shape_valid(plan) {
+        invalid.insert("plan:invalid".into());
+    }
+    if results.schema_version != RESULTS_SCHEMA_VERSION {
+        invalid.insert("results:schema_version".into());
+    }
+    if results.plan_digest != plan.plan_digest {
+        invalid.insert("results:plan_digest".into());
+    }
+    if results.source_head_sha != plan.bindings.source_head_sha {
+        invalid.insert("results:source_head_sha".into());
+    }
+    if results.delivered_head_sha != plan.bindings.delivered_head_sha
+        || results.delivered_head_sha != exact_delivered_head_sha
+    {
+        invalid.insert("results:delivered_head_sha".into());
+    }
+
+    let required: BTreeSet<_> = plan
+        .requirements
+        .iter()
+        .map(|item| item.id.clone())
+        .collect();
+    if required.len() != plan.requirements.len() {
+        invalid.insert("plan:duplicate_requirement".into());
+    }
+    let mut counts = BTreeMap::<String, usize>::new();
+    let mut failed = BTreeSet::new();
+    for result in &results.results {
+        *counts.entry(result.id.clone()).or_default() += 1;
+        if !required.contains(&result.id) {
+            invalid.insert(format!("{}:unexpected", result.id));
+        }
+        if result.plan_digest != plan.plan_digest {
+            invalid.insert(format!("{}:plan_digest", result.id));
+        }
+        if result.source_head_sha != plan.bindings.source_head_sha {
+            invalid.insert(format!("{}:source_head_sha", result.id));
+        }
+        if result.delivered_head_sha != plan.bindings.delivered_head_sha
+            || result.delivered_head_sha != exact_delivered_head_sha
+        {
+            invalid.insert(format!("{}:delivered_head_sha", result.id));
+        }
+        if !valid_digest(&result.evidence_digest) {
+            invalid.insert(format!("{}:evidence_digest", result.id));
+        }
+        if result.status == EvidenceStatus::Failed {
+            failed.insert(result.id.clone());
+        }
+    }
+    let missing: Vec<_> = required
+        .iter()
+        .filter(|id| !counts.contains_key(*id))
+        .cloned()
+        .collect();
+    let duplicate: Vec<_> = counts
+        .into_iter()
+        .filter_map(|(id, count)| (count != 1).then_some(id))
+        .collect();
+    let invalid: Vec<_> = invalid.into_iter().collect();
+    let failed: Vec<_> = failed.into_iter().collect();
+    let passed =
+        missing.is_empty() && duplicate.is_empty() && invalid.is_empty() && failed.is_empty();
+    VerificationVerdict {
+        schema_version: VERDICT_SCHEMA_VERSION.into(),
+        plan_digest: plan.plan_digest.clone(),
+        status: if passed {
+            VerdictStatus::Passed
+        } else {
+            VerdictStatus::Failed
+        },
+        source_head_sha: plan.bindings.source_head_sha.clone(),
+        delivered_head_sha: exact_delivered_head_sha.into(),
+        missing,
+        duplicate,
+        invalid,
+        failed,
+    }
+}
+
+fn validate_document(document: &IntentIrDocument, label: &str) -> Result<(), String> {
+    if document.schema_version != crate::intent_ir::SCHEMA_VERSION {
+        return Err(format!("{label} document uses unsupported schema_version"));
+    }
+    if !document.graph_id.starts_with("axiom://graph/") || !valid_graph_id(&document.graph_id) {
+        return Err(format!("{label} document has invalid graph_id"));
+    }
+    if !valid_graph_id(&document.package)
+        || document.provenance.producer.is_empty()
+        || document.provenance.path_policy != "package_relative"
+        || !valid_raw_digest(&document.provenance.source_digest)
+        || document.provenance.inputs.is_empty()
+        || document.nodes.is_empty()
+    {
+        return Err(format!("{label} document is not a complete Intent IR snapshot"));
+    }
+    let node_ids: BTreeSet<_> = document.nodes.iter().map(|node| node.id.as_str()).collect();
+    if node_ids.len() != document.nodes.len()
+        || document.nodes.iter().any(|node| !valid_graph_id(&node.id) || node.kind.is_empty())
+        || document.provenance.inputs.iter().any(|input| {
+            !valid_graph_id(&input.package)
+                || !valid_relative_path(&input.path)
+                || !valid_raw_digest(&input.digest)
+        })
+        || document.edges.iter().any(|edge| {
+            edge.kind.is_empty()
+                || !node_ids.contains(edge.from.as_str())
+                || !node_ids.contains(edge.to.as_str())
+        })
+    {
+        return Err(format!("{label} document has invalid semantic references or provenance"));
+    }
+    Ok(())
+}
+
+fn validate_semantic_diff(
+    before: &IntentIrDocument,
+    after: &IntentIrDocument,
+    diff: &SemanticDiffContract,
+) -> Result<(), String> {
+    if diff.schema_version != "axiom.semantic_diff.v0" || !diff.ok || diff.command != "semantic-diff" {
+        return Err("semantic diff uses an invalid contract envelope".into());
+    }
+    let before_nodes: BTreeMap<_, _> = before.nodes.iter().map(|node| (&node.id, node)).collect();
+    let after_nodes: BTreeMap<_, _> = after.nodes.iter().map(|node| (&node.id, node)).collect();
+    let mut expected = BTreeSet::new();
+    for id in before_nodes.keys().chain(after_nodes.keys()).copied().collect::<BTreeSet<_>>() {
+        match (before_nodes.get(id), after_nodes.get(id)) {
+            (None, Some(_)) => { expected.insert(("added".to_string(), (*id).clone())); }
+            (Some(_), None) => { expected.insert(("removed".to_string(), (*id).clone())); }
+            (Some(left), Some(right)) if left != right => {
+                expected.insert(("modified".to_string(), (*id).clone()));
+            }
+            _ => {}
+        }
+    }
+    let before_edges: BTreeMap<_, _> = before.edges.iter().map(|edge| (edge_key(edge), edge)).collect();
+    let after_edges: BTreeMap<_, _> = after.edges.iter().map(|edge| (edge_key(edge), edge)).collect();
+    for key in before_edges.keys().chain(after_edges.keys()).cloned().collect::<BTreeSet<_>>() {
+        let change = match (before_edges.get(&key), after_edges.get(&key)) {
+            (None, Some(_)) => Some("added"),
+            (Some(_), None) => Some("removed"),
+            (Some(left), Some(right)) if left != right => Some("modified"),
+            _ => None,
+        };
+        if let Some(change) = change {
+            expected.insert((change.into(), semantic_edge_id(&key.1, &key.0, &key.2)));
+        }
+    }
+    let observed: BTreeSet<_> = diff
+        .changes
+        .iter()
+        .map(|change| (change.change.clone(), change.node_id.clone()))
+        .collect();
+    let summary_total = diff.summary.breaking + diff.summary.additive + diff.summary.informational;
+    let record_invalid = diff.changes.iter().any(|change| {
+        if change.node_kind == "Edge" {
+            let Some(kind) = change.edge_kind.as_deref() else { return true; };
+            let Some(from) = change.edge_from.as_deref() else { return true; };
+            let Some(to) = change.edge_to.as_deref() else { return true; };
+            change.node_id != semantic_edge_id(kind, from, to)
+                || change.severity != "breaking"
+                || change.description != format!("{} {} edge {} -> {}", change.change, kind, from, to)
+        } else {
+            if change.edge_kind.is_some() || change.edge_from.is_some() || change.edge_to.is_some() {
+                return true;
+            }
+            let node = match change.change.as_str() {
+                "added" => after_nodes.get(&change.node_id).copied(),
+                "removed" | "modified" => before_nodes.get(&change.node_id).copied(),
+                _ => None,
+            };
+            node.is_none_or(|node| {
+                let severity = match change.change.as_str() {
+                    "added" => semantic_added_severity(&node.kind),
+                    "removed" => semantic_removed_severity(&node.kind),
+                    "modified" => semantic_modified_severity(&node.kind),
+                    _ => "invalid",
+                };
+                change.node_kind != node.kind
+                    || change.severity != severity
+                    || change.description
+                        != format!("{} {} {}", change.change, node.kind, node.name)
+            })
+        }
+    });
+    if observed.len() != diff.changes.len()
+        || observed != expected
+        || summary_total != diff.changes.len()
+        || diff.summary.breaking != diff.changes.iter().filter(|change| change.severity == "breaking").count()
+        || diff.summary.additive != diff.changes.iter().filter(|change| change.severity == "additive").count()
+        || diff.summary.informational != diff.changes.iter().filter(|change| change.severity == "informational").count()
+        || record_invalid
+        || diff.changes.iter().any(|change| {
+            !matches!(change.change.as_str(), "added" | "removed" | "modified")
+                || !matches!(change.severity.as_str(), "breaking" | "additive" | "informational")
+        })
+    {
+        return Err(format!(
+            "semantic diff does not exactly match the supplied Intent IR snapshots: expected={expected:?} observed={observed:?} summary_total={summary_total} changes={}",
+            diff.changes.len()
+        ));
+    }
+    Ok(())
+}
+
+fn semantic_added_severity(kind: &str) -> &'static str {
+    if matches!(kind, "Capability" | "Effect" | "RuntimeSurface") { "breaking" } else { "additive" }
+}
+
+fn semantic_removed_severity(kind: &str) -> &'static str {
+    if matches!(kind, "Module" | "Type" | "Function") { "informational" } else { "breaking" }
+}
+
+fn semantic_modified_severity(kind: &str) -> &'static str {
+    if matches!(kind, "Capability" | "Effect" | "Axiom" | "Artifact" | "RuntimeSurface") {
+        "breaking"
+    } else {
+        "informational"
+    }
+}
+
+fn semantic_edge_id(kind: &str, from: &str, to: &str) -> String {
+    format!(
+        "axiom://edge/{}/{}/{}",
+        kind,
+        from.trim_start_matches("axiom://"),
+        to.trim_start_matches("axiom://")
+    )
+}
+
+fn node_changes(
+    before: &IntentIrDocument,
+    after: &IntentIrDocument,
+    unknown: &mut BTreeSet<String>,
+) -> Vec<SemanticChange> {
+    let left: BTreeMap<_, _> = before.nodes.iter().map(|node| (&node.id, node)).collect();
+    let right: BTreeMap<_, _> = after.nodes.iter().map(|node| (&node.id, node)).collect();
+    left.keys()
+        .chain(right.keys())
+        .copied()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .filter_map(|id| match (left.get(id), right.get(id)) {
+            (None, Some(node)) => Some(node_change(ChangeKind::Added, node, unknown)),
+            (Some(node), None) => Some(node_change(ChangeKind::Removed, node, unknown)),
+            (Some(old), Some(new)) if old != new => Some(modified_node_change(old, new, unknown)),
+            _ => None,
+        })
+        .collect()
+}
+
+fn modified_node_change(
+    old: &IntentIrNode,
+    new: &IntentIrNode,
+    unknown: &mut BTreeSet<String>,
+) -> SemanticChange {
+    let mut impact = node_impact(old, unknown);
+    impact.extend(node_impact(new, unknown));
+    impact.sort();
+    impact.dedup();
+    SemanticChange {
+        id: format!("node:modified:{}", new.id),
+        change_kind: ChangeKind::Modified,
+        node_kind: new.kind.clone(),
+        semantic_id: new.id.clone(),
+        source_path: new
+            .source_span
+            .as_ref()
+            .or(old.source_span.as_ref())
+            .map(|span| span.path.clone()),
+        impact,
+    }
+}
+
+fn node_change(
+    change_kind: ChangeKind,
+    node: &IntentIrNode,
+    unknown: &mut BTreeSet<String>,
+) -> SemanticChange {
+    let impact = node_impact(node, unknown);
+    SemanticChange {
+        id: format!("node:{}:{}", change_name(change_kind), node.id),
+        change_kind,
+        node_kind: node.kind.clone(),
+        semantic_id: node.id.clone(),
+        source_path: node.source_span.as_ref().map(|span| span.path.clone()),
+        impact,
+    }
+}
+
+fn edge_changes(
+    before: &IntentIrDocument,
+    after: &IntentIrDocument,
+    unknown: &mut BTreeSet<String>,
+) -> Vec<SemanticChange> {
+    let left: BTreeMap<_, _> = before
+        .edges
+        .iter()
+        .map(|edge| (edge_key(edge), edge))
+        .collect();
+    let right: BTreeMap<_, _> = after
+        .edges
+        .iter()
+        .map(|edge| (edge_key(edge), edge))
+        .collect();
+    left.keys()
+        .chain(right.keys())
+        .cloned()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .filter_map(|key| match (left.get(&key), right.get(&key)) {
+            (None, Some(edge)) => Some(edge_change(ChangeKind::Added, edge, unknown)),
+            (Some(edge), None) => Some(edge_change(ChangeKind::Removed, edge, unknown)),
+            (Some(old), Some(new)) if old != new => {
+                Some(edge_change(ChangeKind::Modified, new, unknown))
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+fn source_changes(
+    before: &IntentIrDocument,
+    after: &IntentIrDocument,
+    unknown: &mut BTreeSet<String>,
+) -> Vec<SemanticChange> {
+    let left: BTreeMap<_, _> = before
+        .provenance
+        .inputs
+        .iter()
+        .map(|input| ((input.package.clone(), input.path.clone()), input))
+        .collect();
+    let right: BTreeMap<_, _> = after
+        .provenance
+        .inputs
+        .iter()
+        .map(|input| ((input.package.clone(), input.path.clone()), input))
+        .collect();
+    left.keys()
+        .chain(right.keys())
+        .cloned()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .filter_map(|(package, path)| {
+            let change_kind = match (
+                left.get(&(package.clone(), path.clone())),
+                right.get(&(package.clone(), path.clone())),
+            ) {
+                (None, Some(_)) => ChangeKind::Added,
+                (Some(_), None) => ChangeKind::Removed,
+                (Some(old), Some(new)) if old != new => ChangeKind::Modified,
+                _ => return None,
+            };
+            let mut impact = Vec::new();
+            for node in before.nodes.iter().chain(&after.nodes).filter(|node| {
+                node.source_span
+                    .as_ref()
+                    .is_some_and(|span| span.path == path)
+            }) {
+                impact.extend(node_impact(node, unknown));
+            }
+            if impact.is_empty() {
+                unknown.insert(format!("source_path:{path}"));
+                impact = all_evidence();
+            }
+            impact.sort();
+            impact.dedup();
+            let semantic_id = format!("source:{package}:{path}");
+            Some(SemanticChange {
+                id: format!("source:{}:{package}:{path}", change_name(change_kind)),
+                change_kind,
+                node_kind: "SourceInput".into(),
+                semantic_id,
+                source_path: Some(path),
+                impact,
+            })
+        })
+        .collect()
+}
+
+fn edge_change(
+    change_kind: ChangeKind,
+    edge: &IntentIrEdge,
+    unknown: &mut BTreeSet<String>,
+) -> SemanticChange {
+    let semantic_id = format!("{}|{}|{}", edge.from, edge.kind, edge.to);
+    SemanticChange {
+        id: format!("edge:{}:{semantic_id}", change_name(change_kind)),
+        change_kind,
+        node_kind: format!("Edge: {}", edge.kind),
+        semantic_id,
+        source_path: None,
+        impact: edge_impact(edge, unknown),
+    }
+}
+
+fn node_impact(node: &IntentIrNode, unknown: &mut BTreeSet<String>) -> Vec<EvidenceKind> {
+    use EvidenceKind::*;
+    let mut kinds = match node.kind.as_str() {
+        "Capability" | "Effect" | "RuntimeSurface" => vec![Positive, Denial, Regression, Security],
+        "Axiom" => vec![Positive, Denial, Regression],
+        "Dependency" => vec![Positive, Regression, Schema, Security],
+        "Artifact" => vec![Regression, Schema, Artifact],
+        "Package" => vec![Regression, Schema, Artifact],
+        "Type" => vec![Positive, Regression, Schema],
+        "Function" | "Constant" | "Global" | "Macro" => vec![Positive, Regression, Schema],
+        "Module" | "Evidence" => vec![Positive, Regression],
+        other => {
+            unknown.insert(format!("node_kind:{other}:{}", node.id));
+            all_evidence()
+        }
+    };
+    let metadata = serde_json::to_string(&node.metadata)
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    if contains_any(
+        &metadata,
+        &["performance", "latency", "throughput", "benchmark"],
+    ) {
+        kinds.push(Performance);
+    }
+    if contains_any(&metadata, &["target", "backend", "contract"]) {
+        kinds.extend([Schema, Artifact]);
+    }
+    kinds.sort();
+    kinds.dedup();
+    kinds
+}
+
+fn edge_impact(edge: &IntentIrEdge, unknown: &mut BTreeSet<String>) -> Vec<EvidenceKind> {
+    use EvidenceKind::*;
+    let mut kinds = match edge.kind.as_str() {
+        "allows_effect" | "requires" | "uses" | "preserves" => {
+            vec![Positive, Denial, Regression, Security]
+        }
+        "depends_on" => vec![Positive, Regression, Schema, Security],
+        "generated_from" => vec![Regression, Schema, Artifact],
+        "declares" => vec![Positive, Regression, Schema],
+        "verified_by" => vec![Positive, Regression],
+        other => {
+            unknown.insert(format!("edge_kind:{other}:{}->{}", edge.from, edge.to));
+            all_evidence()
+        }
+    };
+    let metadata = serde_json::to_string(&edge.metadata)
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    if contains_any(
+        &metadata,
+        &["performance", "latency", "throughput", "benchmark"],
+    ) {
+        kinds.push(Performance);
+    }
+    kinds.sort();
+    kinds.dedup();
+    kinds
+}
+
+fn all_evidence() -> Vec<EvidenceKind> {
+    use EvidenceKind::*;
+    vec![
+        Positive,
+        Denial,
+        Regression,
+        Schema,
+        Artifact,
+        Security,
+        Performance,
+    ]
+}
+
+fn edge_key(edge: &IntentIrEdge) -> (String, String, String) {
+    (edge.from.clone(), edge.kind.clone(), edge.to.clone())
+}
+
+fn snapshot_digest(document: &IntentIrDocument) -> Result<String, String> {
+    let mut canonical = document.clone();
+    canonical.nodes.sort_by(|a, b| a.id.cmp(&b.id));
+    canonical.edges.sort_by_key(edge_key);
+    canonical.diagnostics.sort();
+    canonical.provenance.inputs.sort();
+    serde_json::to_vec(&canonical)
+        .map(|bytes| sha256_digest(&bytes))
+        .map_err(|error| error.to_string())
+}
+
+fn validate_sha(sha: &str) -> Result<(), String> {
+    if sha.len() == 40
+        && sha
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+    {
+        Ok(())
+    } else {
+        Err("commit SHA must be exactly 40 lowercase hexadecimal characters".into())
+    }
+}
+
+fn valid_digest(digest: &str) -> bool {
+    digest.len() == 71
+        && digest.starts_with("sha256:")
+        && digest[7..]
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+}
+
+fn valid_raw_digest(digest: &str) -> bool {
+    digest.len() == 64
+        && digest
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+}
+
+fn plan_digest_matches(plan: &VerificationPlan) -> bool {
+    if !valid_digest(&plan.plan_digest) {
+        return false;
+    }
+    let mut canonical = plan.clone();
+    let expected = canonical.plan_digest.clone();
+    canonical.plan_digest.clear();
+    serde_json::to_vec(&canonical).is_ok_and(|bytes| sha256_digest(&bytes) == expected)
+}
+
+fn plan_shape_valid(plan: &VerificationPlan) -> bool {
+    let mut expected = BTreeMap::<EvidenceKind, BTreeSet<String>>::new();
+    for change in &plan.changes {
+        for kind in &change.impact {
+            expected.entry(*kind).or_default().insert(change.semantic_id.clone());
+        }
+    }
+    let observed: BTreeMap<_, _> = plan
+        .requirements
+        .iter()
+        .map(|requirement| (requirement.kind, requirement.semantic_ids.iter().cloned().collect()))
+        .collect();
+    if expected != observed {
+        return false;
+    }
+    if plan.schema_version != PLAN_SCHEMA_VERSION
+        || !plan_digest_matches(plan)
+        || validate_sha(&plan.bindings.source_head_sha).is_err()
+        || validate_sha(&plan.bindings.delivered_head_sha).is_err()
+        || !valid_digest(&plan.bindings.before_snapshot_digest)
+        || !valid_digest(&plan.bindings.after_snapshot_digest)
+        || !valid_graph_id(&plan.bindings.before_graph_id)
+        || !valid_graph_id(&plan.bindings.after_graph_id)
+        || (plan.changes.is_empty() != plan.requirements.is_empty())
+        || plan.coverage.explanation.is_empty()
+        || plan.changes.iter().any(|change| {
+            change.id.is_empty()
+                || change.node_kind.is_empty()
+                || change.semantic_id.is_empty()
+                || change.impact.is_empty()
+                || !all_unique(&change.impact)
+                || change
+                    .source_path
+                    .as_ref()
+                    .is_some_and(|path| !valid_relative_path(path))
+        })
+        || plan.requirements.iter().any(|requirement| {
+            requirement.id != format!("evidence-{}", kind_name(requirement.kind))
+                || requirement.reason.is_empty()
+                || requirement.semantic_ids.is_empty()
+                || !all_unique(&requirement.semantic_ids)
+        })
+        || !all_unique(&plan.coverage.unknown_impacts)
+    {
+        return false;
+    }
+    match plan.coverage.confidence {
+        CoverageConfidence::Complete => {
+            plan.coverage.complete && plan.coverage.unknown_impacts.is_empty()
+        }
+        CoverageConfidence::Conservative => {
+            !plan.coverage.complete
+                && !plan.coverage.unknown_impacts.is_empty()
+                && expected.keys().copied().collect::<BTreeSet<_>>()
+                    == all_evidence().into_iter().collect()
+        }
+    }
+}
+
+fn all_unique<T: Ord + Clone>(values: &[T]) -> bool {
+    values.iter().cloned().collect::<BTreeSet<_>>().len() == values.len()
+}
+
+fn valid_graph_id(id: &str) -> bool {
+    id.strip_prefix("axiom://").is_some_and(|rest| {
+        !rest.is_empty()
+            && rest
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || b"._~:/#@!$&'()*+,;=%-".contains(&byte))
+    })
+}
+
+fn valid_relative_path(value: &str) -> bool {
+    let path = Path::new(value);
+    !value.is_empty()
+        && !path.is_absolute()
+        && path
+            .components()
+            .all(|component| matches!(component, Component::Normal(_)))
+}
+
+fn contains_any(value: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|needle| value.contains(needle))
+}
+
+fn kind_name(kind: EvidenceKind) -> &'static str {
+    match kind {
+        EvidenceKind::Positive => "positive",
+        EvidenceKind::Denial => "denial",
+        EvidenceKind::Regression => "regression",
+        EvidenceKind::Schema => "schema",
+        EvidenceKind::Artifact => "artifact",
+        EvidenceKind::Security => "security",
+        EvidenceKind::Performance => "performance",
+    }
+}
+
+fn requirement_reason(kind: EvidenceKind) -> &'static str {
+    match kind {
+        EvidenceKind::Positive => "Changed behavior must succeed on its declared positive path.",
+        EvidenceKind::Denial => "Denied and invalid behavior must remain fail-closed.",
+        EvidenceKind::Regression => "Adjacent established behavior must remain unchanged.",
+        EvidenceKind::Schema => "Public and serialized contracts must remain schema-valid.",
+        EvidenceKind::Artifact => "Generated artifacts must match semantic inputs and provenance.",
+        EvidenceKind::Security => {
+            "Capability, dependency, and trust-boundary changes require security evidence."
+        }
+        EvidenceKind::Performance => {
+            "Performance-sensitive behavior requires fresh baseline evidence."
+        }
+    }
+}
+
+fn change_name(kind: ChangeKind) -> &'static str {
+    match kind {
+        ChangeKind::Added => "added",
+        ChangeKind::Removed => "removed",
+        ChangeKind::Modified => "modified",
+    }
+}
+
+// Local SHA-256 keeps this contract deterministic without introducing a new dependency.
+fn sha256_digest(input: &[u8]) -> String {
+    const K: [u32; 64] = [
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4,
+        0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe,
+        0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f,
+        0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+        0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc,
+        0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+        0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116,
+        0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7,
+        0xc67178f2,
+    ];
+    let mut message = input.to_vec();
+    let bit_len = (message.len() as u64).wrapping_mul(8);
+    message.push(0x80);
+    while message.len() % 64 != 56 {
+        message.push(0);
+    }
+    message.extend_from_slice(&bit_len.to_be_bytes());
+    let mut h = [
+        0x6a09e667u32,
+        0xbb67ae85,
+        0x3c6ef372,
+        0xa54ff53a,
+        0x510e527f,
+        0x9b05688c,
+        0x1f83d9ab,
+        0x5be0cd19,
+    ];
+    for block in message.chunks_exact(64) {
+        let mut w = [0u32; 64];
+        for (index, word) in block.chunks_exact(4).enumerate() {
+            w[index] = u32::from_be_bytes(word.try_into().expect("SHA word"));
+        }
+        for i in 16..64 {
+            let s0 = w[i - 15].rotate_right(7) ^ w[i - 15].rotate_right(18) ^ (w[i - 15] >> 3);
+            let s1 = w[i - 2].rotate_right(17) ^ w[i - 2].rotate_right(19) ^ (w[i - 2] >> 10);
+            w[i] = w[i - 16]
+                .wrapping_add(s0)
+                .wrapping_add(w[i - 7])
+                .wrapping_add(s1);
+        }
+        let [mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut hh] = h;
+        for i in 0..64 {
+            let s1 = e.rotate_right(6) ^ e.rotate_right(11) ^ e.rotate_right(25);
+            let ch = (e & f) ^ (!e & g);
+            let t1 = hh
+                .wrapping_add(s1)
+                .wrapping_add(ch)
+                .wrapping_add(K[i])
+                .wrapping_add(w[i]);
+            let s0 = a.rotate_right(2) ^ a.rotate_right(13) ^ a.rotate_right(22);
+            let maj = (a & b) ^ (a & c) ^ (b & c);
+            hh = g;
+            g = f;
+            f = e;
+            e = d.wrapping_add(t1);
+            d = c;
+            c = b;
+            b = a;
+            a = t1.wrapping_add(s0.wrapping_add(maj));
+        }
+        for (state, value) in h.iter_mut().zip([a, b, c, d, e, f, g, hh]) {
+            *state = state.wrapping_add(value);
+        }
+    }
+    format!(
+        "sha256:{}",
+        h.iter()
+            .map(|word| format!("{word:08x}"))
+            .collect::<String>()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::intent_ir::{IntentIrInput, IntentIrProvenance, SourceSpan};
+    use serde_json::{Map, json};
+
+    fn document(nodes: Vec<IntentIrNode>) -> IntentIrDocument {
+        let mut complete_nodes = vec![node("axiom://package/test", "Package")];
+        complete_nodes.extend(nodes);
+        IntentIrDocument {
+            schema_version: crate::intent_ir::SCHEMA_VERSION.into(),
+            graph_id: "axiom://graph/test".into(),
+            package: "axiom://package/test".into(),
+            provenance: IntentIrProvenance {
+                producer: "test".into(),
+                source_digest: "0".repeat(64),
+                path_policy: "package_relative".into(),
+                inputs: vec![IntentIrInput {
+                    package: "axiom://package/test".into(),
+                    path: "src/main.ax".into(),
+                    digest: "0".repeat(64),
+                }],
+            },
+            diagnostics: vec![],
+            nodes: complete_nodes,
+            edges: vec![],
+        }
+    }
+
+    fn node(id: &str, kind: &str) -> IntentIrNode {
+        let id = if id.starts_with("axiom://") {
+            id.to_owned()
+        } else {
+            format!("axiom://package/test/node/{id}")
+        };
+        IntentIrNode {
+            id: id.clone(),
+            kind: kind.into(),
+            name: id,
+            description: None,
+            source_span: Some(SourceSpan {
+                path: "src/main.ax".into(),
+                line: Some(1),
+                column: Some(1),
+            }),
+            metadata: Map::new(),
+        }
+    }
+
+    #[test]
+    fn capability_change_never_yields_empty_or_only_positive_plan() {
+        let before = document(vec![]);
+        let after = document(vec![node("axiom://capability/net", "Capability")]);
+        let plan = plan_verification(&before, &after, &"a".repeat(40), &"b".repeat(40)).unwrap();
+        let kinds: BTreeSet<_> = plan.requirements.iter().map(|item| item.kind).collect();
+        assert!(kinds.is_superset(&BTreeSet::from([
+            EvidenceKind::Positive,
+            EvidenceKind::Denial,
+            EvidenceKind::Regression,
+            EvidenceKind::Security,
+        ])));
+    }
+
+    #[test]
+    fn unknown_change_broadens_to_every_suite() {
+        let before = document(vec![]);
+        let after = document(vec![node("axiom://future/x", "FuturePrimitive")]);
+        let plan = plan_verification(&before, &after, &"a".repeat(40), &"b".repeat(40)).unwrap();
+        assert_eq!(plan.requirements.len(), 7);
+        assert_eq!(plan.coverage.confidence, CoverageConfidence::Conservative);
+        assert!(!plan.coverage.complete);
+    }
+
+    #[test]
+    fn ordering_does_not_change_snapshot_or_plan_digest() {
+        let a = node("axiom://function/a", "Function");
+        let b = node("axiom://function/b", "Function");
+        let before = document(vec![]);
+        let left = plan_verification(
+            &before,
+            &document(vec![a.clone(), b.clone()]),
+            &"a".repeat(40),
+            &"b".repeat(40),
+        )
+        .unwrap();
+        let right = plan_verification(
+            &before,
+            &document(vec![b, a]),
+            &"a".repeat(40),
+            &"b".repeat(40),
+        )
+        .unwrap();
+        assert_eq!(left, right);
+    }
+
+    #[test]
+    fn exact_one_fresh_passing_result_is_required() {
+        let plan = plan_verification(
+            &document(vec![]),
+            &document(vec![node("x", "Module")]),
+            &"a".repeat(40),
+            &"b".repeat(40),
+        )
+        .unwrap();
+        let results = VerificationResults {
+            schema_version: RESULTS_SCHEMA_VERSION.into(),
+            plan_digest: plan.plan_digest.clone(),
+            source_head_sha: "a".repeat(40),
+            delivered_head_sha: "b".repeat(40),
+            results: plan
+                .requirements
+                .iter()
+                .map(|requirement| EvidenceResult {
+                    id: requirement.id.clone(),
+                    plan_digest: plan.plan_digest.clone(),
+                    source_head_sha: "a".repeat(40),
+                    delivered_head_sha: "b".repeat(40),
+                    status: EvidenceStatus::Passed,
+                    evidence_digest: sha256_digest(requirement.id.as_bytes()),
+                })
+                .collect(),
+        };
+        assert_eq!(
+            evaluate_verification(&plan, &results, &"b".repeat(40)).status,
+            VerdictStatus::Passed
+        );
+        let mut duplicate = results.clone();
+        duplicate.results.push(duplicate.results[0].clone());
+        assert_eq!(
+            evaluate_verification(&plan, &duplicate, &"b".repeat(40)).status,
+            VerdictStatus::Failed
+        );
+        assert_eq!(
+            evaluate_verification(&plan, &results, &"c".repeat(40)).status,
+            VerdictStatus::Failed
+        );
+        let mut tampered = plan.clone();
+        tampered.requirements[0].reason.push_str(" altered");
+        assert_eq!(
+            evaluate_verification(&tampered, &results, &"b".repeat(40)).status,
+            VerdictStatus::Failed
+        );
+    }
+
+    #[test]
+    fn sha256_matches_known_vector() {
+        assert_eq!(
+            sha256_digest(b"abc"),
+            "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    #[test]
+    fn performance_metadata_adds_baseline_requirement() {
+        let mut changed = node("x", "Function");
+        changed
+            .metadata
+            .insert("performance_sensitive".into(), json!(true));
+        let plan = plan_verification(
+            &document(vec![]),
+            &document(vec![changed]),
+            &"a".repeat(40),
+            &"b".repeat(40),
+        )
+        .unwrap();
+        assert!(
+            plan.requirements
+                .iter()
+                .any(|item| item.kind == EvidenceKind::Performance)
+        );
+    }
+
+    #[test]
+    fn modified_nodes_preserve_removed_security_and_performance_impact() {
+        let mut old = node("x", "Capability");
+        old.metadata
+            .insert("performance_sensitive".into(), json!(true));
+        let new = node("x", "Function");
+        let plan = plan_verification(
+            &document(vec![old]),
+            &document(vec![new]),
+            &"a".repeat(40),
+            &"b".repeat(40),
+        )
+        .unwrap();
+        let kinds: BTreeSet<_> = plan.requirements.iter().map(|item| item.kind).collect();
+        assert!(kinds.contains(&EvidenceKind::Denial));
+        assert!(kinds.contains(&EvidenceKind::Security));
+        assert!(kinds.contains(&EvidenceKind::Performance));
+    }
+
+    #[test]
+    fn source_digest_change_maps_through_source_spans() {
+        let mut before = document(vec![node("x", "Function")]);
+        let mut after = before.clone();
+        before.provenance.inputs[0].digest = "1".repeat(64);
+        after.provenance.inputs[0].digest = "2".repeat(64);
+        let plan = plan_verification(&before, &after, &"a".repeat(40), &"b".repeat(40)).unwrap();
+        assert!(
+            plan.changes
+                .iter()
+                .any(|change| change.node_kind == "SourceInput")
+        );
+        assert!(
+            plan.requirements
+                .iter()
+                .any(|item| item.kind == EvidenceKind::Regression)
+        );
+    }
+
+    #[test]
+    fn mapped_and_top_level_unknown_change_still_broadens_every_suite() {
+        let before = document(vec![]);
+        let mut after = document(vec![node("added", "Function")]);
+        after.provenance.producer = "different-producer".into();
+        let plan = plan_verification(&before, &after, &"a".repeat(40), &"b".repeat(40)).unwrap();
+        assert_eq!(plan.coverage.confidence, CoverageConfidence::Conservative);
+        assert_eq!(
+            plan.requirements.iter().map(|item| item.kind).collect::<BTreeSet<_>>(),
+            all_evidence().into_iter().collect()
+        );
+    }
+
+    #[test]
+    fn conservative_plan_cannot_be_redigested_with_a_narrower_suite() {
+        let before = document(vec![]);
+        let after = document(vec![node("future", "FuturePrimitive")]);
+        let mut plan = plan_verification(&before, &after, &"a".repeat(40), &"b".repeat(40)).unwrap();
+        plan.changes[0].impact = vec![EvidenceKind::Positive];
+        plan.requirements.retain(|item| item.kind == EvidenceKind::Positive);
+        plan.plan_digest.clear();
+        plan.plan_digest = sha256_digest(&serde_json::to_vec(&plan).unwrap());
+        assert!(!plan_shape_valid(&plan));
+    }
+}

--- a/stage1/crates/axiomc/src/verification_planner_cli.rs
+++ b/stage1/crates/axiomc/src/verification_planner_cli.rs
@@ -1,0 +1,104 @@
+use axiomc::diagnostics::Diagnostic;
+use axiomc::intent_ir::IntentIrDocument;
+use axiomc::verification_planner::{SemanticDiffContract, VerificationResults, VerdictStatus, evaluate_verification, plan_verification_with_diff};
+use serde::de::DeserializeOwned;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+pub(super) fn run(
+    before: &Path,
+    after: &Path,
+    diff: &Path,
+    project: &Path,
+    source_head: &str,
+    delivered_head: &str,
+    results: Option<&Path>,
+    json: bool,
+) -> i32 {
+    match execute(before, after, diff, project, source_head, delivered_head, results) {
+        Ok(Output::Plan(plan)) => {
+            if json {
+                super::print_json("verification-plan", &plan)
+            } else {
+                println!(
+                    "requirements={} changes={} coverage={:?}",
+                    plan.requirements.len(), plan.changes.len(), plan.coverage.confidence
+                );
+                0
+            }
+        }
+        Ok(Output::Verdict(verdict)) => {
+            let status = if verdict.status == VerdictStatus::Passed { 0 } else { 1 };
+            if json {
+                super::print_json_with_status("verification-plan", &verdict, status)
+            } else {
+                println!("status={:?} missing={} invalid={} failed={}", verdict.status, verdict.missing.len(), verdict.invalid.len(), verdict.failed.len());
+                status
+            }
+        }
+        Err(error) => super::print_error("verification-plan", error, json),
+    }
+}
+
+enum Output {
+    Plan(axiomc::verification_planner::VerificationPlan),
+    Verdict(axiomc::verification_planner::VerificationVerdict),
+}
+
+fn execute(
+    before: &Path,
+    after: &Path,
+    diff: &Path,
+    project: &Path,
+    source_head: &str,
+    delivered_head: &str,
+    results: Option<&Path>,
+) -> Result<Output, Diagnostic> {
+    let before_binding = before.display().to_string();
+    let after_binding = after.display().to_string();
+    let before = load::<IntentIrDocument>(before, "before Intent IR")?;
+    let after = load::<IntentIrDocument>(after, "after Intent IR")?;
+    let diff = load::<SemanticDiffContract>(diff, "semantic diff")?;
+    if diff.old != before_binding || diff.new != after_binding {
+        return Err(Diagnostic::new(
+            "verification_plan",
+            "semantic diff input paths do not match the supplied Intent IR snapshots",
+        ));
+    }
+    let observed_head = current_head(project)?;
+    if delivered_head != observed_head {
+        return Err(Diagnostic::new(
+            "verification_plan",
+            format!("delivered head {delivered_head} is stale; current project HEAD is {observed_head}"),
+        ));
+    }
+    let plan = plan_verification_with_diff(&before, &after, &diff, source_head, &observed_head)
+        .map_err(|error| Diagnostic::new("verification_plan", error))?;
+    let Some(results_path) = results else { return Ok(Output::Plan(plan)); };
+    let results = load::<VerificationResults>(results_path, "verification results")?;
+    Ok(Output::Verdict(evaluate_verification(&plan, &results, &observed_head)))
+}
+
+fn current_head(project: &Path) -> Result<String, Diagnostic> {
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(project)
+        .output()
+        .map_err(|error| Diagnostic::new("verification_plan", format!("failed to inspect project HEAD: {error}")))?;
+    if !output.status.success() {
+        return Err(Diagnostic::new("verification_plan", "project HEAD is unavailable"));
+    }
+    String::from_utf8(output.stdout)
+        .map(|head| head.trim().to_owned())
+        .map_err(|error| Diagnostic::new("verification_plan", format!("project HEAD is not UTF-8: {error}")))
+}
+
+fn load<T: DeserializeOwned>(path: &Path, label: &str) -> Result<T, Diagnostic> {
+    let bytes = fs::read(path).map_err(|error| {
+        Diagnostic::new("verification_plan", format!("failed to read {label} {}: {error}", path.display()))
+    })?;
+    serde_json::from_slice(&bytes).map_err(|error| {
+        Diagnostic::new("verification_plan", format!("invalid {label} {}: {error}", path.display()))
+    })
+}

--- a/stage1/crates/axiomc/tests/agent_task_contract.rs
+++ b/stage1/crates/axiomc/tests/agent_task_contract.rs
@@ -1,0 +1,274 @@
+use jsonschema::Validator;
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("..")
+}
+
+fn fixture(name: &str) -> PathBuf {
+    repo_root()
+        .join("stage1/json-fixtures/task-contract")
+        .join(name)
+}
+
+fn project() -> PathBuf {
+    repo_root().join("stage1/examples/agent_native_authorize")
+}
+
+fn read_json(path: &Path) -> Value {
+    serde_json::from_str(&fs::read_to_string(path).expect("read JSON fixture"))
+        .expect("fixture is valid JSON")
+}
+
+fn run(spec: &Path) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .current_dir(project())
+        .args([
+            "task-contract",
+            spec.to_str().expect("UTF-8 spec path"),
+            "--project",
+            ".",
+            "--json",
+        ])
+        .output()
+        .expect("run task-contract")
+}
+
+fn successful_json(spec: &Path) -> (Output, Value) {
+    let output = run(spec);
+    assert!(
+        output.status.success(),
+        "task-contract failed; stdout: {}; stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let payload = serde_json::from_slice(&output.stdout).expect("task-contract emits JSON");
+    (output, payload)
+}
+
+fn schemas() -> (Value, Value) {
+    let root = repo_root().join("stage1/schemas");
+    (
+        read_json(&root.join("axiom-agent-task-spec-v0.schema.json")),
+        read_json(&root.join("axiom-agent-task-v0.schema.json")),
+    )
+}
+
+fn output_validator(input_schema: &Value, output_schema: &Value) -> Validator {
+    // Resolve the public output schema's local task-definition reference in
+    // memory. The checked-in schema keeps the URI reference so schema-aware
+    // tools can share one task definition instead of drifting copies.
+    let mut resolved = output_schema.clone();
+    resolved["$defs"] = input_schema["$defs"].clone();
+    resolved["properties"]["contract"]["allOf"][0] = input_schema["$defs"]["taskBase"].clone();
+    jsonschema::validator_for(&resolved).expect("compile resolved output schema")
+}
+
+fn assert_output_valid(validator: &Validator, payload: &Value) {
+    let errors: Vec<_> = validator
+        .iter_errors(payload)
+        .map(|error| error.to_string())
+        .collect();
+    assert!(errors.is_empty(), "output schema errors: {errors:#?}");
+}
+
+#[test]
+fn approved_feature_is_schema_valid_byte_deterministic_and_project_relative() {
+    let spec_path = fixture("feature-approved.spec.json");
+    let spec = read_json(&spec_path);
+    let (input_schema, output_schema) = schemas();
+    assert!(
+        jsonschema::validator_for(&input_schema)
+            .expect("compile input schema")
+            .is_valid(&spec)
+    );
+
+    let (first, payload) = successful_json(&spec_path);
+    let (second, _) = successful_json(&spec_path);
+    assert_eq!(
+        first.stdout, second.stdout,
+        "contract JSON must be byte stable"
+    );
+    assert_output_valid(&output_validator(&input_schema, &output_schema), &payload);
+    assert_eq!(payload["project"], ".");
+    assert_eq!(
+        payload["contract"]["scope"]["allowed_files"],
+        spec["task"]["scope"]["allowed_files"]
+    );
+
+    let rendered = String::from_utf8(first.stdout).expect("UTF-8 JSON");
+    assert!(!rendered.contains(repo_root().to_str().expect("UTF-8 repository path")));
+    for path in payload["contract"]["scope"]["allowed_files"]
+        .as_array()
+        .expect("allowed files")
+    {
+        let path = path.as_str().expect("path string");
+        assert!(!Path::new(path).is_absolute());
+        assert!(!path.split('/').any(|part| part == ".."));
+    }
+}
+
+#[test]
+fn approved_repair_preserves_repair_plan_boundaries_losslessly() {
+    let spec_path = fixture("repair-approved.spec.json");
+    let spec = read_json(&spec_path);
+    let (input_schema, output_schema) = schemas();
+    let (_, payload) = successful_json(&spec_path);
+
+    assert_output_valid(&output_validator(&input_schema, &output_schema), &payload);
+    assert_eq!(payload["contract"]["repair"], spec["task"]["repair"]);
+    assert_eq!(
+        payload["contract"]["repair"]["allowed_files"],
+        payload["contract"]["scope"]["allowed_files"]
+    );
+    let repair_evidence = payload["contract"]["repair"]["required_evidence"]
+        .as_array()
+        .expect("repair evidence");
+    let contract_evidence = payload["contract"]["required_evidence"]
+        .as_array()
+        .expect("contract evidence");
+    for kind in repair_evidence {
+        assert!(contract_evidence.iter().any(|entry| entry["kind"] == *kind));
+    }
+}
+
+#[test]
+fn schema_matches_runtime_optional_defaults_and_typed_repair_diagnostics() {
+    let mut spec = read_json(&fixture("repair-approved.spec.json"));
+    spec["task"]["scope"]["denied_files"] = serde_json::json!([]);
+    spec["task"]["repair"]["diagnostics"] = serde_json::json!([{
+        "kind": "capability",
+        "message": "capability is denied",
+        "repair": {"action": "remove_capability_use"}
+    }]);
+
+    let (input_schema, output_schema) = schemas();
+    let validator = jsonschema::validator_for(&input_schema).expect("compile input schema");
+    assert!(validator.is_valid(&spec));
+
+    let temp = tempfile::tempdir().expect("temp directory");
+    let path = temp.path().join("defaults-and-typed-diagnostic.json");
+    fs::write(&path, serde_json::to_vec_pretty(&spec).unwrap()).expect("write task spec");
+    let (_, payload) = successful_json(&path);
+    assert_output_valid(&output_validator(&input_schema, &output_schema), &payload);
+    assert!(payload["contract"]["scope"].get("denied_files").is_none());
+    assert_eq!(
+        payload["contract"]["repair"]["diagnostics"],
+        serde_json::json!([{
+            "kind": "capability",
+            "message": "capability is denied",
+            "repair": {"action": "remove_capability_use"}
+        }])
+    );
+}
+
+#[test]
+fn invalid_authority_scope_conflicts_actions_budgets_dependencies_and_delivery_fail_closed() {
+    let baseline = read_json(&fixture("feature-approved.spec.json"));
+    let cases: Vec<(&str, Box<dyn Fn(&mut Value)>)> = vec![
+        (
+            "ambiguous authority",
+            Box::new(|v| v["task"]["authority"]["issue"] = 1420.into()),
+        ),
+        (
+            "unapproved authority",
+            Box::new(|v| v["task"]["authority"]["approval"]["state"] = "pending".into()),
+        ),
+        (
+            "missing scope",
+            Box::new(|v| {
+                v["task"]
+                    .as_object_mut()
+                    .unwrap()
+                    .remove("scope")
+                    .map(drop)
+                    .unwrap()
+            }),
+        ),
+        (
+            "conflicting commands",
+            Box::new(|v| {
+                let required = v["task"]["commands"]["required"].clone();
+                v["task"]["commands"]["forbidden"] = required;
+            }),
+        ),
+        (
+            "conflicting capabilities",
+            Box::new(|v| {
+                let required = v["task"]["capabilities"]["required"].clone();
+                v["task"]["capabilities"]["forbidden"] = required;
+            }),
+        ),
+        (
+            "conflicting acceptance",
+            Box::new(|v| {
+                let mut opposite = v["task"]["acceptance_criteria"][0].clone();
+                opposite["expected"] = "fail".into();
+                v["task"]["acceptance_criteria"]
+                    .as_array_mut()
+                    .unwrap()
+                    .push(opposite);
+            }),
+        ),
+        (
+            "irreversible action",
+            Box::new(|v| v["task"]["delivery_permissions"]["irreversible_actions"] = true.into()),
+        ),
+        (
+            "unknown terminal condition field",
+            Box::new(|v| v["task"]["terminal_conditions"]["unexpected"] = true.into()),
+        ),
+        (
+            "scope widening",
+            Box::new(|v| {
+                v["task"]["scope"]["allowed_files"] = serde_json::json!(["../outside.ax"])
+            }),
+        ),
+        (
+            "invalid budget",
+            Box::new(|v| v["task"]["budgets"]["time_seconds"] = 0.into()),
+        ),
+        (
+            "dangling dependency",
+            Box::new(
+                |v| v["task"]["dependencies"] = serde_json::json!([{"id":"a","status":"satisfied","depends_on":["missing"],"precondition":"ready"}]),
+            ),
+        ),
+        (
+            "dependency cycle",
+            Box::new(|v| {
+                v["task"]["dependencies"] = serde_json::json!([
+                    {"id":"a","status":"satisfied","depends_on":["b"],"precondition":"b ready"},
+                    {"id":"b","status":"satisfied","depends_on":["a"],"precondition":"a ready"}
+                ])
+            }),
+        ),
+        (
+            "delivery above class",
+            Box::new(|v| {
+                v["task"]["autonomy"]["class"] = 1.into();
+                v["task"]["delivery_permissions"]["push"] = true.into();
+            }),
+        ),
+    ];
+
+    let temp = tempfile::tempdir().expect("temp directory");
+    for (name, mutate) in cases {
+        let mut invalid = baseline.clone();
+        mutate(&mut invalid);
+        let path = temp.path().join(format!("{}.json", name.replace(' ', "-")));
+        fs::write(&path, serde_json::to_vec_pretty(&invalid).unwrap()).expect("write invalid spec");
+        let output = run(&path);
+        assert!(!output.status.success(), "{name} must fail closed");
+        assert!(
+            !String::from_utf8_lossy(&output.stdout).contains("\"contract\""),
+            "{name} emitted an executable contract"
+        );
+    }
+}

--- a/stage1/crates/axiomc/tests/intent_ir_contract.rs
+++ b/stage1/crates/axiomc/tests/intent_ir_contract.rs
@@ -47,6 +47,15 @@ fn agent_native_authorize_emits_schema_valid_byte_stable_intent_ir() {
             "agent-native fixture must emit {required}"
         );
     }
+    assert!(
+        document["nodes"]
+            .as_array()
+            .expect("Intent IR nodes")
+            .iter()
+            .filter(|node| matches!(node["kind"].as_str(), Some("Function" | "Type")))
+            .all(|node| node["metadata"]["visibility"].is_string()),
+        "function and type nodes must expose visibility for public-contract impact mapping"
+    );
 
     assert_contract_traceability(&document);
     assert_axiom_neutral(&first.stdout);

--- a/stage1/crates/axiomc/tests/intent_ir_contract.rs
+++ b/stage1/crates/axiomc/tests/intent_ir_contract.rs
@@ -1,0 +1,287 @@
+use serde_json::Value;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+#[test]
+fn agent_native_authorize_emits_schema_valid_byte_stable_intent_ir() {
+    let project = example("agent_native_authorize");
+    let first = inspect_intent(&project);
+    let second = inspect_intent(&project);
+    let relative = inspect_intent_from(
+        project.parent().expect("examples directory"),
+        Path::new("agent_native_authorize"),
+    );
+
+    assert_eq!(
+        first.stdout, second.stdout,
+        "unchanged Intent IR must be byte-stable"
+    );
+    assert_eq!(
+        first.stdout, relative.stdout,
+        "absolute and relative invocation paths must emit identical Intent IR"
+    );
+    let document = parse_and_validate(&first);
+    assert_eq!(document["schema_version"], "axiom.intent_ir.v0");
+
+    let kinds = document["nodes"]
+        .as_array()
+        .expect("Intent IR nodes")
+        .iter()
+        .filter_map(|node| node["kind"].as_str())
+        .collect::<BTreeSet<_>>();
+    for required in [
+        "Package",
+        "Module",
+        "Function",
+        "Capability",
+        "Effect",
+        "Axiom",
+        "Evidence",
+        "Artifact",
+        "RuntimeSurface",
+    ] {
+        assert!(
+            kinds.contains(required),
+            "agent-native fixture must emit {required}"
+        );
+    }
+
+    assert_contract_traceability(&document);
+    assert_axiom_neutral(&first.stdout);
+}
+
+#[test]
+fn workspace_emits_multiple_packages_and_dependency_nodes() {
+    let project = example("workspace");
+    let first = inspect_intent(&project);
+    let second = inspect_intent(&project);
+
+    assert_eq!(
+        first.stdout, second.stdout,
+        "workspace Intent IR must be byte-stable"
+    );
+    let document = parse_and_validate(&first);
+    let nodes = document["nodes"].as_array().expect("Intent IR nodes");
+    assert!(
+        nodes
+            .iter()
+            .filter(|node| node["kind"] == "Package")
+            .count()
+            >= 3,
+        "workspace root and both member packages must be represented"
+    );
+    assert!(
+        nodes.iter().any(|node| node["kind"] == "Dependency"),
+        "workspace dependency must be represented"
+    );
+    assert_contract_traceability(&document);
+    assert_axiom_neutral(&first.stdout);
+}
+
+#[test]
+fn incomplete_module_is_an_explicit_traceable_diagnostic() {
+    let temp = tempfile::tempdir().expect("temporary package");
+    fs::create_dir(temp.path().join("src")).expect("create source directory");
+    fs::write(
+        temp.path().join("axiom.toml"),
+        r#"[package]
+name = "incomplete-intent"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+"#,
+    )
+    .expect("write manifest");
+    fs::write(temp.path().join("src/main.ax"), "fn incomplete( {\n")
+        .expect("write malformed source");
+
+    let output = inspect_intent(temp.path());
+    let document = parse_and_validate(&output);
+    let diagnostics = document["diagnostics"]
+        .as_array()
+        .expect("Intent IR diagnostics");
+    assert!(
+        diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic["code"] == "intent_ir_incomplete_module"),
+        "malformed input must be reported instead of silently omitted"
+    );
+    assert_contract_traceability(&document);
+}
+
+#[test]
+fn semantic_consumers_reuse_canonical_node_ids() {
+    let project = example("agent_native_authorize");
+    let intent = parse_and_validate(&inspect_intent(&project));
+    let node_ids = intent["nodes"]
+        .as_array()
+        .expect("Intent IR nodes")
+        .iter()
+        .map(|node| node["id"].as_str().expect("node id"))
+        .collect::<BTreeSet<_>>();
+
+    let repair = run_json(&["repair-plan", project.to_str().unwrap(), "--json"]);
+    for task in repair["tasks"].as_array().expect("repair tasks") {
+        assert!(node_ids.contains(task["target_node"].as_str().expect("repair target")));
+    }
+    let evidence = run_json(&["evidence", project.to_str().unwrap(), "--json"]);
+    for item in evidence["evidence"].as_array().expect("evidence items") {
+        assert!(node_ids.contains(item["target"].as_str().expect("evidence target")));
+    }
+    let artifacts = run_json(&["inspect", "artifacts", project.to_str().unwrap(), "--json"]);
+    for artifact in artifacts["artifacts"].as_array().expect("artifacts") {
+        for source in artifact["generated_from"].as_array().expect("artifact sources") {
+            assert!(node_ids.contains(source.as_str().expect("artifact source")));
+        }
+    }
+    let verification = run_json(&["verify", project.to_str().unwrap(), "--json"]);
+    for axiom in verification["axioms"].as_array().expect("verified axioms") {
+        assert!(node_ids.contains(axiom["id"].as_str().expect("axiom id")));
+        for backing in axiom["backing_evidence"].as_array().expect("backing evidence") {
+            assert!(node_ids.contains(backing["semantic_node"].as_str().expect("evidence node")));
+        }
+    }
+}
+
+#[test]
+fn declared_types_and_decisions_emit_their_node_families() {
+    for (fixture, expected_kind) in [("structs", "Type"), ("decision_records", "Decision")] {
+        let document = parse_and_validate(&inspect_intent(&example(fixture)));
+        assert!(
+            document["nodes"]
+                .as_array()
+                .expect("Intent IR nodes")
+                .iter()
+                .any(|node| node["kind"] == expected_kind),
+            "{fixture} must emit {expected_kind}"
+        );
+        assert_contract_traceability(&document);
+    }
+}
+
+fn assert_contract_traceability(document: &Value) {
+    let nodes = document["nodes"].as_array().expect("Intent IR nodes");
+    let node_ids = nodes
+        .iter()
+        .map(|node| node["id"].as_str().expect("node id"))
+        .collect::<BTreeSet<_>>();
+    let edges = document["edges"].as_array().expect("Intent IR edges");
+
+    for edge in edges {
+        let from = edge["from"].as_str().expect("edge from");
+        let to = edge["to"].as_str().expect("edge to");
+        assert!(node_ids.contains(from), "edge source {from} must exist");
+        assert!(node_ids.contains(to), "edge target {to} must exist");
+    }
+    for artifact in nodes.iter().filter(|node| node["kind"] == "Artifact") {
+        let id = artifact["id"].as_str().expect("artifact id");
+        assert!(
+            edges.iter().any(|edge| {
+                edge["from"] == id
+                    && matches!(edge["kind"].as_str(), Some("generated_from" | "implements"))
+            }),
+            "artifact {id} must trace to a semantic node"
+        );
+    }
+    for diagnostic in document["diagnostics"]
+        .as_array()
+        .expect("Intent IR diagnostics")
+    {
+        for node_id in diagnostic["node_ids"]
+            .as_array()
+            .expect("diagnostic node ids")
+        {
+            let node_id = node_id.as_str().expect("diagnostic node id");
+            assert!(
+                node_ids.contains(node_id),
+                "diagnostic target {node_id} must exist"
+            );
+        }
+    }
+
+    for input in document["provenance"]["inputs"]
+        .as_array()
+        .expect("provenance inputs")
+    {
+        let path = input["path"].as_str().expect("provenance path");
+        assert!(
+            !Path::new(path).is_absolute(),
+            "provenance path must be relative: {path}"
+        );
+        assert!(!path.split('/').any(|segment| segment == ".."));
+        let package = input["package"].as_str().expect("provenance package");
+        assert!(
+            node_ids.contains(package),
+            "provenance package {package} must exist"
+        );
+    }
+}
+
+fn assert_axiom_neutral(bytes: &[u8]) {
+    let serialized = String::from_utf8_lossy(bytes).to_ascii_lowercase();
+    for forbidden in ["cargo", "cranelift", "rustc", "rust::", ".rs\""] {
+        assert!(
+            !serialized.contains(forbidden),
+            "Intent IR captured host term {forbidden}"
+        );
+    }
+}
+
+fn parse_and_validate(output: &Output) -> Value {
+    assert!(
+        output.status.success(),
+        "inspect intent failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.stderr.is_empty(), "JSON mode must not write stderr");
+    let document: Value = serde_json::from_slice(&output.stdout).expect("parse Intent IR JSON");
+    let schema: Value =
+        serde_json::from_str(&fs::read_to_string(schema_path()).expect("read Intent IR schema"))
+            .expect("parse Intent IR schema");
+    let validator = jsonschema::validator_for(&schema).expect("compile Intent IR schema");
+    if let Err(error) = validator.validate(&document) {
+        panic!("Intent IR failed schema validation: {error}");
+    }
+    document
+}
+
+fn inspect_intent(project: &Path) -> Output {
+    inspect_intent_from(Path::new(env!("CARGO_MANIFEST_DIR")), project)
+}
+
+fn inspect_intent_from(cwd: &Path, project: &Path) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .current_dir(cwd)
+        .args([
+            "inspect",
+            "intent",
+            project.to_str().expect("UTF-8 fixture path"),
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc inspect intent")
+}
+
+fn run_json(args: &[&str]) -> Value {
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args(args)
+        .output()
+        .expect("run semantic consumer");
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!("consumer JSON failed: {error}: {}", String::from_utf8_lossy(&output.stderr))
+    })
+}
+
+fn example(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../examples")
+        .join(name)
+}
+
+fn schema_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../schemas/axiom-intent-ir-v0.schema.json")
+}

--- a/stage1/crates/axiomc/tests/schema_metadata.rs
+++ b/stage1/crates/axiomc/tests/schema_metadata.rs
@@ -16,6 +16,74 @@ fn compile_validator(schema: &Value) -> Validator {
 }
 
 #[test]
+fn agent_task_v0_schemas_are_strict_and_current() {
+    let input: Value = serde_json::from_str(
+        &fs::read_to_string(schema_dir().join("axiom-agent-task-spec-v0.schema.json"))
+            .expect("read agent task specification schema"),
+    )
+    .expect("agent task specification schema is valid JSON");
+    let output: Value = serde_json::from_str(
+        &fs::read_to_string(schema_dir().join("axiom-agent-task-v0.schema.json"))
+            .expect("read agent task contract schema"),
+    )
+    .expect("agent task contract schema is valid JSON");
+
+    assert_eq!(
+        input["$id"],
+        "https://axiom.omt.global/schemas/axiom-agent-task-spec-v0.schema.json"
+    );
+    assert_eq!(
+        output["$id"],
+        "https://axiom.omt.global/schemas/axiom-agent-task-v0.schema.json"
+    );
+    assert_eq!(
+        input["properties"]["schema_version"]["const"],
+        "axiom.agent_task.spec.v0"
+    );
+    assert_eq!(
+        output["properties"]["schema_version"]["const"],
+        "axiom.agent_task.v0"
+    );
+    assert_eq!(output["properties"]["command"]["const"], "task-contract");
+    assert_eq!(input["additionalProperties"], false);
+    assert_eq!(input["properties"]["task"]["unevaluatedProperties"], false);
+    assert_eq!(input["$defs"]["authority"]["additionalProperties"], false);
+    assert_eq!(
+        input["$defs"]["terminalConditions"]["additionalProperties"],
+        false
+    );
+    assert_eq!(
+        input["$defs"]["deliveryPermissions"]["properties"]["approve_own_pull_request"]["const"],
+        false
+    );
+    assert_eq!(
+        input["$defs"]["deliveryPermissions"]["properties"]["force_push"]["const"],
+        false
+    );
+
+    // Compile the self-contained input schema here. The output contract reuses
+    // the exact task definition by URI so consumers cannot validate against a
+    // looser parallel definition.
+    let validator = compile_validator(&input);
+    let fixture_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("json-fixtures")
+        .join("task-contract")
+        .join("feature-approved.spec.json");
+    let mut fixture: Value = serde_json::from_str(
+        &fs::read_to_string(fixture_path).expect("read approved task fixture"),
+    )
+    .expect("approved task fixture is valid JSON");
+    assert!(validator.is_valid(&fixture));
+    fixture["task"]["terminal_conditions"]["unexpected"] = serde_json::json!(true);
+    assert!(
+        !validator.is_valid(&fixture),
+        "terminal conditions must reject undeclared fields"
+    );
+}
+
+#[test]
 fn intent_ir_v0_requires_deterministic_provenance_and_traceable_diagnostics() {
     let schema: Value = serde_json::from_str(
         &fs::read_to_string(schema_dir().join("axiom-intent-ir-v0.schema.json"))

--- a/stage1/crates/axiomc/tests/schema_metadata.rs
+++ b/stage1/crates/axiomc/tests/schema_metadata.rs
@@ -16,6 +16,43 @@ fn compile_validator(schema: &Value) -> Validator {
 }
 
 #[test]
+fn intent_ir_v0_requires_deterministic_provenance_and_traceable_diagnostics() {
+    let schema: Value = serde_json::from_str(
+        &fs::read_to_string(schema_dir().join("axiom-intent-ir-v0.schema.json"))
+            .expect("read Intent IR schema"),
+    )
+    .expect("Intent IR schema is valid JSON");
+    let validator = compile_validator(&schema);
+    let fixture_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("examples")
+        .join("intent_ir_smoke")
+        .join("intent-ir.json");
+    let fixture: Value = serde_json::from_str(
+        &fs::read_to_string(fixture_path).expect("read Intent IR smoke fixture"),
+    )
+    .expect("Intent IR smoke fixture is valid JSON");
+
+    assert!(validator.is_valid(&fixture));
+    assert_eq!(fixture["provenance"]["path_policy"], "package_relative");
+    assert_eq!(fixture["diagnostics"], serde_json::json!([]));
+
+    let mut absolute_input = fixture.clone();
+    absolute_input["provenance"]["inputs"][0]["path"] = serde_json::json!("/checkout/src/main.ax");
+    assert!(!validator.is_valid(&absolute_input));
+
+    let mut untraceable_diagnostic = fixture;
+    untraceable_diagnostic["diagnostics"] = serde_json::json!([{
+        "code": "intent_ir_incomplete_module",
+        "severity": "warning",
+        "message": "module could not be represented",
+        "node_ids": []
+    }]);
+    assert!(!validator.is_valid(&untraceable_diagnostic));
+}
+
+#[test]
 fn formatter_edit_v1_schema_metadata_is_current() {
     let schema: Value = serde_json::from_str(
         &fs::read_to_string(schema_dir().join("axiom-format-edit-v1.schema.json"))

--- a/stage1/crates/axiomc/tests/schema_metadata.rs
+++ b/stage1/crates/axiomc/tests/schema_metadata.rs
@@ -16,6 +16,159 @@ fn compile_validator(schema: &Value) -> Validator {
 }
 
 #[test]
+fn verification_planner_v0_schemas_are_strict_and_exact_head_bound() {
+    let plan: Value = serde_json::from_str(
+        &fs::read_to_string(schema_dir().join("axiom-verification-plan-v0.schema.json"))
+            .expect("read verification plan schema"),
+    )
+    .expect("verification plan schema is valid JSON");
+    let results: Value = serde_json::from_str(
+        &fs::read_to_string(schema_dir().join("axiom-verification-results-v0.schema.json"))
+            .expect("read verification results schema"),
+    )
+    .expect("verification results schema is valid JSON");
+    let verdict: Value = serde_json::from_str(
+        &fs::read_to_string(schema_dir().join("axiom-verification-verdict-v0.schema.json"))
+            .expect("read verification verdict schema"),
+    )
+    .expect("verification verdict schema is valid JSON");
+
+    for (schema, id, version) in [
+        (
+            &plan,
+            "https://axiom.omt.global/schemas/axiom-verification-plan-v0.schema.json",
+            "axiom.verification_plan.v0",
+        ),
+        (
+            &results,
+            "https://axiom.omt.global/schemas/axiom-verification-results-v0.schema.json",
+            "axiom.verification_results.v0",
+        ),
+        (
+            &verdict,
+            "https://axiom.omt.global/schemas/axiom-verification-verdict-v0.schema.json",
+            "axiom.verification_verdict.v0",
+        ),
+    ] {
+        assert_eq!(schema["$id"], id);
+        assert_eq!(schema["properties"]["schema_version"]["const"], version);
+        assert_eq!(schema["additionalProperties"], false);
+        compile_validator(schema);
+    }
+
+    let digest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    let source_sha = "1111111111111111111111111111111111111111";
+    let delivered_sha = "2222222222222222222222222222222222222222";
+    let requirement_id = "evidence-positive";
+    let mut result = serde_json::json!({
+        "schema_version": "axiom.verification_results.v0",
+        "plan_digest": digest,
+        "source_head_sha": source_sha,
+        "delivered_head_sha": delivered_sha,
+        "results": [{
+            "id": requirement_id,
+            "plan_digest": digest,
+            "source_head_sha": source_sha,
+            "delivered_head_sha": delivered_sha,
+            "status": "passed",
+            "evidence_digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        }]
+    });
+    let result_validator = compile_validator(&results);
+    result_validator
+        .validate(&result)
+        .expect("exact-head result validates");
+    result["results"][0]["delivered_head_sha"] =
+        serde_json::json!("not-a-commit");
+    assert!(
+        !result_validator.is_valid(&result),
+        "result evidence cannot omit a valid delivered head binding"
+    );
+
+    assert_eq!(plan["allOf"][0]["then"]["properties"]["requirements"]["minItems"], 1);
+    assert_eq!(plan["$defs"]["requirement"]["additionalProperties"], false);
+    assert_eq!(results["$defs"]["result"]["additionalProperties"], false);
+    assert_eq!(verdict["$defs"]["ids"]["uniqueItems"], true);
+    let impossible_success = serde_json::json!({
+        "schema_version": "axiom.verification_verdict.v0",
+        "plan_digest": digest,
+        "status": "passed",
+        "source_head_sha": source_sha,
+        "delivered_head_sha": delivered_sha,
+        "missing": [requirement_id],
+        "duplicate": [],
+        "invalid": [],
+        "failed": []
+    });
+    assert!(
+        !compile_validator(&verdict).is_valid(&impossible_success),
+        "a passing verdict cannot retain evidence blockers"
+    );
+}
+
+#[test]
+fn execution_transaction_v0_schemas_are_strict_and_secret_safe() {
+    let policy: Value = serde_json::from_str(
+        &fs::read_to_string(schema_dir().join("axiom-execution-policy-v0.schema.json"))
+            .expect("read execution policy schema"),
+    )
+    .expect("execution policy schema is valid JSON");
+    let audit: Value = serde_json::from_str(
+        &fs::read_to_string(schema_dir().join("axiom-execution-transaction-v0.schema.json"))
+            .expect("read execution transaction schema"),
+    )
+    .expect("execution transaction schema is valid JSON");
+
+    assert_eq!(
+        policy["$id"],
+        "https://axiom.omt.global/schemas/axiom-execution-policy-v0.schema.json"
+    );
+    assert_eq!(
+        audit["$id"],
+        "https://axiom.omt.global/schemas/axiom-execution-transaction-v0.schema.json"
+    );
+    assert_eq!(policy["additionalProperties"], false);
+    assert_eq!(audit["additionalProperties"], false);
+    assert_eq!(policy["properties"]["paths"]["properties"]["follow_symlinks"]["const"], false);
+    assert_eq!(policy["properties"]["commands"]["properties"]["allow_shell"]["const"], false);
+    assert_eq!(policy["properties"]["delivery"]["properties"]["allow_force_push"]["const"], false);
+    assert_eq!(policy["properties"]["delivery"]["properties"]["allow_self_approval"]["const"], false);
+    assert_eq!(policy["properties"]["delivery"]["properties"]["allow_policy_edits"]["const"], false);
+
+    let fixture_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("json-fixtures")
+        .join("execution-transaction");
+    let mut policy_fixture: Value = serde_json::from_str(
+        &fs::read_to_string(fixture_root.join("strict-local.policy.json"))
+            .expect("read execution policy fixture"),
+    )
+    .expect("execution policy fixture is valid JSON");
+    let audit_fixture: Value = serde_json::from_str(
+        &fs::read_to_string(fixture_root.join("interrupted.audit.json"))
+            .expect("read execution audit fixture"),
+    )
+    .expect("execution audit fixture is valid JSON");
+    compile_validator(&policy)
+        .validate(&policy_fixture)
+        .expect("execution policy fixture matches schema");
+    compile_validator(&audit)
+        .validate(&audit_fixture)
+        .expect("execution audit fixture matches schema");
+
+    let serialized = serde_json::to_string(&audit_fixture).expect("serialize audit fixture");
+    assert!(!serialized.contains("secret_value"));
+    assert!(!serialized.contains(&["github_", "pat_"].concat()));
+
+    policy_fixture["network"]["allowed_hosts"] = serde_json::json!(["example.com"]);
+    assert!(
+        !compile_validator(&policy).is_valid(&policy_fixture),
+        "deny-mode network policy cannot retain an allowlist"
+    );
+}
+
+#[test]
 fn agent_task_v0_schemas_are_strict_and_current() {
     let input: Value = serde_json::from_str(
         &fs::read_to_string(schema_dir().join("axiom-agent-task-spec-v0.schema.json"))

--- a/stage1/crates/axiomc/tests/transactional_workspace.rs
+++ b/stage1/crates/axiomc/tests/transactional_workspace.rs
@@ -1,0 +1,204 @@
+use axiomc::transactional_workspace::{TransactionPhase, TransactionalWorkspace, WorkspacePolicy};
+use jsonschema::Validator;
+use serde_json::Value;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+fn git(root: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .expect("run git fixture command");
+    assert!(
+        output.status.success(),
+        "git {:?}: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).expect("git output is UTF-8")
+}
+
+fn fixture() -> (TempDir, PathBuf, String) {
+    let root = TempDir::new().expect("create fixture root");
+    let source = root.path().join("source");
+    fs::create_dir(&source).expect("create source repository");
+    git(&source, &["init", "-q"]);
+    git(&source, &["config", "user.email", "test@example.invalid"]);
+    git(&source, &["config", "user.name", "Test"]);
+    fs::write(source.join("allowed.txt"), b"original").expect("write allowed fixture");
+    fs::write(source.join("owned.txt"), b"committed").expect("write owned fixture");
+    git(&source, &["add", "allowed.txt", "owned.txt"]);
+    git(
+        &source,
+        &["-c", "commit.gpgsign=false", "commit", "-qm", "base"],
+    );
+    let sha = git(&source, &["rev-parse", "HEAD"]).trim().to_owned();
+    (root, source, sha)
+}
+
+fn policy() -> WorkspacePolicy {
+    WorkspacePolicy {
+        allowed_read_paths: BTreeSet::from(["allowed.txt".to_owned()]),
+        allowed_write_paths: BTreeSet::from(["allowed.txt".to_owned(), "created.txt".to_owned()]),
+        allowed_commands: BTreeSet::from(["git".to_owned()]),
+        allow_network: false,
+        verified_sandbox: true,
+    }
+}
+
+fn audit_validator() -> Validator {
+    let schema_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("schemas")
+        .join("axiom-execution-transaction-v0.schema.json");
+    let schema: Value = serde_json::from_str(
+        &fs::read_to_string(schema_path).expect("read execution transaction schema"),
+    )
+    .expect("parse execution transaction schema");
+    jsonschema::validator_for(&schema).expect("compile execution transaction schema")
+}
+
+#[test]
+fn denial_matrix_fails_closed_without_out_of_scope_mutation() {
+    let (root, source, sha) = fixture();
+    let worktree = root.path().join("transaction");
+    let mut transaction =
+        TransactionalWorkspace::create(&source, &worktree, &sha, policy()).expect("create");
+
+    assert!(transaction.write("../owned.txt", b"traversal").is_err());
+    assert!(transaction.write("owned.txt", b"scope escape").is_err());
+    assert!(transaction.delete("owned.txt").is_err());
+    assert!(transaction.rename("owned.txt", "created.txt").is_err());
+    #[cfg(unix)]
+    assert!(transaction.chmod("owned.txt", 0o777).is_err());
+    assert!(transaction
+        .write(".codex/policies/policy.json", b"bypass")
+        .is_err());
+    assert!(transaction.authorize_external("sh", false).is_err());
+    assert!(transaction.authorize_external("git", true).is_err());
+    for operation in [
+        "push_protected_branch",
+        "force_push",
+        "self_approve",
+        "edit_policy",
+    ] {
+        assert!(TransactionalWorkspace::reject_delivery_operation(operation).is_err());
+    }
+    assert_eq!(fs::read(source.join("owned.txt")).unwrap(), b"committed");
+}
+
+#[cfg(unix)]
+#[test]
+fn symlink_escape_is_denied_for_write_rename_delete_and_chmod() {
+    use std::os::unix::fs::symlink;
+
+    let (root, source, sha) = fixture();
+    let worktree = root.path().join("transaction");
+    let mut scoped = policy();
+    for path in ["escape/owned.txt", "escape/renamed.txt"] {
+        scoped.allowed_write_paths.insert(path.to_owned());
+    }
+    let mut transaction =
+        TransactionalWorkspace::create(&source, &worktree, &sha, scoped).expect("create");
+    symlink(&source, worktree.join("escape")).expect("create escape symlink");
+
+    assert!(transaction.write("escape/owned.txt", b"escape").is_err());
+    assert!(transaction.delete("escape/owned.txt").is_err());
+    assert!(transaction
+        .rename("escape/owned.txt", "escape/renamed.txt")
+        .is_err());
+    assert!(transaction.chmod("escape/owned.txt", 0o600).is_err());
+    assert_eq!(fs::read(source.join("owned.txt")).unwrap(), b"committed");
+}
+
+#[test]
+fn failed_transaction_rolls_back_and_preserves_dirty_source_index() {
+    let (root, source, sha) = fixture();
+    fs::write(source.join("owned.txt"), b"user dirty").expect("make source dirty");
+    fs::write(source.join("untracked.txt"), b"user untracked").expect("make untracked file");
+    let before = git(&source, &["status", "--porcelain=v1"]);
+    let worktree = root.path().join("transaction");
+    let mut transaction =
+        TransactionalWorkspace::create(&source, &worktree, &sha, policy()).expect("create");
+    transaction.write("allowed.txt", b"changed").expect("write");
+    transaction
+        .write("created.txt", b"created")
+        .expect("create");
+    transaction.abort().expect("rollback");
+
+    assert_eq!(transaction.state().phase, TransactionPhase::Aborted);
+    assert_eq!(fs::read(worktree.join("allowed.txt")).unwrap(), b"original");
+    assert!(!worktree.join("created.txt").exists());
+    assert_eq!(fs::read(source.join("owned.txt")).unwrap(), b"user dirty");
+    assert_eq!(
+        fs::read(source.join("untracked.txt")).unwrap(),
+        b"user untracked"
+    );
+    assert_eq!(git(&source, &["status", "--porcelain=v1"]), before);
+    assert!(git(&source, &["diff", "--cached", "--name-only"]).is_empty());
+}
+
+#[test]
+fn interrupted_transaction_is_inspectable_and_can_resume_or_roll_back() {
+    let (root, source, sha) = fixture();
+    let worktree = root.path().join("transaction");
+    let mut transaction =
+        TransactionalWorkspace::create(&source, &worktree, &sha, policy()).expect("create");
+    transaction.read("allowed.txt").expect("record read");
+    transaction.write("created.txt", b"partial").expect("write");
+    assert!(transaction.authorize_external("git", false).is_err());
+    transaction
+        .record_artifact("allowed.txt")
+        .expect("record artifact");
+    transaction.mark_interrupted().expect("interrupt");
+    drop(transaction);
+
+    let mut recovered = TransactionalWorkspace::recover(&worktree).expect("inspect journal");
+    assert_eq!(recovered.state().phase, TransactionPhase::Interrupted);
+    let first = recovered.deterministic_audit_json().expect("first audit");
+    assert_eq!(
+        first,
+        recovered.deterministic_audit_json().expect("second audit")
+    );
+    let audit: Value = serde_json::from_str(&first).expect("audit is JSON");
+    audit_validator()
+        .validate(&audit)
+        .expect("runtime audit matches the execution transaction schema");
+    assert_eq!(audit["base_sha"], sha);
+    assert_eq!(audit["status"], "interrupted");
+    assert!(audit["recovery"]["resumable"].as_bool().unwrap());
+    for field in ["checkpoints", "reads", "writes", "commands", "artifacts"] {
+        assert!(
+            !audit[field]
+                .as_array()
+                .expect("audit collection")
+                .is_empty(),
+            "runtime audit records {field}"
+        );
+    }
+    assert_eq!(
+        audit["reads"][0]["digest"],
+        "sha256:0682c5f2076f099c34cfdd15a9e063849ed437a49677e6fcc5b4198c76575be5"
+    );
+    assert_eq!(
+        audit["writes"][0]["after_digest"],
+        "sha256:9834a14ab9bcaa0f6a8da71073617eac8f004e596a3fa11d807b84631b825d9d"
+    );
+    assert_eq!(audit["commands"][0]["outcome"], "denied");
+    assert_eq!(audit["commands"][0]["exit_code"], 126);
+    assert_eq!(
+        audit["artifacts"][0]["digest"],
+        "sha256:0682c5f2076f099c34cfdd15a9e063849ed437a49677e6fcc5b4198c76575be5"
+    );
+    assert!(!first.contains("secret_value"));
+    recovered.resume().expect("resume");
+    recovered.mark_interrupted().expect("interrupt again");
+    recovered.abort().expect("rollback recovered transaction");
+    assert!(!worktree.join("created.txt").exists());
+    assert_eq!(fs::read(source.join("owned.txt")).unwrap(), b"committed");
+}

--- a/stage1/crates/axiomc/tests/verification_planner_contract.rs
+++ b/stage1/crates/axiomc/tests/verification_planner_contract.rs
@@ -1,0 +1,273 @@
+use axiomc::intent_ir::IntentIrDocument;
+use axiomc::verification_planner::{
+    CoverageConfidence, EvidenceKind, EvidenceResult, EvidenceStatus, RESULTS_SCHEMA_VERSION,
+    VerificationResults, VerdictStatus, evaluate_verification, plan_verification,
+};
+use jsonschema::Validator;
+use serde::Deserialize;
+use serde_json::Value;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const SOURCE_SHA: &str = "1111111111111111111111111111111111111111";
+const DELIVERED_SHA: &str = "2222222222222222222222222222222222222222";
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FixtureCase {
+    scenario: String,
+    before: IntentIrDocument,
+    after: IntentIrDocument,
+    expected_evidence: Vec<EvidenceKind>,
+}
+
+fn repository_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("..")
+}
+
+fn fixture_root() -> PathBuf {
+    repository_root()
+        .join("stage1")
+        .join("json-fixtures")
+        .join("verification-planner")
+}
+
+fn schema(name: &str) -> (Value, Validator) {
+    let value: Value = serde_json::from_str(
+        &fs::read_to_string(
+            repository_root()
+                .join("stage1")
+                .join("schemas")
+                .join(name),
+        )
+        .expect("read verification schema"),
+    )
+    .expect("verification schema is JSON");
+    let validator = jsonschema::validator_for(&value).expect("compile verification schema");
+    (value, validator)
+}
+
+fn read_case(name: &str) -> FixtureCase {
+    serde_json::from_str(
+        &fs::read_to_string(fixture_root().join(name)).expect("read planner fixture"),
+    )
+    .expect("planner fixture follows the typed corpus contract")
+}
+
+fn passing_results(plan: &axiomc::verification_planner::VerificationPlan) -> VerificationResults {
+    VerificationResults {
+        schema_version: RESULTS_SCHEMA_VERSION.into(),
+        plan_digest: plan.plan_digest.clone(),
+        source_head_sha: plan.bindings.source_head_sha.clone(),
+        delivered_head_sha: plan.bindings.delivered_head_sha.clone(),
+        results: plan
+            .requirements
+            .iter()
+            .map(|requirement| EvidenceResult {
+                id: requirement.id.clone(),
+                plan_digest: plan.plan_digest.clone(),
+                source_head_sha: plan.bindings.source_head_sha.clone(),
+                delivered_head_sha: plan.bindings.delivered_head_sha.clone(),
+                status: EvidenceStatus::Passed,
+                evidence_digest: format!("sha256:{:064x}", requirement.id.len()),
+            })
+            .collect(),
+    }
+}
+
+#[test]
+fn semantic_fixture_corpus_maps_every_required_impact_deterministically() {
+    let (_, plan_validator) = schema("axiom-verification-plan-v0.schema.json");
+    for name in [
+        "localized.json",
+        "public-api.json",
+        "capability-escalation.json",
+        "schema-change.json",
+        "artifact-drift.json",
+        "performance-sensitive.json",
+        "unknown-impact.json",
+    ] {
+        let case = read_case(name);
+        let first = plan_verification(&case.before, &case.after, SOURCE_SHA, DELIVERED_SHA)
+            .unwrap_or_else(|error| panic!("{} plans: {error}", case.scenario));
+        let second = plan_verification(&case.before, &case.after, SOURCE_SHA, DELIVERED_SHA)
+            .expect("same fixture plans twice");
+        assert_eq!(first, second, "{} plan is deterministic", case.scenario);
+        assert_eq!(
+            serde_json::to_vec(&first).expect("serialize first plan"),
+            serde_json::to_vec(&second).expect("serialize second plan"),
+            "{} plan is byte stable",
+            case.scenario
+        );
+        plan_validator
+            .validate(&serde_json::to_value(&first).expect("plan value"))
+            .unwrap_or_else(|error| panic!("{} plan matches schema: {error}", case.scenario));
+        let actual: BTreeSet<_> = first.requirements.iter().map(|item| item.kind).collect();
+        let expected: BTreeSet<_> = case.expected_evidence.into_iter().collect();
+        assert_eq!(actual, expected, "{} evidence mapping", case.scenario);
+        assert!(
+            !first.requirements.is_empty(),
+            "{} semantic change cannot yield an empty plan",
+            case.scenario
+        );
+    }
+}
+
+#[test]
+fn planner_quality_baseline_is_complete_for_the_1417_dimensions() {
+    let scenarios = [
+        "localized.json", "public-api.json", "capability-escalation.json", "schema-change.json",
+        "artifact-drift.json", "performance-sensitive.json", "unknown-impact.json",
+    ];
+    let measured = scenarios
+        .iter()
+        .filter(|name| {
+            let case = read_case(name);
+            plan_verification(&case.before, &case.after, SOURCE_SHA, DELIVERED_SHA)
+                .is_ok_and(|plan| !plan.requirements.is_empty())
+        })
+        .count();
+    let baseline: Value = serde_json::from_str(
+        &fs::read_to_string(fixture_root().join("quality-baseline.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(baseline["schema_version"], "axiom.verification_planner_quality.v0");
+    assert_eq!(baseline["governing_suite"], 1417);
+    assert_eq!(baseline["scenario_count"], scenarios.len());
+    assert_eq!(baseline["mapped_scenarios"], measured);
+    assert_eq!(baseline["empty_changed_plans"], 0);
+    assert_eq!(baseline["unknown_scenarios_broadened"], 1);
+}
+
+#[test]
+fn unknown_impact_broadens_to_every_suite_and_is_explained() {
+    let case = read_case("unknown-impact.json");
+    let plan = plan_verification(&case.before, &case.after, SOURCE_SHA, DELIVERED_SHA)
+        .expect("unknown impact plans conservatively");
+    assert_eq!(plan.requirements.len(), 7);
+    assert_eq!(plan.coverage.confidence, CoverageConfidence::Conservative);
+    assert!(!plan.coverage.complete);
+    assert!(!plan.coverage.unknown_impacts.is_empty());
+    assert!(plan.coverage.explanation.contains("broadened"));
+}
+
+#[test]
+fn terminal_success_requires_schema_valid_fresh_exactly_once_evidence() {
+    let case = read_case("capability-escalation.json");
+    let plan = plan_verification(&case.before, &case.after, SOURCE_SHA, DELIVERED_SHA)
+        .expect("capability plan");
+    let (_, results_validator) = schema("axiom-verification-results-v0.schema.json");
+    let (_, verdict_validator) = schema("axiom-verification-verdict-v0.schema.json");
+    let results = passing_results(&plan);
+    results_validator
+        .validate(&serde_json::to_value(&results).expect("results value"))
+        .expect("fresh result envelope matches schema");
+    let verdict = evaluate_verification(&plan, &results, DELIVERED_SHA);
+    assert_eq!(verdict.status, VerdictStatus::Passed);
+    verdict_validator
+        .validate(&serde_json::to_value(&verdict).expect("verdict value"))
+        .expect("passing verdict matches schema");
+
+    let mut missing = results.clone();
+    let missing_id = missing.results.pop().expect("planned result").id;
+    let verdict = evaluate_verification(&plan, &missing, DELIVERED_SHA);
+    assert_eq!(verdict.status, VerdictStatus::Failed);
+    assert_eq!(verdict.missing, vec![missing_id]);
+    verdict_validator
+        .validate(&serde_json::to_value(&verdict).expect("failed verdict value"))
+        .expect("failed verdict identifies at least one blocker");
+
+    let mut duplicate = results.clone();
+    duplicate.results.push(duplicate.results[0].clone());
+    assert!(
+        !results_validator.is_valid(&serde_json::to_value(&duplicate).expect("duplicate value")),
+        "duplicate result envelope is not schema-valid"
+    );
+    let verdict = evaluate_verification(&plan, &duplicate, DELIVERED_SHA);
+    assert_eq!(verdict.status, VerdictStatus::Failed);
+    assert!(!verdict.duplicate.is_empty());
+
+    let mut stale = results.clone();
+    stale.results[0].delivered_head_sha = "3333333333333333333333333333333333333333".into();
+    let verdict = evaluate_verification(&plan, &stale, DELIVERED_SHA);
+    assert_eq!(verdict.status, VerdictStatus::Failed);
+    assert!(verdict.invalid.iter().any(|item| item.contains("delivered_head_sha")));
+
+    let mut failed = results;
+    failed.results[0].status = EvidenceStatus::Failed;
+    let verdict = evaluate_verification(&plan, &failed, DELIVERED_SHA);
+    assert_eq!(verdict.status, VerdictStatus::Failed);
+    assert_eq!(verdict.failed, vec![failed.results[0].id.clone()]);
+}
+
+#[test]
+fn malformed_or_stale_inputs_fail_closed() {
+    let case = read_case("localized.json");
+    assert!(
+        plan_verification(&case.before, &case.after, "short", DELIVERED_SHA).is_err(),
+        "abbreviated source commits are not exact-head bindings"
+    );
+    let mut unsupported = case.after;
+    unsupported.schema_version = "axiom.intent_ir.v999".into();
+    assert!(
+        plan_verification(&case.before, &unsupported, SOURCE_SHA, DELIVERED_SHA).is_err(),
+        "unsupported semantic input does not produce a plan"
+    );
+}
+
+#[test]
+fn cli_emits_the_versioned_plan_and_evaluates_exact_head_results() {
+    let case = read_case("capability-escalation.json");
+    let temp = tempfile::tempdir().expect("temporary CLI fixture");
+    let before = temp.path().join("before.json");
+    let after = temp.path().join("after.json");
+    fs::write(&before, serde_json::to_vec(&case.before).unwrap()).unwrap();
+    fs::write(&after, serde_json::to_vec(&case.after).unwrap()).unwrap();
+    let diff = temp.path().join("diff.json");
+    let diff_output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args(["semantic-diff", before.to_str().unwrap(), after.to_str().unwrap(), "--json"])
+        .output()
+        .expect("run semantic diff CLI");
+    assert!(diff_output.status.success());
+    fs::write(&diff, diff_output.stdout).unwrap();
+    let delivered_head = git_head(&repository_root());
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "verification-plan", before.to_str().unwrap(), after.to_str().unwrap(),
+            "--diff", diff.to_str().unwrap(), "--project", repository_root().to_str().unwrap(),
+            "--source-head", SOURCE_SHA, "--delivered-head", &delivered_head, "--json",
+        ])
+        .output()
+        .expect("run verification-plan CLI");
+    assert!(output.status.success(), "stdout={} stderr={}", String::from_utf8_lossy(&output.stdout), String::from_utf8_lossy(&output.stderr));
+    let plan: axiomc::verification_planner::VerificationPlan =
+        serde_json::from_slice(&output.stdout).expect("CLI plan JSON");
+    assert_eq!(plan.schema_version, "axiom.verification_plan.v0");
+
+    let results_path = temp.path().join("results.json");
+    fs::write(&results_path, serde_json::to_vec(&passing_results(&plan)).unwrap()).unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "verification-plan", before.to_str().unwrap(), after.to_str().unwrap(),
+            "--diff", diff.to_str().unwrap(), "--project", repository_root().to_str().unwrap(),
+            "--source-head", SOURCE_SHA, "--delivered-head", &delivered_head,
+            "--results", results_path.to_str().unwrap(), "--json",
+        ])
+        .output()
+        .expect("run verification evaluator CLI");
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+    let verdict: Value = serde_json::from_slice(&output.stdout).expect("CLI verdict JSON");
+    assert_eq!(verdict["schema_version"], "axiom.verification_verdict.v0");
+    assert_eq!(verdict["status"], "passed");
+}
+
+fn git_head(project: &Path) -> String {
+    let output = Command::new("git").args(["rev-parse", "HEAD"]).current_dir(project).output().unwrap();
+    assert!(output.status.success());
+    String::from_utf8(output.stdout).unwrap().trim().into()
+}

--- a/stage1/examples/agent_native_authorize/fixtures/README.md
+++ b/stage1/examples/agent_native_authorize/fixtures/README.md
@@ -6,6 +6,19 @@ These fixtures show the #787 flow:
 intent -> semantic graph -> effects -> evidence -> artifacts
 ```
 
+Intent IR is emitted live from this package rather than maintained as a second
+hand-written snapshot. The contract test runs the command twice, validates both
+the schema and byte stability, and verifies that every artifact and diagnostic
+traces to an emitted semantic node:
+
+```bash
+axiomc inspect intent stage1/examples/agent_native_authorize --json
+```
+
+The same test uses `stage1/examples/workspace` as the multi-package fixture so
+the contract covers workspace member packages and dependencies without cloning
+source into a fixture-only tree.
+
 Regenerate them with:
 
 ```bash

--- a/stage1/examples/intent_ir_smoke/intent-ir.json
+++ b/stage1/examples/intent_ir_smoke/intent-ir.json
@@ -2,6 +2,18 @@
   "schema_version": "axiom.intent_ir.v0",
   "graph_id": "axiom://graph/intent-ir-smoke",
   "package": "axiom://package/intent-ir-smoke",
+  "provenance": {
+    "producer": "axiomc",
+    "source_digest": "397c418b30fe5ee633bed7c513c8e55d498d120472229ca74b26b7a2518c32f1",
+    "path_policy": "package_relative",
+    "inputs": [
+      {
+        "package": "axiom://package/intent-ir-smoke",
+        "path": "src/main.ax",
+        "digest": "397c418b30fe5ee633bed7c513c8e55d498d120472229ca74b26b7a2518c32f1"
+      }
+    ]
+  },
   "nodes": [
     {
       "id": "axiom://package/intent-ir-smoke",
@@ -99,5 +111,6 @@
       "kind": "generated_from",
       "to": "axiom://package/intent-ir-smoke/function/greet"
     }
-  ]
+  ],
+  "diagnostics": []
 }

--- a/stage1/json-fixtures/execution-transaction/interrupted.audit.json
+++ b/stage1/json-fixtures/execution-transaction/interrupted.audit.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "axiom.execution_transaction.v0",
+  "transaction_id": "txn-0123456789abcdef",
+  "task_contract_digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+  "policy_digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+  "base_sha": "2222222222222222222222222222222222222222",
+  "branch": "codex/fixture-transaction",
+  "status": "interrupted",
+  "checkpoints": [
+    { "sequence": 0, "kind": "initial", "tree_sha": "2222222222222222222222222222222222222222", "created_before": "transaction" },
+    { "sequence": 2, "kind": "before_write", "tree_sha": "2222222222222222222222222222222222222222", "created_before": "write:docs/transactional-workspace-v0.md" }
+  ],
+  "reads": [
+    { "sequence": 1, "path": "docs/agent-task-contract-v0.md", "digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444" }
+  ],
+  "writes": [
+    { "sequence": 3, "operation": "create", "path": "docs/transactional-workspace-v0.md", "before_digest": null, "after_digest": "sha256:5555555555555555555555555555555555555555555555555555555555555555" }
+  ],
+  "commands": [
+    { "sequence": 4, "argv": ["git", "diff", "--check"], "capabilities": ["filesystem.read"], "network_hosts": [], "secret_refs": [], "outcome": "executed", "exit_code": 0, "stdout_digest": "sha256:6666666666666666666666666666666666666666666666666666666666666666", "stderr_digest": "sha256:6666666666666666666666666666666666666666666666666666666666666666" }
+  ],
+  "artifacts": [
+    { "sequence": 5, "path": "docs/transactional-workspace-v0.md", "digest": "sha256:5555555555555555555555555555555555555555555555555555555555555555", "kind": "documentation" }
+  ],
+  "rollback": { "attempted": false, "result": "not_required", "restored_checkpoint": null, "source_checkout_untouched": true },
+  "recovery": { "resumable": true, "rollback_safe": true, "next_sequence": 6, "journal_digest": "sha256:7777777777777777777777777777777777777777777777777777777777777777" }
+}

--- a/stage1/json-fixtures/execution-transaction/strict-local.policy.json
+++ b/stage1/json-fixtures/execution-transaction/strict-local.policy.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": "axiom.execution_policy.v0",
+  "task_contract_digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+  "base_sha": "2222222222222222222222222222222222222222",
+  "workspace": {
+    "branch": "codex/fixture-transaction",
+    "source_checkout": "/source/axiomlang",
+    "isolated_worktree": "/transactions/txn-0123456789abcdef",
+    "require_clean_isolated_worktree": true
+  },
+  "paths": {
+    "read": ["docs/agent-task-contract-v0.md", "stage1/crates/axiomc/src"],
+    "write": ["docs/transactional-workspace-v0.md"],
+    "protected": [".codex/policies", ".github/workflows"],
+    "allow_chmod": false,
+    "allow_rename": false,
+    "allow_delete": false,
+    "follow_symlinks": false
+  },
+  "commands": {
+    "allowed": ["git diff --check"],
+    "forbidden": ["git push", "gh pr review", "rm"],
+    "allow_shell": false
+  },
+  "capabilities": {
+    "allowed": ["filesystem.read", "filesystem.write"],
+    "forbidden": ["credentials.read", "network", "policy.write"]
+  },
+  "network": { "mode": "deny", "allowed_hosts": [] },
+  "secrets": { "allow_environment": false, "brokered_refs": ["secret-ref:github/app-token"] },
+  "delivery": {
+    "allow_external_mutations": false,
+    "allow_protected_branch_push": false,
+    "allow_force_push": false,
+    "allow_self_approval": false,
+    "allow_policy_edits": false
+  }
+}

--- a/stage1/json-fixtures/task-contract/feature-approved.spec.json
+++ b/stage1/json-fixtures/task-contract/feature-approved.spec.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": "axiom.agent_task.spec.v0",
+  "task": {
+    "id": "issue-1419-feature",
+    "kind": "feature",
+    "objective": "Add a deterministic task-contract inspection command.",
+    "authority": {
+      "governing_issue": "https://github.com/OMT-Global/axiomlang/issues/1419",
+      "repository": "OMT-Global/axiomlang",
+      "issue": 1419,
+      "source_revision": "1111111111111111111111111111111111111111",
+      "source_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+      "approval": {
+        "state": "approved",
+        "approver": "pheidon",
+        "method": "maintainer_review"
+      }
+    },
+    "scope": {
+      "affected_semantic_nodes": ["axiom://package/agent-native-authorize"],
+      "allowed_files": ["src/authorize.ax", "src/main.ax"]
+    },
+    "capabilities": {
+      "required": ["filesystem.read"],
+      "forbidden": ["credentials.read", "network.connect"]
+    },
+    "commands": {
+      "required": ["cargo test --manifest-path stage1/Cargo.toml -p axiomc --test agent_task_contract"],
+      "forbidden": ["git push --force"]
+    },
+    "acceptance_criteria": [
+      { "id": "schema-valid", "requirement": "The feature fixture validates against the public output schema.", "expected": "pass", "evidence_refs": ["schema"] },
+      { "id": "byte-deterministic", "requirement": "Identical inputs produce byte-identical output.", "expected": "pass", "evidence_refs": ["cli-test"] }
+    ],
+    "required_evidence": [
+      { "id": "cli-test", "kind": "unit_test", "command": "cargo test --manifest-path stage1/Cargo.toml -p axiomc --test agent_task_contract" },
+      { "id": "schema", "kind": "schema_validation", "command": "cargo test --manifest-path stage1/Cargo.toml -p axiomc --test schema_metadata" }
+    ],
+    "dependencies": [
+      { "id": "intent-ir-v0", "status": "satisfied", "depends_on": [], "precondition": "Canonical Intent IR emission is available." }
+    ],
+    "autonomy": { "class": 2, "risk": "high" },
+    "budgets": { "time_seconds": 3600, "tokens": 200000, "retries": 2, "cost_usd_micros": 5000000 },
+    "rollback": {
+      "checkpoint": "exact approved base revision",
+      "commands": ["git diff --check"]
+    },
+    "terminal_conditions": {
+      "success": ["All required evidence passes on the exact head."],
+      "stop": ["A requested file is outside allowed_files."],
+      "escalation": ["Authority or acceptance criteria become ambiguous."]
+    },
+    "delivery_permissions": {
+      "commit": true,
+      "push": true,
+      "pull_request": true,
+      "review": false,
+      "merge": false,
+      "deploy": false,
+      "approve_own_pull_request": false,
+      "force_push": false,
+      "direct_push_protected": false,
+      "irreversible_actions": false
+    }
+  }
+}

--- a/stage1/json-fixtures/task-contract/repair-approved.spec.json
+++ b/stage1/json-fixtures/task-contract/repair-approved.spec.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": "axiom.agent_task.spec.v0",
+  "task": {
+    "id": "issue-1419-repair",
+    "kind": "repair",
+    "objective": "Repair a capability denial without widening its diagnostic scope.",
+    "authority": {
+      "governing_issue": "https://github.com/OMT-Global/axiomlang/issues/1419",
+      "repository": "OMT-Global/axiomlang",
+      "issue": 1419,
+      "source_revision": "3333333333333333333333333333333333333333",
+      "source_digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+      "approval": { "state": "approved", "approver": "pheidon", "method": "signed_spec" }
+    },
+    "scope": {
+      "affected_semantic_nodes": ["axiom://package/agent-native-authorize"],
+      "allowed_files": ["src/main.ax"]
+    },
+    "capabilities": { "required": [], "forbidden": ["net"] },
+    "commands": {
+      "required": ["axiomc check . --json"],
+      "forbidden": ["curl", "git push --force"]
+    },
+    "acceptance_criteria": [
+      { "id": "bounded-repair", "requirement": "The capability denial is resolved without editing another file.", "expected": "pass", "evidence_refs": ["denial", "schema"] }
+    ],
+    "required_evidence": [
+      { "id": "denial", "kind": "capability_denial_test", "command": "axiomc check . --json" },
+      { "id": "schema", "kind": "schema_validation", "command": "cargo test --manifest-path stage1/Cargo.toml -p axiomc --test schema_metadata" }
+    ],
+    "dependencies": [],
+    "autonomy": { "class": 1, "risk": "medium" },
+    "budgets": { "time_seconds": 900, "tokens": 40000, "retries": 1, "cost_usd_micros": 1000000 },
+    "rollback": { "checkpoint": "clean isolated worktree", "commands": ["git diff --check"] },
+    "terminal_conditions": {
+      "success": ["The required capability denial evidence passes."],
+      "stop": ["A repair proposes a path outside src/main.ax."],
+      "escalation": ["The diagnostic no longer matches the approved source revision."]
+    },
+    "delivery_permissions": {
+      "commit": false,
+      "push": false,
+      "pull_request": false,
+      "review": false,
+      "merge": false,
+      "deploy": false,
+      "approve_own_pull_request": false,
+      "force_push": false,
+      "direct_push_protected": false,
+      "irreversible_actions": false
+    },
+    "repair": {
+      "id": "repair-001",
+      "reason": "capability_denied",
+      "target_node": "axiom://package/agent-native-authorize",
+      "allowed_files": ["src/main.ax"],
+      "required_evidence": ["capability_denial_test", "schema_validation"],
+      "diagnostics": [
+        {
+          "kind": "capability",
+          "code": "capability_denied",
+          "message": "capability `net` is not allowed",
+          "path": "src/main.ax",
+          "line": 1,
+          "column": 1
+        }
+      ]
+    }
+  }
+}

--- a/stage1/json-fixtures/verification-planner/artifact-drift.json
+++ b/stage1/json-fixtures/verification-planner/artifact-drift.json
@@ -1,0 +1,16 @@
+{
+  "scenario": "artifact-drift",
+  "before": {
+    "schema_version": "axiom.intent_ir.v0", "graph_id": "axiom://graph/planner-artifact", "package": "axiom://package/planner-artifact",
+    "provenance": {"producer": "fixture", "source_digest": "0000000000000000000000000000000000000000000000000000000000000041", "path_policy": "package_relative", "inputs": [{"package": "axiom://package/planner-artifact", "path": "api.ax", "digest": "1000000000000000000000000000000000000000000000000000000000000041"}]},
+    "nodes": [{"id": "axiom://package/planner-artifact", "kind": "Package", "name": "planner-artifact"}, {"id": "axiom://package/planner-artifact/artifact/openapi", "kind": "Artifact", "name": "openapi", "description": "old output", "source_span": {"path": "api.ax"}, "metadata": {"target": "openapi"}}],
+    "edges": [{"from": "axiom://package/planner-artifact", "kind": "emits", "to": "axiom://package/planner-artifact/artifact/openapi"}], "diagnostics": []
+  },
+  "after": {
+    "schema_version": "axiom.intent_ir.v0", "graph_id": "axiom://graph/planner-artifact", "package": "axiom://package/planner-artifact",
+    "provenance": {"producer": "fixture", "source_digest": "0000000000000000000000000000000000000000000000000000000000000042", "path_policy": "package_relative", "inputs": [{"package": "axiom://package/planner-artifact", "path": "api.ax", "digest": "2000000000000000000000000000000000000000000000000000000000000041"}]},
+    "nodes": [{"id": "axiom://package/planner-artifact", "kind": "Package", "name": "planner-artifact"}, {"id": "axiom://package/planner-artifact/artifact/openapi", "kind": "Artifact", "name": "openapi", "description": "new output", "source_span": {"path": "api.ax"}, "metadata": {"target": "openapi"}}],
+    "edges": [{"from": "axiom://package/planner-artifact", "kind": "emits", "to": "axiom://package/planner-artifact/artifact/openapi"}], "diagnostics": []
+  },
+  "expected_evidence": ["regression", "schema", "artifact"]
+}

--- a/stage1/json-fixtures/verification-planner/capability-escalation.json
+++ b/stage1/json-fixtures/verification-planner/capability-escalation.json
@@ -1,0 +1,15 @@
+{
+  "scenario": "capability-escalation",
+  "before": {
+    "schema_version": "axiom.intent_ir.v0", "graph_id": "axiom://graph/planner-capability", "package": "axiom://package/planner-capability",
+    "provenance": {"producer": "fixture", "source_digest": "0000000000000000000000000000000000000000000000000000000000000021", "path_policy": "package_relative", "inputs": [{"package": "axiom://package/planner-capability", "path": "src/main.ax", "digest": "1000000000000000000000000000000000000000000000000000000000000021"}]},
+    "nodes": [{"id": "axiom://package/planner-capability", "kind": "Package", "name": "planner-capability"}], "edges": [], "diagnostics": []
+  },
+  "after": {
+    "schema_version": "axiom.intent_ir.v0", "graph_id": "axiom://graph/planner-capability", "package": "axiom://package/planner-capability",
+    "provenance": {"producer": "fixture", "source_digest": "0000000000000000000000000000000000000000000000000000000000000022", "path_policy": "package_relative", "inputs": [{"package": "axiom://package/planner-capability", "path": "src/main.ax", "digest": "2000000000000000000000000000000000000000000000000000000000000021"}]},
+    "nodes": [{"id": "axiom://package/planner-capability", "kind": "Package", "name": "planner-capability"}, {"id": "axiom://package/planner-capability/capability/net", "kind": "Capability", "name": "net", "source_span": {"path": "src/main.ax", "line": 1}}],
+    "edges": [{"from": "axiom://package/planner-capability", "kind": "requires", "to": "axiom://package/planner-capability/capability/net"}], "diagnostics": []
+  },
+  "expected_evidence": ["positive", "denial", "regression", "security"]
+}

--- a/stage1/json-fixtures/verification-planner/localized.json
+++ b/stage1/json-fixtures/verification-planner/localized.json
@@ -1,0 +1,16 @@
+{
+  "scenario": "localized",
+  "before": {
+    "schema_version": "axiom.intent_ir.v0", "graph_id": "axiom://graph/planner-localized", "package": "axiom://package/planner-localized",
+    "provenance": {"producer": "fixture", "source_digest": "0000000000000000000000000000000000000000000000000000000000000001", "path_policy": "package_relative", "inputs": [{"package": "axiom://package/planner-localized", "path": "src/main.ax", "digest": "1000000000000000000000000000000000000000000000000000000000000001"}]},
+    "nodes": [{"id": "axiom://package/planner-localized", "kind": "Package", "name": "planner-localized"}, {"id": "axiom://package/planner-localized/function/normalize", "kind": "Function", "name": "normalize", "description": "old body", "source_span": {"path": "src/main.ax", "line": 1}}],
+    "edges": [{"from": "axiom://package/planner-localized", "kind": "declares", "to": "axiom://package/planner-localized/function/normalize"}], "diagnostics": []
+  },
+  "after": {
+    "schema_version": "axiom.intent_ir.v0", "graph_id": "axiom://graph/planner-localized", "package": "axiom://package/planner-localized",
+    "provenance": {"producer": "fixture", "source_digest": "0000000000000000000000000000000000000000000000000000000000000002", "path_policy": "package_relative", "inputs": [{"package": "axiom://package/planner-localized", "path": "src/main.ax", "digest": "2000000000000000000000000000000000000000000000000000000000000001"}]},
+    "nodes": [{"id": "axiom://package/planner-localized", "kind": "Package", "name": "planner-localized"}, {"id": "axiom://package/planner-localized/function/normalize", "kind": "Function", "name": "normalize", "description": "new body", "source_span": {"path": "src/main.ax", "line": 1}}],
+    "edges": [{"from": "axiom://package/planner-localized", "kind": "declares", "to": "axiom://package/planner-localized/function/normalize"}], "diagnostics": []
+  },
+  "expected_evidence": ["positive", "regression", "schema"]
+}

--- a/stage1/json-fixtures/verification-planner/performance-sensitive.json
+++ b/stage1/json-fixtures/verification-planner/performance-sensitive.json
@@ -1,0 +1,16 @@
+{
+  "scenario": "performance-sensitive",
+  "before": {
+    "schema_version": "axiom.intent_ir.v0", "graph_id": "axiom://graph/planner-performance", "package": "axiom://package/planner-performance",
+    "provenance": {"producer": "fixture", "source_digest": "0000000000000000000000000000000000000000000000000000000000000051", "path_policy": "package_relative", "inputs": [{"package": "axiom://package/planner-performance", "path": "src/search.ax", "digest": "1000000000000000000000000000000000000000000000000000000000000051"}]},
+    "nodes": [{"id": "axiom://package/planner-performance", "kind": "Package", "name": "planner-performance"}, {"id": "axiom://package/planner-performance/function/search", "kind": "Function", "name": "search", "description": "linear", "source_span": {"path": "src/search.ax"}, "metadata": {"benchmark": "search-latency"}}],
+    "edges": [{"from": "axiom://package/planner-performance", "kind": "declares", "to": "axiom://package/planner-performance/function/search"}], "diagnostics": []
+  },
+  "after": {
+    "schema_version": "axiom.intent_ir.v0", "graph_id": "axiom://graph/planner-performance", "package": "axiom://package/planner-performance",
+    "provenance": {"producer": "fixture", "source_digest": "0000000000000000000000000000000000000000000000000000000000000052", "path_policy": "package_relative", "inputs": [{"package": "axiom://package/planner-performance", "path": "src/search.ax", "digest": "2000000000000000000000000000000000000000000000000000000000000051"}]},
+    "nodes": [{"id": "axiom://package/planner-performance", "kind": "Package", "name": "planner-performance"}, {"id": "axiom://package/planner-performance/function/search", "kind": "Function", "name": "search", "description": "indexed", "source_span": {"path": "src/search.ax"}, "metadata": {"benchmark": "search-latency"}}],
+    "edges": [{"from": "axiom://package/planner-performance", "kind": "declares", "to": "axiom://package/planner-performance/function/search"}], "diagnostics": []
+  },
+  "expected_evidence": ["positive", "regression", "schema", "performance"]
+}

--- a/stage1/json-fixtures/verification-planner/public-api.json
+++ b/stage1/json-fixtures/verification-planner/public-api.json
@@ -1,0 +1,16 @@
+{
+  "scenario": "public-api",
+  "before": {
+    "schema_version": "axiom.intent_ir.v0", "graph_id": "axiom://graph/planner-public-api", "package": "axiom://package/planner-public-api",
+    "provenance": {"producer": "fixture", "source_digest": "0000000000000000000000000000000000000000000000000000000000000011", "path_policy": "package_relative", "inputs": [{"package": "axiom://package/planner-public-api", "path": "src/api.ax", "digest": "1000000000000000000000000000000000000000000000000000000000000011"}]},
+    "nodes": [{"id": "axiom://package/planner-public-api", "kind": "Package", "name": "planner-public-api"}, {"id": "axiom://package/planner-public-api/type/Request", "kind": "Type", "name": "Request", "description": "one field", "source_span": {"path": "src/api.ax", "line": 1}, "metadata": {"public": true}}],
+    "edges": [{"from": "axiom://package/planner-public-api", "kind": "declares", "to": "axiom://package/planner-public-api/type/Request"}], "diagnostics": []
+  },
+  "after": {
+    "schema_version": "axiom.intent_ir.v0", "graph_id": "axiom://graph/planner-public-api", "package": "axiom://package/planner-public-api",
+    "provenance": {"producer": "fixture", "source_digest": "0000000000000000000000000000000000000000000000000000000000000012", "path_policy": "package_relative", "inputs": [{"package": "axiom://package/planner-public-api", "path": "src/api.ax", "digest": "2000000000000000000000000000000000000000000000000000000000000011"}]},
+    "nodes": [{"id": "axiom://package/planner-public-api", "kind": "Package", "name": "planner-public-api"}, {"id": "axiom://package/planner-public-api/type/Request", "kind": "Type", "name": "Request", "description": "two fields", "source_span": {"path": "src/api.ax", "line": 1}, "metadata": {"public": true}}],
+    "edges": [{"from": "axiom://package/planner-public-api", "kind": "declares", "to": "axiom://package/planner-public-api/type/Request"}], "diagnostics": []
+  },
+  "expected_evidence": ["positive", "regression", "schema"]
+}

--- a/stage1/json-fixtures/verification-planner/quality-baseline.json
+++ b/stage1/json-fixtures/verification-planner/quality-baseline.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": "axiom.verification_planner_quality.v0",
+  "governing_suite": 1417,
+  "follow_up_suite": 1424,
+  "scenario_count": 7,
+  "mapped_scenarios": 7,
+  "empty_changed_plans": 0,
+  "unknown_scenarios_broadened": 1
+}

--- a/stage1/json-fixtures/verification-planner/schema-change.json
+++ b/stage1/json-fixtures/verification-planner/schema-change.json
@@ -1,0 +1,16 @@
+{
+  "scenario": "schema-change",
+  "before": {
+    "schema_version": "axiom.intent_ir.v0", "graph_id": "axiom://graph/planner-schema", "package": "axiom://package/planner-schema",
+    "provenance": {"producer": "fixture", "source_digest": "0000000000000000000000000000000000000000000000000000000000000031", "path_policy": "package_relative", "inputs": [{"package": "axiom://package/planner-schema", "path": "schemas/event.json", "digest": "1000000000000000000000000000000000000000000000000000000000000031"}]},
+    "nodes": [{"id": "axiom://package/planner-schema", "kind": "Package", "name": "planner-schema"}, {"id": "axiom://package/planner-schema/type/Event", "kind": "Type", "name": "Event", "description": "schema v1", "source_span": {"path": "schemas/event.json"}, "metadata": {"schema": "event-v1"}}],
+    "edges": [{"from": "axiom://package/planner-schema", "kind": "declares", "to": "axiom://package/planner-schema/type/Event"}], "diagnostics": []
+  },
+  "after": {
+    "schema_version": "axiom.intent_ir.v0", "graph_id": "axiom://graph/planner-schema", "package": "axiom://package/planner-schema",
+    "provenance": {"producer": "fixture", "source_digest": "0000000000000000000000000000000000000000000000000000000000000032", "path_policy": "package_relative", "inputs": [{"package": "axiom://package/planner-schema", "path": "schemas/event.json", "digest": "2000000000000000000000000000000000000000000000000000000000000031"}]},
+    "nodes": [{"id": "axiom://package/planner-schema", "kind": "Package", "name": "planner-schema"}, {"id": "axiom://package/planner-schema/type/Event", "kind": "Type", "name": "Event", "description": "schema v2", "source_span": {"path": "schemas/event.json"}, "metadata": {"schema": "event-v2"}}],
+    "edges": [{"from": "axiom://package/planner-schema", "kind": "declares", "to": "axiom://package/planner-schema/type/Event"}], "diagnostics": []
+  },
+  "expected_evidence": ["positive", "regression", "schema"]
+}

--- a/stage1/json-fixtures/verification-planner/unknown-impact.json
+++ b/stage1/json-fixtures/verification-planner/unknown-impact.json
@@ -1,0 +1,16 @@
+{
+  "scenario": "unknown-impact",
+  "before": {
+    "schema_version": "axiom.intent_ir.v0", "graph_id": "axiom://graph/planner-unknown", "package": "axiom://package/planner-unknown",
+    "provenance": {"producer": "fixture", "source_digest": "0000000000000000000000000000000000000000000000000000000000000061", "path_policy": "package_relative", "inputs": [{"package": "axiom://package/planner-unknown", "path": "decisions/routing.json", "digest": "1000000000000000000000000000000000000000000000000000000000000061"}]},
+    "nodes": [{"id": "axiom://package/planner-unknown", "kind": "Package", "name": "planner-unknown"}, {"id": "axiom://package/planner-unknown/decision/routing", "kind": "Decision", "name": "routing", "description": "old", "source_span": {"path": "decisions/routing.json"}}],
+    "edges": [{"from": "axiom://package/planner-unknown", "kind": "declares", "to": "axiom://package/planner-unknown/decision/routing"}], "diagnostics": []
+  },
+  "after": {
+    "schema_version": "axiom.intent_ir.v0", "graph_id": "axiom://graph/planner-unknown", "package": "axiom://package/planner-unknown",
+    "provenance": {"producer": "fixture", "source_digest": "0000000000000000000000000000000000000000000000000000000000000062", "path_policy": "package_relative", "inputs": [{"package": "axiom://package/planner-unknown", "path": "decisions/routing.json", "digest": "2000000000000000000000000000000000000000000000000000000000000061"}]},
+    "nodes": [{"id": "axiom://package/planner-unknown", "kind": "Package", "name": "planner-unknown"}, {"id": "axiom://package/planner-unknown/decision/routing", "kind": "Decision", "name": "routing", "description": "new", "source_span": {"path": "decisions/routing.json"}}],
+    "edges": [{"from": "axiom://package/planner-unknown", "kind": "declares", "to": "axiom://package/planner-unknown/decision/routing"}], "diagnostics": []
+  },
+  "expected_evidence": ["positive", "denial", "regression", "schema", "artifact", "security", "performance"]
+}

--- a/stage1/schemas/axiom-agent-task-spec-v0.schema.json
+++ b/stage1/schemas/axiom-agent-task-spec-v0.schema.json
@@ -1,0 +1,246 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axiom.omt.global/schemas/axiom-agent-task-spec-v0.schema.json",
+  "title": "Axiom approved agent task specification v0",
+  "type": "object",
+  "required": ["schema_version", "task"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": { "const": "axiom.agent_task.spec.v0" },
+    "task": {
+      "allOf": [{ "$ref": "#/$defs/task" }],
+      "unevaluatedProperties": false
+    }
+  },
+  "$defs": {
+    "nonEmpty": { "type": "string", "minLength": 1 },
+    "relativePath": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?!/)(?![A-Za-z]:)(?!.*(?:^|/)\\.{1,2}(?:/|$))(?!.*[\\\\*?])(?!.*//)(?!.*\/$).+$"
+    },
+    "stringSet": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/nonEmpty" }
+    },
+    "evidenceKind": {
+      "enum": [
+        "unit_test", "property_test", "conformance_fixture",
+        "capability_denial_test", "golden_output", "schema_validation",
+        "security_fixture", "benchmark_baseline", "manual_review",
+        "risk_note", "ci_status", "review_state"
+      ]
+    },
+    "evidence": {
+      "type": "object",
+      "required": ["id", "kind", "command"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9._-]*$" },
+        "kind": { "$ref": "#/$defs/evidenceKind" },
+        "command": { "$ref": "#/$defs/nonEmpty" }
+      }
+    },
+    "acceptanceCriterion": {
+      "type": "object",
+      "required": ["id", "requirement", "expected", "evidence_refs"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9._-]*$" },
+        "requirement": { "$ref": "#/$defs/nonEmpty" },
+        "expected": { "enum": ["pass", "fail"] },
+        "evidence_refs": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/nonEmpty" } }
+      }
+    },
+    "authority": {
+      "type": "object",
+      "required": [
+        "governing_issue", "repository", "issue", "source_revision",
+        "source_digest", "approval"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "governing_issue": { "type": "string", "pattern": "^https://github\\.com/[^/]+/[^/]+/issues/[1-9][0-9]*$" },
+        "repository": { "type": "string", "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$" },
+        "issue": { "type": "integer", "minimum": 1 },
+        "source_revision": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "source_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+        "approval": {
+          "type": "object",
+          "required": ["state", "approver", "method"],
+          "additionalProperties": false,
+          "properties": {
+            "state": { "const": "approved" },
+            "approver": { "$ref": "#/$defs/nonEmpty" },
+            "method": { "enum": ["issue_label", "issue_comment", "signed_spec", "maintainer_review"] }
+          }
+        }
+      }
+    },
+    "scope": {
+      "type": "object",
+      "required": ["affected_semantic_nodes", "allowed_files"],
+      "additionalProperties": false,
+      "properties": {
+        "affected_semantic_nodes": {
+          "type": "array", "minItems": 1,
+          "items": { "type": "string", "pattern": "^axiom://[A-Za-z0-9._~:/#@!$&'()*+,;=%-]+$" }
+        },
+        "allowed_files": {
+          "type": "array", "minItems": 1,
+          "items": { "$ref": "#/$defs/relativePath" }
+        },
+        "denied_files": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/relativePath" }
+        }
+      }
+    },
+    "allowDeny": {
+      "type": "object",
+      "required": ["required", "forbidden"],
+      "additionalProperties": false,
+      "properties": {
+        "required": { "$ref": "#/$defs/stringSet" },
+        "forbidden": { "$ref": "#/$defs/stringSet" }
+      }
+    },
+    "dependency": {
+      "type": "object",
+      "required": ["id", "status", "depends_on", "precondition"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "#/$defs/nonEmpty" },
+        "status": { "const": "satisfied" },
+        "depends_on": { "$ref": "#/$defs/stringSet" },
+        "precondition": { "type": "string" }
+      }
+    },
+    "autonomy": {
+      "type": "object",
+      "required": ["class", "risk"],
+      "additionalProperties": false,
+      "properties": {
+        "class": { "type": "integer", "minimum": 1, "maximum": 3 },
+        "risk": { "enum": ["low", "medium", "high"] }
+      }
+    },
+    "budgets": {
+      "type": "object",
+      "required": ["time_seconds", "tokens", "retries", "cost_usd_micros"],
+      "additionalProperties": false,
+      "properties": {
+        "time_seconds": { "type": "integer", "minimum": 1, "maximum": 86400 },
+        "tokens": { "type": "integer", "minimum": 1, "maximum": 10000000 },
+        "retries": { "type": "integer", "minimum": 0, "maximum": 20 },
+        "cost_usd_micros": { "type": "integer", "minimum": 0, "maximum": 1000000000 }
+      }
+    },
+    "rollback": {
+      "type": "object",
+      "required": ["checkpoint", "commands"],
+      "additionalProperties": false,
+      "properties": {
+        "checkpoint": { "$ref": "#/$defs/nonEmpty" },
+        "commands": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/nonEmpty" } }
+      }
+    },
+    "terminalConditions": {
+      "type": "object",
+      "required": ["success", "stop", "escalation"],
+      "additionalProperties": false,
+      "properties": {
+        "success": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/nonEmpty" } },
+        "stop": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/nonEmpty" } },
+        "escalation": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/nonEmpty" } }
+      }
+    },
+    "deliveryPermissions": {
+      "type": "object",
+      "required": [
+        "commit", "push", "pull_request", "review", "merge", "deploy",
+        "approve_own_pull_request", "force_push", "direct_push_protected",
+        "irreversible_actions"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "commit": { "type": "boolean" },
+        "push": { "type": "boolean" },
+        "pull_request": { "type": "boolean" },
+        "review": { "type": "boolean" },
+        "merge": { "type": "boolean" },
+        "deploy": { "type": "boolean" },
+        "approve_own_pull_request": { "const": false },
+        "force_push": { "const": false },
+        "direct_push_protected": { "const": false },
+        "irreversible_actions": { "const": false }
+      }
+    },
+    "diagnostic": {
+      "type": "object",
+      "required": ["kind", "message"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "$ref": "#/$defs/nonEmpty" },
+        "code": { "type": "string" },
+        "message": { "$ref": "#/$defs/nonEmpty" },
+        "help": { "type": "string" },
+        "path": { "$ref": "#/$defs/relativePath" },
+        "line": { "type": "integer", "minimum": 1 },
+        "column": { "type": "integer", "minimum": 1 },
+        "related": { "type": "array" },
+        "repair": { "type": "object" }
+      }
+    },
+    "repair": {
+      "type": "object",
+      "required": ["id", "reason", "target_node", "allowed_files", "required_evidence", "diagnostics"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "pattern": "^repair-[0-9]+$" },
+        "reason": { "$ref": "#/$defs/nonEmpty" },
+        "target_node": { "type": "string", "pattern": "^axiom://[A-Za-z0-9._~:/#@!$&'()*+,;=%-]+$" },
+        "allowed_files": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/relativePath" } },
+        "required_evidence": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/evidenceKind" } },
+        "diagnostics": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/diagnostic" } }
+      }
+    },
+    "taskBase": {
+      "type": "object",
+      "required": [
+        "id", "kind", "objective", "authority", "scope", "capabilities",
+        "commands", "acceptance_criteria", "required_evidence", "dependencies",
+        "autonomy", "budgets", "rollback", "terminal_conditions",
+        "delivery_permissions"
+      ],
+      "properties": {
+        "id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9._-]*$" },
+        "kind": { "enum": ["feature", "migration", "refactor", "operational", "repair"] },
+        "objective": { "$ref": "#/$defs/nonEmpty" },
+        "authority": { "$ref": "#/$defs/authority" },
+        "scope": { "$ref": "#/$defs/scope" },
+        "capabilities": { "$ref": "#/$defs/allowDeny" },
+        "commands": { "$ref": "#/$defs/allowDeny" },
+        "acceptance_criteria": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/acceptanceCriterion" } },
+        "required_evidence": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/evidence" } },
+        "dependencies": { "type": "array", "uniqueItems": true, "items": { "$ref": "#/$defs/dependency" } },
+        "autonomy": { "$ref": "#/$defs/autonomy" },
+        "budgets": { "$ref": "#/$defs/budgets" },
+        "rollback": { "$ref": "#/$defs/rollback" },
+        "terminal_conditions": { "$ref": "#/$defs/terminalConditions" },
+        "delivery_permissions": { "$ref": "#/$defs/deliveryPermissions" },
+        "repair": { "$ref": "#/$defs/repair" }
+      },
+      "allOf": [
+        { "if": { "properties": { "kind": { "const": "repair" } } }, "then": { "required": ["repair"] } },
+        { "if": { "properties": { "kind": { "enum": ["feature", "migration", "refactor", "operational"] } } }, "then": { "not": { "required": ["repair"] } } }
+      ]
+    },
+    "task": {
+      "allOf": [
+        { "$ref": "#/$defs/taskBase" }
+      ],
+      "unevaluatedProperties": false
+    }
+  }
+}

--- a/stage1/schemas/axiom-agent-task-v0.schema.json
+++ b/stage1/schemas/axiom-agent-task-v0.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axiom.omt.global/schemas/axiom-agent-task-v0.schema.json",
+  "title": "Axiom agent task contract v0",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "project", "contract"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": { "const": "axiom.agent_task.v0" },
+    "ok": { "const": true },
+    "command": { "const": "task-contract" },
+    "project": {
+      "type": "string", "minLength": 1,
+      "pattern": "^(?!/)(?![A-Za-z]:)(?!.*(?:^|/)\\.\\.(?:/|$))(?!.*\\\\).+$"
+    },
+    "contract": {
+      "allOf": [
+        { "$ref": "axiom-agent-task-spec-v0.schema.json#/$defs/taskBase" },
+        {
+          "type": "object",
+          "required": ["schema_version", "contract_digest"],
+          "properties": {
+            "schema_version": { "const": "axiom.agent_task.v0" },
+            "contract_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    }
+  }
+}

--- a/stage1/schemas/axiom-execution-policy-v0.schema.json
+++ b/stage1/schemas/axiom-execution-policy-v0.schema.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axiom.omt.global/schemas/axiom-execution-policy-v0.schema.json",
+  "title": "AxiOM Execution Policy v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "task_contract_digest", "base_sha", "workspace", "paths", "commands", "capabilities", "network", "secrets", "delivery"],
+  "properties": {
+    "schema_version": { "const": "axiom.execution_policy.v0" },
+    "task_contract_digest": { "$ref": "#/$defs/digest" },
+    "base_sha": { "$ref": "#/$defs/sha" },
+    "workspace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["branch", "source_checkout", "isolated_worktree", "require_clean_isolated_worktree"],
+      "properties": {
+        "branch": { "type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9._/-]*$" },
+        "source_checkout": { "$ref": "#/$defs/absolutePath" },
+        "isolated_worktree": { "$ref": "#/$defs/absolutePath" },
+        "require_clean_isolated_worktree": { "const": true }
+      }
+    },
+    "paths": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["read", "write", "protected", "allow_chmod", "allow_rename", "allow_delete", "follow_symlinks"],
+      "properties": {
+        "read": { "$ref": "#/$defs/relativePaths" },
+        "write": { "$ref": "#/$defs/relativePaths" },
+        "protected": { "$ref": "#/$defs/relativePaths" },
+        "allow_chmod": { "type": "boolean" },
+        "allow_rename": { "type": "boolean" },
+        "allow_delete": { "type": "boolean" },
+        "follow_symlinks": { "const": false }
+      }
+    },
+    "commands": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["allowed", "forbidden", "allow_shell"],
+      "properties": {
+        "allowed": { "$ref": "#/$defs/nonEmptyStrings" },
+        "forbidden": { "$ref": "#/$defs/strings" },
+        "allow_shell": { "const": false }
+      }
+    },
+    "capabilities": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["allowed", "forbidden"],
+      "properties": {
+        "allowed": { "$ref": "#/$defs/strings" },
+        "forbidden": { "$ref": "#/$defs/strings" }
+      }
+    },
+    "network": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "allowed_hosts"],
+      "properties": {
+        "mode": { "enum": ["deny", "allowlist"] },
+        "allowed_hosts": { "$ref": "#/$defs/strings" }
+      }
+    },
+    "secrets": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["allow_environment", "brokered_refs"],
+      "properties": {
+        "allow_environment": { "const": false },
+        "brokered_refs": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "type": "string", "pattern": "^secret-ref:[A-Za-z0-9][A-Za-z0-9._/-]*$" }
+        }
+      }
+    },
+    "delivery": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["allow_external_mutations", "allow_protected_branch_push", "allow_force_push", "allow_self_approval", "allow_policy_edits"],
+      "properties": {
+        "allow_external_mutations": { "type": "boolean" },
+        "allow_protected_branch_push": { "const": false },
+        "allow_force_push": { "const": false },
+        "allow_self_approval": { "const": false },
+        "allow_policy_edits": { "const": false }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "network": { "properties": { "mode": { "const": "deny" } }, "required": ["mode"] } } },
+      "then": { "properties": { "network": { "properties": { "allowed_hosts": { "maxItems": 0 } } } } }
+    },
+    {
+      "if": { "properties": { "network": { "properties": { "mode": { "const": "allowlist" } }, "required": ["mode"] } } },
+      "then": { "properties": { "network": { "properties": { "allowed_hosts": { "minItems": 1 } } } } }
+    }
+  ],
+  "$defs": {
+    "sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "absolutePath": { "type": "string", "pattern": "^/" },
+    "relativePath": { "type": "string", "minLength": 1, "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$))(?!.*//)[^\\u0000]+$" },
+    "relativePaths": { "type": "array", "uniqueItems": true, "items": { "$ref": "#/$defs/relativePath" } },
+    "strings": { "type": "array", "uniqueItems": true, "items": { "type": "string", "minLength": 1 } },
+    "nonEmptyStrings": { "type": "array", "minItems": 1, "uniqueItems": true, "items": { "type": "string", "minLength": 1 } }
+  }
+}

--- a/stage1/schemas/axiom-execution-transaction-v0.schema.json
+++ b/stage1/schemas/axiom-execution-transaction-v0.schema.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axiom.omt.global/schemas/axiom-execution-transaction-v0.schema.json",
+  "title": "AxiOM Execution Transaction and Audit v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "transaction_id", "task_contract_digest", "policy_digest", "base_sha", "branch", "status", "checkpoints", "reads", "writes", "commands", "artifacts", "rollback", "recovery"],
+  "properties": {
+    "schema_version": { "const": "axiom.execution_transaction.v0" },
+    "transaction_id": { "type": "string", "pattern": "^txn-[0-9a-f]{16}$" },
+    "task_contract_digest": { "$ref": "#/$defs/digest" },
+    "policy_digest": { "$ref": "#/$defs/digest" },
+    "base_sha": { "$ref": "#/$defs/sha" },
+    "branch": { "type": "string", "minLength": 1 },
+    "status": { "enum": ["prepared", "running", "interrupted", "succeeded", "failed", "rolled_back"] },
+    "checkpoints": { "type": "array", "items": { "$ref": "#/$defs/checkpoint" } },
+    "reads": { "type": "array", "items": { "$ref": "#/$defs/fileObservation" } },
+    "writes": { "type": "array", "items": { "$ref": "#/$defs/write" } },
+    "commands": { "type": "array", "items": { "$ref": "#/$defs/command" } },
+    "artifacts": { "type": "array", "items": { "$ref": "#/$defs/artifact" } },
+    "rollback": { "$ref": "#/$defs/rollback" },
+    "recovery": { "$ref": "#/$defs/recovery" }
+  },
+  "$defs": {
+    "sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "relativePath": { "type": "string", "minLength": 1, "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$))(?!.*//)[^\\u0000]+$" },
+    "sequence": { "type": "integer", "minimum": 0 },
+    "checkpoint": {
+      "type": "object", "additionalProperties": false,
+      "required": ["sequence", "kind", "tree_sha", "created_before"],
+      "properties": {
+        "sequence": { "$ref": "#/$defs/sequence" },
+        "kind": { "enum": ["initial", "before_write", "before_delivery"] },
+        "tree_sha": { "$ref": "#/$defs/sha" },
+        "created_before": { "type": "string", "minLength": 1 }
+      }
+    },
+    "fileObservation": {
+      "type": "object", "additionalProperties": false,
+      "required": ["sequence", "path", "digest"],
+      "properties": { "sequence": { "$ref": "#/$defs/sequence" }, "path": { "$ref": "#/$defs/relativePath" }, "digest": { "$ref": "#/$defs/digest" } }
+    },
+    "write": {
+      "type": "object", "additionalProperties": false,
+      "required": ["sequence", "operation", "path", "before_digest", "after_digest"],
+      "properties": {
+        "sequence": { "$ref": "#/$defs/sequence" },
+        "operation": { "enum": ["create", "modify", "chmod", "rename", "delete"] },
+        "path": { "$ref": "#/$defs/relativePath" },
+        "destination": { "$ref": "#/$defs/relativePath" },
+        "before_digest": { "anyOf": [{ "$ref": "#/$defs/digest" }, { "type": "null" }] },
+        "after_digest": { "anyOf": [{ "$ref": "#/$defs/digest" }, { "type": "null" }] }
+      }
+    },
+    "command": {
+      "type": "object", "additionalProperties": false,
+      "required": ["sequence", "argv", "capabilities", "network_hosts", "outcome", "exit_code", "stdout_digest", "stderr_digest"],
+      "properties": {
+        "sequence": { "$ref": "#/$defs/sequence" },
+        "argv": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+        "capabilities": { "type": "array", "uniqueItems": true, "items": { "type": "string", "minLength": 1 } },
+        "network_hosts": { "type": "array", "uniqueItems": true, "items": { "type": "string", "minLength": 1 } },
+        "outcome": { "enum": ["denied", "executed"] },
+        "secret_refs": { "type": "array", "uniqueItems": true, "items": { "type": "string", "pattern": "^secret-ref:[A-Za-z0-9][A-Za-z0-9._/-]*$" } },
+        "exit_code": { "type": "integer" },
+        "stdout_digest": { "$ref": "#/$defs/digest" },
+        "stderr_digest": { "$ref": "#/$defs/digest" }
+      }
+    },
+    "artifact": {
+      "type": "object", "additionalProperties": false,
+      "required": ["sequence", "path", "digest", "kind"],
+      "properties": { "sequence": { "$ref": "#/$defs/sequence" }, "path": { "$ref": "#/$defs/relativePath" }, "digest": { "$ref": "#/$defs/digest" }, "kind": { "type": "string", "minLength": 1 } }
+    },
+    "rollback": {
+      "type": "object", "additionalProperties": false,
+      "required": ["attempted", "result", "restored_checkpoint", "source_checkout_untouched"],
+      "properties": {
+        "attempted": { "type": "boolean" },
+        "result": { "enum": ["not_required", "succeeded", "failed", "requires_delivery_revert"] },
+        "restored_checkpoint": { "anyOf": [{ "type": "integer", "minimum": 0 }, { "type": "null" }] },
+        "source_checkout_untouched": { "type": "boolean" }
+      }
+    },
+    "recovery": {
+      "type": "object", "additionalProperties": false,
+      "required": ["resumable", "rollback_safe", "next_sequence", "journal_digest"],
+      "properties": {
+        "resumable": { "type": "boolean" },
+        "rollback_safe": { "type": "boolean" },
+        "next_sequence": { "type": "integer", "minimum": 0 },
+        "journal_digest": { "$ref": "#/$defs/digest" }
+      }
+    }
+  }
+}

--- a/stage1/schemas/axiom-intent-ir-v0.schema.json
+++ b/stage1/schemas/axiom-intent-ir-v0.schema.json
@@ -3,7 +3,15 @@
   "$id": "https://axiom-lang.dev/schemas/axiom-intent-ir-v0.schema.json",
   "title": "Axiom Intent IR v0",
   "type": "object",
-  "required": ["schema_version", "graph_id", "package", "nodes", "edges"],
+  "required": [
+    "schema_version",
+    "graph_id",
+    "package",
+    "provenance",
+    "nodes",
+    "edges",
+    "diagnostics"
+  ],
   "additionalProperties": false,
   "properties": {
     "schema_version": {
@@ -16,6 +24,9 @@
     "package": {
       "$ref": "#/$defs/nodeId"
     },
+    "provenance": {
+      "$ref": "#/$defs/provenance"
+    },
     "nodes": {
       "type": "array",
       "minItems": 1,
@@ -27,6 +38,12 @@
       "type": "array",
       "items": {
         "$ref": "#/$defs/edge"
+      }
+    },
+    "diagnostics": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/diagnostic"
       }
     }
   },
@@ -140,6 +157,84 @@
         "end_column": {
           "type": "integer",
           "minimum": 1
+        }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "required": ["producer", "source_digest", "path_policy", "inputs"],
+      "additionalProperties": false,
+      "properties": {
+        "producer": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_digest": {
+          "$ref": "#/$defs/digest"
+        },
+        "path_policy": {
+          "const": "package_relative"
+        },
+        "inputs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/provenanceInput"
+          }
+        }
+      }
+    },
+    "provenanceInput": {
+      "type": "object",
+      "required": ["package", "path", "digest"],
+      "additionalProperties": false,
+      "properties": {
+        "package": {
+          "$ref": "#/$defs/nodeId"
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$)).+$"
+        },
+        "digest": {
+          "$ref": "#/$defs/digest"
+        }
+      }
+    },
+    "digest": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "diagnostic": {
+      "type": "object",
+      "required": ["code", "severity", "message", "node_ids"],
+      "additionalProperties": false,
+      "properties": {
+        "code": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]+$"
+        },
+        "severity": {
+          "enum": ["info", "warning", "error"]
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1
+        },
+        "node_ids": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/nodeId"
+          }
+        },
+        "node_kind": {
+          "$ref": "#/$defs/nodeKind"
+        },
+        "source_span": {
+          "$ref": "#/$defs/sourceSpan"
         }
       }
     }

--- a/stage1/schemas/axiom-verification-plan-v0.schema.json
+++ b/stage1/schemas/axiom-verification-plan-v0.schema.json
@@ -1,0 +1,126 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axiom.omt.global/schemas/axiom-verification-plan-v0.schema.json",
+  "title": "Axiom semantic verification plan v0",
+  "type": "object",
+  "required": ["schema_version", "plan_digest", "bindings", "changes", "requirements", "coverage"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": { "const": "axiom.verification_plan.v0" },
+    "plan_digest": { "$ref": "#/$defs/digest" },
+    "bindings": { "$ref": "#/$defs/bindings" },
+    "changes": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/change" }
+    },
+    "requirements": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/requirement" }
+    },
+    "coverage": { "$ref": "#/$defs/coverage" }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "changes": { "minItems": 1 } }, "required": ["changes"] },
+      "then": { "properties": { "requirements": { "minItems": 1 } } }
+    },
+    {
+      "if": { "properties": { "coverage": { "properties": { "confidence": { "const": "complete" } }, "required": ["confidence"] } } },
+      "then": { "properties": { "coverage": { "properties": { "complete": { "const": true }, "unknown_impacts": { "maxItems": 0 } } } } },
+      "else": { "properties": { "coverage": { "properties": { "complete": { "const": false }, "unknown_impacts": { "minItems": 1 } } } } }
+    }
+  ],
+  "$defs": {
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "headSha": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{40}$"
+    },
+    "nodeId": {
+      "type": "string",
+      "pattern": "^axiom://[A-Za-z0-9._~:/#@!$&'()*+,;=%-]+$"
+    },
+    "relativePath": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$)).+$"
+    },
+    "bindings": {
+      "type": "object",
+      "required": ["before_graph_id", "after_graph_id", "before_snapshot_digest", "after_snapshot_digest", "source_head_sha", "delivered_head_sha"],
+      "additionalProperties": false,
+      "properties": {
+        "before_graph_id": { "$ref": "#/$defs/nodeId" },
+        "after_graph_id": { "$ref": "#/$defs/nodeId" },
+        "before_snapshot_digest": { "$ref": "#/$defs/digest" },
+        "after_snapshot_digest": { "$ref": "#/$defs/digest" },
+        "source_head_sha": { "$ref": "#/$defs/headSha" },
+        "delivered_head_sha": { "$ref": "#/$defs/headSha" }
+      }
+    },
+    "change": {
+      "type": "object",
+      "required": ["id", "change_kind", "node_kind", "semantic_id", "source_path", "impact"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "change_kind": { "enum": ["added", "removed", "modified"] },
+        "node_kind": { "type": "string", "minLength": 1 },
+        "semantic_id": { "type": "string", "minLength": 1 },
+        "source_path": {
+          "oneOf": [
+            { "$ref": "#/$defs/relativePath" },
+            { "type": "null" }
+          ]
+        },
+        "impact": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/evidenceKind" }
+        }
+      }
+    },
+    "requirement": {
+      "type": "object",
+      "required": ["id", "kind", "reason", "semantic_ids"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "#/$defs/evidenceId" },
+        "kind": { "$ref": "#/$defs/evidenceKind" },
+        "reason": { "type": "string", "minLength": 1 },
+        "semantic_ids": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "coverage": {
+      "type": "object",
+      "required": ["confidence", "complete", "explanation", "unknown_impacts"],
+      "additionalProperties": false,
+      "properties": {
+        "confidence": { "enum": ["complete", "conservative"] },
+        "complete": { "type": "boolean" },
+        "explanation": { "type": "string", "minLength": 1 },
+        "unknown_impacts": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "evidenceKind": {
+      "enum": ["positive", "denial", "regression", "schema", "artifact", "security", "performance"]
+    },
+    "evidenceId": {
+      "enum": ["evidence-positive", "evidence-denial", "evidence-regression", "evidence-schema", "evidence-artifact", "evidence-security", "evidence-performance"]
+    }
+  }
+}

--- a/stage1/schemas/axiom-verification-results-v0.schema.json
+++ b/stage1/schemas/axiom-verification-results-v0.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axiom.omt.global/schemas/axiom-verification-results-v0.schema.json",
+  "title": "Axiom semantic verification results v0",
+  "type": "object",
+  "required": ["schema_version", "plan_digest", "source_head_sha", "delivered_head_sha", "results"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": { "const": "axiom.verification_results.v0" },
+    "plan_digest": { "$ref": "#/$defs/digest" },
+    "source_head_sha": { "$ref": "#/$defs/headSha" },
+    "delivered_head_sha": { "$ref": "#/$defs/headSha" },
+    "results": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/result" }
+    }
+  },
+  "$defs": {
+    "digest": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+    "headSha": { "type": "string", "pattern": "^[a-f0-9]{40}$" },
+    "result": {
+      "type": "object",
+      "required": ["id", "plan_digest", "source_head_sha", "delivered_head_sha", "status", "evidence_digest"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "#/$defs/evidenceId" },
+        "plan_digest": { "$ref": "#/$defs/digest" },
+        "source_head_sha": { "$ref": "#/$defs/headSha" },
+        "delivered_head_sha": { "$ref": "#/$defs/headSha" },
+        "status": { "enum": ["passed", "failed"] },
+        "evidence_digest": { "$ref": "#/$defs/digest" }
+      }
+    },
+    "evidenceId": {
+      "enum": ["evidence-positive", "evidence-denial", "evidence-regression", "evidence-schema", "evidence-artifact", "evidence-security", "evidence-performance"]
+    }
+  }
+}

--- a/stage1/schemas/axiom-verification-verdict-v0.schema.json
+++ b/stage1/schemas/axiom-verification-verdict-v0.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axiom.omt.global/schemas/axiom-verification-verdict-v0.schema.json",
+  "title": "Axiom semantic verification verdict v0",
+  "type": "object",
+  "required": ["schema_version", "plan_digest", "status", "source_head_sha", "delivered_head_sha", "missing", "duplicate", "invalid", "failed"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": { "const": "axiom.verification_verdict.v0" },
+    "plan_digest": { "$ref": "#/$defs/digest" },
+    "status": { "enum": ["passed", "failed"] },
+    "source_head_sha": { "$ref": "#/$defs/headSha" },
+    "delivered_head_sha": { "$ref": "#/$defs/headSha" },
+    "missing": { "$ref": "#/$defs/ids" },
+    "duplicate": { "$ref": "#/$defs/ids" },
+    "invalid": { "$ref": "#/$defs/ids" },
+    "failed": { "$ref": "#/$defs/ids" }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "status": { "const": "passed" } }, "required": ["status"] },
+      "then": {
+        "properties": {
+          "missing": { "maxItems": 0 },
+          "duplicate": { "maxItems": 0 },
+          "invalid": { "maxItems": 0 },
+          "failed": { "maxItems": 0 }
+        }
+      },
+      "else": {
+        "anyOf": [
+          { "properties": { "missing": { "minItems": 1 } } },
+          { "properties": { "duplicate": { "minItems": 1 } } },
+          { "properties": { "invalid": { "minItems": 1 } } },
+          { "properties": { "failed": { "minItems": 1 } } }
+        ]
+      }
+    }
+  ],
+  "$defs": {
+    "digest": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+    "headSha": { "type": "string", "pattern": "^[a-f0-9]{40}$" },
+    "ids": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1 }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add `axiomc inspect intent <path> --json` as the canonical `axiom.intent_ir.v0` package/workspace graph API
- emit every semantic node family when present with package-rooted, module-qualified IDs, normalized source spans, deterministic provenance, and explicit node-linked completeness diagnostics
- make verification, evidence, repair planning, artifact inspection/planning, and semantic diff reuse canonical graph identities
- add live multi-package, all-family, malformed-source, artifact/provenance, consumer-convergence, Rust-capture, schema, and relative/absolute byte-stability coverage

## Governing Issue

Closes #1418

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected when applicable (not applicable)
- [x] PR author enabled auto-merge where GitHub allows it
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Flow Contract

- Owner lane: semantic IR
- Repair owner: Codex
- Autonomy class: review-gated autonomous
- Risk class: high

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] PR author enabled auto-merge where GitHub allows it

## Merge Automation

- [x] PR author enabled auto-merge with `gh pr merge --auto --squash`

## Notes

- Passed: Intent IR contract tests (5), schema metadata tests (9), canonical consumer unit filters, compiler source-size ratchet, capability-ledger/docs validation, `cargo check`, and `git diff --check`.
- The full binary suite passed 91/92; its sole failure is the pre-existing `check_properties_runs_property_only_tests` baseline failure. The pre-existing Cranelift build/public-schema snapshot failures reproduce unchanged on `origin/main`. GitHub CI is the authoritative complete run.
- Semantic nodes added/changed: canonical Package, Module, Type, Function, Capability, Effect, Axiom, Evidence, Artifact, Decision, Dependency, and RuntimeSurface emission. Schema changed: `axiom-intent-ir-v0` now requires normalized provenance and traceable diagnostics. Evidence changed: live agent-native, workspace, type, decision, malformed-source, and consumer-convergence tests.
- Rust capture risk: high and explicitly tested; schema/node identities remain Axiom-neutral and exclude Rust, Cargo, and Cranelift implementation terms. Agent inspection impact: one byte-stable graph now supplies package-qualified IDs, provenance, diagnostics, artifacts, evidence, repair targets, and semantic diff input.
