### PR TITLE
Measure CRAP thresholds from LCOV coverage

### DIFF
--- a/docs/stage1-crap-thresholds.md
+++ b/docs/stage1-crap-thresholds.md
@@ -12,10 +12,10 @@ CRAP = complexity^2 * (1 - coverage)^3 + complexity
 ```
 
 The proposal script is dependency-free so it can run in the existing shell-only
-CI shape. It estimates function complexity from Rust control-flow tokens and can
-fold in line coverage from an optional LCOV report. When no coverage report is
-available, functions are ranked as if uncovered so the output is conservative,
-but still report-only.
+CI shape. It estimates function complexity from Rust control-flow tokens and
+uses line coverage from an optional LCOV report. Without an LCOV report,
+functions are explicitly reported as **unmeasured**: they do not receive a
+fabricated zero-coverage CRAP score and cannot trip an enforcement gate.
 
 ## Proposed thresholds
 
@@ -44,7 +44,8 @@ This writes `stage1/quality/crap-threshold-proposal.json` with:
 
 - report-only status and `ciBlocking: false`
 - the proposed threshold bands above
-- observed bootstrap thresholds from the current hotspot distribution
+- measured and unmeasured function counts, plus observed scores when coverage
+  evidence was supplied
 - the top stage1 Rust hotspots for review
 
 Optional LCOV input can be supplied directly:
@@ -55,4 +56,6 @@ python3 scripts/ci/propose-stage1-crap-thresholds.py \
   --output stage1/quality/crap-threshold-proposal.json
 ```
 
-Do not wire `--enforce` into CI until the proposal is explicitly accepted.
+`--enforce` requires `--lcov`; this prevents default-zero estimates from
+blocking work. Do not wire enforcement into CI until the baseline policy is
+explicitly accepted.

--- a/scripts/ci/propose-stage1-crap-thresholds.py
+++ b/scripts/ci/propose-stage1-crap-thresholds.py
@@ -27,10 +27,12 @@ class FunctionMetric:
     end_line: int
     lines: int
     complexity: int
-    coverage: float
+    coverage: float | None
 
     @property
-    def crap(self) -> float:
+    def crap(self) -> float | None:
+        if self.coverage is None:
+            return None
         uncovered = 1.0 - self.coverage
         return (self.complexity**2 * uncovered**3) + self.complexity
 
@@ -107,7 +109,36 @@ def function_ranges(path: Path) -> list[tuple[str, int, int, list[str]]]:
     return ranges
 
 
-def collect_metrics(source_root: Path, default_coverage: float) -> list[FunctionMetric]:
+def parse_lcov(path: Path) -> dict[Path, dict[int, int]]:
+    """Read LCOV line hit counts keyed by resolved source path."""
+    coverage: dict[Path, dict[int, int]] = {}
+    current: Path | None = None
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        if raw_line.startswith("SF:"):
+            candidate = Path(raw_line.removeprefix("SF:"))
+            current = candidate.resolve() if candidate.is_absolute() else (REPO_ROOT / candidate).resolve()
+        elif raw_line.startswith("DA:") and current is not None:
+            try:
+                line, hits = raw_line.removeprefix("DA:").split(",", 1)
+                coverage.setdefault(current, {})[int(line)] = int(hits)
+            except ValueError as error:
+                raise ValueError(f"invalid LCOV data record {raw_line!r}") from error
+        elif raw_line == "end_of_record":
+            current = None
+    return coverage
+
+
+def function_coverage(path: Path, start: int, end: int, lcov: dict[Path, dict[int, int]] | None) -> float | None:
+    if lcov is None:
+        return None
+    lines = lcov.get(path.resolve(), {})
+    relevant = [hits for line, hits in lines.items() if start <= line <= end]
+    if not relevant:
+        return 0.0
+    return sum(hits > 0 for hits in relevant) / len(relevant)
+
+
+def collect_metrics(source_root: Path, lcov: dict[Path, dict[int, int]] | None) -> list[FunctionMetric]:
     metrics: list[FunctionMetric] = []
     for path in sorted(source_root.rglob("*.rs")):
         for name, start, end, body in function_ranges(path):
@@ -119,7 +150,7 @@ def collect_metrics(source_root: Path, default_coverage: float) -> list[Function
                     end_line=end,
                     lines=end - start + 1,
                     complexity=cyclomatic_complexity(body),
-                    coverage=default_coverage,
+                    coverage=function_coverage(path, start, end, lcov),
                 )
             )
     return metrics
@@ -130,21 +161,30 @@ def proposal(
     threshold: float,
     max_hotspots: int,
     source_root: Path,
+    lcov_path: Path | None,
 ) -> dict:
-    hotspots = sorted(metrics, key=lambda metric: metric.crap, reverse=True)[:max_hotspots]
+    measured = [metric for metric in metrics if metric.crap is not None]
+    hotspots = sorted(measured, key=lambda metric: metric.crap or 0.0, reverse=True)[:max_hotspots]
     return {
         "schema_version": "axiom.stage1.crap-threshold-proposal.v1",
         "blocking": False,
         "source_root": str(source_root),
         "threshold": threshold,
         "inputs": {
-            "coverage": "defaulted until coverage artifacts are wired into extended validation",
+            "coverage": {
+                "source": "lcov" if lcov_path else "unmeasured",
+                "path": str(lcov_path) if lcov_path else None,
+                "measured_functions": len(measured),
+                "unmeasured_functions": len(metrics) - len(measured),
+            },
             "complexity": "heuristic branch-token scan over stage1 Rust sources",
         },
         "summary": {
             "functions_scanned": len(metrics),
-            "hotspots_over_threshold": sum(1 for metric in metrics if metric.crap > threshold),
-            "max_crap": round(max((metric.crap for metric in metrics), default=0.0), 2),
+            "functions_with_coverage": len(measured),
+            "functions_without_coverage": len(metrics) - len(measured),
+            "hotspots_over_threshold": sum(1 for metric in measured if (metric.crap or 0.0) > threshold),
+            "max_crap": round(max((metric.crap or 0.0 for metric in measured), default=0.0), 2),
         },
         "hotspots": [
             {
@@ -155,8 +195,8 @@ def proposal(
                 "lines": metric.lines,
                 "complexity": metric.complexity,
                 "coverage": metric.coverage,
-                "crap": round(metric.crap, 2),
-                "over_threshold": metric.crap > threshold,
+                "crap": round(metric.crap or 0.0, 2),
+                "over_threshold": (metric.crap or 0.0) > threshold,
             }
             for metric in hotspots
         ],
@@ -172,7 +212,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--source-root", type=Path, default=DEFAULT_SOURCE_ROOT)
     parser.add_argument("--threshold", type=float, default=DEFAULT_THRESHOLD)
-    parser.add_argument("--default-coverage", type=float, default=0.0)
+    parser.add_argument("--lcov", type=Path, default=None, help="LCOV line coverage report")
     parser.add_argument("--max-hotspots", type=int, default=20)
     parser.add_argument("--output", type=Path, default=None)
     parser.add_argument("--enforce", action="store_true")
@@ -185,12 +225,23 @@ def main() -> int:
         print(f"error: source root is not a directory: {args.source_root}", file=sys.stderr)
         return 2
 
-    metrics = collect_metrics(args.source_root, args.default_coverage)
+    if args.lcov and not args.lcov.is_file():
+        print(f"error: LCOV report does not exist: {args.lcov}", file=sys.stderr)
+        return 2
+    if args.enforce and not args.lcov:
+        print("error: --enforce requires --lcov coverage evidence", file=sys.stderr)
+        return 2
+    try:
+        lcov = parse_lcov(args.lcov) if args.lcov else None
+    except (OSError, ValueError) as error:
+        print(f"error: failed to parse LCOV report: {error}", file=sys.stderr)
+        return 2
+    metrics = collect_metrics(args.source_root, lcov)
     if not metrics:
         print(f"error: no Rust functions discovered under source root: {args.source_root}", file=sys.stderr)
         return 2
 
-    report = proposal(metrics, args.threshold, args.max_hotspots, args.source_root)
+    report = proposal(metrics, args.threshold, args.max_hotspots, args.source_root, args.lcov)
     payload = json.dumps(report, indent=2, sort_keys=True) + "\n"
     if args.output:
         args.output.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/ci/test-propose-stage1-crap-thresholds.sh
+++ b/scripts/ci/test-propose-stage1-crap-thresholds.sh
@@ -41,7 +41,32 @@ impl Worker {
 }
 RS
 
-report="$(python3 "$repo_root/scripts/ci/propose-stage1-crap-thresholds.py" --source-root "$temp_dir" --threshold 2)"
+cat >"$temp_dir/sample.lcov" <<LCOV
+TN:
+SF:$temp_dir/sample.rs
+DA:1,1
+DA:2,1
+DA:5,1
+DA:6,1
+DA:7,0
+DA:8,0
+DA:9,0
+DA:10,0
+DA:11,0
+DA:12,0
+DA:13,0
+DA:14,0
+DA:18,1
+DA:19,1
+DA:20,1
+DA:24,1
+DA:25,1
+DA:28,1
+DA:29,1
+end_of_record
+LCOV
+
+report="$(python3 "$repo_root/scripts/ci/propose-stage1-crap-thresholds.py" --source-root "$temp_dir" --lcov "$temp_dir/sample.lcov" --threshold 2)"
 python3 - "$report" <<'PY'
 import json
 import sys
@@ -49,16 +74,35 @@ import sys
 report = json.loads(sys.argv[1])
 assert report["blocking"] is False
 assert report["summary"]["functions_scanned"] == 5
+assert report["summary"]["functions_with_coverage"] == 5
+assert report["inputs"]["coverage"]["source"] == "lcov"
 assert report["summary"]["hotspots_over_threshold"] >= 1
 hotspot_names = {hotspot["function"] for hotspot in report["hotspots"]}
 assert {"run", "limit", "reset"}.issubset(hotspot_names)
 assert report["hotspots"][0]["function"] == "hotspot"
 PY
 
-if python3 "$repo_root/scripts/ci/propose-stage1-crap-thresholds.py" --source-root "$temp_dir" --threshold 2 --enforce >/dev/null; then
+if python3 "$repo_root/scripts/ci/propose-stage1-crap-thresholds.py" --source-root "$temp_dir" --lcov "$temp_dir/sample.lcov" --threshold 2 --enforce >/dev/null; then
   echo "--enforce must fail when hotspots exceed the threshold" >&2
   exit 1
 fi
+
+if python3 "$repo_root/scripts/ci/propose-stage1-crap-thresholds.py" --source-root "$temp_dir" --threshold 2 --enforce >/dev/null 2>"$temp_dir/enforce.err"; then
+  echo "--enforce without LCOV must fail" >&2
+  exit 1
+fi
+grep -q -- "--enforce requires --lcov" "$temp_dir/enforce.err"
+
+unmeasured="$(python3 "$repo_root/scripts/ci/propose-stage1-crap-thresholds.py" --source-root "$temp_dir" --threshold 2)"
+python3 - "$unmeasured" <<'PY'
+import json
+import sys
+
+report = json.loads(sys.argv[1])
+assert report["inputs"]["coverage"]["source"] == "unmeasured"
+assert report["summary"]["functions_without_coverage"] == 5
+assert report["summary"]["hotspots_over_threshold"] == 0
+PY
 
 if python3 "$repo_root/scripts/ci/propose-stage1-crap-thresholds.py" --source-root "$temp_dir/missing" >/dev/null 2>"$temp_dir/missing.err"; then
   echo "missing --source-root must fail" >&2


### PR DESCRIPTION
## Summary

- Parse LCOV line-hit records and calculate per-function coverage for the stage1 CRAP proposal.
- Report functions without coverage explicitly instead of assigning an invented zero-coverage score.
- Require LCOV evidence for `--enforce`, with self-tests for measured, unmeasured, and rejected enforcement paths.

## Governing Issue

Refs #1463. This PR delivers the real-coverage CRAP slice; fuzz corpora, changed-code coverage floors, mutation enforcement, and nightly qualification remain under #1463.

## Validation

- [x] `bash scripts/ci/test-propose-stage1-crap-thresholds.sh`
- [x] `python3 scripts/ci/propose-stage1-crap-thresholds.py --source-root stage1/crates/axiomc/src --threshold 30`
- [x] `git diff --check`
- [x] Autoreview against `origin/main`
- [ ] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks: no local coverage artifact is committed; unmeasured mode is intentionally non-blocking.

## Bootstrap Governance

- [x] Changes are scoped to #1463.
- [x] Contributor and governance guidance are unchanged.
- [x] No real secrets, runtime auth, or machine-local env files are committed.
- [ ] Auto-merge awaits independent approval and required checks.

## Flow Contract

- Owner lane: Ares
- Repair owner: Codex
- Autonomy class: 2, review-gated
- Risk class: high

## Flow Merge Readiness

- [x] Every implementation blocker has a next actor and action: CI qualification supplies LCOV, then the remaining #1463 gates can ratchet against real baselines.
- [x] No active blocking requested changes exist on this new PR.
- [ ] Non-author approval is present when required.
- [ ] Auto-merge awaits independent approval and required checks.

## Merge Automation

- [ ] Auto-merge awaits independent approval and required checks.

## Notes

- The report-only default deliberately does not claim a quality score without coverage evidence. `--enforce` now fails closed unless an LCOV report is supplied.
