### PR TITLE
Implement bounded repair executor

### DIFF
--- a/docs/autonomous-agent-roadmap.md
+++ b/docs/autonomous-agent-roadmap.md
@@ -82,7 +82,10 @@ defined in [Verification Planner v0](verification-planner-v0.md).
 Implement the Repair Executor v0 design as a general task/repair engine. Start
 with dry-run and deterministic repairs, then allow policy-gated assisted patch
 proposals. Enforce retry, time, token, and cost budgets with explicit terminal
-states.
+states. The executable request, report, interruption, retry, and rollback
+contract is defined in [Bounded Executor v0](bounded-executor-v0.md). A report
+can reach terminal success only after fresh evidence for the resulting
+candidate; proposals remain untrusted data and cannot widen task authority.
 
 ### A5: Independent delivery — #1423
 

--- a/docs/bounded-executor-v0.md
+++ b/docs/bounded-executor-v0.md
@@ -1,0 +1,114 @@
+# Bounded Executor v0
+
+Bounded Executor v0 is the local, transactional execution engine governed by
+[#1422](https://github.com/OMT-Global/axiomlang/issues/1422). It consumes an
+approved `axiom.agent_task.v0` contract, an exact transaction, and a typed
+repair request. It does not infer authority from issue prose or diagnostics.
+
+The executor is deliberately not a delivery controller. It may produce a
+reviewable local candidate, evidence, and an audit report. It cannot approve,
+merge, force-push, edit policy, or silently acquire a capability. External
+delivery remains separately governed by #1423.
+
+## Versioned contracts
+
+- `axiom.executor_request.v0` binds the task, transaction, operation, proposal,
+  verification input, and inherited budget ceilings.
+- `axiom.executor_report.v0` records the deterministic state transition,
+  effective authority, candidate digest, cumulative budget and retry use,
+  evidence verdict, escalation, and rollback result.
+- `axiom.executor_resume.v0` identifies an interrupted report and transaction
+  by digest and supplies no new authority. Resume ceilings must be equal to or
+  narrower than the original remaining budget.
+
+All three schemas reject undeclared fields and have typed runtime parsers. An
+executor request is converted only after its task, transaction id, policy
+digest (the v0 `transaction_digest` field), base, budgets, retry policy, and
+optional proposal match the supplied runtime objects. A
+resume request is consumed by recovery and must match the sealed report,
+transaction journal, remaining budgets, event sequence, and candidate. Reports
+use sorted collections and stable identifiers so equal inputs produce
+byte-identical dry-run output.
+
+## Authority intersection
+
+Effective authority is the intersection of the task contract, embedded repair
+task, workspace policy, and typed proposal. The executor rejects, rather than
+clips and continues, any proposal that widens allowed files, commands,
+capabilities, budgets, or delivery permissions. Patch targets are canonicalized
+again immediately before mutation; traversal, absolute paths, symlink escape,
+rename escape, chmod escape, and policy-file mutation fail closed.
+
+An assisted proposal is data. It must carry a known operation, target path,
+preimage digest, and replacement payload. Diagnostic text is never executed or
+interpreted as a command. The executor alone validates and applies proposals.
+
+## State machine
+
+The ordered states are `planned`, `dry_run`, `edited`, `evidence_failed`,
+`verification_passed`, `resolved`, `rolled_back`, `rejected`, `escalated`, and
+`interrupted`. Only `resolved` is terminal success. Dry-run never mutates and
+never resolves. An interruption is inspectable and resumable only
+when the task, transaction, policy, journal, candidate, and remaining budgets
+still match their recorded digests.
+
+Every transition is appended to a hash-chained audit. In addition to the event
+chain, the report carries a domain-separated HMAC over every serialized
+authority and state field. The report contains only the seal key id and MAC;
+the recovery key is runtime authority and is never serialized. Recovery rejects
+a missing, stale, wrong-key, or caller-recomputed unkeyed seal. A resume
+continues its sequence, attempt counts, and cumulative resource use; it cannot
+reset them.
+When an effect may have occurred but cannot be proven, resume is rejected and
+rollback is required.
+
+## Retry and stop policy
+
+Failures are classified as `code`, `evidence`, `environment`, `conflict`,
+`policy`, or `unknown`. Code, evidence, environment, and conflict failures may
+retry only when that exact cause appears in the sealed `approved_causes` retry
+policy and the global ceiling remains. The requested set can only narrow the
+signed task contract capabilities `executor.retry.code`,
+`executor.retry.evidence`, `executor.retry.environment`, and
+`executor.retry.conflict`; it cannot create retry authority. An absent retry
+policy permits no retry. Policy and unknown cannot appear in the approved set
+and are always non-retryable. Identical failure fingerprints stop on their
+second occurrence.
+Contradictory evidence, an invalid proposal, authority mismatch,
+scope escape, preimage mismatch, exhausted time/token/cost/retry budget, or an
+unsupported irreversible action stops and escalates.
+
+## Evidence and success
+
+Evidence must be produced after the latest candidate and bound to its digest.
+The executor first asks the transactional workspace to read the exact proposal
+path from the delivered Git commit. The delivered head must descend from the
+transaction base, contain the exact candidate bytes, include the proposal path,
+and change no path outside the workspace write scope. Only after that trusted
+proof does the executor create and seal a candidate binding across candidate
+digest, delivered head, transaction id, policy digest, and verification-plan
+digest. Callers cannot construct this binding. Delivery must present its exact
+binding digest; changing any member invalidates it.
+Every required evidence id appears exactly once. Missing, stale, duplicate,
+schema-invalid, contradictory, or failing evidence prevents success. A
+previously green check cannot prove a changed candidate. Evidence regression
+rolls the transaction back when rollback is safe; otherwise it leaves a clear
+non-terminal report requiring operator action. It never reports resolved.
+
+Terminal success additionally requires an unchanged authority digest, an
+inspectable successful transaction, no unresolved escalation, and authenticated
+delivery-provider evidence when the task contract requires delivery. Provider
+evidence is MAC-authenticated with a runtime-only trust key and records provider
+id, exact candidate binding, fetch epoch, required-check result, independent
+review result, and conversation resolution. The trusted provider enforces
+maximum age against the runtime system clock; callers cannot provide the time
+used for freshness validation or replace this evidence with aggregate `fresh`
+or `satisfied` booleans. Self-review and auto-merge are outside this engine.
+
+## Fixture corpus
+
+The contract corpus covers deterministic success, rejected scope escape,
+evidence regression with rollback, bounded identical retry, interruption and
+resume without budget reset, and explicit rollback. Integration tests validate
+every runtime report against the strict schemas and assert that failure paths
+cannot serialize as success.

--- a/docs/repair-executor-v0.md
+++ b/docs/repair-executor-v0.md
@@ -5,10 +5,10 @@ Repair Executor v0 is the proposed closed-loop successor to
 only approved task-local edits, reruns the required evidence, and refreshes
 delivery signals before a task can be marked resolved.
 
-This document is the accepted design contract from #858. It does not itself add
-an auto-fixer or change the Repair Plan v0 read-only boundary. Implementation is
-now governed by [#1422](https://github.com/OMT-Global/axiomlang/issues/1422),
-within the authority, containment, and verification foundations in #1419-#1421.
+This document is the accepted design contract from #858. The executable local
+contract is now defined by [Bounded Executor v0](bounded-executor-v0.md) under
+[#1422](https://github.com/OMT-Global/axiomlang/issues/1422), within the
+authority, containment, and verification foundations in #1419-#1421.
 Merge-capable delivery remains a separate Class 3 decision under #1423.
 
 ## Goals

--- a/docs/roadmap-agent-native-ledger.md
+++ b/docs/roadmap-agent-native-ledger.md
@@ -48,7 +48,7 @@ canonical issue has already shipped or has an active PR.
 | Artifact target generators | #847 | #848, #849, #850, #851 | shipped | OpenAPI, policy, SQL, OpenTofu, and runbook generation must converge on complete Intent IR under #1418. |
 | Delivery signals | #852 | #853, #854 | shipped | Signals remain evidence only; autonomous external mutations belong to #1423. |
 | Verification, semantic diff, and decisions | #855 | #856, #857 | shipped | Use these surfaces as inputs to the verification planner in #1421. |
-| Repair executor design | #858 | #784, #854 | design accepted; implementation open | `docs/repair-executor-v0.md` is the contract; implementation is #1422 and merge-capable delivery is separately gated by #1423. |
+| Repair executor design | #858 | #784, #854 | implementation review-gated | `docs/repair-executor-v0.md` supplies the accepted design; #1422 implements its bounded local engine and #1423 separately gates merge-capable delivery. |
 
 ## Autonomous Agent Execution
 
@@ -61,7 +61,7 @@ The complete roadmap is [Autonomous Agent Execution Roadmap](autonomous-agent-ro
 | Typed task contract | #1419 | implemented; review-gated | Preserve approved source authority and compile strict feature/repair specs into deterministic bounded contracts; rejected or ambiguous authority fails closed. |
 | Transactional workspace | #1420 | implemented; review-gated | Preserve the strict execution policy, isolated exact-SHA workspace, dirty-source boundary, deterministic audit, and crash-safe rollback contract. |
 | Verification planner | #1421 | implemented; review-gated | Preserve deterministic semantic-impact mapping, conservative unknown-impact coverage, strict evidence schemas, and exact-head terminal verdicts. |
-| Bounded executor | #1422 | ready after #1419-#1421 | Implement dry-run, deterministic repair, assisted proposals, budgets, retries, and auditable terminal states. |
+| Bounded executor | #1422 | implemented; review-gated | Preserve authority intersection, dry-run purity, typed deterministic repairs, bounded classified retries, resumable audit state, rollback, and fresh candidate-bound evidence. |
 | Delivery controller | #1423 | human approval required before merge-capable code | Require independent review; prohibit self-approval, force-push, and policy bypass. |
 | Autonomy evaluation | #1424 | ready for planning | Gate promotion on correctness, containment, recovery, escalation, time, and cost, including tasks that must stop. |
 

--- a/stage1/compiler-contracts/snapshots/capability-ledger.json
+++ b/stage1/compiler-contracts/snapshots/capability-ledger.json
@@ -912,6 +912,24 @@
     },
     {
       "evidenceTier": "static_spike",
+      "name": "https://axiom.omt.global/schemas/axiom-executor-report-v0.schema.json",
+      "source": "stage1/schemas/axiom-executor-report-v0.schema.json",
+      "status": "checked"
+    },
+    {
+      "evidenceTier": "static_spike",
+      "name": "https://axiom.omt.global/schemas/axiom-executor-request-v0.schema.json",
+      "source": "stage1/schemas/axiom-executor-request-v0.schema.json",
+      "status": "checked"
+    },
+    {
+      "evidenceTier": "static_spike",
+      "name": "https://axiom.omt.global/schemas/axiom-executor-resume-v0.schema.json",
+      "source": "stage1/schemas/axiom-executor-resume-v0.schema.json",
+      "status": "checked"
+    },
+    {
+      "evidenceTier": "static_spike",
       "name": "https://axiom.omt.global/schemas/axiom-format-edit-v1.schema.json",
       "source": "stage1/schemas/axiom-format-edit-v1.schema.json",
       "status": "checked"
@@ -1708,11 +1726,11 @@
       "direct_runtime": 2,
       "production_qualified": 0,
       "scaffold": 5,
-      "static_spike": 193,
+      "static_spike": 196,
       "unsupported": 5
     },
     "runtimeAbiRows": 34,
-    "schemas": 35,
+    "schemas": 38,
     "stdlibFunctions": 299,
     "stdlibModules": 34,
     "supportedNativeBackend": "cranelift"

--- a/stage1/crates/axiomc/src/bounded_executor.rs
+++ b/stage1/crates/axiomc/src/bounded_executor.rs
@@ -1,0 +1,1753 @@
+//! Deterministic, fail-closed execution authority for one approved task.
+//!
+//! This module deliberately has no command, network, model, or delivery
+//! implementation. Proposals and verification results are untrusted data;
+//! only a validated transaction may receive the single built-in file edit.
+
+use crate::agent_task::{AgentTaskContract, Budgets, TASK_SCHEMA_VERSION};
+use crate::transactional_workspace::{TransactionPhase, TransactionalWorkspace};
+use crate::verification_planner::{VERDICT_SCHEMA_VERSION, VerdictStatus, VerificationVerdict};
+use serde::{Deserialize, Serialize};
+
+pub const EXECUTOR_SCHEMA_VERSION: &str = "axiom.bounded_executor.v0";
+pub const REQUEST_SCHEMA_VERSION: &str = "axiom.executor_request.v0";
+pub const RESUME_SCHEMA_VERSION: &str = "axiom.executor_resume.v0";
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionMode {
+    Deterministic,
+    Assisted,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionState {
+    Planned,
+    DryRun,
+    Edited,
+    EvidenceFailed,
+    VerificationPassed,
+    Resolved,
+    RolledBack,
+    Rejected,
+    Escalated,
+    Interrupted,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum FailureCause {
+    Code,
+    Evidence,
+    Environment,
+    Conflict,
+    Policy,
+    Unknown,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(deny_unknown_fields)]
+pub struct BudgetUsage {
+    pub time_seconds: u64,
+    pub tokens: u64,
+    pub retries: u32,
+    pub cost_usd_micros: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ExecutorBudgets {
+    pub limits: Budgets,
+    pub consumed: BudgetUsage,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ReplaceTextProposal {
+    pub path: String,
+    pub expected_before_digest: String,
+    pub find: String,
+    pub replacement: String,
+    pub candidate_digest: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ExecutionFailure {
+    pub cause: FailureCause,
+    pub fingerprint: String,
+    pub message: String,
+    pub attempt: u32,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ExecutionEvent {
+    pub sequence: u64,
+    pub kind: String,
+    pub detail: String,
+    pub state: ExecutionState,
+    pub budget_usage: BudgetUsage,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub candidate_digest: Option<String>,
+    pub previous_digest: String,
+    pub event_digest: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct SignedDeliveryEvidence {
+    pub provider_id: String,
+    pub candidate_digest: String,
+    pub plan_digest: String,
+    pub delivered_head_sha: String,
+    pub transaction_id: String,
+    pub policy_digest: String,
+    pub fetched_at_epoch_seconds: u64,
+    pub required_checks_passed: bool,
+    pub review_satisfied: bool,
+    pub conversations_resolved: bool,
+    pub evidence_mac: String,
+}
+
+#[derive(Clone)]
+pub struct ExecutorSealKey {
+    key_id: String,
+    secret: Vec<u8>,
+}
+
+#[derive(Clone)]
+pub struct DeliveryEvidenceKey {
+    provider_id: String,
+    secret: Vec<u8>,
+}
+
+pub struct TrustedDeliveryEvidenceProvider {
+    key: DeliveryEvidenceKey,
+    max_age_seconds: u64,
+}
+
+impl ExecutorSealKey {
+    pub fn from_secret(key_id: &str, secret: &[u8]) -> Result<Self, String> {
+        validate_key(key_id, secret)?;
+        Ok(Self {
+            key_id: key_id.into(),
+            secret: secret.into(),
+        })
+    }
+    pub fn key_id(&self) -> &str {
+        &self.key_id
+    }
+}
+
+impl DeliveryEvidenceKey {
+    pub fn from_secret(provider_id: &str, secret: &[u8]) -> Result<Self, String> {
+        validate_key(provider_id, secret)?;
+        Ok(Self {
+            provider_id: provider_id.into(),
+            secret: secret.into(),
+        })
+    }
+    pub fn sign(
+        &self,
+        mut evidence: SignedDeliveryEvidence,
+    ) -> Result<SignedDeliveryEvidence, String> {
+        if evidence.provider_id != self.provider_id {
+            return Err("delivery provider ID mismatch".into());
+        }
+        evidence.evidence_mac.clear();
+        let bytes = serde_json::to_vec(&evidence).map_err(|error| error.to_string())?;
+        evidence.evidence_mac = hmac_digest(&self.secret, b"axiom-delivery-evidence-v0", &bytes);
+        Ok(evidence)
+    }
+}
+
+impl TrustedDeliveryEvidenceProvider {
+    pub fn new(key: DeliveryEvidenceKey, max_age_seconds: u64) -> Result<Self, String> {
+        if max_age_seconds == 0 {
+            return Err("delivery evidence freshness window must be positive".into());
+        }
+        Ok(Self {
+            key,
+            max_age_seconds,
+        })
+    }
+    fn verify(&self, evidence: &SignedDeliveryEvidence) -> Result<(), String> {
+        if evidence.provider_id != self.key.provider_id {
+            return Err("untrusted delivery evidence provider".into());
+        }
+        let mut unsigned = evidence.clone();
+        unsigned.evidence_mac.clear();
+        let bytes = serde_json::to_vec(&unsigned).map_err(|error| error.to_string())?;
+        let expected = hmac_digest(&self.key.secret, b"axiom-delivery-evidence-v0", &bytes);
+        if !constant_time_eq(expected.as_bytes(), evidence.evidence_mac.as_bytes()) {
+            return Err("delivery evidence MAC mismatch".into());
+        }
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|_| "system clock is before the Unix epoch")?
+            .as_secs();
+        if evidence.fetched_at_epoch_seconds > now
+            || now - evidence.fetched_at_epoch_seconds > self.max_age_seconds
+        {
+            return Err("delivery evidence is stale or future-dated".into());
+        }
+        if !evidence.required_checks_passed
+            || !evidence.review_satisfied
+            || !evidence.conversations_resolved
+        {
+            return Err("delivery evidence is not satisfactory".into());
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct CandidateBinding {
+    pub candidate_digest: String,
+    pub delivered_head_sha: String,
+    pub transaction_id: String,
+    pub policy_digest: String,
+    pub plan_digest: String,
+    pub binding_digest: String,
+}
+
+impl CandidateBinding {
+    fn new(
+        candidate_digest: &str,
+        delivered_head_sha: &str,
+        transaction_id: &str,
+        policy_digest: &str,
+        plan_digest: &str,
+    ) -> Self {
+        let binding_digest = candidate_binding_digest(
+            candidate_digest,
+            delivered_head_sha,
+            transaction_id,
+            policy_digest,
+            plan_digest,
+        );
+        Self {
+            candidate_digest: candidate_digest.into(),
+            delivered_head_sha: delivered_head_sha.into(),
+            transaction_id: transaction_id.into(),
+            policy_digest: policy_digest.into(),
+            plan_digest: plan_digest.into(),
+            binding_digest,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(deny_unknown_fields)]
+pub struct RetryPolicy {
+    pub approved_causes: Vec<FailureCause>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ExecutorRequest {
+    pub schema_version: String,
+    pub task_contract_digest: String,
+    pub transaction_id: String,
+    pub transaction_digest: String,
+    pub base_sha: String,
+    pub mode: ExecutionMode,
+    pub dry_run: bool,
+    pub budgets: Budgets,
+    pub retry_policy: RetryPolicy,
+    pub proposal: Option<ReplaceTextProposal>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ExecutorResumeRequest {
+    pub schema_version: String,
+    pub executor_state_mac: String,
+    pub seal_key_id: String,
+    pub task_contract_digest: String,
+    pub transaction_id: String,
+    pub transaction_digest: String,
+    pub candidate_digest: Option<String>,
+    pub remaining_budgets: BudgetUsage,
+    pub next_event_sequence: u64,
+}
+
+impl ExecutorRequest {
+    pub fn parse(bytes: &[u8]) -> Result<Self, String> {
+        let request: Self = serde_json::from_slice(bytes)
+            .map_err(|error| format!("invalid executor request: {error}"))?;
+        if request.schema_version != REQUEST_SCHEMA_VERSION {
+            return Err("unsupported executor request schema".into());
+        }
+        Ok(request)
+    }
+}
+
+impl ExecutorResumeRequest {
+    pub fn parse(bytes: &[u8]) -> Result<Self, String> {
+        let request: Self = serde_json::from_slice(bytes)
+            .map_err(|error| format!("invalid executor resume request: {error}"))?;
+        if request.schema_version != RESUME_SCHEMA_VERSION {
+            return Err("unsupported executor resume schema".into());
+        }
+        Ok(request)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RollbackOutcome {
+    NotRequired,
+    Succeeded,
+    Failed,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BoundedExecutor {
+    schema_version: String,
+    task_contract_digest: String,
+    base_sha: String,
+    dry_run: bool,
+    state: ExecutionState,
+    budgets: ExecutorBudgets,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    proposal: Option<ReplaceTextProposal>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    candidate_digest: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    verification: Option<VerificationVerdict>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    candidate_binding: Option<CandidateBinding>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    delivery: Option<SignedDeliveryEvidence>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    transaction_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    policy_digest: Option<String>,
+    rollback: RollbackOutcome,
+    failures: Vec<ExecutionFailure>,
+    events: Vec<ExecutionEvent>,
+    state_digest: String,
+    seal_key_id: String,
+    seal_mac: String,
+    #[serde(skip)]
+    seal_key: Option<ExecutorSealKey>,
+    retry_policy: RetryPolicy,
+    allowed_files: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    repair_allowed_files: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    interrupted_from: Option<ExecutionState>,
+}
+
+impl BoundedExecutor {
+    pub fn from_request(
+        request: ExecutorRequest,
+        contract: &AgentTaskContract,
+        workspace: &TransactionalWorkspace,
+        current: Option<&[u8]>,
+        seal_key: &ExecutorSealKey,
+    ) -> Result<Self, String> {
+        if request.schema_version != REQUEST_SCHEMA_VERSION
+            || request.task_contract_digest != contract.contract_digest
+            || request.transaction_id != workspace.state().transaction_id
+            || request.transaction_digest != workspace.state().policy_digest
+            || request.base_sha != workspace.state().base_sha
+            || request.budgets != contract.budgets
+            || request.mode != ExecutionMode::Deterministic
+        {
+            return Err("executor request exceeds or mismatches approved authority".into());
+        }
+        let mut executor = Self::new_with_retry_policy(
+            contract,
+            &request.base_sha,
+            request.dry_run,
+            request.retry_policy,
+            seal_key,
+        )?;
+        executor.bind_transaction(workspace)?;
+        match (request.proposal, current) {
+            (Some(proposal), Some(bytes)) => {
+                let validated = executor.propose_replace(
+                    &proposal.path,
+                    bytes,
+                    &proposal.find,
+                    &proposal.replacement,
+                )?;
+                if validated != proposal {
+                    return Err(
+                        "executor request proposal digest does not match observed bytes".into(),
+                    );
+                }
+            }
+            (None, None) => {}
+            (Some(_), None) => {
+                return Err("replace-text request requires observed current bytes".into());
+            }
+            (None, Some(_)) => return Err("current bytes supplied without a typed proposal".into()),
+        }
+        Ok(executor)
+    }
+
+    pub fn new(
+        contract: &AgentTaskContract,
+        base_sha: &str,
+        dry_run: bool,
+        seal_key: &ExecutorSealKey,
+    ) -> Result<Self, String> {
+        Self::new_with_retry_policy(
+            contract,
+            base_sha,
+            dry_run,
+            RetryPolicy::default(),
+            seal_key,
+        )
+    }
+
+    pub fn new_with_retry_policy(
+        contract: &AgentTaskContract,
+        base_sha: &str,
+        dry_run: bool,
+        retry_policy: RetryPolicy,
+        seal_key: &ExecutorSealKey,
+    ) -> Result<Self, String> {
+        validate_sha(base_sha)?;
+        validate_contract(contract)?;
+        validate_retry_policy(&retry_policy)?;
+        let authorized = authorized_retry_causes(contract);
+        if retry_policy
+            .approved_causes
+            .iter()
+            .any(|cause| !authorized.contains(cause))
+        {
+            return Err("retry policy is not authorized by the signed task contract".into());
+        }
+        if contract.authority.source_revision != base_sha {
+            return Err("task authority source_revision does not match executor base SHA".into());
+        }
+        let mut executor = Self {
+            schema_version: EXECUTOR_SCHEMA_VERSION.into(),
+            task_contract_digest: contract.contract_digest.clone(),
+            base_sha: base_sha.into(),
+            dry_run,
+            state: ExecutionState::Planned,
+            budgets: ExecutorBudgets {
+                limits: contract.budgets.clone(),
+                consumed: BudgetUsage::default(),
+            },
+            proposal: None,
+            candidate_digest: None,
+            verification: None,
+            candidate_binding: None,
+            delivery: None,
+            transaction_id: None,
+            policy_digest: None,
+            rollback: RollbackOutcome::NotRequired,
+            failures: Vec::new(),
+            events: Vec::new(),
+            state_digest: empty_digest(),
+            seal_key_id: seal_key.key_id.clone(),
+            seal_mac: String::new(),
+            seal_key: Some(seal_key.clone()),
+            retry_policy,
+            allowed_files: contract.scope.allowed_files.clone(),
+            repair_allowed_files: contract
+                .repair_plan
+                .as_ref()
+                .map(|repair| repair.allowed_files.clone()),
+            interrupted_from: None,
+        };
+        executor.record("planned", &contract.id)?;
+        Ok(executor)
+    }
+
+    pub fn state(&self) -> ExecutionState {
+        self.state
+    }
+    pub fn budgets(&self) -> &ExecutorBudgets {
+        &self.budgets
+    }
+    pub fn rollback_outcome(&self) -> RollbackOutcome {
+        self.rollback
+    }
+    pub fn candidate_digest(&self) -> Option<&str> {
+        self.candidate_digest.as_deref()
+    }
+    pub fn task_contract_digest(&self) -> &str {
+        &self.task_contract_digest
+    }
+    pub fn seal_mac(&self) -> &str {
+        &self.seal_mac
+    }
+    pub fn failures(&self) -> &[ExecutionFailure] {
+        &self.failures
+    }
+    pub fn events(&self) -> &[ExecutionEvent] {
+        &self.events
+    }
+    pub fn candidate_binding(&self) -> Option<&CandidateBinding> {
+        self.candidate_binding.as_ref()
+    }
+
+    pub fn resume_request(&self) -> Result<ExecutorResumeRequest, String> {
+        self.validate_integrity()?;
+        Ok(ExecutorResumeRequest {
+            schema_version: RESUME_SCHEMA_VERSION.into(),
+            executor_state_mac: self.seal_mac.clone(),
+            seal_key_id: self.seal_key_id.clone(),
+            task_contract_digest: self.task_contract_digest.clone(),
+            transaction_id: self
+                .transaction_id
+                .clone()
+                .ok_or("executor is not transaction-bound")?,
+            transaction_digest: self
+                .policy_digest
+                .clone()
+                .ok_or("executor is not policy-bound")?,
+            candidate_digest: self.candidate_digest.clone(),
+            remaining_budgets: self.remaining_budgets()?,
+            next_event_sequence: self.events.len() as u64,
+        })
+    }
+
+    fn remaining_budgets(&self) -> Result<BudgetUsage, String> {
+        Ok(BudgetUsage {
+            time_seconds: self
+                .budgets
+                .limits
+                .time_seconds
+                .checked_sub(self.budgets.consumed.time_seconds)
+                .ok_or("invalid time consumption")?,
+            tokens: self
+                .budgets
+                .limits
+                .tokens
+                .checked_sub(self.budgets.consumed.tokens)
+                .ok_or("invalid token consumption")?,
+            retries: self
+                .budgets
+                .limits
+                .retries
+                .checked_sub(self.budgets.consumed.retries)
+                .ok_or("invalid retry consumption")?,
+            cost_usd_micros: self
+                .budgets
+                .limits
+                .cost_usd_micros
+                .checked_sub(self.budgets.consumed.cost_usd_micros)
+                .ok_or("invalid cost consumption")?,
+        })
+    }
+
+    /// Restore a serialized executor only when its immutable authority, base,
+    /// budgets, and hash chain still match the approved task contract.
+    pub fn recover(
+        bytes: &[u8],
+        request: &ExecutorResumeRequest,
+        contract: &AgentTaskContract,
+        workspace: &TransactionalWorkspace,
+        seal_key: &ExecutorSealKey,
+    ) -> Result<Self, String> {
+        validate_contract(contract)?;
+        let base_sha = &workspace.state().base_sha;
+        validate_sha(base_sha)?;
+        let mut executor: Self = serde_json::from_slice(bytes)
+            .map_err(|error| format!("invalid executor state: {error}"))?;
+        executor.seal_key = Some(seal_key.clone());
+        if request.schema_version != RESUME_SCHEMA_VERSION
+            || request.executor_state_mac != executor.seal_mac
+            || request.seal_key_id != executor.seal_key_id
+            || request.seal_key_id != seal_key.key_id
+            || request.task_contract_digest != executor.task_contract_digest
+            || request.transaction_id != workspace.state().transaction_id
+            || request.transaction_digest != workspace.state().policy_digest
+            || request.candidate_digest != executor.candidate_digest
+            || request.remaining_budgets != executor.remaining_budgets()?
+            || request.next_event_sequence != executor.events.len() as u64
+        {
+            return Err("resume request does not match sealed executor state".into());
+        }
+        if executor.schema_version != EXECUTOR_SCHEMA_VERSION
+            || executor.task_contract_digest != contract.contract_digest
+            || executor.base_sha != *base_sha
+            || executor.budgets.limits != contract.budgets
+            || executor.allowed_files != contract.scope.allowed_files
+            || executor.repair_allowed_files
+                != contract
+                    .repair_plan
+                    .as_ref()
+                    .map(|repair| repair.allowed_files.clone())
+        {
+            return Err(
+                "executor state authority does not match the approved task contract".into(),
+            );
+        }
+        if workspace.state().task_contract_digest != executor.task_contract_digest
+            || executor.transaction_id.as_deref() != Some(&workspace.state().transaction_id)
+            || executor.policy_digest.as_deref() != Some(&workspace.state().policy_digest)
+        {
+            return Err("executor recovery does not match the transaction binding".into());
+        }
+        if exceeds(&executor.budgets.consumed, &executor.budgets.limits) {
+            return Err("executor state contains widened budget consumption".into());
+        }
+        if executor.state == ExecutionState::Interrupted {
+            if executor.interrupted_from.is_none() {
+                return Err("interrupted executor is missing its prior state".into());
+            }
+        } else if executor.interrupted_from.is_some() {
+            return Err("non-interrupted executor contains stale recovery state".into());
+        }
+        if let Some(proposal) = &executor.proposal {
+            validate_digest(&proposal.expected_before_digest)?;
+            validate_digest(&proposal.candidate_digest)?;
+            if !executor.allowed_files.contains(&proposal.path)
+                || executor
+                    .repair_allowed_files
+                    .as_ref()
+                    .is_some_and(|paths| !paths.contains(&proposal.path))
+            {
+                return Err("serialized proposal escapes approved task scope".into());
+            }
+        }
+        executor.validate_integrity()?;
+        Ok(executor)
+    }
+
+    /// Validate a typed proposal and compute the exact resulting file digest.
+    /// The caller-supplied bytes are observed data, not authorization.
+    pub fn propose_replace(
+        &mut self,
+        path: &str,
+        current: &[u8],
+        find: &str,
+        replacement: &str,
+    ) -> Result<ReplaceTextProposal, String> {
+        self.guard()?;
+        self.require_state(ExecutionState::Planned)?;
+        self.authorize_path(path)?;
+        if find.is_empty() {
+            return self.reject("replacement search text must not be empty");
+        }
+        let source = std::str::from_utf8(current)
+            .map_err(|_| "replace-text proposals require UTF-8 input".to_string())?;
+        if source.matches(find).count() != 1 {
+            return self.reject("replacement search text must occur exactly once");
+        }
+        let candidate = source.replacen(find, replacement, 1).into_bytes();
+        let proposal = ReplaceTextProposal {
+            path: path.into(),
+            expected_before_digest: digest(current),
+            find: find.into(),
+            replacement: replacement.into(),
+            candidate_digest: digest(&candidate),
+        };
+        self.proposal = Some(proposal.clone());
+        self.candidate_digest = Some(proposal.candidate_digest.clone());
+        if self.dry_run {
+            self.state = ExecutionState::DryRun;
+        }
+        self.record("proposal_validated", path)?;
+        Ok(proposal)
+    }
+
+    /// Bind resumable state to an existing task transaction without mutating it.
+    pub fn bind_transaction(&mut self, workspace: &TransactionalWorkspace) -> Result<(), String> {
+        self.guard()?;
+        self.require_state(ExecutionState::Planned)?;
+        self.validate_workspace(workspace)?;
+        self.transaction_id = Some(workspace.state().transaction_id.clone());
+        self.policy_digest = Some(workspace.state().policy_digest.clone());
+        self.record("transaction_bound", &workspace.state().transaction_id)
+    }
+
+    /// Apply only the previously validated proposal through the transaction.
+    /// Dry-run returns without reading or writing the workspace.
+    pub fn apply_proposal(&mut self, workspace: &mut TransactionalWorkspace) -> Result<(), String> {
+        self.guard()?;
+        if self.dry_run {
+            return Err("dry-run is side-effect free and cannot apply a proposal".into());
+        }
+        self.require_state(ExecutionState::Planned)?;
+        let proposal = self
+            .proposal
+            .clone()
+            .ok_or_else(|| "no validated proposal exists".to_string())?;
+        self.validate_workspace(workspace)?;
+        let current = workspace.read(&proposal.path).map_err(|error| {
+            self.failure_error(FailureCause::Environment, "workspace_read", &error)
+        })?;
+        if digest(&current) != proposal.expected_before_digest {
+            return Err(self.failure_error(
+                FailureCause::Conflict,
+                "candidate_base_changed",
+                "workspace content differs from the proposed base",
+            ));
+        }
+        let source = std::str::from_utf8(&current)
+            .map_err(|_| "workspace content is no longer UTF-8".to_string())?;
+        if source.matches(&proposal.find).count() != 1 {
+            return Err(self.failure_error(
+                FailureCause::Conflict,
+                "candidate_match_changed",
+                "replacement search text no longer occurs exactly once",
+            ));
+        }
+        let candidate = source
+            .replacen(&proposal.find, &proposal.replacement, 1)
+            .into_bytes();
+        if digest(&candidate) != proposal.candidate_digest {
+            return Err(self.failure_error(
+                FailureCause::Policy,
+                "candidate_digest_mismatch",
+                "proposal does not reproduce its exact candidate digest",
+            ));
+        }
+        workspace
+            .write(&proposal.path, &candidate)
+            .map_err(|error| self.failure_error(FailureCause::Policy, "workspace_write", &error))?;
+        self.transaction_id = Some(workspace.state().transaction_id.clone());
+        self.policy_digest = Some(workspace.state().policy_digest.clone());
+        self.state = ExecutionState::Edited;
+        self.record("proposal_applied", &proposal.candidate_digest)
+    }
+
+    pub fn submit_verification(
+        &mut self,
+        workspace: &mut TransactionalWorkspace,
+        verdict: VerificationVerdict,
+    ) -> Result<(), String> {
+        self.guard()?;
+        self.require_state(ExecutionState::Edited)?;
+        self.validate_workspace(workspace)?;
+        if verdict.schema_version != VERDICT_SCHEMA_VERSION
+            || validate_digest(&verdict.plan_digest).is_err()
+            || validate_sha(&verdict.source_head_sha).is_err()
+            || validate_sha(&verdict.delivered_head_sha).is_err()
+        {
+            return Err(self.failure_error(
+                FailureCause::Evidence,
+                "verification_schema",
+                "unsupported verification verdict schema",
+            ));
+        }
+        if verdict.source_head_sha != self.base_sha {
+            return Err(self.failure_error(
+                FailureCause::Conflict,
+                "verification_base",
+                "verification verdict is bound to another source head",
+            ));
+        }
+        if verdict.delivered_head_sha == self.base_sha {
+            return Err(self.failure_error(
+                FailureCause::Evidence,
+                "verification_unchanged_head",
+                "verification must cover a delivered head containing the candidate edit",
+            ));
+        }
+        let proposal = self
+            .proposal
+            .clone()
+            .ok_or_else(|| "verification requires an applied proposal".to_string())?;
+        let delivered = workspace
+            .read_at_commit(&proposal.path, &verdict.delivered_head_sha)
+            .map_err(|error| {
+                self.failure_error(FailureCause::Evidence, "candidate_head_proof", &error)
+            })?;
+        if digest(&delivered) != proposal.candidate_digest {
+            return Err(self.failure_error(
+                FailureCause::Evidence,
+                "candidate_head_binding",
+                "delivered head does not contain the exact candidate bytes",
+            ));
+        }
+        let binding = CandidateBinding::new(
+            &proposal.candidate_digest,
+            &verdict.delivered_head_sha,
+            self.transaction_id
+                .as_deref()
+                .ok_or("executor is not transaction-bound")?,
+            self.policy_digest
+                .as_deref()
+                .ok_or("executor is not policy-bound")?,
+            &verdict.plan_digest,
+        );
+        self.verification = Some(verdict.clone());
+        self.candidate_binding = Some(binding);
+        let has_failures = !verdict.missing.is_empty()
+            || !verdict.duplicate.is_empty()
+            || !verdict.invalid.is_empty()
+            || !verdict.failed.is_empty();
+        if (verdict.status == VerdictStatus::Passed && has_failures)
+            || (verdict.status == VerdictStatus::Failed && !has_failures)
+        {
+            self.state = ExecutionState::Escalated;
+            self.record("verification_contradictory", &verdict.plan_digest)?;
+            return Err("contradictory verification evidence requires escalation".into());
+        }
+        if verdict.status == VerdictStatus::Failed {
+            self.state = ExecutionState::EvidenceFailed;
+            self.record("verification_failed", &verdict.plan_digest)?;
+            return Ok(());
+        }
+        self.state = ExecutionState::VerificationPassed;
+        self.record("verification_passed", &verdict.plan_digest)
+    }
+
+    /// Delivery state is supplied as typed evidence. The Class-2 executor has
+    /// no delivery mutation primitive and cannot manufacture this verdict.
+    pub fn submit_delivery(
+        &mut self,
+        workspace: &TransactionalWorkspace,
+        evidence: SignedDeliveryEvidence,
+        provider: &TrustedDeliveryEvidenceProvider,
+    ) -> Result<(), String> {
+        self.guard()?;
+        self.require_state(ExecutionState::VerificationPassed)?;
+        self.validate_workspace(workspace)?;
+        provider.verify(&evidence).map_err(|error| {
+            self.failure_error(FailureCause::Evidence, "delivery_provider", &error)
+        })?;
+        if self.candidate_digest.as_deref() != Some(&evidence.candidate_digest) {
+            return Err(self.failure_error(
+                FailureCause::Conflict,
+                "delivery_candidate",
+                "delivery verdict is bound to another candidate",
+            ));
+        }
+        let verification = self
+            .verification
+            .as_ref()
+            .ok_or_else(|| "delivery recheck requires a verification verdict".to_string())?;
+        let binding = self
+            .candidate_binding
+            .as_ref()
+            .ok_or_else(|| "delivery recheck requires a candidate binding".to_string())?;
+        if evidence.plan_digest != verification.plan_digest
+            || evidence.delivered_head_sha != verification.delivered_head_sha
+            || evidence.transaction_id != binding.transaction_id
+            || evidence.policy_digest != binding.policy_digest
+            || validate_sha(&evidence.delivered_head_sha).is_err()
+        {
+            return Err(self.failure_error(
+                FailureCause::Evidence,
+                "delivery_binding",
+                "delivery verdict is not bound to the verified plan and head",
+            ));
+        }
+        self.delivery = Some(evidence.clone());
+        self.state = ExecutionState::Resolved;
+        self.record("resolved", &evidence.candidate_digest)
+    }
+
+    pub fn rollback(&mut self, workspace: &mut TransactionalWorkspace) -> Result<(), String> {
+        self.guard()?;
+        if matches!(
+            self.state,
+            ExecutionState::Resolved | ExecutionState::DryRun | ExecutionState::RolledBack
+        ) {
+            return Err("executor state cannot be rolled back".into());
+        }
+        self.validate_workspace(workspace)?;
+        match workspace.abort() {
+            Ok(()) => {
+                self.rollback = RollbackOutcome::Succeeded;
+                self.state = ExecutionState::RolledBack;
+                self.record("rolled_back", &workspace.state().transaction_id)
+            }
+            Err(error) => {
+                self.rollback = RollbackOutcome::Failed;
+                self.state = ExecutionState::Escalated;
+                let _ = self.record("rollback_failed", &error);
+                Err(error)
+            }
+        }
+    }
+
+    pub fn charge_budget(&mut self, usage: BudgetUsage) -> Result<(), String> {
+        self.guard()?;
+        self.ensure_nonterminal()?;
+        let next = BudgetUsage {
+            time_seconds: self
+                .budgets
+                .consumed
+                .time_seconds
+                .checked_add(usage.time_seconds)
+                .ok_or_else(|| "time budget overflow".to_string())?,
+            tokens: self
+                .budgets
+                .consumed
+                .tokens
+                .checked_add(usage.tokens)
+                .ok_or_else(|| "token budget overflow".to_string())?,
+            retries: self
+                .budgets
+                .consumed
+                .retries
+                .checked_add(usage.retries)
+                .ok_or_else(|| "retry budget overflow".to_string())?,
+            cost_usd_micros: self
+                .budgets
+                .consumed
+                .cost_usd_micros
+                .checked_add(usage.cost_usd_micros)
+                .ok_or_else(|| "cost budget overflow".to_string())?,
+        };
+        if next.time_seconds > self.budgets.limits.time_seconds
+            || next.tokens > self.budgets.limits.tokens
+            || next.retries > self.budgets.limits.retries
+            || next.cost_usd_micros > self.budgets.limits.cost_usd_micros
+        {
+            self.state = ExecutionState::Escalated;
+            self.record("budget_exhausted", "execution")?;
+            return Err("execution budget exhausted; escalation required".into());
+        }
+        self.budgets.consumed = next;
+        self.record("budget_charged", "execution")
+    }
+
+    /// Records a retryable failure. Identical consecutive failures stop, and
+    /// unknown/policy failures always escalate without retrying.
+    pub fn retry_failure(
+        &mut self,
+        cause: FailureCause,
+        code: &str,
+        message: &str,
+    ) -> Result<(), String> {
+        self.guard()?;
+        self.ensure_nonterminal()?;
+        let fingerprint = digest(format!("{cause:?}\0{code}\0{message}").as_bytes());
+        let repeated = self
+            .failures
+            .last()
+            .is_some_and(|prior| prior.fingerprint == fingerprint);
+        let attempt = self.budgets.consumed.retries.saturating_add(1);
+        self.failures.push(ExecutionFailure {
+            cause,
+            fingerprint,
+            message: message.into(),
+            attempt,
+        });
+        if matches!(cause, FailureCause::Unknown | FailureCause::Policy)
+            || !self.retry_policy.approved_causes.contains(&cause)
+            || repeated
+        {
+            self.state = ExecutionState::Escalated;
+            self.record("failure_escalated", code)?;
+            return Err("failure requires escalation".into());
+        }
+        let next = self
+            .budgets
+            .consumed
+            .retries
+            .checked_add(1)
+            .ok_or_else(|| "retry budget overflow".to_string())?;
+        if next > self.budgets.limits.retries {
+            self.state = ExecutionState::Escalated;
+            self.record("budget_exhausted", "retry")?;
+            return Err("execution retry budget exhausted; escalation required".into());
+        }
+        self.budgets.consumed.retries = next;
+        self.record("retry_approved", code)
+    }
+
+    pub fn interrupt(&mut self) -> Result<(), String> {
+        self.guard()?;
+        self.ensure_nonterminal()?;
+        if self.state == ExecutionState::Interrupted {
+            return Err("executor is already interrupted".into());
+        }
+        let prior = self.state;
+        self.interrupted_from = Some(prior);
+        self.state = ExecutionState::Interrupted;
+        self.record("interrupted", &format!("{prior:?}"))
+    }
+
+    pub fn resume(&mut self) -> Result<(), String> {
+        self.guard()?;
+        self.require_state(ExecutionState::Interrupted)?;
+        let restored = self
+            .interrupted_from
+            .take()
+            .ok_or_else(|| "interrupted executor is missing its prior state".to_string())?;
+        self.state = restored;
+        self.record("resumed", "execution")
+    }
+
+    pub fn validate_chain(&self) -> Result<(), String> {
+        let mut previous = empty_digest();
+        let mut prior_usage = BudgetUsage::default();
+        for (index, event) in self.events.iter().enumerate() {
+            if event.sequence != index as u64 || event.previous_digest != previous {
+                return Err("executor event chain is discontinuous".into());
+            }
+            if event.budget_usage.time_seconds < prior_usage.time_seconds
+                || event.budget_usage.tokens < prior_usage.tokens
+                || event.budget_usage.retries < prior_usage.retries
+                || event.budget_usage.cost_usd_micros < prior_usage.cost_usd_micros
+            {
+                return Err("executor event budgets are not monotonic".into());
+            }
+            let expected = event_digest(event, &previous)?;
+            if event.event_digest != expected {
+                return Err("executor event digest mismatch".into());
+            }
+            previous = expected;
+            prior_usage = event.budget_usage.clone();
+        }
+        if self.state_digest != previous {
+            return Err("executor state digest mismatch".into());
+        }
+        if let Some(last) = self.events.last() {
+            if last.state != self.state
+                || last.budget_usage != self.budgets.consumed
+                || last.candidate_digest != self.candidate_digest
+            {
+                return Err("executor state does not match its final chained snapshot".into());
+            }
+        }
+        Ok(())
+    }
+
+    pub fn validate_integrity(&self) -> Result<(), String> {
+        self.validate_chain()?;
+        let expected = self.compute_seal()?;
+        if !constant_time_eq(self.seal_mac.as_bytes(), expected.as_bytes()) {
+            return Err("executor authority-state seal mismatch".into());
+        }
+        Ok(())
+    }
+
+    fn authorize_path(&mut self, path: &str) -> Result<(), String> {
+        if !canonical_relative(path) || !self.allowed_files.iter().any(|allowed| allowed == path) {
+            return self.reject("proposal path is outside the task allowed_files");
+        }
+        if self
+            .repair_allowed_files
+            .as_ref()
+            .is_some_and(|allowed| !allowed.iter().any(|candidate| candidate == path))
+        {
+            return self.reject("proposal path is outside the repair-plan allowed_files");
+        }
+        Ok(())
+    }
+
+    fn validate_workspace(&mut self, workspace: &TransactionalWorkspace) -> Result<(), String> {
+        let state = workspace.state();
+        if state.task_contract_digest != self.task_contract_digest {
+            return self.reject("workspace is bound to another task contract");
+        }
+        if state.base_sha != self.base_sha {
+            return self.reject("workspace is bound to another base SHA");
+        }
+        if state.phase != TransactionPhase::Active {
+            return self.reject("workspace transaction is not active");
+        }
+        if let Some(transaction_id) = &self.transaction_id {
+            if transaction_id != &state.transaction_id
+                || self.policy_digest.as_deref() != Some(&state.policy_digest)
+            {
+                return self.reject("workspace no longer matches the sealed transaction binding");
+            }
+        }
+        if state.policy.allow_network {
+            return self.reject("workspace policy grants forbidden network authority");
+        }
+        if !state.policy.allowed_commands.is_empty() {
+            return self.reject("workspace policy grants unsupported command authority");
+        }
+        if state
+            .policy
+            .allowed_write_paths
+            .iter()
+            .any(|path| !self.allowed_files.contains(path))
+        {
+            return self.reject("workspace write policy exceeds the task allowed_files");
+        }
+        if self.repair_allowed_files.as_ref().is_some_and(|repair| {
+            state
+                .policy
+                .allowed_write_paths
+                .iter()
+                .any(|path| !repair.contains(path))
+        }) {
+            return self.reject("workspace write policy exceeds the repair allowed_files");
+        }
+        Ok(())
+    }
+
+    fn failure_error(&mut self, cause: FailureCause, code: &str, message: &str) -> String {
+        let _ = self.retry_failure(cause, code, message);
+        message.into()
+    }
+
+    fn reject<T>(&mut self, message: &str) -> Result<T, String> {
+        self.state = ExecutionState::Rejected;
+        self.failures.push(ExecutionFailure {
+            cause: FailureCause::Policy,
+            fingerprint: digest(message.as_bytes()),
+            message: message.into(),
+            attempt: self.budgets.consumed.retries,
+        });
+        let _ = self.record("rejected", message);
+        Err(message.into())
+    }
+
+    fn require_state(&self, expected: ExecutionState) -> Result<(), String> {
+        if self.state == expected {
+            Ok(())
+        } else {
+            Err(format!("executor must be in {expected:?} state"))
+        }
+    }
+
+    fn ensure_nonterminal(&self) -> Result<(), String> {
+        if matches!(
+            self.state,
+            ExecutionState::Resolved
+                | ExecutionState::RolledBack
+                | ExecutionState::Rejected
+                | ExecutionState::Escalated
+        ) {
+            Err("executor is terminal".into())
+        } else {
+            Ok(())
+        }
+    }
+
+    fn record(&mut self, kind: &str, detail: &str) -> Result<(), String> {
+        let previous = self.state_digest.clone();
+        let sequence = self.events.len() as u64;
+        let mut event = ExecutionEvent {
+            sequence,
+            kind: kind.into(),
+            detail: detail.into(),
+            state: self.state,
+            budget_usage: self.budgets.consumed.clone(),
+            candidate_digest: self.candidate_digest.clone(),
+            previous_digest: previous,
+            event_digest: String::new(),
+        };
+        event.event_digest = event_digest(&event, &event.previous_digest)?;
+        let event_digest = event.event_digest.clone();
+        self.events.push(event);
+        self.state_digest = event_digest;
+        self.seal_mac = self.compute_seal()?;
+        Ok(())
+    }
+
+    fn compute_seal(&self) -> Result<String, String> {
+        let mut snapshot = self.clone();
+        snapshot.seal_mac.clear();
+        let key = self
+            .seal_key
+            .as_ref()
+            .ok_or("executor seal key is unavailable")?;
+        if key.key_id != self.seal_key_id {
+            return Err("executor seal key ID mismatch".into());
+        }
+        let bytes = serde_json::to_vec(&snapshot).map_err(|error| error.to_string())?;
+        Ok(hmac_digest(&key.secret, b"axiom-executor-state-v0", &bytes))
+    }
+
+    fn guard(&self) -> Result<(), String> {
+        self.validate_integrity()
+    }
+}
+
+fn validate_contract(contract: &AgentTaskContract) -> Result<(), String> {
+    if contract.schema_version != TASK_SCHEMA_VERSION {
+        return Err("unsupported agent task contract schema".into());
+    }
+    validate_digest(&contract.contract_digest)?;
+    let mut canonical = contract.clone();
+    canonical.contract_digest.clear();
+    let encoded = serde_json::to_vec(&canonical).map_err(|error| error.to_string())?;
+    if digest(&encoded) != contract.contract_digest {
+        return Err("agent task contract digest mismatch".into());
+    }
+    if contract.scope.allowed_files.is_empty() {
+        return Err("task has no allowed files".into());
+    }
+    if let Some(repair) = &contract.repair_plan {
+        if repair.allowed_files.is_empty()
+            || repair
+                .allowed_files
+                .iter()
+                .any(|path| !contract.scope.allowed_files.contains(path))
+        {
+            return Err("repair-plan scope is not a non-empty task-scope subset".into());
+        }
+    }
+    if contract.delivery_permissions.commit
+        || contract.delivery_permissions.push
+        || contract.delivery_permissions.pull_request
+        || contract.delivery_permissions.merge
+        || contract.delivery_permissions.review
+        || contract.delivery_permissions.deploy
+        || contract.delivery_permissions.approve_own_pull_request
+        || contract.delivery_permissions.force_push
+        || contract.delivery_permissions.direct_push_protected
+        || contract.delivery_permissions.irreversible_actions
+    {
+        return Err("bounded executor refuses delivery or irreversible authority".into());
+    }
+    Ok(())
+}
+
+fn exceeds(usage: &BudgetUsage, limits: &Budgets) -> bool {
+    usage.time_seconds > limits.time_seconds
+        || usage.tokens > limits.tokens
+        || usage.retries > limits.retries
+        || usage.cost_usd_micros > limits.cost_usd_micros
+}
+
+fn validate_retry_policy(policy: &RetryPolicy) -> Result<(), String> {
+    if policy
+        .approved_causes
+        .iter()
+        .any(|cause| matches!(cause, FailureCause::Unknown | FailureCause::Policy))
+    {
+        Err("unknown and policy failures may never be approved for retry".into())
+    } else {
+        let mut causes = policy.approved_causes.clone();
+        causes.sort_by_key(|cause| format!("{cause:?}"));
+        causes.dedup();
+        if causes.len() != policy.approved_causes.len() {
+            Err("retry policy contains duplicate causes".into())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// Retry authority is derived only from capability names inside the signed
+/// task contract; an executor request can narrow this set but never add to it.
+fn authorized_retry_causes(contract: &AgentTaskContract) -> Vec<FailureCause> {
+    [
+        ("executor.retry.code", FailureCause::Code),
+        ("executor.retry.evidence", FailureCause::Evidence),
+        ("executor.retry.environment", FailureCause::Environment),
+        ("executor.retry.conflict", FailureCause::Conflict),
+    ]
+    .into_iter()
+    .filter_map(|(name, cause)| {
+        contract
+            .capabilities
+            .required
+            .iter()
+            .any(|item| item == name)
+            .then_some(cause)
+    })
+    .collect()
+}
+
+fn candidate_binding_digest(
+    candidate: &str,
+    head: &str,
+    transaction: &str,
+    policy: &str,
+    plan: &str,
+) -> String {
+    digest(format!("{candidate}\0{head}\0{transaction}\0{policy}\0{plan}").as_bytes())
+}
+
+fn canonical_relative(path: &str) -> bool {
+    !path.is_empty()
+        && !path.starts_with('/')
+        && path
+            .split('/')
+            .all(|part| !part.is_empty() && part != "." && part != "..")
+}
+
+fn validate_sha(value: &str) -> Result<(), String> {
+    if value.len() == 40
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+    {
+        Ok(())
+    } else {
+        Err("base SHA must be 40 lowercase hexadecimal characters".into())
+    }
+}
+
+fn validate_digest(value: &str) -> Result<(), String> {
+    if value.len() == 71
+        && value.starts_with("sha256:")
+        && value[7..]
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+    {
+        Ok(())
+    } else {
+        Err("digest must use sha256:<64 lowercase hex> form".into())
+    }
+}
+
+fn validate_key(key_id: &str, secret: &[u8]) -> Result<(), String> {
+    if key_id.is_empty()
+        || key_id.len() > 64
+        || !key_id.bytes().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'.' | b'_' | b'-')
+        })
+    {
+        return Err("key ID must be 1-64 canonical lowercase ASCII characters".into());
+    }
+    if secret.len() < 32 {
+        return Err("authentication keys must contain at least 32 bytes".into());
+    }
+    Ok(())
+}
+
+fn hmac_digest(key: &[u8], domain: &[u8], payload: &[u8]) -> String {
+    let mut block = [0u8; 64];
+    if key.len() > 64 {
+        block[..32].copy_from_slice(&sha256_raw(key));
+    } else {
+        block[..key.len()].copy_from_slice(key);
+    }
+    let mut inner = Vec::with_capacity(64 + domain.len() + 1 + payload.len());
+    inner.extend(block.iter().map(|byte| byte ^ 0x36));
+    inner.extend_from_slice(domain);
+    inner.push(0);
+    inner.extend_from_slice(payload);
+    let inner_hash = sha256_raw(&inner);
+    let mut outer = Vec::with_capacity(96);
+    outer.extend(block.iter().map(|byte| byte ^ 0x5c));
+    outer.extend_from_slice(&inner_hash);
+    format!("hmac-sha256:{}", hex_bytes(&sha256_raw(&outer)))
+}
+
+fn sha256_raw(bytes: &[u8]) -> [u8; 32] {
+    let encoded = sha256(bytes);
+    let mut output = [0u8; 32];
+    for (index, pair) in encoded.as_bytes().chunks_exact(2).enumerate() {
+        output[index] = (hex_nibble(pair[0]) << 4) | hex_nibble(pair[1]);
+    }
+    output
+}
+
+fn hex_nibble(byte: u8) -> u8 {
+    match byte {
+        b'0'..=b'9' => byte - b'0',
+        b'a'..=b'f' => byte - b'a' + 10,
+        _ => unreachable!("SHA output is hex"),
+    }
+}
+fn hex_bytes(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    left.iter()
+        .zip(right)
+        .fold(0u8, |diff, (a, b)| diff | (a ^ b))
+        == 0
+}
+
+fn empty_digest() -> String {
+    digest(b"")
+}
+
+fn event_digest(event: &ExecutionEvent, previous: &str) -> Result<String, String> {
+    let snapshot = serde_json::to_vec(&(
+        event.sequence,
+        &event.kind,
+        &event.detail,
+        event.state,
+        &event.budget_usage,
+        &event.candidate_digest,
+        previous,
+    ))
+    .map_err(|error| error.to_string())?;
+    Ok(digest(&snapshot))
+}
+
+fn digest(bytes: &[u8]) -> String {
+    format!("sha256:{}", sha256(bytes))
+}
+
+fn sha256(bytes: &[u8]) -> String {
+    const K: [u32; 64] = [
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4,
+        0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe,
+        0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f,
+        0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+        0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc,
+        0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+        0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116,
+        0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7,
+        0xc67178f2,
+    ];
+    let mut message = bytes.to_vec();
+    let bit_len = (message.len() as u64).wrapping_mul(8);
+    message.push(0x80);
+    while message.len() % 64 != 56 {
+        message.push(0);
+    }
+    message.extend_from_slice(&bit_len.to_be_bytes());
+    let mut h = [
+        0x6a09e667u32,
+        0xbb67ae85,
+        0x3c6ef372,
+        0xa54ff53a,
+        0x510e527f,
+        0x9b05688c,
+        0x1f83d9ab,
+        0x5be0cd19,
+    ];
+    for block in message.chunks_exact(64) {
+        let mut w = [0u32; 64];
+        for (index, word) in block.chunks_exact(4).enumerate() {
+            w[index] = u32::from_be_bytes(word.try_into().expect("SHA word"));
+        }
+        for index in 16..64 {
+            let s0 = w[index - 15].rotate_right(7)
+                ^ w[index - 15].rotate_right(18)
+                ^ (w[index - 15] >> 3);
+            let s1 = w[index - 2].rotate_right(17)
+                ^ w[index - 2].rotate_right(19)
+                ^ (w[index - 2] >> 10);
+            w[index] = w[index - 16]
+                .wrapping_add(s0)
+                .wrapping_add(w[index - 7])
+                .wrapping_add(s1);
+        }
+        let mut v = h;
+        for index in 0..64 {
+            let s1 = v[4].rotate_right(6) ^ v[4].rotate_right(11) ^ v[4].rotate_right(25);
+            let ch = (v[4] & v[5]) ^ (!v[4] & v[6]);
+            let t1 = v[7]
+                .wrapping_add(s1)
+                .wrapping_add(ch)
+                .wrapping_add(K[index])
+                .wrapping_add(w[index]);
+            let s0 = v[0].rotate_right(2) ^ v[0].rotate_right(13) ^ v[0].rotate_right(22);
+            let maj = (v[0] & v[1]) ^ (v[0] & v[2]) ^ (v[1] & v[2]);
+            let t2 = s0.wrapping_add(maj);
+            v = [
+                t1.wrapping_add(t2),
+                v[0],
+                v[1],
+                v[2],
+                v[3].wrapping_add(t1),
+                v[4],
+                v[5],
+                v[6],
+            ];
+        }
+        for index in 0..8 {
+            h[index] = h[index].wrapping_add(v[index]);
+        }
+    }
+    h.iter().map(|word| format!("{word:08x}")).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent_task::*;
+
+    fn seal_key() -> ExecutorSealKey {
+        ExecutorSealKey::from_secret("test-seal", &[7u8; 32]).unwrap()
+    }
+
+    fn contract() -> AgentTaskContract {
+        let mut value = AgentTaskContract {
+            schema_version: TASK_SCHEMA_VERSION.into(),
+            contract_digest: String::new(),
+            id: "task-1422".into(),
+            task_kind: TaskKind::Repair,
+            objective: "repair one file".into(),
+            authority: Authority {
+                governing_issue: "https://github.com/OMT-Global/axiomlang/issues/1422".into(),
+                repository: "OMT-Global/axiomlang".into(),
+                issue: 1422,
+                source_revision: "c".repeat(40),
+                source_digest: format!("sha256:{}", "b".repeat(64)),
+                approval: Approval {
+                    state: AuthorityStatus::Approved,
+                    approver: "Pheidon".into(),
+                    method: "maintainer_review".into(),
+                },
+            },
+            scope: Scope {
+                affected_semantic_nodes: vec!["axiom://package/test".into()],
+                allowed_files: vec!["src/main.ax".into()],
+                denied_files: vec![],
+            },
+            capabilities: PermissionSet {
+                required: vec!["executor.retry.code".into()],
+                forbidden: vec!["network".into()],
+            },
+            commands: PermissionSet {
+                required: vec![],
+                forbidden: vec!["git push".into()],
+            },
+            acceptance_criteria: vec![],
+            required_evidence: vec![],
+            dependencies: vec![],
+            autonomy: Autonomy {
+                class: 2,
+                risk: RiskClass::Medium,
+            },
+            budgets: Budgets {
+                time_seconds: 10,
+                tokens: 20,
+                retries: 2,
+                cost_usd_micros: 30,
+            },
+            rollback: RollbackPlan {
+                checkpoint: "base".into(),
+                commands: vec!["rollback".into()],
+            },
+            terminal_conditions: TerminalConditions {
+                success: vec!["verified".into()],
+                stop: vec!["budget".into()],
+                escalation: vec!["unknown".into()],
+            },
+            delivery_permissions: DeliveryPermissions {
+                commit: false,
+                push: false,
+                pull_request: false,
+                review: false,
+                merge: false,
+                deploy: false,
+                approve_own_pull_request: false,
+                force_push: false,
+                direct_push_protected: false,
+                irreversible_actions: false,
+            },
+            repair_plan: Some(RepairPlan {
+                id: "repair-1".into(),
+                reason: "diagnostic".into(),
+                target_node: "axiom://package/test".into(),
+                allowed_files: vec!["src/main.ax".into()],
+                required_evidence: vec![],
+                diagnostics: vec![],
+            }),
+        };
+        let bytes = serde_json::to_vec(&value).unwrap();
+        value.contract_digest = digest(&bytes);
+        value
+    }
+
+    #[test]
+    fn proposal_is_exact_deterministic_and_dry_run_is_side_effect_free() {
+        let mut executor =
+            BoundedExecutor::new(&contract(), &"c".repeat(40), true, &seal_key()).unwrap();
+        let proposal = executor
+            .propose_replace("src/main.ax", b"old\n", "old", "new")
+            .unwrap();
+        assert_eq!(proposal.candidate_digest, digest(b"new\n"));
+        assert_eq!(executor.state, ExecutionState::DryRun);
+        assert!(executor.validate_chain().is_ok());
+    }
+
+    #[test]
+    fn rejects_scope_escape_and_repair_scope_widening() {
+        let mut executor =
+            BoundedExecutor::new(&contract(), &"c".repeat(40), false, &seal_key()).unwrap();
+        assert!(
+            executor
+                .propose_replace("../main.ax", b"old", "old", "new")
+                .is_err()
+        );
+        assert_eq!(executor.state, ExecutionState::Rejected);
+        let mut invalid = contract();
+        invalid
+            .repair_plan
+            .as_mut()
+            .unwrap()
+            .allowed_files
+            .push("other.ax".into());
+        assert!(BoundedExecutor::new(&invalid, &"c".repeat(40), false, &seal_key()).is_err());
+    }
+
+    #[test]
+    fn rejects_tampered_contract_digest_and_delivery_authority() {
+        let mut invalid = contract();
+        invalid.objective.push('!');
+        assert!(BoundedExecutor::new(&invalid, &"c".repeat(40), false, &seal_key()).is_err());
+        assert!(BoundedExecutor::new(&contract(), &"d".repeat(40), false, &seal_key()).is_err());
+        let mut invalid = contract();
+        invalid.delivery_permissions.merge = true;
+        let bytes = {
+            invalid.contract_digest.clear();
+            serde_json::to_vec(&invalid).unwrap()
+        };
+        invalid.contract_digest = digest(&bytes);
+        assert!(BoundedExecutor::new(&invalid, &"c".repeat(40), false, &seal_key()).is_err());
+    }
+
+    #[test]
+    fn budgets_are_monotonic_and_exhaustion_escalates() {
+        let mut executor =
+            BoundedExecutor::new(&contract(), &"c".repeat(40), false, &seal_key()).unwrap();
+        executor
+            .charge_budget(BudgetUsage {
+                tokens: 20,
+                ..BudgetUsage::default()
+            })
+            .unwrap();
+        assert!(
+            executor
+                .charge_budget(BudgetUsage {
+                    tokens: 1,
+                    ..BudgetUsage::default()
+                })
+                .is_err()
+        );
+        assert_eq!(executor.budgets.consumed.tokens, 20);
+        assert_eq!(executor.state, ExecutionState::Escalated);
+    }
+
+    #[test]
+    fn identical_failure_and_unknown_failure_escalate() {
+        let mut executor = BoundedExecutor::new_with_retry_policy(
+            &contract(),
+            &"c".repeat(40),
+            false,
+            RetryPolicy {
+                approved_causes: vec![FailureCause::Code],
+            },
+            &seal_key(),
+        )
+        .unwrap();
+        executor
+            .retry_failure(FailureCause::Code, "E1", "same")
+            .unwrap();
+        assert!(
+            executor
+                .retry_failure(FailureCause::Code, "E1", "same")
+                .is_err()
+        );
+        assert_eq!(executor.state, ExecutionState::Escalated);
+        let mut executor =
+            BoundedExecutor::new(&contract(), &"c".repeat(40), false, &seal_key()).unwrap();
+        assert!(
+            executor
+                .retry_failure(FailureCause::Unknown, "E2", "unknown")
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn interruption_resume_preserves_hash_chain_and_state() {
+        let mut executor =
+            BoundedExecutor::new(&contract(), &"c".repeat(40), true, &seal_key()).unwrap();
+        executor
+            .propose_replace("src/main.ax", b"old", "old", "new")
+            .unwrap();
+        executor.interrupt().unwrap();
+        executor.resume().unwrap();
+        assert_eq!(executor.state, ExecutionState::DryRun);
+        assert!(executor.validate_chain().is_ok());
+        executor.events[1].budget_usage.tokens = 1;
+        assert!(executor.validate_chain().is_err());
+    }
+
+    #[test]
+    fn seal_rejects_tampering_with_every_resumable_authority_family() {
+        let mut original =
+            BoundedExecutor::new(&contract(), &"c".repeat(40), true, &seal_key()).unwrap();
+        original
+            .propose_replace("src/main.ax", b"old", "old", "new")
+            .unwrap();
+        assert!(original.validate_integrity().is_ok());
+
+        let mut tampered = original.clone();
+        tampered.proposal.as_mut().unwrap().replacement.push('!');
+        assert!(tampered.validate_integrity().is_err());
+        let mut tampered = original.clone();
+        tampered.transaction_id = Some("txn-0000000000000000".into());
+        assert!(tampered.validate_integrity().is_err());
+        let mut tampered = original.clone();
+        tampered.policy_digest = Some(digest(b"widened"));
+        assert!(tampered.validate_integrity().is_err());
+        let mut tampered = original.clone();
+        tampered.rollback = RollbackOutcome::Succeeded;
+        assert!(tampered.validate_integrity().is_err());
+        let mut tampered = original.clone();
+        tampered.interrupted_from = Some(ExecutionState::Planned);
+        assert!(tampered.validate_integrity().is_err());
+        let mut tampered = original.clone();
+        tampered.failures.push(ExecutionFailure {
+            cause: FailureCause::Code,
+            fingerprint: digest(b"x"),
+            message: "x".into(),
+            attempt: 1,
+        });
+        assert!(tampered.validate_integrity().is_err());
+        let mut tampered = original.clone();
+        tampered.verification = Some(VerificationVerdict {
+            schema_version: VERDICT_SCHEMA_VERSION.into(),
+            plan_digest: digest(b"plan"),
+            status: VerdictStatus::Passed,
+            source_head_sha: "c".repeat(40),
+            delivered_head_sha: "d".repeat(40),
+            missing: vec![],
+            duplicate: vec![],
+            invalid: vec![],
+            failed: vec![],
+        });
+        assert!(tampered.validate_integrity().is_err());
+        let mut tampered = original.clone();
+        tampered.delivery = Some(SignedDeliveryEvidence {
+            provider_id: "test-provider".into(),
+            candidate_digest: digest(b"new"),
+            plan_digest: digest(b"plan"),
+            delivered_head_sha: "d".repeat(40),
+            transaction_id: "txn-0000000000000000".into(),
+            policy_digest: digest(b"policy"),
+            fetched_at_epoch_seconds: 1,
+            required_checks_passed: true,
+            review_satisfied: true,
+            conversations_resolved: true,
+            evidence_mac: "hmac-sha256:00".into(),
+        });
+        assert!(tampered.validate_integrity().is_err());
+    }
+
+    #[test]
+    fn authenticated_seal_rejects_plain_rehash_and_wrong_key() {
+        let mut executor =
+            BoundedExecutor::new(&contract(), &"c".repeat(40), true, &seal_key()).unwrap();
+        executor
+            .propose_replace("src/main.ax", b"old", "old", "new")
+            .unwrap();
+        let encoded = serde_json::to_vec(&executor).unwrap();
+        assert!(!encoded.windows(32).any(|window| window == [7u8; 32]));
+
+        executor.proposal.as_mut().unwrap().replacement = "attacker".into();
+        let mut unkeyed = executor.clone();
+        unkeyed.seal_mac.clear();
+        executor.seal_mac = digest(&serde_json::to_vec(&unkeyed).unwrap());
+        assert!(executor.validate_integrity().is_err());
+
+        let mut wrong_key =
+            BoundedExecutor::new(&contract(), &"c".repeat(40), true, &seal_key()).unwrap();
+        wrong_key.seal_key = Some(ExecutorSealKey::from_secret("test-seal", &[8u8; 32]).unwrap());
+        assert!(wrong_key.validate_integrity().is_err());
+    }
+
+    #[test]
+    fn sha256_known_vector() {
+        assert_eq!(
+            sha256(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+        assert_eq!(
+            hmac_digest(&[b'k'; 32], b"domain", b"payload"),
+            "hmac-sha256:865e52dc58092803db170c127fb28f8387e65bd82a65417a0971fa350ca011b6"
+        );
+    }
+}

--- a/stage1/crates/axiomc/src/bounded_executor.rs
+++ b/stage1/crates/axiomc/src/bounded_executor.rs
@@ -753,18 +753,15 @@ impl BoundedExecutor {
             .proposal
             .clone()
             .ok_or_else(|| "verification requires an applied proposal".to_string())?;
-        let delivered = workspace
-            .read_at_commit(&proposal.path, &verdict.delivered_head_sha)
+        workspace
+            .authorize_verified_candidate_commit(
+                &proposal.path,
+                &verdict.delivered_head_sha,
+                &proposal.candidate_digest,
+            )
             .map_err(|error| {
                 self.failure_error(FailureCause::Evidence, "candidate_head_proof", &error)
             })?;
-        if digest(&delivered) != proposal.candidate_digest {
-            return Err(self.failure_error(
-                FailureCause::Evidence,
-                "candidate_head_binding",
-                "delivered head does not contain the exact candidate bytes",
-            ));
-        }
         let binding = CandidateBinding::new(
             &proposal.candidate_digest,
             &verdict.delivered_head_sha,

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -1,4 +1,4 @@
-pub mod agent_task;
+pub mod agent_task; pub mod bounded_executor;
 pub(crate) mod borrowck;
 #[path = "project/build_contract.rs"]
 pub mod build_contract;

--- a/stage1/crates/axiomc/src/transactional_workspace.rs
+++ b/stage1/crates/axiomc/src/transactional_workspace.rs
@@ -197,7 +197,10 @@ impl TransactionalWorkspace {
             .canonicalize()
             .map_err(|e| format!("cannot canonicalize source checkout: {e}"))?;
         if !worktree.is_absolute() || worktree.starts_with(&source) {
-            return Err("transaction worktree must be an absolute sibling outside the source checkout".into());
+            return Err(
+                "transaction worktree must be an absolute sibling outside the source checkout"
+                    .into(),
+            );
         }
         if worktree.exists() {
             return Err("transaction worktree already exists".into());
@@ -290,7 +293,12 @@ impl TransactionalWorkspace {
         if observed_head.trim() != state.base_sha && state.phase != TransactionPhase::Committed {
             return Err("transaction HEAD no longer matches its exact base SHA".into());
         }
-        if state.events.iter().enumerate().any(|(index, event)| event.sequence != index as u64) {
+        if state
+            .events
+            .iter()
+            .enumerate()
+            .any(|(index, event)| event.sequence != index as u64)
+        {
             return Err("transaction journal sequence is corrupt".into());
         }
         if state.pending_effect.is_none()
@@ -316,9 +324,13 @@ impl TransactionalWorkspace {
             return Err("only an interrupted transaction may be resumed".into());
         }
         if self.state.pending_effect.is_some() {
-            return Err("an interrupted filesystem effect is ambiguous; rollback is required".into());
+            return Err(
+                "an interrupted filesystem effect is ambiguous; rollback is required".into(),
+            );
         }
-        if checkout_fingerprint(&self.root(), &self.state.policy)? != self.state.workspace_fingerprint {
+        if checkout_fingerprint(&self.root(), &self.state.policy)?
+            != self.state.workspace_fingerprint
+        {
             return Err("transaction worktree changed after its last durable event".into());
         }
         self.state.phase = TransactionPhase::Active;
@@ -335,6 +347,84 @@ impl TransactionalWorkspace {
             .unwrap_or_else(|_| "failed".into());
         self.record("read", path, &audit_result)?;
         result
+    }
+
+    /// Read the exact Git blob for an authorized path at a full commit SHA.
+    /// This is the trusted candidate-to-delivered-head proof used by the
+    /// bounded executor; callers cannot substitute self-asserted bytes.
+    pub fn read_at_commit(&mut self, path: &str, commit_sha: &str) -> Result<Vec<u8>, String> {
+        self.require_active()?;
+        validate_sha(commit_sha)?;
+        validate_relative(path)?;
+        if !self.state.policy.allowed_read_paths.contains(path) {
+            return Err("path is outside task read scope".into());
+        }
+        let root = self.root();
+        let verified = git(
+            &root,
+            &["rev-parse", "--verify", &format!("{commit_sha}^{{commit}}")],
+        )?;
+        if verified.trim() != commit_sha {
+            return Err("delivered head must be an exact full commit SHA".into());
+        }
+        let ancestry = Command::new("git")
+            .args([
+                "merge-base",
+                "--is-ancestor",
+                &self.state.base_sha,
+                commit_sha,
+            ])
+            .current_dir(&root)
+            .status()
+            .map_err(|error| format!("failed to verify delivered ancestry: {error}"))?;
+        if !ancestry.success() {
+            return Err("delivered head is not a descendant of the transaction base".into());
+        }
+        let changed = Command::new("git")
+            .args([
+                "diff",
+                "--name-only",
+                "-z",
+                &self.state.base_sha,
+                commit_sha,
+            ])
+            .current_dir(&root)
+            .output()
+            .map_err(|error| format!("failed to inspect delivered scope: {error}"))?;
+        if !changed.status.success() {
+            return Err("cannot inspect delivered-head file scope".into());
+        }
+        let mut contains_candidate = false;
+        for changed_path in changed
+            .stdout
+            .split(|byte| *byte == 0)
+            .filter(|path| !path.is_empty())
+        {
+            let changed_path = std::str::from_utf8(changed_path)
+                .map_err(|_| "delivered-head paths are not UTF-8".to_string())?;
+            validate_relative(changed_path)?;
+            if !self.state.policy.allowed_write_paths.contains(changed_path) {
+                return Err("delivered head changes a path outside task write scope".into());
+            }
+            contains_candidate |= changed_path == path;
+        }
+        if !contains_candidate {
+            return Err("delivered head does not change the proposed candidate path".into());
+        }
+        let output = Command::new("git")
+            .args(["show", &format!("{commit_sha}:{path}")])
+            .current_dir(&root)
+            .output()
+            .map_err(|error| format!("failed to inspect delivered blob: {error}"))?;
+        if !output.status.success() {
+            return Err(format!(
+                "cannot read delivered blob: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            ));
+        }
+        let blob_digest = sha256_digest(&output.stdout);
+        self.record("read_commit", &format!("{commit_sha}:{path}"), &blob_digest)?;
+        Ok(output.stdout)
     }
 
     pub fn write(&mut self, path: &str, bytes: &[u8]) -> Result<(), String> {
@@ -600,8 +690,10 @@ impl TransactionalWorkspace {
             artifacts,
             rollback,
             recovery: RecoveryAudit {
-                resumable: matches!(self.state.phase, TransactionPhase::Active | TransactionPhase::Interrupted)
-                    && self.state.pending_effect.is_none()
+                resumable: matches!(
+                    self.state.phase,
+                    TransactionPhase::Active | TransactionPhase::Interrupted
+                ) && self.state.pending_effect.is_none()
                     && workspace_matches,
                 rollback_safe: !matches!(self.state.phase, TransactionPhase::Committed),
                 next_sequence: self.state.events.len() as u64,
@@ -674,7 +766,12 @@ impl TransactionalWorkspace {
         persist(&self.state_path, &mut self.state)
     }
 
-    fn finish_effect(&mut self, operation: &str, subject: &str, result: &str) -> Result<(), String> {
+    fn finish_effect(
+        &mut self,
+        operation: &str,
+        subject: &str,
+        result: &str,
+    ) -> Result<(), String> {
         self.record(operation, subject, result)?;
         self.state.pending_effect = None;
         self.state.workspace_fingerprint = checkout_fingerprint(&self.root(), &self.state.policy)?;
@@ -699,7 +796,11 @@ fn validate_policy(policy: &WorkspacePolicy) -> Result<(), String> {
 }
 
 fn validate_sha(sha: &str) -> Result<(), String> {
-    if sha.len() == 40 && sha.bytes().all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase()) {
+    if sha.len() == 40
+        && sha
+            .bytes()
+            .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+    {
         Ok(())
     } else {
         Err("base SHA must be a full 40-character hexadecimal commit id".into())
@@ -869,7 +970,11 @@ fn tree_fingerprint(root: &Path) -> Result<String, String> {
             let mode = metadata_mode(&metadata);
             if metadata.file_type().is_symlink() {
                 let target = fs::read_link(&child).map_err(|e| e.to_string())?;
-                rows.push(format!("L\0{}\0{mode:o}\0{}", normalized(relative), normalized(&target)));
+                rows.push(format!(
+                    "L\0{}\0{mode:o}\0{}",
+                    normalized(relative),
+                    normalized(&target)
+                ));
             } else if metadata.is_dir() {
                 rows.push(format!("D\0{}\0{mode:o}", normalized(relative)));
                 visit(root, &child, rows)?;
@@ -992,11 +1097,7 @@ mod tests {
         let source = dir.path().join("source");
         fs::create_dir(&source).unwrap();
         git(&source, &["init", "-q"]).unwrap();
-        git(
-            &source,
-            &["config", "user.email", "test@example.invalid"],
-        )
-        .unwrap();
+        git(&source, &["config", "user.email", "test@example.invalid"]).unwrap();
         git(&source, &["config", "user.name", "Test"]).unwrap();
         fs::write(source.join("allowed.txt"), b"original").unwrap();
         fs::write(source.join("outside.txt"), b"owned").unwrap();
@@ -1006,10 +1107,7 @@ mod tests {
             &["-c", "commit.gpgsign=false", "commit", "-qm", "base"],
         )
         .unwrap();
-        let sha = git(&source, &["rev-parse", "HEAD"])
-            .unwrap()
-            .trim()
-            .into();
+        let sha = git(&source, &["rev-parse", "HEAD"]).unwrap().trim().into();
         (dir, source, sha)
     }
 
@@ -1026,25 +1124,20 @@ mod tests {
         let (repo, source, sha) = fixture();
         fs::write(source.join("outside.txt"), b"user dirty").unwrap();
         let worktree = repo.path().join("txn");
-        let mut txn =
-            TransactionalWorkspace::create(&source, &worktree, &sha, policy()).unwrap();
+        let mut txn = TransactionalWorkspace::create(&source, &worktree, &sha, policy()).unwrap();
         txn.write("allowed.txt", b"changed").unwrap();
         txn.write("new.txt", b"new").unwrap();
         txn.abort().unwrap();
         assert_eq!(fs::read(worktree.join("allowed.txt")).unwrap(), b"original");
         assert!(!worktree.join("new.txt").exists());
-        assert_eq!(
-            fs::read(source.join("outside.txt")).unwrap(),
-            b"user dirty"
-        );
+        assert_eq!(fs::read(source.join("outside.txt")).unwrap(), b"user dirty");
     }
 
     #[test]
     fn traversal_and_unapproved_commands_fail_closed() {
         let (repo, source, sha) = fixture();
         let worktree = repo.path().join("txn");
-        let mut txn =
-            TransactionalWorkspace::create(&source, &worktree, &sha, policy()).unwrap();
+        let mut txn = TransactionalWorkspace::create(&source, &worktree, &sha, policy()).unwrap();
         assert!(txn.write("../outside.txt", b"bad").is_err());
         assert!(txn.write("outside.txt", b"bad").is_err());
         assert!(txn.authorize_external("sh", false).is_err());
@@ -1068,8 +1161,7 @@ mod tests {
     fn crash_recovery_verifies_state_and_can_resume() {
         let (repo, source, sha) = fixture();
         let worktree = repo.path().join("txn");
-        let mut txn =
-            TransactionalWorkspace::create(&source, &worktree, &sha, policy()).unwrap();
+        let mut txn = TransactionalWorkspace::create(&source, &worktree, &sha, policy()).unwrap();
         txn.mark_interrupted().unwrap();
         drop(txn);
         let mut recovered = TransactionalWorkspace::recover(&worktree).unwrap();
@@ -1082,8 +1174,7 @@ mod tests {
     fn crash_during_effect_requires_rollback() {
         let (repo, source, sha) = fixture();
         let worktree = repo.path().join("txn");
-        let mut txn =
-            TransactionalWorkspace::create(&source, &worktree, &sha, policy()).unwrap();
+        let mut txn = TransactionalWorkspace::create(&source, &worktree, &sha, policy()).unwrap();
         txn.state.pending_effect = Some("write:allowed.txt".into());
         txn.state.phase = TransactionPhase::Interrupted;
         persist(&txn.state_path, &mut txn.state).unwrap();
@@ -1099,8 +1190,7 @@ mod tests {
     fn recovery_rejects_unjournaled_workspace_mutation() {
         let (repo, source, sha) = fixture();
         let worktree = repo.path().join("txn");
-        let mut txn =
-            TransactionalWorkspace::create(&source, &worktree, &sha, policy()).unwrap();
+        let mut txn = TransactionalWorkspace::create(&source, &worktree, &sha, policy()).unwrap();
         txn.mark_interrupted().unwrap();
         drop(txn);
         fs::write(worktree.join("allowed.txt"), b"unjournaled").unwrap();
@@ -1111,11 +1201,11 @@ mod tests {
     fn audit_is_deterministic_and_redacts_secret_references() {
         let (repo, source, sha) = fixture();
         let worktree = repo.path().join("txn");
-        let mut txn =
-            TransactionalWorkspace::create(&source, &worktree, &sha, policy()).unwrap();
-        assert!(txn
-            .authorize_external("secret://broker/key", false)
-            .is_err());
+        let mut txn = TransactionalWorkspace::create(&source, &worktree, &sha, policy()).unwrap();
+        assert!(
+            txn.authorize_external("secret://broker/key", false)
+                .is_err()
+        );
         let first = txn.deterministic_audit_json().unwrap();
         let second = txn.deterministic_audit_json().unwrap();
         assert_eq!(first, second);

--- a/stage1/crates/axiomc/src/transactional_workspace.rs
+++ b/stage1/crates/axiomc/src/transactional_workspace.rs
@@ -64,6 +64,11 @@ pub struct TransactionState {
     pub pending_effect: Option<String>,
     pub workspace_fingerprint: String,
     pub source_fingerprint: String,
+    /// The one candidate commit proven to contain the executor's exact
+    /// authorized bytes. Active recovery may accept this head in addition to
+    /// `base_sha`; arbitrary descendants remain forbidden.
+    #[serde(default)]
+    pub authorized_candidate_head: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -265,6 +270,7 @@ impl TransactionalWorkspace {
                 pending_effect: None,
                 workspace_fingerprint,
                 source_fingerprint,
+                authorized_candidate_head: None,
             },
         };
         this.record("checkpoint", exact_sha, "created")?;
@@ -290,8 +296,19 @@ impl TransactionalWorkspace {
             return Err("transaction state belongs to another worktree".into());
         }
         let observed_head = git(&root, &["rev-parse", "HEAD"])?;
-        if observed_head.trim() != state.base_sha && state.phase != TransactionPhase::Committed {
+        let observed_head = observed_head.trim();
+        let authorized_candidate = state
+            .authorized_candidate_head
+            .as_deref()
+            .is_some_and(|head| head == observed_head);
+        if observed_head != state.base_sha
+            && state.phase != TransactionPhase::Committed
+            && !authorized_candidate
+        {
             return Err("transaction HEAD no longer matches its exact base SHA".into());
+        }
+        if let Some(candidate_head) = &state.authorized_candidate_head {
+            validate_sha(candidate_head)?;
         }
         if state
             .events
@@ -425,6 +442,26 @@ impl TransactionalWorkspace {
         let blob_digest = sha256_digest(&output.stdout);
         self.record("read_commit", &format!("{commit_sha}:{path}"), &blob_digest)?;
         Ok(output.stdout)
+    }
+
+    /// Durably authorize the exact candidate head after its blob was proven to
+    /// match a previously approved candidate digest. This is intentionally
+    /// crate-private: only the bounded executor may extend active recovery
+    /// beyond `base_sha`, and only for its one verified candidate commit.
+    pub(crate) fn authorize_verified_candidate_commit(
+        &mut self,
+        path: &str,
+        commit_sha: &str,
+        candidate_digest: &str,
+    ) -> Result<(), String> {
+        validate_digest(candidate_digest)?;
+        let candidate = self.read_at_commit(path, commit_sha)?;
+        if sha256_digest(&candidate) != candidate_digest {
+            return Err("delivered head does not contain the exact candidate bytes".into());
+        }
+        self.state.authorized_candidate_head = Some(commit_sha.into());
+        self.state.workspace_fingerprint = checkout_fingerprint(&self.root(), &self.state.policy)?;
+        self.record("candidate_head_authorized", commit_sha, candidate_digest)
     }
 
     pub fn write(&mut self, path: &str, bytes: &[u8]) -> Result<(), String> {
@@ -1194,6 +1231,23 @@ mod tests {
         txn.mark_interrupted().unwrap();
         drop(txn);
         fs::write(worktree.join("allowed.txt"), b"unjournaled").unwrap();
+        assert!(TransactionalWorkspace::recover(&worktree).is_err());
+    }
+
+    #[test]
+    fn recovery_rejects_an_unjournaled_descendant_head() {
+        let (repo, source, sha) = fixture();
+        let worktree = repo.path().join("txn");
+        let mut txn = TransactionalWorkspace::create(&source, &worktree, &sha, policy()).unwrap();
+        txn.write("allowed.txt", b"changed").unwrap();
+        git(&worktree, &["add", "allowed.txt"]).unwrap();
+        git(
+            &worktree,
+            &["-c", "commit.gpgsign=false", "commit", "-qm", "candidate"],
+        )
+        .unwrap();
+        drop(txn);
+
         assert!(TransactionalWorkspace::recover(&worktree).is_err());
     }
 

--- a/stage1/crates/axiomc/tests/bounded_executor_contract.rs
+++ b/stage1/crates/axiomc/tests/bounded_executor_contract.rs
@@ -437,6 +437,51 @@ fn evidence_regression_and_explicit_abort_roll_back_the_transaction() {
 }
 
 #[test]
+fn verified_candidate_head_survives_restart_and_can_be_rolled_back() {
+    let harness = harness();
+    let (mut executor, mut workspace, original) = apply_fixture(&harness);
+    let delivered_head = commit_candidate(&harness);
+    executor
+        .submit_verification(
+            &mut workspace,
+            verdict(
+                &harness.base_sha,
+                &delivered_head,
+                VerdictStatus::Passed,
+                vec![],
+            ),
+        )
+        .unwrap();
+    assert_eq!(
+        workspace.state().authorized_candidate_head.as_deref(),
+        Some(delivered_head.as_str())
+    );
+
+    executor.interrupt().unwrap();
+    let resume = executor.resume_request().unwrap();
+    let encoded = serde_json::to_vec(&executor).unwrap();
+    drop(workspace);
+
+    let mut recovered_workspace = TransactionalWorkspace::recover(&harness.transaction)
+        .expect("recover the verified candidate transaction head");
+    let mut recovered_executor = BoundedExecutor::recover(
+        &encoded,
+        &resume,
+        &harness.contract,
+        &recovered_workspace,
+        &seal_key(),
+    )
+    .expect("recover the sealed executor after verification");
+    recovered_executor.resume().unwrap();
+    recovered_executor.rollback(&mut recovered_workspace).unwrap();
+    assert_eq!(recovered_executor.state(), ExecutionState::RolledBack);
+    assert_eq!(
+        fs::read(harness.transaction.join("src/main.ax")).unwrap(),
+        original
+    );
+}
+
+#[test]
 fn delivery_requires_authentic_fresh_satisfactory_provider_evidence() {
     let key = delivery_key();
     let provider = TrustedDeliveryEvidenceProvider::new(key.clone(), 60).unwrap();

--- a/stage1/crates/axiomc/tests/bounded_executor_contract.rs
+++ b/stage1/crates/axiomc/tests/bounded_executor_contract.rs
@@ -1,0 +1,644 @@
+use axiomc::agent_task::{AgentTaskContract, compile_task_contract};
+use axiomc::bounded_executor::{
+    BoundedExecutor, BudgetUsage, DeliveryEvidenceKey, ExecutionMode, ExecutionState,
+    ExecutorRequest, ExecutorResumeRequest, ExecutorSealKey, FailureCause, RetryPolicy,
+    SignedDeliveryEvidence, TrustedDeliveryEvidenceProvider,
+};
+use axiomc::transactional_workspace::{TransactionalWorkspace, WorkspacePolicy};
+use axiomc::verification_planner::{VerdictStatus, VerificationVerdict};
+use jsonschema::Validator;
+use serde_json::Value;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tempfile::TempDir;
+
+const DIGEST: &str = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const KEY_BYTES: &[u8; 32] = b"0123456789abcdef0123456789abcdef";
+
+fn seal_key() -> ExecutorSealKey {
+    ExecutorSealKey::from_secret("executor-test", KEY_BYTES).unwrap()
+}
+
+fn delivery_key() -> DeliveryEvidenceKey {
+    DeliveryEvidenceKey::from_secret("github-test", KEY_BYTES).unwrap()
+}
+
+fn now_epoch_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("..")
+}
+
+fn fixture(name: &str) -> Value {
+    serde_json::from_str(
+        &fs::read_to_string(
+            repo_root()
+                .join("stage1/json-fixtures/bounded-executor")
+                .join(name),
+        )
+        .expect("read bounded-executor fixture"),
+    )
+    .expect("bounded-executor fixture is JSON")
+}
+
+fn validator(name: &str) -> Validator {
+    let schema: Value = serde_json::from_str(
+        &fs::read_to_string(repo_root().join("stage1/schemas").join(name))
+            .expect("read bounded-executor schema"),
+    )
+    .expect("bounded-executor schema is JSON");
+    jsonschema::validator_for(&schema).expect("compile bounded-executor schema")
+}
+
+fn git(root: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .env("GIT_AUTHOR_DATE", "2000-01-01T00:00:00Z")
+        .env("GIT_COMMITTER_DATE", "2000-01-01T00:00:00Z")
+        .output()
+        .expect("run git fixture command");
+    assert!(
+        output.status.success(),
+        "git {args:?}: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).expect("git output is UTF-8")
+}
+
+struct Harness {
+    _root: TempDir,
+    source: PathBuf,
+    transaction: PathBuf,
+    base_sha: String,
+    contract: AgentTaskContract,
+}
+
+fn harness() -> Harness {
+    let root = tempfile::tempdir().expect("create executor fixture root");
+    let source = root.path().join("source");
+    fs::create_dir_all(source.join("src")).expect("create fixture project");
+    fs::copy(
+        repo_root().join("stage1/examples/agent_native_authorize/axiom.toml"),
+        source.join("axiom.toml"),
+    )
+    .expect("copy project manifest");
+    fs::copy(
+        repo_root().join("stage1/examples/agent_native_authorize/src/main.ax"),
+        source.join("src/main.ax"),
+    )
+    .expect("copy project source");
+    git(&source, &["init", "-q"]);
+    git(&source, &["config", "user.email", "test@example.invalid"]);
+    git(&source, &["config", "user.name", "Executor Contract Test"]);
+    git(&source, &["add", "axiom.toml", "src/main.ax"]);
+    git(
+        &source,
+        &["-c", "commit.gpgsign=false", "commit", "-qm", "base"],
+    );
+    let base_sha = git(&source, &["rev-parse", "HEAD"]).trim().to_owned();
+
+    let mut spec: Value = serde_json::from_str(
+        &fs::read_to_string(
+            repo_root().join("stage1/json-fixtures/task-contract/repair-approved.spec.json"),
+        )
+        .expect("read repair task fixture"),
+    )
+    .expect("repair task fixture is JSON");
+    spec["task"]["authority"]["source_revision"] = base_sha.clone().into();
+    let spec_path = root.path().join("task.json");
+    fs::write(&spec_path, serde_json::to_vec_pretty(&spec).unwrap()).expect("write task fixture");
+    let contract = compile_task_contract(&source, &spec_path)
+        .expect("compile approved task")
+        .contract;
+    let transaction = root.path().join("transaction");
+    Harness {
+        _root: root,
+        source,
+        transaction,
+        base_sha,
+        contract,
+    }
+}
+
+fn workspace(harness: &Harness) -> TransactionalWorkspace {
+    let policy = WorkspacePolicy {
+        allowed_read_paths: BTreeSet::from(["src/main.ax".into()]),
+        allowed_write_paths: BTreeSet::from(["src/main.ax".into()]),
+        allowed_commands: BTreeSet::new(),
+        allow_network: false,
+        verified_sandbox: true,
+    };
+    TransactionalWorkspace::create_for_task(
+        &harness.source,
+        &harness.transaction,
+        &harness.base_sha,
+        policy,
+        &harness.contract.contract_digest,
+        DIGEST,
+        "codex/executor-fixture",
+    )
+    .expect("create task-bound transaction")
+}
+
+fn verdict(
+    base_sha: &str,
+    delivered_head_sha: &str,
+    status: VerdictStatus,
+    failed: Vec<String>,
+) -> VerificationVerdict {
+    VerificationVerdict {
+        schema_version: "axiom.verification_verdict.v0".into(),
+        plan_digest: DIGEST.into(),
+        status,
+        source_head_sha: base_sha.into(),
+        delivered_head_sha: delivered_head_sha.into(),
+        missing: Vec::new(),
+        duplicate: Vec::new(),
+        invalid: Vec::new(),
+        failed,
+    }
+}
+
+fn apply_fixture(harness: &Harness) -> (BoundedExecutor, TransactionalWorkspace, Vec<u8>) {
+    let mut workspace = workspace(harness);
+    let original = workspace.read("src/main.ax").expect("read candidate base");
+    let mut executor =
+        BoundedExecutor::new(&harness.contract, &harness.base_sha, false, &seal_key()).unwrap();
+    executor
+        .propose_replace("src/main.ax", &original, "print authorized", "print true")
+        .unwrap();
+    executor.apply_proposal(&mut workspace).unwrap();
+    (executor, workspace, original)
+}
+
+fn assert_report_valid(executor: &BoundedExecutor) {
+    let value = serde_json::to_value(executor).expect("serialize executor report");
+    let encoded = serde_json::to_string(&value).unwrap();
+    assert!(!encoded.contains("0123456789abcdef0123456789abcdef"));
+    assert!(!encoded.contains("\"seal_key\":"));
+    let errors: Vec<_> = validator("axiom-executor-report-v0.schema.json")
+        .iter_errors(&value)
+        .map(|error| error.to_string())
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "executor report schema errors: {errors:#?}\n{value:#}"
+    );
+}
+
+fn commit_candidate(harness: &Harness) -> String {
+    git(&harness.transaction, &["add", "src/main.ax"]);
+    git(
+        &harness.transaction,
+        &["-c", "commit.gpgsign=false", "commit", "-qm", "candidate"],
+    );
+    git(&harness.transaction, &["rev-parse", "HEAD"])
+        .trim()
+        .to_owned()
+}
+
+fn verified_harness() -> (Harness, BoundedExecutor, TransactionalWorkspace, String) {
+    let harness = harness();
+    let (mut executor, mut workspace, _) = apply_fixture(&harness);
+    let delivered_head = commit_candidate(&harness);
+    executor
+        .submit_verification(
+            &mut workspace,
+            verdict(
+                &harness.base_sha,
+                &delivered_head,
+                VerdictStatus::Passed,
+                vec![],
+            ),
+        )
+        .unwrap();
+    (harness, executor, workspace, delivered_head)
+}
+
+fn signed_delivery(
+    executor: &BoundedExecutor,
+    head: &str,
+    key: &DeliveryEvidenceKey,
+    fetched_at: u64,
+    components: (bool, bool, bool),
+) -> SignedDeliveryEvidence {
+    let binding = executor.candidate_binding().unwrap();
+    key.sign(SignedDeliveryEvidence {
+        provider_id: "github-test".into(),
+        candidate_digest: executor.candidate_digest().unwrap().into(),
+        plan_digest: DIGEST.into(),
+        delivered_head_sha: head.into(),
+        transaction_id: binding.transaction_id.clone(),
+        policy_digest: binding.policy_digest.clone(),
+        fetched_at_epoch_seconds: fetched_at,
+        required_checks_passed: components.0,
+        review_satisfied: components.1,
+        conversations_resolved: components.2,
+        evidence_mac: String::new(),
+    })
+    .unwrap()
+}
+
+#[test]
+fn dry_run_and_scope_escape_fixtures_are_deterministic_and_fail_closed() {
+    let success = fixture("deterministic-success.json");
+    let harness = harness();
+    let current = success["initial"].as_str().unwrap().as_bytes();
+    let mut first =
+        BoundedExecutor::new(&harness.contract, &harness.base_sha, true, &seal_key()).unwrap();
+    first
+        .propose_replace(
+            success["path"].as_str().unwrap(),
+            current,
+            success["find"].as_str().unwrap(),
+            success["replacement"].as_str().unwrap(),
+        )
+        .unwrap();
+    let mut second =
+        BoundedExecutor::new(&harness.contract, &harness.base_sha, true, &seal_key()).unwrap();
+    second
+        .propose_replace(
+            success["path"].as_str().unwrap(),
+            current,
+            success["find"].as_str().unwrap(),
+            success["replacement"].as_str().unwrap(),
+        )
+        .unwrap();
+    assert_eq!(
+        serde_json::to_vec(&first).unwrap(),
+        serde_json::to_vec(&second).unwrap()
+    );
+    assert_eq!(first.state(), ExecutionState::DryRun);
+    assert_report_valid(&first);
+
+    let escape = fixture("scope-escape.json");
+    let mut executor =
+        BoundedExecutor::new(&harness.contract, &harness.base_sha, false, &seal_key()).unwrap();
+    assert!(
+        executor
+            .propose_replace(
+                escape["path"].as_str().unwrap(),
+                escape["initial"].as_str().unwrap().as_bytes(),
+                escape["find"].as_str().unwrap(),
+                escape["replacement"].as_str().unwrap(),
+            )
+            .is_err()
+    );
+    assert_eq!(executor.state(), ExecutionState::Rejected);
+    assert_report_valid(&executor);
+}
+
+#[test]
+fn identical_retry_stops_and_interruption_recovery_preserves_consumption() {
+    let retry = fixture("bounded-retry.json");
+    let harness = harness();
+    let mut executor = BoundedExecutor::new_with_retry_policy(
+        &harness.contract,
+        &harness.base_sha,
+        false,
+        RetryPolicy {
+            approved_causes: vec![FailureCause::Code],
+        },
+        &seal_key(),
+    )
+    .unwrap();
+    executor
+        .retry_failure(
+            FailureCause::Code,
+            retry["failure_code"].as_str().unwrap(),
+            retry["failure_message"].as_str().unwrap(),
+        )
+        .unwrap();
+    assert!(
+        executor
+            .retry_failure(
+                FailureCause::Code,
+                retry["failure_code"].as_str().unwrap(),
+                retry["failure_message"].as_str().unwrap()
+            )
+            .is_err()
+    );
+    assert_eq!(executor.state(), ExecutionState::Escalated);
+    assert_report_valid(&executor);
+
+    let resume = fixture("interruption-resume.json");
+    let mut workspace = workspace(&harness);
+    let mut executor =
+        BoundedExecutor::new(&harness.contract, &harness.base_sha, false, &seal_key()).unwrap();
+    let current = workspace.read("src/main.ax").unwrap();
+    executor
+        .propose_replace("src/main.ax", &current, "print authorized", "print true")
+        .unwrap();
+    executor.apply_proposal(&mut workspace).unwrap();
+    let usage: BudgetUsage =
+        serde_json::from_value(resume["budget_charge_before_interrupt"].clone()).unwrap();
+    executor.charge_budget(usage.clone()).unwrap();
+    executor.interrupt().unwrap();
+    let request = executor.resume_request().unwrap();
+    let parsed = ExecutorResumeRequest::parse(&serde_json::to_vec(&request).unwrap()).unwrap();
+    let encoded = serde_json::to_vec(&executor).unwrap();
+    let mut recovered = BoundedExecutor::recover(
+        &encoded,
+        &parsed,
+        &harness.contract,
+        &workspace,
+        &seal_key(),
+    )
+    .unwrap();
+    recovered.resume().unwrap();
+    assert_eq!(recovered.budgets().consumed, usage);
+    assert_eq!(recovered.state(), ExecutionState::Edited);
+    assert_report_valid(&recovered);
+    workspace.abort().unwrap();
+}
+
+#[test]
+fn success_requires_fresh_candidate_bound_evidence_and_is_schema_valid() {
+    let _case = fixture("deterministic-success.json");
+    let harness = harness();
+    let (mut executor, mut workspace, _) = apply_fixture(&harness);
+    let delivered_head = commit_candidate(&harness);
+    executor
+        .submit_verification(
+            &mut workspace,
+            verdict(
+                &harness.base_sha,
+                &delivered_head,
+                VerdictStatus::Passed,
+                vec![],
+            ),
+        )
+        .unwrap();
+    let candidate_binding = executor.candidate_binding().unwrap().clone();
+    let candidate_digest = executor.candidate_digest().unwrap().to_owned();
+    let evidence_key = delivery_key();
+    let provider = TrustedDeliveryEvidenceProvider::new(evidence_key.clone(), 60).unwrap();
+    let evidence = evidence_key
+        .sign(SignedDeliveryEvidence {
+            provider_id: "github-test".into(),
+            candidate_digest,
+            plan_digest: DIGEST.into(),
+            delivered_head_sha: delivered_head,
+            transaction_id: candidate_binding.transaction_id,
+            policy_digest: candidate_binding.policy_digest,
+            fetched_at_epoch_seconds: now_epoch_seconds(),
+            required_checks_passed: true,
+            review_satisfied: true,
+            conversations_resolved: true,
+            evidence_mac: String::new(),
+        })
+        .unwrap();
+    executor
+        .submit_delivery(&workspace, evidence, &provider)
+        .unwrap();
+    assert_eq!(executor.state(), ExecutionState::Resolved);
+    assert_report_valid(&executor);
+}
+
+#[test]
+fn evidence_regression_and_explicit_abort_roll_back_the_transaction() {
+    let _regression = fixture("evidence-regression.json");
+    let _rollback = fixture("rollback.json");
+    let harness = harness();
+    let (mut executor, mut workspace, original) = apply_fixture(&harness);
+    let delivered_head = commit_candidate(&harness);
+    executor
+        .submit_verification(
+            &mut workspace,
+            verdict(
+                &harness.base_sha,
+                &delivered_head,
+                VerdictStatus::Failed,
+                vec!["evidence-regression".into()],
+            ),
+        )
+        .unwrap();
+    assert_eq!(executor.state(), ExecutionState::EvidenceFailed);
+    assert_ne!(workspace.read("src/main.ax").unwrap(), original);
+    executor.rollback(&mut workspace).unwrap();
+    assert_eq!(executor.state(), ExecutionState::RolledBack);
+    assert_eq!(
+        fs::read(harness.transaction.join("src/main.ax")).unwrap(),
+        original
+    );
+    assert_report_valid(&executor);
+}
+
+#[test]
+fn delivery_requires_authentic_fresh_satisfactory_provider_evidence() {
+    let key = delivery_key();
+    let provider = TrustedDeliveryEvidenceProvider::new(key.clone(), 60).unwrap();
+    let now = now_epoch_seconds();
+
+    let (_harness, mut executor, workspace, head) = verified_harness();
+    let mut fabricated = signed_delivery(&executor, &head, &key, now, (true, true, true));
+    fabricated.required_checks_passed = false;
+    assert!(
+        executor
+            .submit_delivery(&workspace, fabricated, &provider)
+            .is_err()
+    );
+    assert_ne!(executor.state(), ExecutionState::Resolved);
+
+    let (_harness, mut executor, workspace, head) = verified_harness();
+    let stale = signed_delivery(
+        &executor,
+        &head,
+        &key,
+        now.saturating_sub(61),
+        (true, true, true),
+    );
+    assert!(
+        executor
+            .submit_delivery(&workspace, stale, &provider)
+            .is_err()
+    );
+    assert_ne!(executor.state(), ExecutionState::Resolved);
+
+    let (_harness, mut executor, workspace, head) = verified_harness();
+    let future = signed_delivery(&executor, &head, &key, now + 60, (true, true, true));
+    assert!(
+        executor
+            .submit_delivery(&workspace, future, &provider)
+            .is_err()
+    );
+    assert_ne!(executor.state(), ExecutionState::Resolved);
+
+    let (_harness, mut executor, workspace, head) = verified_harness();
+    let unsatisfactory = signed_delivery(&executor, &head, &key, now, (true, false, true));
+    assert!(
+        executor
+            .submit_delivery(&workspace, unsatisfactory, &provider)
+            .is_err()
+    );
+    assert_ne!(executor.state(), ExecutionState::Resolved);
+}
+
+#[test]
+fn typed_request_is_consumed_and_authority_widening_is_rejected() {
+    let harness = harness();
+    let mut workspace = workspace(&harness);
+    let current = workspace.read("src/main.ax").unwrap();
+    let mut planner =
+        BoundedExecutor::new(&harness.contract, &harness.base_sha, true, &seal_key()).unwrap();
+    let proposal = planner
+        .propose_replace("src/main.ax", &current, "print authorized", "print true")
+        .unwrap();
+    let request = ExecutorRequest {
+        schema_version: "axiom.executor_request.v0".into(),
+        task_contract_digest: harness.contract.contract_digest.clone(),
+        transaction_id: workspace.state().transaction_id.clone(),
+        transaction_digest: workspace.state().policy_digest.clone(),
+        base_sha: harness.base_sha.clone(),
+        mode: ExecutionMode::Deterministic,
+        dry_run: true,
+        budgets: harness.contract.budgets.clone(),
+        retry_policy: RetryPolicy {
+            approved_causes: vec![FailureCause::Evidence],
+        },
+        proposal: Some(proposal),
+    };
+    let encoded = serde_json::to_vec(&request).unwrap();
+    let parsed = ExecutorRequest::parse(&encoded).unwrap();
+    validator("axiom-executor-request-v0.schema.json")
+        .validate(&serde_json::from_slice::<Value>(&encoded).unwrap())
+        .expect("runtime request matches schema");
+    let executor = BoundedExecutor::from_request(
+        parsed,
+        &harness.contract,
+        &workspace,
+        Some(&current),
+        &seal_key(),
+    )
+    .unwrap();
+    assert_eq!(executor.state(), ExecutionState::DryRun);
+    assert_report_valid(&executor);
+
+    let mut widened = request.clone();
+    widened.budgets.tokens += 1;
+    assert!(
+        BoundedExecutor::from_request(
+            widened,
+            &harness.contract,
+            &workspace,
+            Some(&current),
+            &seal_key(),
+        )
+        .is_err()
+    );
+    let mut forbidden_retry = request;
+    forbidden_retry.retry_policy.approved_causes = vec![FailureCause::Policy];
+    assert!(
+        BoundedExecutor::from_request(
+            forbidden_retry,
+            &harness.contract,
+            &workspace,
+            Some(&current),
+            &seal_key(),
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn sealed_report_resume_and_candidate_binding_reject_tampering() {
+    let harness = harness();
+    let (mut executor, mut workspace, _) = apply_fixture(&harness);
+    executor.interrupt().unwrap();
+    let resume = executor.resume_request().unwrap();
+    let encoded = serde_json::to_vec(&executor).unwrap();
+
+    let mut tampered_report: Value = serde_json::from_slice(&encoded).unwrap();
+    tampered_report["retry_policy"]["approved_causes"] = serde_json::json!(["code"]);
+    assert!(
+        BoundedExecutor::recover(
+            &serde_json::to_vec(&tampered_report).unwrap(),
+            &resume,
+            &harness.contract,
+            &workspace,
+            &seal_key(),
+        )
+        .is_err()
+    );
+
+    let mut unkeyed_reseal: Value = serde_json::from_slice(&encoded).unwrap();
+    let plain = unkeyed_reseal["state_digest"]
+        .as_str()
+        .unwrap()
+        .strip_prefix("sha256:")
+        .unwrap();
+    unkeyed_reseal["seal_mac"] = format!("hmac-sha256:{plain}").into();
+    assert!(
+        BoundedExecutor::recover(
+            &serde_json::to_vec(&unkeyed_reseal).unwrap(),
+            &resume,
+            &harness.contract,
+            &workspace,
+            &seal_key(),
+        )
+        .is_err()
+    );
+
+    let wrong_key =
+        ExecutorSealKey::from_secret("executor-test", b"abcdef0123456789abcdef0123456789").unwrap();
+    assert!(
+        BoundedExecutor::recover(&encoded, &resume, &harness.contract, &workspace, &wrong_key,)
+            .is_err()
+    );
+
+    let mut widened_resume = resume.clone();
+    widened_resume.remaining_budgets.tokens += 1;
+    assert!(
+        BoundedExecutor::recover(
+            &encoded,
+            &widened_resume,
+            &harness.contract,
+            &workspace,
+            &seal_key(),
+        )
+        .is_err()
+    );
+
+    let mut recovered = BoundedExecutor::recover(
+        &encoded,
+        &resume,
+        &harness.contract,
+        &workspace,
+        &seal_key(),
+    )
+    .unwrap();
+    recovered.resume().unwrap();
+    fs::write(
+        harness.transaction.join("axiom.toml"),
+        "[package]\nname = \"agent-native-authorize\"\nversion = \"0.1.0\"\n# unrelated\n",
+    )
+    .unwrap();
+    git(&harness.transaction, &["add", "axiom.toml"]);
+    git(
+        &harness.transaction,
+        &["-c", "commit.gpgsign=false", "commit", "-qm", "unrelated"],
+    );
+    let unrelated = git(&harness.transaction, &["rev-parse", "HEAD"])
+        .trim()
+        .to_owned();
+    assert!(
+        recovered
+            .submit_verification(
+                &mut workspace,
+                verdict(&harness.base_sha, &unrelated, VerdictStatus::Passed, vec![]),
+            )
+            .is_err()
+    );
+}

--- a/stage1/crates/axiomc/tests/schema_metadata.rs
+++ b/stage1/crates/axiomc/tests/schema_metadata.rs
@@ -55,7 +55,6 @@ fn verification_planner_v0_schemas_are_strict_and_exact_head_bound() {
         assert_eq!(schema["additionalProperties"], false);
         compile_validator(schema);
     }
-
     let digest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     let source_sha = "1111111111111111111111111111111111111111";
     let delivered_sha = "2222222222222222222222222222222222222222";
@@ -78,14 +77,16 @@ fn verification_planner_v0_schemas_are_strict_and_exact_head_bound() {
     result_validator
         .validate(&result)
         .expect("exact-head result validates");
-    result["results"][0]["delivered_head_sha"] =
-        serde_json::json!("not-a-commit");
+    result["results"][0]["delivered_head_sha"] = serde_json::json!("not-a-commit");
     assert!(
         !result_validator.is_valid(&result),
         "result evidence cannot omit a valid delivered head binding"
     );
 
-    assert_eq!(plan["allOf"][0]["then"]["properties"]["requirements"]["minItems"], 1);
+    assert_eq!(
+        plan["allOf"][0]["then"]["properties"]["requirements"]["minItems"],
+        1
+    );
     assert_eq!(plan["$defs"]["requirement"]["additionalProperties"], false);
     assert_eq!(results["$defs"]["result"]["additionalProperties"], false);
     assert_eq!(verdict["$defs"]["ids"]["uniqueItems"], true);
@@ -103,6 +104,109 @@ fn verification_planner_v0_schemas_are_strict_and_exact_head_bound() {
     assert!(
         !compile_validator(&verdict).is_valid(&impossible_success),
         "a passing verdict cannot retain evidence blockers"
+    );
+}
+
+#[test]
+fn bounded_executor_v0_schemas_are_strict_and_fail_closed() {
+    let schemas: Vec<Value> = [
+        "axiom-executor-request-v0.schema.json",
+        "axiom-executor-report-v0.schema.json",
+        "axiom-executor-resume-v0.schema.json",
+    ]
+    .into_iter()
+    .map(|name| {
+        serde_json::from_str(
+            &fs::read_to_string(schema_dir().join(name)).expect("read executor schema"),
+        )
+        .expect("executor schema is valid JSON")
+    })
+    .collect();
+    for (schema, id, version) in [
+        (
+            &schemas[0],
+            "https://axiom.omt.global/schemas/axiom-executor-request-v0.schema.json",
+            "axiom.executor_request.v0",
+        ),
+        (
+            &schemas[1],
+            "https://axiom.omt.global/schemas/axiom-executor-report-v0.schema.json",
+            "axiom.bounded_executor.v0",
+        ),
+        (
+            &schemas[2],
+            "https://axiom.omt.global/schemas/axiom-executor-resume-v0.schema.json",
+            "axiom.executor_resume.v0",
+        ),
+    ] {
+        assert_eq!(schema["$id"], id);
+        assert_eq!(schema["properties"]["schema_version"]["const"], version);
+        assert_eq!(schema["additionalProperties"], false);
+        compile_validator(schema);
+    }
+
+    assert_eq!(
+        schemas[1]["properties"]["seal_mac"]["$ref"],
+        "#/$defs/mac"
+    );
+    assert!(schemas[1]["properties"].get("seal_key").is_none());
+    assert!(schemas[2]["properties"].get("seal_key").is_none());
+    assert!(
+        schemas[1]["$defs"]["signedDeliveryEvidence"]["properties"]
+            .get("fresh")
+            .is_none()
+    );
+    assert_eq!(
+        schemas[1]["$defs"]["signedDeliveryEvidence"]["properties"]["evidence_mac"]["$ref"],
+        "#/$defs/mac"
+    );
+
+    let digest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    let sha = "1111111111111111111111111111111111111111";
+    let resolved = serde_json::json!({
+        "schema_version": "axiom.bounded_executor.v0",
+        "task_contract_digest": digest,
+        "base_sha": sha,
+        "dry_run": false,
+        "state": "resolved",
+        "budgets": {
+            "limits": { "time_seconds": 1, "tokens": 1, "retries": 0, "cost_usd_micros": 0 },
+            "consumed": { "time_seconds": 0, "tokens": 0, "retries": 0, "cost_usd_micros": 0 }
+        },
+        "failures": [],
+        "events": [{
+            "sequence": 0,
+            "kind": "resolved",
+            "detail": "candidate",
+            "state": "resolved",
+            "budget_usage": { "time_seconds": 0, "tokens": 0, "retries": 0, "cost_usd_micros": 0 },
+            "previous_digest": digest,
+            "event_digest": digest
+        }],
+        "state_digest": digest
+    });
+    assert!(
+        !compile_validator(&schemas[1]).is_valid(&resolved),
+        "resolved cannot omit proposal, candidate, fresh verification, or delivery evidence"
+    );
+
+    let mut resume = serde_json::json!({
+        "schema_version": "axiom.executor_resume.v0",
+        "executor_state_mac": "hmac-sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "seal_key_id": "executor-test",
+        "task_contract_digest": digest,
+        "transaction_id": "txn-0123456789abcdef",
+        "transaction_digest": digest,
+        "candidate_digest": null,
+        "remaining_budgets": { "time_seconds": 0, "tokens": 0, "retries": 0, "cost_usd_micros": 0 },
+        "next_event_sequence": 1
+    });
+    let validator = compile_validator(&schemas[2]);
+    assert!(validator.is_valid(&resume));
+    resume["widened_files"] = serde_json::json!(["outside.ax"]);
+    assert!(
+        !validator.is_valid(&resume),
+        "resume cannot carry widened authority"
     );
 }
 
@@ -129,11 +233,26 @@ fn execution_transaction_v0_schemas_are_strict_and_secret_safe() {
     );
     assert_eq!(policy["additionalProperties"], false);
     assert_eq!(audit["additionalProperties"], false);
-    assert_eq!(policy["properties"]["paths"]["properties"]["follow_symlinks"]["const"], false);
-    assert_eq!(policy["properties"]["commands"]["properties"]["allow_shell"]["const"], false);
-    assert_eq!(policy["properties"]["delivery"]["properties"]["allow_force_push"]["const"], false);
-    assert_eq!(policy["properties"]["delivery"]["properties"]["allow_self_approval"]["const"], false);
-    assert_eq!(policy["properties"]["delivery"]["properties"]["allow_policy_edits"]["const"], false);
+    assert_eq!(
+        policy["properties"]["paths"]["properties"]["follow_symlinks"]["const"],
+        false
+    );
+    assert_eq!(
+        policy["properties"]["commands"]["properties"]["allow_shell"]["const"],
+        false
+    );
+    assert_eq!(
+        policy["properties"]["delivery"]["properties"]["allow_force_push"]["const"],
+        false
+    );
+    assert_eq!(
+        policy["properties"]["delivery"]["properties"]["allow_self_approval"]["const"],
+        false
+    );
+    assert_eq!(
+        policy["properties"]["delivery"]["properties"]["allow_policy_edits"]["const"],
+        false
+    );
 
     let fixture_root = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("..")

--- a/stage1/json-fixtures/bounded-executor/bounded-retry.json
+++ b/stage1/json-fixtures/bounded-executor/bounded-retry.json
@@ -1,0 +1,8 @@
+{
+  "scenario": "bounded_retry",
+  "failure_cause": "code",
+  "failure_code": "compile_failed",
+  "failure_message": "same deterministic failure",
+  "repeat_count": 2,
+  "expected_state": "escalated"
+}

--- a/stage1/json-fixtures/bounded-executor/deterministic-success.json
+++ b/stage1/json-fixtures/bounded-executor/deterministic-success.json
@@ -1,0 +1,8 @@
+{
+  "scenario": "deterministic_success",
+  "path": "src/main.ax",
+  "initial": "fn main() { old() }\n",
+  "find": "old()",
+  "replacement": "new()",
+  "expected_state": "resolved"
+}

--- a/stage1/json-fixtures/bounded-executor/evidence-regression.json
+++ b/stage1/json-fixtures/bounded-executor/evidence-regression.json
@@ -1,0 +1,8 @@
+{
+  "scenario": "evidence_regression",
+  "path": "src/main.ax",
+  "initial": "fn main() { old() }\n",
+  "find": "old()",
+  "replacement": "new()",
+  "expected_state": "rolled_back"
+}

--- a/stage1/json-fixtures/bounded-executor/interruption-resume.json
+++ b/stage1/json-fixtures/bounded-executor/interruption-resume.json
@@ -1,0 +1,9 @@
+{
+  "scenario": "interruption_resume",
+  "path": "src/main.ax",
+  "initial": "fn main() { old() }\n",
+  "find": "old()",
+  "replacement": "new()",
+  "budget_charge_before_interrupt": { "time_seconds": 2, "tokens": 3, "retries": 0, "cost_usd_micros": 4 },
+  "expected_state": "dry_run"
+}

--- a/stage1/json-fixtures/bounded-executor/rollback.json
+++ b/stage1/json-fixtures/bounded-executor/rollback.json
@@ -1,0 +1,8 @@
+{
+  "scenario": "rollback",
+  "path": "src/main.ax",
+  "initial": "fn main() { old() }\n",
+  "find": "old()",
+  "replacement": "new()",
+  "expected_state": "rolled_back"
+}

--- a/stage1/json-fixtures/bounded-executor/scope-escape.json
+++ b/stage1/json-fixtures/bounded-executor/scope-escape.json
@@ -1,0 +1,8 @@
+{
+  "scenario": "scope_escape",
+  "path": "../outside.ax",
+  "initial": "old\n",
+  "find": "old",
+  "replacement": "new",
+  "expected_state": "rejected"
+}

--- a/stage1/json-fixtures/task-contract/repair-approved.spec.json
+++ b/stage1/json-fixtures/task-contract/repair-approved.spec.json
@@ -16,7 +16,10 @@
       "affected_semantic_nodes": ["axiom://package/agent-native-authorize"],
       "allowed_files": ["src/main.ax"]
     },
-    "capabilities": { "required": [], "forbidden": ["net"] },
+    "capabilities": {
+      "required": ["executor.retry.code", "executor.retry.evidence"],
+      "forbidden": ["net"]
+    },
     "commands": {
       "required": ["axiomc check . --json"],
       "forbidden": ["curl", "git push --force"]

--- a/stage1/schemas/axiom-executor-report-v0.schema.json
+++ b/stage1/schemas/axiom-executor-report-v0.schema.json
@@ -1,0 +1,203 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axiom.omt.global/schemas/axiom-executor-report-v0.schema.json",
+  "title": "Axiom bounded executor report v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "task_contract_digest", "base_sha", "dry_run", "state", "budgets", "retry_policy", "allowed_files", "rollback", "failures", "events", "state_digest", "seal_key_id", "seal_mac"],
+  "properties": {
+    "schema_version": { "const": "axiom.bounded_executor.v0" },
+    "task_contract_digest": { "$ref": "#/$defs/digest" },
+    "base_sha": { "$ref": "#/$defs/sha" },
+    "dry_run": { "type": "boolean" },
+    "state": { "enum": ["planned", "dry_run", "edited", "evidence_failed", "verification_passed", "resolved", "rejected", "escalated", "interrupted", "rolled_back"] },
+    "budgets": { "$ref": "#/$defs/executorBudgets" },
+    "retry_policy": { "$ref": "#/$defs/retryPolicy" },
+    "transaction_id": { "type": "string", "pattern": "^txn-[0-9a-f]{16}$" },
+    "policy_digest": { "$ref": "#/$defs/digest" },
+    "allowed_files": { "$ref": "#/$defs/pathSet" },
+    "repair_allowed_files": { "$ref": "#/$defs/pathSet" },
+    "rollback": { "enum": ["not_required", "succeeded", "failed"] },
+    "interrupted_from": { "enum": ["planned", "dry_run", "edited", "evidence_failed", "verification_passed"] },
+    "proposal": { "$ref": "#/$defs/replaceTextProposal" },
+    "candidate_digest": { "$ref": "#/$defs/digest" },
+    "verification": { "$ref": "#/$defs/verificationVerdict" },
+    "candidate_binding": { "$ref": "#/$defs/candidateBinding" },
+    "delivery": { "$ref": "#/$defs/signedDeliveryEvidence" },
+    "failures": { "type": "array", "items": { "$ref": "#/$defs/failure" } },
+    "events": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/event" } },
+    "state_digest": { "$ref": "#/$defs/digest" },
+    "seal_key_id": { "$ref": "#/$defs/keyId" },
+    "seal_mac": { "$ref": "#/$defs/mac" }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "state": { "const": "dry_run" } }, "required": ["state"] },
+      "then": {
+        "properties": { "dry_run": { "const": true } },
+        "required": ["proposal", "candidate_digest"],
+        "not": { "anyOf": [{ "required": ["verification"] }, { "required": ["delivery"] }] }
+      }
+    },
+    {
+      "if": { "properties": { "state": { "const": "resolved" } }, "required": ["state"] },
+      "then": {
+        "properties": {
+          "dry_run": { "const": false },
+          "verification": {
+            "properties": {
+              "status": { "const": "passed" },
+              "missing": { "maxItems": 0 },
+              "duplicate": { "maxItems": 0 },
+              "invalid": { "maxItems": 0 },
+              "failed": { "maxItems": 0 }
+            }
+          },
+          "delivery": {
+            "properties": {
+              "required_checks_passed": { "const": true },
+              "review_satisfied": { "const": true },
+              "conversations_resolved": { "const": true }
+            }
+          }
+        },
+        "required": ["proposal", "candidate_digest", "verification", "candidate_binding", "delivery"]
+      }
+    },
+    {
+      "if": { "properties": { "state": { "const": "evidence_failed" } }, "required": ["state"] },
+      "then": { "required": ["verification"], "not": { "required": ["delivery"] } }
+    },
+    {
+      "if": { "properties": { "state": { "const": "interrupted" } }, "required": ["state"] },
+      "then": { "required": ["interrupted_from"] }
+    },
+    {
+      "if": { "properties": { "state": { "const": "rolled_back" } }, "required": ["state"] },
+      "then": { "properties": { "rollback": { "const": "succeeded" } } }
+    }
+  ],
+  "$defs": {
+    "digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "mac": { "type": "string", "pattern": "^hmac-sha256:[0-9a-f]{64}$" },
+    "keyId": { "type": "string", "minLength": 1, "maxLength": 64, "pattern": "^[a-z0-9._-]+$" },
+    "sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "relativePath": { "type": "string", "minLength": 1, "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$))(?!.*//)[^\\u0000]+$" },
+    "limits": {
+      "type": "object", "additionalProperties": false,
+      "required": ["time_seconds", "tokens", "retries", "cost_usd_micros"],
+      "properties": {
+        "time_seconds": { "type": "integer", "minimum": 1 },
+        "tokens": { "type": "integer", "minimum": 1 },
+        "retries": { "type": "integer", "minimum": 0 },
+        "cost_usd_micros": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "usage": {
+      "type": "object", "additionalProperties": false,
+      "required": ["time_seconds", "tokens", "retries", "cost_usd_micros"],
+      "properties": {
+        "time_seconds": { "type": "integer", "minimum": 0 },
+        "tokens": { "type": "integer", "minimum": 0 },
+        "retries": { "type": "integer", "minimum": 0 },
+        "cost_usd_micros": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "executorBudgets": {
+      "type": "object", "additionalProperties": false,
+      "required": ["limits", "consumed"],
+      "properties": { "limits": { "$ref": "#/$defs/limits" }, "consumed": { "$ref": "#/$defs/usage" } }
+    },
+    "retryPolicy": {
+      "type": "object", "additionalProperties": false,
+      "required": ["approved_causes"],
+      "properties": {
+        "approved_causes": {
+          "type": "array", "uniqueItems": true,
+          "items": { "enum": ["code", "evidence", "environment", "conflict"] }
+        }
+      }
+    },
+    "replaceTextProposal": {
+      "type": "object", "additionalProperties": false,
+      "required": ["path", "expected_before_digest", "find", "replacement", "candidate_digest"],
+      "properties": {
+        "path": { "$ref": "#/$defs/relativePath" },
+        "expected_before_digest": { "$ref": "#/$defs/digest" },
+        "find": { "type": "string", "minLength": 1 },
+        "replacement": { "type": "string" },
+        "candidate_digest": { "$ref": "#/$defs/digest" }
+      }
+    },
+    "verificationVerdict": {
+      "type": "object", "additionalProperties": false,
+      "required": ["schema_version", "plan_digest", "status", "source_head_sha", "delivered_head_sha", "missing", "duplicate", "invalid", "failed"],
+      "properties": {
+        "schema_version": { "const": "axiom.verification_verdict.v0" },
+        "plan_digest": { "$ref": "#/$defs/digest" },
+        "status": { "enum": ["passed", "failed"] },
+        "source_head_sha": { "$ref": "#/$defs/sha" },
+        "delivered_head_sha": { "$ref": "#/$defs/sha" },
+        "missing": { "$ref": "#/$defs/stringSet" },
+        "duplicate": { "$ref": "#/$defs/stringSet" },
+        "invalid": { "$ref": "#/$defs/stringSet" },
+        "failed": { "$ref": "#/$defs/stringSet" }
+      }
+    },
+    "signedDeliveryEvidence": {
+      "type": "object", "additionalProperties": false,
+      "required": ["provider_id", "candidate_digest", "plan_digest", "delivered_head_sha", "transaction_id", "policy_digest", "fetched_at_epoch_seconds", "required_checks_passed", "review_satisfied", "conversations_resolved", "evidence_mac"],
+      "properties": {
+        "provider_id": { "$ref": "#/$defs/keyId" },
+        "candidate_digest": { "$ref": "#/$defs/digest" },
+        "plan_digest": { "$ref": "#/$defs/digest" },
+        "delivered_head_sha": { "$ref": "#/$defs/sha" },
+        "transaction_id": { "type": "string", "pattern": "^txn-[0-9a-f]{16}$" },
+        "policy_digest": { "$ref": "#/$defs/digest" },
+        "fetched_at_epoch_seconds": { "type": "integer", "minimum": 0 },
+        "required_checks_passed": { "type": "boolean" },
+        "review_satisfied": { "type": "boolean" },
+        "conversations_resolved": { "type": "boolean" },
+        "evidence_mac": { "$ref": "#/$defs/mac" }
+      }
+    },
+    "candidateBinding": {
+      "type": "object", "additionalProperties": false,
+      "required": ["candidate_digest", "delivered_head_sha", "transaction_id", "policy_digest", "plan_digest", "binding_digest"],
+      "properties": {
+        "candidate_digest": { "$ref": "#/$defs/digest" },
+        "delivered_head_sha": { "$ref": "#/$defs/sha" },
+        "transaction_id": { "type": "string", "pattern": "^txn-[0-9a-f]{16}$" },
+        "policy_digest": { "$ref": "#/$defs/digest" },
+        "plan_digest": { "$ref": "#/$defs/digest" },
+        "binding_digest": { "$ref": "#/$defs/digest" }
+      }
+    },
+    "failure": {
+      "type": "object", "additionalProperties": false,
+      "required": ["cause", "fingerprint", "message", "attempt"],
+      "properties": {
+        "cause": { "enum": ["code", "evidence", "environment", "conflict", "policy", "unknown"] },
+        "fingerprint": { "$ref": "#/$defs/digest" },
+        "message": { "type": "string", "minLength": 1 },
+        "attempt": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "event": {
+      "type": "object", "additionalProperties": false,
+      "required": ["sequence", "kind", "detail", "state", "budget_usage", "previous_digest", "event_digest"],
+      "properties": {
+        "sequence": { "type": "integer", "minimum": 0 },
+        "kind": { "type": "string", "minLength": 1 },
+        "detail": { "type": "string", "minLength": 1 },
+        "state": { "enum": ["planned", "dry_run", "edited", "evidence_failed", "verification_passed", "resolved", "rolled_back", "rejected", "escalated", "interrupted"] },
+        "budget_usage": { "$ref": "#/$defs/usage" },
+        "candidate_digest": { "$ref": "#/$defs/digest" },
+        "previous_digest": { "$ref": "#/$defs/digest" },
+        "event_digest": { "$ref": "#/$defs/digest" }
+      }
+    },
+    "stringSet": { "type": "array", "uniqueItems": true, "items": { "type": "string", "minLength": 1 } },
+    "pathSet": { "type": "array", "minItems": 1, "uniqueItems": true, "items": { "$ref": "#/$defs/relativePath" } }
+  }
+}

--- a/stage1/schemas/axiom-executor-request-v0.schema.json
+++ b/stage1/schemas/axiom-executor-request-v0.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axiom.omt.global/schemas/axiom-executor-request-v0.schema.json",
+  "title": "Axiom bounded executor request v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "task_contract_digest", "transaction_id", "transaction_digest", "base_sha", "mode", "dry_run", "budgets", "retry_policy", "proposal"],
+  "properties": {
+    "schema_version": { "const": "axiom.executor_request.v0" },
+    "task_contract_digest": { "$ref": "#/$defs/digest" },
+    "transaction_id": { "type": "string", "pattern": "^txn-[0-9a-f]{16}$" },
+    "transaction_digest": { "$ref": "#/$defs/digest" },
+    "base_sha": { "$ref": "#/$defs/sha" },
+    "mode": { "enum": ["deterministic", "assisted"] },
+    "dry_run": { "type": "boolean" },
+    "budgets": { "$ref": "#/$defs/budgets" },
+    "retry_policy": { "$ref": "#/$defs/retryPolicy" },
+    "proposal": {
+      "oneOf": [
+        { "$ref": "#/$defs/replaceTextProposal" },
+        { "type": "null" }
+      ]
+    }
+  },
+  "$defs": {
+    "digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "relativePath": { "type": "string", "minLength": 1, "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$))(?!.*//)[^\\u0000]+$" },
+    "budgets": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["time_seconds", "tokens", "retries", "cost_usd_micros"],
+      "properties": {
+        "time_seconds": { "type": "integer", "minimum": 1 },
+        "tokens": { "type": "integer", "minimum": 1 },
+        "retries": { "type": "integer", "minimum": 0 },
+        "cost_usd_micros": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "retryPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["approved_causes"],
+      "properties": {
+        "approved_causes": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "enum": ["code", "evidence", "environment", "conflict"] }
+        }
+      }
+    },
+    "replaceTextProposal": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "expected_before_digest", "find", "replacement", "candidate_digest"],
+      "properties": {
+        "path": { "$ref": "#/$defs/relativePath" },
+        "expected_before_digest": { "$ref": "#/$defs/digest" },
+        "find": { "type": "string", "minLength": 1 },
+        "replacement": { "type": "string" },
+        "candidate_digest": { "$ref": "#/$defs/digest" }
+      }
+    }
+  }
+}

--- a/stage1/schemas/axiom-executor-resume-v0.schema.json
+++ b/stage1/schemas/axiom-executor-resume-v0.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axiom.omt.global/schemas/axiom-executor-resume-v0.schema.json",
+  "title": "Axiom bounded executor resume request v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "executor_state_mac", "seal_key_id", "task_contract_digest", "transaction_id", "transaction_digest", "candidate_digest", "remaining_budgets", "next_event_sequence"],
+  "properties": {
+    "schema_version": { "const": "axiom.executor_resume.v0" },
+    "executor_state_mac": { "$ref": "#/$defs/mac" },
+    "seal_key_id": { "$ref": "#/$defs/keyId" },
+    "task_contract_digest": { "$ref": "#/$defs/digest" },
+    "transaction_id": { "type": "string", "pattern": "^txn-[0-9a-f]{16}$" },
+    "transaction_digest": { "$ref": "#/$defs/digest" },
+    "candidate_digest": {
+      "oneOf": [
+        { "$ref": "#/$defs/digest" },
+        { "type": "null" }
+      ]
+    },
+    "remaining_budgets": { "$ref": "#/$defs/budgets" },
+    "next_event_sequence": { "type": "integer", "minimum": 1 }
+  },
+  "$defs": {
+    "digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "mac": { "type": "string", "pattern": "^hmac-sha256:[0-9a-f]{64}$" },
+    "keyId": { "type": "string", "minLength": 1, "maxLength": 64, "pattern": "^[a-z0-9._-]+$" },
+    "budgets": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["time_seconds", "tokens", "retries", "cost_usd_micros"],
+      "properties": {
+        "time_seconds": { "type": "integer", "minimum": 0 },
+        "tokens": { "type": "integer", "minimum": 0 },
+        "retries": { "type": "integer", "minimum": 0 },
+        "cost_usd_micros": { "type": "integer", "minimum": 0 }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- implement the bounded repair executor with versioned request, report, and resume contracts
- enforce contract/policy/proposal authority intersection, transactional rollback, exact-head evidence checks, bounded retries, and authenticated resumable state
- add deterministic fixtures for success, scope escape, evidence regression, retry exhaustion, interruption/resume, and rollback

## Governing Issue

Closes #1422

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Passed locally:

- `bounded_executor_contract` (7 tests)
- `transactional_workspace` (4 tests)
- `agent_task_contract` (4 tests)
- `verification_planner_contract` (6 tests)
- `make capability-ledger` (checker plus 3 contract tests)
- compiler source-monolith plan and ratchet check
- standard-library property workload and Stage1 proof workload
- `git diff --check`

`make stage1-test` is currently blocked by pre-existing integration-test harness imports in `hir_unit.rs` and `lib_unit.rs`; the identical failure reproduces on clean current `main` and is not changed by this PR.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected when applicable (not applicable)
- [x] PR author enabled auto-merge where GitHub allows it
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Flow Contract

- Owner lane: Daedalus
- Repair owner: Codex
- Autonomy class: review-gated
- Risk class: high

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] PR author enabled auto-merge where GitHub allows it

## Merge Automation

- [x] PR author enabled auto-merge with `gh pr merge --auto --squash`

## Notes

- The executor is local-only: it cannot approve, merge, force-push, edit policy, or acquire capabilities.
- The fast-check scripts used a verified issue-state snapshot because Python's local SSL trust could not fetch GitHub issue state directly.
