### PR TITLE
Repair extended-validation runner context

### DIFF
--- a/.github/workflows/extended-validation.yml
+++ b/.github/workflows/extended-validation.yml
@@ -102,7 +102,6 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ github.token }}
       AXIOM_QUALIFICATION_OUTPUT_DIR: artifacts/toolchain-qualification
-      AXIOM_QUALIFICATION_TARGET: ${{ runner.os }}-${{ runner.arch }}
       AXIOM_QUALIFICATION_TRIGGER: ${{ github.event_name }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4 pinned 2026-05-30

--- a/scripts/ci/test-extended-validation-workflow.sh
+++ b/scripts/ci/test-extended-validation-workflow.sh
@@ -88,7 +88,14 @@ if "needs.changes.outputs.extended == 'true'" not in extended_job:
     errors.append("extended-checks must consume the extended selection output")
 if "bash scripts/ci/run-extended-validation.sh" not in extended_job:
     errors.append("extended-checks must invoke the extended validation entrypoint")
-for exact_head_fragment in ("--head-sha '${{ github.sha }}'", "--trigger '${{ github.event_name }}'"):
+job_preamble = extended_job.split("\n    steps:\n", 1)[0]
+if re.search(r"\$\{\{\s*runner\s*(?:\.|\[)", job_preamble):
+    errors.append("extended-checks must not use the runner context before step execution")
+for exact_head_fragment in (
+    "--head-sha '${{ github.sha }}'",
+    "--target '${{ runner.os }}-${{ runner.arch }}'",
+    "--trigger '${{ github.event_name }}'",
+):
     if exact_head_fragment not in extended_job:
         errors.append(f"extended-checks must pass exact qualification provenance: {exact_head_fragment}")
 if "if: always()" not in extended_job or "actions/upload-artifact@" not in extended_job:


### PR DESCRIPTION
## Summary

- Remove the invalid job-level `runner` context reference that makes Extended Validation fail before creating jobs.
- Retain the exact runner target at step scope, where GitHub Actions exposes `runner.os` and `runner.arch`.
- Extend the workflow contract test to reject dot or bracket runner-context expressions before step execution.

## Governing Issue

Closes #1521

## Validation

- [x] `bash scripts/ci/test-extended-validation-workflow.sh`
- [x] `bash -n scripts/ci/test-extended-validation-workflow.sh`
- [x] Direct regression assertions cover `${{runner.os}}` and `${{ runner["os"] }}`
- [x] `bash scripts/ci/run-fast-checks.sh`
- [x] `git diff --check`
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] No checks were intentionally skipped

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor and PR guidance are unchanged
- [x] PR author will enable auto-merge after publication
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Flow Contract

- Owner lane: Hephaestus
- Repair owner: Codex
- Autonomy class: Class 2, review-gated
- Risk class: Medium

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] PR author will enable auto-merge where GitHub allows it

## Merge Automation

- [x] PR author will enable auto-merge with `gh pr merge --auto --squash`

## Notes

- GitHub reported `Unrecognized named-value: 'runner'` at the removed job-level environment expression.
- The prior zero-job failures were workflow compilation failures, not runner-capacity or test failures.
- The configured external autoreview was unavailable because unpublished-diff export was denied. An independent internal reviewer returned clean after two accepted regression-test hardening findings were fixed.
