### PR TITLE
Add remote branch prune plan manifest and self-checks

### DIFF
--- a/docs/remote-branch-prune-plan.md
+++ b/docs/remote-branch-prune-plan.md
@@ -1,0 +1,65 @@
+# Remote branch prune plan
+
+Issue #1164 uses `scripts/ci/remote-branch-prune-plan.py` to produce a
+deterministic branch-to-SHA-to-PR manifest before any remote branch deletion.
+The planner is read-only. A `candidate` is eligible for maintainer review; it
+is not approval to delete.
+
+The live planner queries every `refs/heads/*` ref and its associated pull
+requests through GitHub GraphQL:
+
+```bash
+python3 scripts/ci/remote-branch-prune-plan.py --json
+```
+
+The report preserves the default branch, protected branches, configured
+historical prefixes, and every branch with an open pull request. Branches
+without a pull request, with an unknown PR state, or whose current SHA differs
+from every terminal PR head are held for manual review. Only an unprotected
+branch at the exact head of a merged or closed PR can become a candidate.
+
+Before deletion, a maintainer must:
+
+1. Review each candidate and explicitly approve the exact branch and SHA.
+2. Re-run the planner immediately before mutation.
+3. Confirm the branch still has the approved SHA and no open pull request.
+4. Delete only the approved names, then re-run the planner and record the new
+   remote branch count.
+
+Use `--preserve-prefix` to add project-specific historical branch families.
+The built-in conservative prefixes are `archive/`, `historical/`, `hotfix/`,
+and `release/`.
+
+Hermetic fixture validation does not require GitHub access:
+
+```bash
+python3 scripts/ci/test-remote-branch-prune-plan.py
+```
+
+## Review snapshot: 2026-07-29
+
+The live repository had 90 remote branches: 17 exact-head candidates, 68 held
+for manual review, and 5 preserved automatically. Automatic head deletion was
+enabled and `main` was the only protected branch reported by GitHub. This table
+is evidence for review, not deletion authority; every row must be regenerated
+and matched by SHA immediately before an approved prune.
+
+| Branch | Exact SHA | Associated terminal PR |
+| --- | --- | --- |
+| `codex/issue-780-effect-model` | `fa100fc44a2f1f3f85eb5b82b9ebf13e5e8033b9` | [#806](https://github.com/OMT-Global/axiomlang/pull/806) merged |
+| `codex/issue-783-artifact-plan` | `14ce8c97eaa525ad0945a2f6c460b1fcc75dc99d` | [#804](https://github.com/OMT-Global/axiomlang/pull/804) merged |
+| `codex/issue-784-repair-plan` | `9a1b413af3f9f65b557287773709daefc52986fe` | [#807](https://github.com/OMT-Global/axiomlang/pull/807) merged |
+| `codex/rust-exit-runtime-serve` | `11317d5dc794ee66e47a1f0e80905593095947bf` | [#1290](https://github.com/OMT-Global/axiomlang/pull/1290) closed |
+| `codex/rust-exit-unsupported-runtime-triage` | `673d6277a381e365576dbe35290e4193f57df737` | [#1263](https://github.com/OMT-Global/axiomlang/pull/1263) closed |
+| `daedalus/1204-cranelift-duplicate-arms` | `15ca7b24e9f3f01debb5406ce83f0fdf9b43ef73` | [#1413](https://github.com/OMT-Global/axiomlang/pull/1413) closed |
+| `daedalus/issue-111` | `41406c86a8265a17965669a845f3559a79b2aaec` | [#496](https://github.com/OMT-Global/axiomlang/pull/496) closed |
+| `daedalus/issue-153` | `43429d54735b09c87f2fa8a77e0d875875943a96` | [#188](https://github.com/OMT-Global/axiomlang/pull/188) merged |
+| `daedalus/issue-218` | `b4d9f7d22a56f6938a222ab2ed89f95dc25425cc` | [#493](https://github.com/OMT-Global/axiomlang/pull/493) closed |
+| `daedalus/issue-219` | `68384126d18f8a0386c6e0f386936514fdf813e7` | [#492](https://github.com/OMT-Global/axiomlang/pull/492) closed |
+| `daedalus/issue-220` | `4c6ae9b673a4a4fb1f95668f5ecee5ad43783d90` | [#491](https://github.com/OMT-Global/axiomlang/pull/491) closed |
+| `daedalus/issue-221` | `30c50f6df601c8dc05278e99e5767631f4d9779a` | [#490](https://github.com/OMT-Global/axiomlang/pull/490) closed |
+| `daedalus/issue-225` | `fdc344ba225b554d0fbafedf13b91ba9e120b4aa` | [#486](https://github.com/OMT-Global/axiomlang/pull/486) closed |
+| `daedalus/issue-226` | `4de9442a589e1dbf42fabd7a37a5dec0dc5cbc97` | [#485](https://github.com/OMT-Global/axiomlang/pull/485) closed |
+| `daedalus/issue-231` | `3f91e6af526dce52095ddcf55fb7eddd46a1f9cf` | [#482](https://github.com/OMT-Global/axiomlang/pull/482) closed |
+| `daedalus/issue-88` | `76eacda191cc1fb7ce8480f4685a1c3b7dd1b345` | [#200](https://github.com/OMT-Global/axiomlang/pull/200) merged |
+| `jmcte/codex/bootstrap-axiom` | `48c3fe5245d7d9720ee734950bf37650fc665272` | [#73](https://github.com/OMT-Global/axiomlang/pull/73) closed |

--- a/scripts/ci/remote-branch-prune-plan.py
+++ b/scripts/ci/remote-branch-prune-plan.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""Build a deterministic, non-mutating remote branch prune plan."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = "axiom.remote_branch_prune_plan.v1"
+TERMINAL_PR_STATES = {"CLOSED", "MERGED"}
+DEFAULT_PRESERVE_PREFIXES = ("archive/", "historical/", "hotfix/", "release/")
+FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
+
+QUERY = """
+query RemoteBranchPrunePlan(
+  $owner: String!
+  $name: String!
+  $cursor: String
+) {
+  repository(owner: $owner, name: $name) {
+    nameWithOwner
+    deleteBranchOnMerge
+    defaultBranchRef {
+      name
+    }
+    refs(
+      refPrefix: "refs/heads/"
+      first: 100
+      after: $cursor
+      orderBy: {field: ALPHABETICAL, direction: ASC}
+    ) {
+      nodes {
+        name
+        target {
+          oid
+        }
+        branchProtectionRule {
+          id
+        }
+        associatedPullRequests(first: 100) {
+          nodes {
+            number
+            state
+            mergedAt
+            closedAt
+            headRefOid
+            title
+            url
+          }
+          pageInfo {
+            hasNextPage
+          }
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+}
+""".strip()
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def parse_repo(value: str) -> tuple[str, str]:
+    parts = value.split("/")
+    if len(parts) != 2 or not all(parts):
+        raise ValueError("repository must use owner/name form")
+    return parts[0], parts[1]
+
+
+def graphql_page(repo: str, cursor: str | None) -> dict[str, Any]:
+    owner, name = parse_repo(repo)
+    command = [
+        "gh",
+        "api",
+        "graphql",
+        "-f",
+        f"query={QUERY}",
+        "-F",
+        f"owner={owner}",
+        "-F",
+        f"name={name}",
+    ]
+    if cursor is not None:
+        command.extend(["-F", f"cursor={cursor}"])
+    result = subprocess.run(command, check=False, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "gh api graphql failed")
+    payload = json.loads(result.stdout)
+    errors = payload.get("errors")
+    if errors:
+        raise RuntimeError(f"GitHub GraphQL returned errors: {errors}")
+    repository = payload.get("data", {}).get("repository")
+    if not isinstance(repository, dict):
+        raise ValueError("GitHub GraphQL response did not contain a repository")
+    return repository
+
+
+def fetch_live_snapshot(repo: str) -> dict[str, Any]:
+    nodes: list[dict[str, Any]] = []
+    cursor: str | None = None
+    repository_metadata: dict[str, Any] | None = None
+    while True:
+        repository = graphql_page(repo, cursor)
+        refs = repository.get("refs")
+        if not isinstance(refs, dict) or not isinstance(refs.get("nodes"), list):
+            raise ValueError("GitHub GraphQL response did not contain branch refs")
+        if repository_metadata is None:
+            repository_metadata = {
+                "nameWithOwner": repository.get("nameWithOwner"),
+                "deleteBranchOnMerge": repository.get("deleteBranchOnMerge"),
+                "defaultBranchRef": repository.get("defaultBranchRef"),
+            }
+        nodes.extend(refs["nodes"])
+        page_info = refs.get("pageInfo")
+        if not isinstance(page_info, dict):
+            raise ValueError("GitHub GraphQL response did not contain ref pagination")
+        if not page_info.get("hasNextPage"):
+            break
+        next_cursor = page_info.get("endCursor")
+        if not isinstance(next_cursor, str) or not next_cursor:
+            raise ValueError("GitHub GraphQL pagination cursor was missing")
+        cursor = next_cursor
+    assert repository_metadata is not None
+    repository_metadata["refs"] = {"nodes": nodes}
+    return repository_metadata
+
+
+def load_snapshot(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("input JSON must be an object")
+    if isinstance(payload.get("data"), dict):
+        payload = payload["data"]
+    if isinstance(payload.get("repository"), dict):
+        payload = payload["repository"]
+    return payload
+
+
+def require_string(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{field} must be a non-empty string")
+    return value
+
+
+def require_sha(value: Any, field: str) -> str:
+    sha = require_string(value, field).lower()
+    if not FULL_SHA.fullmatch(sha):
+        raise ValueError(f"{field} must be a full 40-character hexadecimal SHA")
+    return sha
+
+
+def normalize_pr(raw: Any, branch_name: str) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise ValueError(f"branch {branch_name!r} has a non-object pull request")
+    number = raw.get("number")
+    if not isinstance(number, int) or isinstance(number, bool) or number < 1:
+        raise ValueError(f"branch {branch_name!r} has a pull request without a valid number")
+    state = require_string(raw.get("state"), f"PR #{number} state").upper()
+    head_sha = raw.get("headRefOid")
+    if head_sha is not None:
+        head_sha = require_sha(head_sha, f"PR #{number} headRefOid")
+    return {
+        "number": number,
+        "state": state,
+        "head_sha": head_sha,
+        "merged_at": raw.get("mergedAt"),
+        "closed_at": raw.get("closedAt"),
+        "title": raw.get("title"),
+        "url": raw.get("url"),
+    }
+
+
+def classify_branch(
+    raw: Any,
+    *,
+    default_branch: str,
+    preserve_prefixes: tuple[str, ...],
+) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise ValueError("branch entry must be an object")
+    name = require_string(raw.get("name"), "branch name")
+    target = raw.get("target")
+    if not isinstance(target, dict):
+        raise ValueError(f"branch {name!r} target must be an object")
+    sha = require_sha(target.get("oid"), f"branch {name!r} target oid")
+    protected = raw.get("branchProtectionRule") is not None
+    associated = raw.get("associatedPullRequests")
+    if not isinstance(associated, dict) or not isinstance(associated.get("nodes"), list):
+        raise ValueError(f"branch {name!r} associatedPullRequests must contain nodes")
+    prs = sorted(
+        (normalize_pr(item, name) for item in associated["nodes"]),
+        key=lambda item: item["number"],
+    )
+    if len({pull_request["number"] for pull_request in prs}) != len(prs):
+        raise ValueError(f"branch {name!r} contains duplicate pull request numbers")
+    pull_requests_truncated = bool(
+        isinstance(associated.get("pageInfo"), dict)
+        and associated["pageInfo"].get("hasNextPage")
+    )
+    matched_prefix = next((prefix for prefix in preserve_prefixes if name.startswith(prefix)), None)
+
+    if name == default_branch:
+        disposition, reason = "preserve", "default_branch"
+    elif protected:
+        disposition, reason = "preserve", "protected_branch"
+    elif matched_prefix is not None:
+        disposition, reason = "preserve", f"preserved_prefix:{matched_prefix}"
+    elif pull_requests_truncated:
+        disposition, reason = "manual_review", "associated_pull_requests_truncated"
+    elif not prs:
+        disposition, reason = "manual_review", "no_associated_pull_request"
+    elif any(pr["state"] == "OPEN" for pr in prs):
+        disposition, reason = "preserve", "open_pull_request"
+    elif any(pr["state"] not in TERMINAL_PR_STATES for pr in prs):
+        disposition, reason = "manual_review", "unknown_pull_request_state"
+    elif not any(pr["head_sha"] == sha for pr in prs):
+        disposition, reason = "manual_review", "branch_sha_differs_from_terminal_pr_head"
+    else:
+        disposition, reason = "candidate", "terminal_pull_request_exact_head"
+
+    return {
+        "name": name,
+        "sha": sha,
+        "protected": protected,
+        "is_default": name == default_branch,
+        "preserved_prefix": matched_prefix,
+        "pull_requests_truncated": pull_requests_truncated,
+        "disposition": disposition,
+        "reason": reason,
+        "pull_requests": prs,
+    }
+
+
+def build_report(
+    *,
+    snapshot: dict[str, Any],
+    repository: str,
+    snapshot_at: str,
+    source: str,
+    preserve_prefixes: tuple[str, ...],
+) -> dict[str, Any]:
+    live_name = require_string(snapshot.get("nameWithOwner"), "repository nameWithOwner")
+    if live_name.casefold() != repository.casefold():
+        raise ValueError(
+            f"snapshot repository {live_name!r} does not match requested {repository!r}"
+        )
+    default_ref = snapshot.get("defaultBranchRef")
+    if not isinstance(default_ref, dict):
+        raise ValueError("repository defaultBranchRef must be an object")
+    default_branch = require_string(default_ref.get("name"), "default branch name")
+    delete_branch_on_merge = snapshot.get("deleteBranchOnMerge")
+    if not isinstance(delete_branch_on_merge, bool):
+        raise ValueError("repository deleteBranchOnMerge must be a boolean")
+    refs = snapshot.get("refs")
+    if not isinstance(refs, dict) or not isinstance(refs.get("nodes"), list):
+        raise ValueError("repository refs must contain nodes")
+    branches = sorted(
+        (
+            classify_branch(
+                item,
+                default_branch=default_branch,
+                preserve_prefixes=preserve_prefixes,
+            )
+            for item in refs["nodes"]
+        ),
+        key=lambda item: item["name"],
+    )
+    names = [branch["name"] for branch in branches]
+    if len(names) != len(set(names)):
+        raise ValueError("snapshot contains duplicate branch names")
+    counts = Counter(branch["disposition"] for branch in branches)
+    reason_counts = Counter(branch["reason"] for branch in branches)
+    candidates = [
+        {"name": branch["name"], "sha": branch["sha"]}
+        for branch in branches
+        if branch["disposition"] == "candidate"
+    ]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "repository": repository,
+        "source": source,
+        "snapshot_at": snapshot_at,
+        "settings": {
+            "default_branch": default_branch,
+            "delete_branch_on_merge": delete_branch_on_merge,
+            "preserve_prefixes": list(preserve_prefixes),
+        },
+        "operator_guards": {
+            "mutates_branches": False,
+            "candidate_means_approved_to_delete": False,
+            "requires_explicit_maintainer_approval": True,
+            "requires_fresh_identical_sha_recheck": True,
+            "requires_open_pr_recheck": True,
+        },
+        "summary": {
+            "remote_branches": len(branches),
+            "by_disposition": dict(sorted(counts.items())),
+            "by_reason": dict(sorted(reason_counts.items())),
+            "candidate_count": len(candidates),
+        },
+        "candidates": candidates,
+        "branches": branches,
+    }
+
+
+def render_text(report: dict[str, Any]) -> str:
+    summary = report["summary"]
+    lines = [
+        (
+            "remote-branch-prune-plan: "
+            f"{summary['remote_branches']} branches, "
+            f"{summary['candidate_count']} review candidates"
+        ),
+        f"repository: {report['repository']}",
+        f"snapshot_at: {report['snapshot_at']}",
+        "dispositions: "
+        + ", ".join(
+            f"{name}={count}"
+            for name, count in sorted(summary["by_disposition"].items())
+        ),
+        "No branch was deleted. Candidates require explicit approval and a fresh SHA recheck.",
+    ]
+    for candidate in report["candidates"]:
+        lines.append(f"candidate {candidate['name']} {candidate['sha']}")
+    return "\n".join(lines)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default="OMT-Global/axiomlang")
+    parser.add_argument("--input", type=Path, help="Fixture or captured GraphQL repository JSON")
+    parser.add_argument("--snapshot-at")
+    parser.add_argument(
+        "--preserve-prefix",
+        action="append",
+        default=[],
+        help="Additional branch-name prefix that must never be proposed",
+    )
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    try:
+        parse_repo(args.repo)
+        if args.input:
+            snapshot = load_snapshot(args.input)
+            source = "input_fixture"
+        else:
+            snapshot = fetch_live_snapshot(args.repo)
+            source = "live_github_graphql"
+        prefixes = tuple(
+            sorted(set(DEFAULT_PRESERVE_PREFIXES).union(args.preserve_prefix))
+        )
+        report = build_report(
+            snapshot=snapshot,
+            repository=args.repo,
+            snapshot_at=args.snapshot_at or utc_now(),
+            source=source,
+            preserve_prefixes=prefixes,
+        )
+    except (OSError, RuntimeError, ValueError, json.JSONDecodeError) as error:
+        print(f"remote-branch-prune-plan: {error}", file=sys.stderr)
+        return 2
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(render_text(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/ci/run-fast-checks.sh
+++ b/scripts/ci/run-fast-checks.sh
@@ -49,6 +49,7 @@ rm -f "$monolith_report"
 python3 "$script_repo_root/scripts/ci/test-report-compiler-source-monoliths.py"
 bash "$script_repo_root/scripts/ci/test-check-rust-exit-command-surface.sh"
 python3 "$script_repo_root/scripts/ci/test-pr-queue-remediation.py"
+python3 "$script_repo_root/scripts/ci/test-remote-branch-prune-plan.py"
 python3 "$script_repo_root/scripts/ci/test-report-delivery-signals.py"
 python3 "$script_repo_root/scripts/ci/test-issue-pr-traceability.py"
 # Checker self-tests must run in a CI lane so their harnesses cannot rot

--- a/scripts/ci/test-remote-branch-prune-plan.py
+++ b/scripts/ci/test-remote-branch-prune-plan.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "ci" / "remote-branch-prune-plan.py"
+SHA_A = "a" * 40
+SHA_B = "b" * 40
+
+spec = importlib.util.spec_from_file_location("remote_branch_prune_plan", SCRIPT_PATH)
+planner = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules["remote_branch_prune_plan"] = planner
+spec.loader.exec_module(planner)
+
+
+def pull_request(
+    number: int,
+    *,
+    state: str = "MERGED",
+    head_sha: str | None = SHA_A,
+) -> dict[str, object]:
+    return {
+        "number": number,
+        "state": state,
+        "headRefOid": head_sha,
+        "mergedAt": "2026-07-01T00:00:00Z" if state == "MERGED" else None,
+        "closedAt": "2026-07-01T00:00:00Z" if state != "OPEN" else None,
+        "title": f"PR {number}",
+        "url": f"https://github.com/OMT-Global/axiomlang/pull/{number}",
+    }
+
+
+def branch(
+    name: str,
+    *,
+    sha: str = SHA_A,
+    protected: bool = False,
+    prs: list[dict[str, object]] | None = None,
+    prs_truncated: bool = False,
+) -> dict[str, object]:
+    return {
+        "name": name,
+        "target": {"oid": sha},
+        "branchProtectionRule": {"id": "protected"} if protected else None,
+        "associatedPullRequests": {
+            "nodes": [] if prs is None else prs,
+            "pageInfo": {"hasNextPage": prs_truncated},
+        },
+    }
+
+
+def snapshot(branches: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        "nameWithOwner": "OMT-Global/axiomlang",
+        "deleteBranchOnMerge": True,
+        "defaultBranchRef": {"name": "main"},
+        "refs": {"nodes": branches},
+    }
+
+
+def report(branches: list[dict[str, object]]) -> dict[str, object]:
+    return planner.build_report(
+        snapshot=snapshot(branches),
+        repository="OMT-Global/axiomlang",
+        snapshot_at="2026-07-29T09:00:00Z",
+        source="fixture",
+        preserve_prefixes=planner.DEFAULT_PRESERVE_PREFIXES,
+    )
+
+
+class RemoteBranchPrunePlanTests(unittest.TestCase):
+    def test_terminal_exact_head_is_a_review_candidate(self) -> None:
+        payload = report(
+            [
+                branch("merged", prs=[pull_request(1)]),
+                branch("closed", prs=[pull_request(2, state="CLOSED")]),
+            ]
+        )
+        self.assertEqual(
+            [item["name"] for item in payload["candidates"]],
+            ["closed", "merged"],
+        )
+
+    def test_default_protected_and_preserved_prefixes_are_preserved(self) -> None:
+        payload = report(
+            [
+                branch("main", protected=True, prs=[pull_request(1)]),
+                branch("protected", protected=True, prs=[pull_request(2)]),
+                branch("release/v1", prs=[pull_request(3)]),
+            ]
+        )
+        dispositions = {
+            item["name"]: (item["disposition"], item["reason"])
+            for item in payload["branches"]
+        }
+        self.assertEqual(dispositions["main"], ("preserve", "default_branch"))
+        self.assertEqual(dispositions["protected"], ("preserve", "protected_branch"))
+        self.assertEqual(
+            dispositions["release/v1"],
+            ("preserve", "preserved_prefix:release/"),
+        )
+
+    def test_open_pull_request_always_preserves_branch(self) -> None:
+        payload = report(
+            [
+                branch(
+                    "active",
+                    prs=[
+                        pull_request(1),
+                        pull_request(2, state="OPEN"),
+                    ],
+                )
+            ]
+        )
+        item = payload["branches"][0]
+        self.assertEqual(item["disposition"], "preserve")
+        self.assertEqual(item["reason"], "open_pull_request")
+
+    def test_no_pr_and_sha_drift_require_manual_review(self) -> None:
+        payload = report(
+            [
+                branch("no-pr"),
+                branch("advanced", sha=SHA_B, prs=[pull_request(1)]),
+            ]
+        )
+        reasons = {item["name"]: item["reason"] for item in payload["branches"]}
+        self.assertEqual(reasons["no-pr"], "no_associated_pull_request")
+        self.assertEqual(
+            reasons["advanced"],
+            "branch_sha_differs_from_terminal_pr_head",
+        )
+
+    def test_unknown_pr_state_requires_manual_review(self) -> None:
+        payload = report(
+            [branch("unknown", prs=[pull_request(1, state="QUEUED")])]
+        )
+        item = payload["branches"][0]
+        self.assertEqual(item["disposition"], "manual_review")
+        self.assertEqual(item["reason"], "unknown_pull_request_state")
+
+    def test_truncated_pull_request_history_requires_manual_review(self) -> None:
+        payload = report(
+            [
+                branch(
+                    "too-many-prs",
+                    prs=[pull_request(1)],
+                    prs_truncated=True,
+                )
+            ]
+        )
+        item = payload["branches"][0]
+        self.assertEqual(item["disposition"], "manual_review")
+        self.assertEqual(item["reason"], "associated_pull_requests_truncated")
+
+    def test_multiple_terminal_prs_are_sorted_and_one_exact_head_is_sufficient(self) -> None:
+        payload = report(
+            [
+                branch(
+                    "reused",
+                    prs=[
+                        pull_request(9, state="CLOSED", head_sha=SHA_B),
+                        pull_request(3, state="MERGED", head_sha=SHA_A),
+                    ],
+                )
+            ]
+        )
+        item = payload["branches"][0]
+        self.assertEqual(item["disposition"], "candidate")
+        self.assertEqual(
+            [pull["number"] for pull in item["pull_requests"]],
+            [3, 9],
+        )
+
+    def test_operator_guards_make_approval_boundary_explicit(self) -> None:
+        guards = report([branch("merged", prs=[pull_request(1)])])[
+            "operator_guards"
+        ]
+        self.assertFalse(guards["mutates_branches"])
+        self.assertFalse(guards["candidate_means_approved_to_delete"])
+        self.assertTrue(guards["requires_explicit_maintainer_approval"])
+        self.assertTrue(guards["requires_fresh_identical_sha_recheck"])
+        self.assertTrue(guards["requires_open_pr_recheck"])
+
+    def test_output_is_deterministic_for_reordered_snapshot(self) -> None:
+        first = report(
+            [
+                branch("z", prs=[pull_request(9)]),
+                branch("a", prs=[pull_request(1)]),
+            ]
+        )
+        second = report(
+            [
+                branch("a", prs=[pull_request(1)]),
+                branch("z", prs=[pull_request(9)]),
+            ]
+        )
+        self.assertEqual(first, second)
+        self.assertEqual([item["name"] for item in first["branches"]], ["a", "z"])
+
+    def test_malformed_branch_sha_and_duplicate_names_fail_closed(self) -> None:
+        with self.assertRaisesRegex(ValueError, "full 40-character"):
+            report([branch("short", sha="abc", prs=[pull_request(1)])])
+        with self.assertRaisesRegex(ValueError, "duplicate branch names"):
+            report(
+                [
+                    branch("same", prs=[pull_request(1)]),
+                    branch("same", prs=[pull_request(2)]),
+                ]
+            )
+        duplicated_pr = branch(
+            "duplicate-pr",
+            prs=[pull_request(1), pull_request(1)],
+        )
+        with self.assertRaisesRegex(ValueError, "duplicate pull request numbers"):
+            report([duplicated_pr])
+
+    def test_cli_emits_json_from_fixture(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            fixture = Path(tmp) / "branches.json"
+            fixture.write_text(
+                json.dumps(snapshot([branch("merged", prs=[pull_request(7)])])),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--input",
+                    str(fixture),
+                    "--snapshot-at",
+                    "2026-07-29T09:00:00Z",
+                    "--json",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["schema_version"], planner.SCHEMA_VERSION)
+        self.assertEqual(payload["candidates"], [{"name": "merged", "sha": SHA_A}])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add a non-mutating GitHub GraphQL planner that inventories every remote branch and classifies it conservatively.
- Emit a deterministic branch-to-SHA-to-PR manifest for maintainer approval before any deletion.
- Add hermetic fail-closed tests and run them in the fast CI suite.
- Document the live 2026-07-29 snapshot and the mandatory fresh-SHA/open-PR recheck.

## Governing Issue

Refs #1164

## Validation

- [x] `python3 -m py_compile scripts/ci/remote-branch-prune-plan.py scripts/ci/test-remote-branch-prune-plan.py`
- [x] `python3 scripts/ci/test-remote-branch-prune-plan.py` — 11 tests passed
- [x] `bash scripts/ci/run-fast-checks.sh` — passed
- [x] Live planner run — 90 branches, 17 review candidates, 68 manual-review holds, 5 automatic preserves
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] No checks were intentionally skipped

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance is unchanged
- [x] PR author will enable auto-merge once the amended exact head is published
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Flow Contract

- Owner lane: Hephaestus
- Repair owner: Codex
- Autonomy class: Class 2, review-gated
- Risk class: Medium

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] PR author enabled auto-merge where GitHub allows it

## Merge Automation

- [x] PR author enabled auto-merge with `gh pr merge --auto --squash`

## Notes

- This PR is planning-only and does not delete remote branches.
- `candidate` means eligible for maintainer review, not approved to delete.
- Before deletion, a maintainer must explicitly approve each branch and SHA, rerun the planner, confirm the SHA is unchanged, and confirm no open PR exists.
