### PR TITLE
Implement Package Resolver v1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,17 @@ stage1-package-graph-boundary:
 stage1-package-graph-boundary-test:
 	bash scripts/ci/test-check-package-graph-boundary.sh
 
+stage1-package-resolver:
+	cargo test --manifest-path stage1/Cargo.toml -p axiomc --locked --lib package_version::tests
+	cargo test --manifest-path stage1/Cargo.toml -p axiomc --locked --lib package_resolver::tests
+	cargo test --manifest-path stage1/Cargo.toml -p axiomc --locked --lib registry_client::tests
+	cargo test --manifest-path stage1/Cargo.toml -p axiomc --locked --lib package_archive::tests
+	cargo test --manifest-path stage1/Cargo.toml -p axiomc --locked --lib package_store::tests
+	cargo test --manifest-path stage1/Cargo.toml -p axiomc --locked --lib package_manager::tests
+	cargo test --manifest-path stage1/Cargo.toml -p axiomc --locked --test package_resolver_cli
+	python3 scripts/ci/check-package-graph-boundary.py --json
+	bash scripts/ci/test-check-package-graph-boundary.sh
+
 stage1-package-trust-contract:
 	python3 scripts/ci/check-package-trust-contract.py --json
 

--- a/docs/compatibility-v1.md
+++ b/docs/compatibility-v1.md
@@ -80,25 +80,23 @@ release history or a previous compiler.
 `previous-contract-fixture/` remains sparse synthetic checker input and is not
 used as the canonical ratchet.
 
-The current source contract is version `0.3.0` with 61 surfaces. Its changes
-from the byte-frozen 52-surface `0.1.0` accepted baseline are the five additive
-Package Trust v1 schemas, the four additive base-contract schemas (Provider
-ABI, Semantic MIR, runtime lifecycle, and persistent LSP), and the additive
-`pkg verify` command path. Per-surface
-versions remain `0.1.0` for unchanged surfaces and are `0.2.0` for the five
-schema additions and the CLI surface, so a contract-level version bump does not
-fabricate semantic drift across the existing inventory.
+The current source contract is version `0.4.0` with 66 surfaces. Its changes
+from the byte-frozen 52-surface `0.1.0` accepted baseline include the five
+Package Trust v1 schemas, four additive base-contract schemas (Provider ABI,
+Semantic MIR, runtime lifecycle, and persistent LSP), two quality schemas
+(quality policy and quality report), and three package-resolver schemas. The existing CLI, manifest, lockfile, `axiom.toml` schema, and stage1
+JSON-envelope schema surfaces also carry their governed package-resolver
+changes. Per-surface versions remain `0.1.0` for unchanged surfaces and are
+`0.2.0` for the schema additions and the CLI surface, so a contract-level
+version bump does not fabricate semantic drift across the existing inventory.
+The CLI surface is version `0.3.0`.
 
-Existing command invocations require no changes. Because Compatibility v1
-conservatively treats any aggregate CLI signature change as breaking, the CLI
-surface carries explicit migration guidance: operators opting into offline
-Package Trust verification provide the exact archive, manifest, provenance,
-package-signature, trust-roots, registry-index, and expectation files and
-select the required `--json` output. The command emits an
-`axiom.package_verification.v1` result, exits `0` for a trusted decision, exits
-`1` for a schema-compatible rejected decision (including missing or malformed
-package inputs), and reserves exit `2` for an operational or output-I/O
-failure.
+Existing command invocations require no changes. Operators adopting registry
+dependencies run `axiomc pkg fetch` to create the v2 lockfile and verified
+cache, use `axiomc pkg update` for explicit re-resolution, and run
+`axiomc pkg vendor` before cache-independent locked offline builds. Standalone
+Package Trust verification remains available through `axiomc pkg verify` with
+the exact artifact and trust metadata paths plus `--json`.
 
 Verify source derivation and the corpus with:
 

--- a/docs/compiler-package-graph.md
+++ b/docs/compiler-package-graph.md
@@ -2,9 +2,9 @@
 
 `compiler.package_graph` is the AxiOM-owned package identity and dependency
 surface for the self-hosted compiler path. It resolves packages from
-`axiom.toml`, `axiom.lock`, source files, and future registry metadata. Cargo is
-developer scaffolding for the current Rust-hosted compiler only; Cargo metadata
-is not package truth.
+`axiom.toml`, `axiom.lock`, source files, authenticated static-registry
+metadata, and verified cache or vendor material. Cargo is developer scaffolding
+for the current Rust-hosted compiler only; Cargo metadata is not package truth.
 
 ## Contract
 
@@ -15,25 +15,39 @@ The package graph accepts these inputs:
 - Root `axiom.lock`.
 - Local workspace member manifests.
 - Local path dependency manifests.
+- Exact authenticated Registry Index v2 bytes, trust roots, and verification
+  expectation named by the root manifest.
+- Exact registry package archive, manifest, provenance, and signature bytes
+  admitted through Package Trust v1.
+- Content-addressed cache or vendor evidence matching lockfile v2.
 - Package source files reachable from each manifest entrypoint and imports.
-- Future registry index records and archive integrity metadata.
 
 It produces a stable `axiom.compiler.package_graph.v1` envelope with:
 
 - The root path, manifest path, and lockfile path.
-- One package node for every locked root, workspace, and local dependency
-  package.
+- One package node for every locked root, workspace, local dependency, and
+  registry dependency package.
 - Package identity from `[package].name`, `[package].version`, and the locked
   source string.
-- Workspace membership and local dependency edges from `axiom.toml`.
+- Workspace membership and dependency edges from `axiom.toml` and lockfile v2.
 - Build entrypoint and output directory from `[build]`.
 - Lockfile integrity data matching the checked-in `axiom.lock`.
+- For registry nodes, the requested/selected version, authenticated source and
+  signer evidence, yank-at-resolution state, cache/vendor disposition, and
+  stable resolver decision.
 - Hash inputs needed by build caches, release evidence, and snapshot bootstrap.
 
 The graph must not read `Cargo.toml`, `Cargo.lock`, `cargo metadata`, or
 `stage1/Cargo.lock` to decide AxiOM package identity. The Rust implementation may
 call Rust code to compute the graph during the bootstrap period, but the
 observable contract must stay expressible in AxiOM package terms.
+
+`axiomc pkg graph --json` exposes the materialized compiler view through the
+separate `axiom.compiler.package_graph.runtime.v1` contract. That runtime
+contract preserves canonical package IDs, locked sources, resolver edge
+decisions, lockfile evidence, Package Trust signer evidence, and cache/vendor
+materialization identities without pretending to be the static boundary
+envelope above.
 
 ## Package Nodes
 
@@ -49,17 +63,46 @@ Each package node has:
 - `out_dir`: the manifest build output directory relative to the package root.
 - `workspace_members`: local workspace members declared by that package.
 - `local_dependencies`: dependency name/path edges declared by that package.
+- Registry dependency data, when applicable: canonical registry/source
+  identity, namespace, selected version, archive digest, publisher/signers,
+  trust decision, and cache or vendor evidence.
+- Resolver decisions: requested constraint, selected package ID, source kind,
+  stable reason, and candidate/yank disposition.
 
 The root package appears first. Remaining package nodes are sorted by locked
 source and then package name so independent implementations can compare graphs
-deterministically.
+deterministically. Resolver coordinates are canonical
+`(registry_identity, source_identity, namespace, package)` tuples sorted
+lexically. Candidate versions use strict release SemVer descending, with
+release ID and target path as lexical tie-breakers; duplicate
+coordinate/version entries are rejected. One selected version is allowed per
+canonical coordinate.
 
 ## Lockfile Integrity
 
-`axiom.lock` remains the package graph integrity source. Official builds must
-reject missing, malformed, or stale lockfiles in locked/offline modes before
-source lowering or backend selection. A graph fixture is valid only when its
-package identities exactly match the decoded lockfile packages.
+`axiom.lock` remains the package graph integrity source. Version 1 is the
+path-only format. A graph containing registry dependencies requires version 2,
+whose compatibility, explicit sorted root IDs, registry, package, and edge
+records bind the full selection and trust evidence. Explicit roots preserve
+virtual and multi-member workspace entry sets without inventing dependency
+edges. Official builds must reject missing, malformed, version-inappropriate,
+or stale lockfiles in locked/offline modes before source lowering or backend
+selection. A graph fixture is valid only when its roots, package identities,
+and edges exactly match the decoded lockfile.
+
+Fresh resolution excludes yanked releases. A locked graph may replay a release
+that was subsequently yanked only when every exact digest, signer, trust-root,
+index-transcript, and release pin still verifies; an update moves away from it
+when a compatible non-yanked release exists. Conflict, yank, work-budget, and
+backtrack outcomes are deterministic and appear in the resolver trace.
+
+`--locked --offline` is a strict no-network mode. Every registry node must be
+recoverable from intact content-addressed cache or vendor evidence and must
+reverify against lockfile v2. There is no registry fallback and no
+authenticate-then-reread path. Once materialized, registry manifests and
+reachable `.ax` sources are consumed from the exact authenticated archive bytes
+carried into a bounded in-memory compiler view; later cache or vendor path
+mutation cannot change compiler input.
 
 The current Rust-hosted compiler already hashes the lockfile into build cache
 keys. The self-hosted graph must preserve that behavior: cache keys and release
@@ -81,8 +124,11 @@ The release-chain evidence for package loading must include:
 
 - The package graph fixture validated by
   `make stage1-package-graph-boundary`.
-- A successful lockfile validation path for root, workspace, and local
-  dependency packages.
+- Package Resolver v1 fixtures validated by `make stage1-package-resolver`,
+  including exact/caret/transitive selection, conflict/yank/tamper/replay,
+  fetch-to-cache, locked-offline, vendor, and package-graph round trips.
+- A successful lockfile validation path for root, workspace, local dependency,
+  and registry dependency packages.
 - Build cache evidence that includes the lockfile hash.
 - Supply-chain output for any host tooling used by the temporary bootstrap
   compiler.
@@ -93,14 +139,25 @@ The checked fixture lives at:
 
 - `stage1/compiler-contracts/schemas/axiom.compiler.package_graph.v1.schema.json`
 - `stage1/compiler-contracts/snapshots/package-graph.json`
+- `stage1/compiler-contracts/schemas/axiom.compiler.package_graph.runtime.v1.schema.json`
+- `stage1/compiler-contracts/snapshots/package-graph-runtime.json`
+- `stage1/schemas/axiom-lockfile-v2.schema.json`
+- `stage1/schemas/axiom-package-resolution-v1.schema.json`
+- `stage1/package-resolver/fixtures/lockfile-v2.json`
+- `stage1/package-resolver/fixtures/resolution-v1.json`
 
 The local validator is:
 
 ```bash
 make stage1-package-graph-boundary
+make stage1-package-resolver
 ```
 
-It validates the schema envelope, compares fixture package identity with
-`stage1/examples/workspace/axiom.lock`, checks the fixture against
-`stage1/examples/workspace/axiom.toml`, and rejects Cargo-derived fields inside
-the graph output.
+The boundary target validates the schema envelope, compares fixture package
+identity with `stage1/examples/workspace/axiom.lock`, checks the fixture against
+`stage1/examples/workspace/axiom.toml`, rejects Cargo-derived fields inside the
+graph output, and validates the registry-manifest, lockfile-v2, and ordered
+resolution-trace fixtures. The resolver target executes the local
+static/loopback registry, authenticated cache/vendor, locked-offline, and
+package-graph round trips. Neither target claims a public hosted registry or
+package edition selection.

--- a/docs/compiler-source-decomposition-plan.md
+++ b/docs/compiler-source-decomposition-plan.md
@@ -247,7 +247,7 @@ matching ceiling in this table in the same PR.
 | Tracked item | Ceiling |
 | --- | ---: |
 | `summary.top_file_line_share` | 0.5767 |
-| `summary.top_file_lines` | 70992 |
+| `summary.top_file_lines` | 71004 |
 | `stage1/crates/axiomc/src/cranelift_backend.rs` | 20076 |
 | `stage1/crates/axiomc/src/cranelift_backend/static_output_purity.rs` | 279 |
 | `stage1/crates/axiomc/src/cranelift_backend/host_env_proc_clock.rs` | 586 |
@@ -258,7 +258,7 @@ matching ceiling in this table in the same PR.
 | `stage1/crates/axiomc/src/cranelift_backend/host_crypto.rs` | 783 |
 | `stage1/crates/axiomc/src/cranelift_backend/host_net_http.rs` | 1121 |
 | `stage1/crates/axiomc/src/hir.rs` | 5849 |
-| `stage1/crates/axiomc/src/project.rs` | 13493 |
+| `stage1/crates/axiomc/src/project.rs` | 13505 |
 | `stage1/crates/axiomc/src/project/build_contract.rs` | 118 |
 | `stage1/crates/axiomc/src/main.rs` | 11875 |
 | `stage1/crates/axiomc/src/formatter.rs` | 191 |

--- a/docs/compiler-source-decomposition-plan.md
+++ b/docs/compiler-source-decomposition-plan.md
@@ -195,19 +195,46 @@ immutable serving, and archive transactions should move into `registry/`
 siblings. CLI parsing and dispatch should then move behind those package-owned
 APIs rather than adding more Package Trust orchestration to `main.rs`.
 
+The Package Resolver v1 slice keeps version and solver semantics out of those
+existing monoliths: strict exact/caret release versions live in
+`package_version.rs`, bounded deterministic single-version selection and its
+trace live in `package_resolver.rs`, and local file/numeric-loopback fixture
+transport lives in `registry_client.rs`. Manifest and lockfile v2 parsing remain
+in the existing `manifest.rs` and `lockfile.rs` package-graph boundary. Archive
+extraction, content-addressed storage, and vendor snapshots belong in dedicated
+package-store siblings rather than `project.rs`, `registry.rs`, or `main.rs`.
+The trust engine grows only for the typed authenticated-catalog boundary. The
+next concrete extraction is `package_trust/catalog.rs`, owning catalog
+authentication, typed release projection, release-scoped expectation
+construction, and their focused tests while preserving the public Package
+Trust wire contract. Command integration should call these package APIs and
+keep public hosted transport and edition selection outside this slice.
+
+The final resolver integration also adds orchestration to `project.rs`,
+`main.rs`, and `registry.rs`. That growth is accepted for this slice because
+extracting it without splitting the shared command and registry transactions
+would obscure their failure semantics; the exact measured ceilings below
+prevent further growth while the next package-owned extraction remains
+explicit. The final security review then required `project.rs` to consume
+authenticated registry manifests and source archives from an in-memory view,
+rather than mutable cache or vendor paths, and required `main.rs` to preserve
+structured resolver failure evidence. Those fail-closed boundaries account for
+the final measured increase recorded here.
+
 ## Current Top Files
 
-Snapshot updated 2026-07-29 after the Package Trust v1 runtime:
+Snapshot updated 2026-07-29 after the Package Resolver v1 security review:
 
 | Rank | Current Rust file | Lines | Target package boundary | First extraction slice |
 | ---: | --- | ---: | --- | --- |
 | 1 | `stage1/crates/axiomc/src/cranelift_backend.rs` | 20,076 | `compiler.backend.native` | Runtime-intrinsic implementations live in `.../cranelift_backend/intrinsics.rs`, the compile-time evaluator in `.../cranelift_backend/evaluator.rs`, host-capability lowering in the `host_*` siblings, and static-output eligibility in `.../cranelift_backend/static_output_purity.rs`; the remaining work is sub-partitioning the mutually-recursive value/control core by value shape. |
-| 2 | `stage1/crates/axiomc/src/project.rs` | 12,096 | `compiler.package_graph`, `compiler.commands`, `compiler.evidence` | Build lowering evidence now lives in `stage1/crates/axiomc/src/project/build_contract.rs`; Documentation v1 now derives public symbols here; continue splitting manifest/workspace loading, command orchestration, provenance/debug records, artifact planning, and the future `compiler.docs` semantic projection along package ownership. |
-| 3 | `stage1/crates/axiomc/src/main.rs` | 11,627 | `compiler.commands` | Formatter reporting and edit planning now live in `stage1/crates/axiomc/src/formatter.rs`; Documentation v1 owns deterministic rendering, HTML/Markdown link validation, search, and doctest orchestration here; Package Trust v1 adds package verification and signed-registry command dispatch. Continue moving command parsing, JSON envelope construction, check/build/run/test/doc/trace orchestration, and package-trust dispatch behind package-owned APIs. |
+
+| 2 | `stage1/crates/axiomc/src/project.rs` | 13,493 | `compiler.package_graph`, `compiler.commands`, `compiler.evidence` | Build lowering evidence now lives in `stage1/crates/axiomc/src/project/build_contract.rs`; Documentation v1 now derives public symbols here; Package Resolver v1 now consumes authenticated registry manifests and sources from a bounded in-memory archive view. Continue splitting manifest/workspace loading, command orchestration, provenance/debug records, artifact planning, and the future `compiler.docs` semantic projection along package ownership. |
+| 3 | `stage1/crates/axiomc/src/main.rs` | 11,875 | `compiler.commands` | Formatter reporting and edit planning now live in `stage1/crates/axiomc/src/formatter.rs`; Documentation v1 owns deterministic rendering, HTML/Markdown link validation, search, and doctest orchestration here; Package Trust v1 adds package verification and signed-registry command dispatch, while Package Resolver v1 adds bounded fetch/update/vendor parsing, structured failure evidence, and dispatch. Continue moving command parsing, JSON envelope construction, check/build/run/test/doc/trace orchestration, and package-management dispatch behind package-owned APIs. |
 | 4 | `stage1/crates/axiomc/src/codegen.rs` | 7,919 | `compiler.backend.generated_rust`, `compiler.backend.contracts` | Isolate generated-Rust compatibility emission from backend target selection and unsupported-feature contracts. |
 | 5 | `stage1/crates/axiomc/src/syntax.rs` | 6,370 | `compiler.syntax`, `compiler.diagnostics` | Split lexer/parser, parse recovery, source spans, macros, and syntax diagnostics behind the syntax boundary. |
 | 6 | `stage1/crates/axiomc/src/hir.rs` | 5,849 | `compiler.hir` | Generic inference and monomorphization now live in `stage1/crates/axiomc/src/hir/generics.rs`; public HIR model types now live in `stage1/crates/axiomc/src/hir/model.rs`; syntax-to-HIR type/literal lowering now lives in `stage1/crates/axiomc/src/hir/types.rs`; type-name, aggregate, and trait-use definition checks now live in `stage1/crates/axiomc/src/hir/definitions.rs`; function/method signatures and trait impl signature validation now live in `stage1/crates/axiomc/src/hir/signatures.rs`; capability analysis now lives in `stage1/crates/axiomc/src/hir/capabilities.rs`; expression typing helpers now live in `stage1/crates/axiomc/src/hir/expressions.rs`; ownership and borrow-state helpers now live in `stage1/crates/axiomc/src/hir/ownership.rs`; property clause checks now live in `stage1/crates/axiomc/src/hir/properties.rs`; reachability/call-graph discovery now lives in `stage1/crates/axiomc/src/hir/reachability.rs`; diagnostic recovery helpers now live in `stage1/crates/axiomc/src/hir/diagnostics.rs`; monomorphized symbol and intrinsic helpers now live in `stage1/crates/axiomc/src/hir/symbols.rs`; source-location helpers now live in `stage1/crates/axiomc/src/hir/source_locations.rs`; return-flow analysis now lives in `stage1/crates/axiomc/src/hir/control_flow.rs`; const-array length validation now lives in `stage1/crates/axiomc/src/hir/const_arrays.rs`; const-function validation now lives in `stage1/crates/axiomc/src/hir/const_functions.rs`; match lowering now lives in `stage1/crates/axiomc/src/hir/matches.rs`; enum variant constructor helpers now live in `stage1/crates/axiomc/src/hir/variants.rs`; async runtime intrinsic lowering now lives in `stage1/crates/axiomc/src/hir/async_runtime.rs`; map intrinsic lowering now lives in `stage1/crates/axiomc/src/hir/maps.rs`; HIR boundary regression tests now live in `stage1/crates/axiomc/tests/hir_unit.rs`; continue splitting remaining HIR helper clusters behind the package APIs in `docs/compiler-hir-ownership-capability.md`. |
-| 7 | `stage1/crates/axiomc/src/package_trust.rs` | 4,471 | `compiler.package_trust` | Preserve the Package Trust v1 wire contract while extracting strict document/schema parsing, trust-root transition evaluation, and package verification into `package_trust/` siblings. |
+| 7 | `stage1/crates/axiomc/src/package_trust.rs` | 5,410 | `compiler.package_trust` | Extract authenticated catalog parsing/projection and release-scoped expectation construction first into `package_trust/catalog.rs`; then move strict document/schema parsing, trust-root transition evaluation, and package verification into focused siblings while preserving the Package Trust v1 wire contract. |
 
 ## Ratchet Ceilings
 
@@ -219,8 +246,8 @@ matching ceiling in this table in the same PR.
 
 | Tracked item | Ceiling |
 | --- | ---: |
-| `summary.top_file_line_share` | 0.7275 |
-| `summary.top_file_lines` | 68400 |
+| `summary.top_file_line_share` | 0.5767 |
+| `summary.top_file_lines` | 70992 |
 | `stage1/crates/axiomc/src/cranelift_backend.rs` | 20076 |
 | `stage1/crates/axiomc/src/cranelift_backend/static_output_purity.rs` | 279 |
 | `stage1/crates/axiomc/src/cranelift_backend/host_env_proc_clock.rs` | 586 |
@@ -231,11 +258,11 @@ matching ceiling in this table in the same PR.
 | `stage1/crates/axiomc/src/cranelift_backend/host_crypto.rs` | 783 |
 | `stage1/crates/axiomc/src/cranelift_backend/host_net_http.rs` | 1121 |
 | `stage1/crates/axiomc/src/hir.rs` | 5849 |
-| `stage1/crates/axiomc/src/project.rs` | 12096 |
+| `stage1/crates/axiomc/src/project.rs` | 13493 |
 | `stage1/crates/axiomc/src/project/build_contract.rs` | 118 |
-| `stage1/crates/axiomc/src/main.rs` | 11627 |
-| `stage1/crates/axiomc/src/formatter.rs` | 219 |
-| `stage1/crates/axiomc/src/formatter_tests.rs` | 137 |
+| `stage1/crates/axiomc/src/main.rs` | 11875 |
+| `stage1/crates/axiomc/src/formatter.rs` | 191 |
+| `stage1/crates/axiomc/src/formatter_tests.rs` | 122 |
 | `stage1/crates/axiomc/src/codegen.rs` | 7919 |
 | `stage1/crates/axiomc/src/syntax.rs` | 6370 |
 | `stage1/crates/axiomc/src/hir/async_runtime.rs` | 188 |
@@ -258,9 +285,9 @@ matching ceiling in this table in the same PR.
 | `stage1/crates/axiomc/src/hir/symbols.rs` | 134 |
 | `stage1/crates/axiomc/src/hir/types.rs` | 241 |
 | `stage1/crates/axiomc/src/hir/variants.rs` | 188 |
-| `stage1/crates/axiomc/src/package_trust.rs` | 4471 |
-| `stage1/crates/axiomc/src/registry.rs` | 4234 |
-| `stage1/crates/axiomc/src/lib.rs` | 24 |
+| `stage1/crates/axiomc/src/package_trust.rs` | 5410 |
+| `stage1/crates/axiomc/src/registry.rs` | 4319 |
+| `stage1/crates/axiomc/src/lib.rs` | 36 |
 
 ## Extraction Order
 
@@ -280,9 +307,11 @@ matching ceiling in this table in the same PR.
    match lowering, enum variant constructor lowering, async runtime intrinsic
    lowering, and map intrinsic lowering are split; continue with remaining HIR
    helper clusters.
-4. `compiler.commands` and `compiler.package_graph`: separate command envelopes
-   from package loading so the snapshot bootstrap can invoke package APIs
-   without Cargo assumptions.
+4. `compiler.commands` and `compiler.package_graph`: keep strict version
+   parsing, deterministic resolution, registry transport, archive/store, and
+   vendor operations in their package-owned modules; then separate command
+   envelopes from package loading so the snapshot bootstrap can invoke package
+   APIs without Cargo assumptions.
 5. `compiler.syntax` and `compiler.diagnostics`: keep public syntax and
    diagnostic fixtures stable while implementation files shrink.
 

--- a/docs/package.md
+++ b/docs/package.md
@@ -4,9 +4,10 @@ Stage1 packages use `axiom.toml` with a deterministic `axiom.lock` lockfile.
 The `axiom.pkg` manifest format is no longer supported.
 
 Package graph truth is AxiOM-owned: `axiom.toml`, `axiom.lock`, local source
-files, workspace members, and future registry integrity records define package
-identity. Cargo remains the current developer host for running the Rust stage1
-compiler, but Cargo metadata is not part of the package graph contract. See
+files, workspace members, authenticated registry records, and exact cached or
+vendored release bytes define package identity. Cargo remains the current
+developer host for running the Rust stage1 compiler, but Cargo metadata is not
+part of the package graph contract. See
 [Compiler Package Graph Boundary](compiler-package-graph.md).
 
 ## Common Commands
@@ -39,10 +40,12 @@ filesystem access is enabled, the `fs` capability includes the manifest-relative
 `configured_root` and canonical `effective_root` so operators can inspect the
 actual package-local filesystem boundary before build or run.
 
-`axiomc pkg graph <path> --json` prints the resolved local package graph without
-mutating manifests or lockfiles. The JSON lists each package root, package
-identity, workspace members, local dependencies, build entrypoint, capabilities,
-and whether that package's `axiom.lock` is current or stale.
+`axiomc pkg graph <path> --json` prints the resolved package graph without
+mutating manifests or lockfiles. Local path nodes retain their package roots;
+registry nodes report the locked source, selected version, Package Trust
+decision, cache or vendor disposition, dependency edges, and deterministic
+resolver decisions. This makes the graph an inspection surface for why a
+version was requested and selected rather than only a list of paths.
 
 Local path dependencies may declare a bounded version constraint:
 
@@ -62,6 +65,12 @@ Checked-in editor and agent metadata lives under `stage1/schemas/`:
 
 - `stage1/schemas/axiom.toml.schema.json` describes the decoded `axiom.toml`
   manifest shape for TOML-aware editors.
+- `stage1/schemas/axiom-lockfile-v2.schema.json` describes the strict
+  compatibility, registry, package, and dependency-edge records written to a
+  registry-enabled `axiom.lock`.
+- `stage1/schemas/axiom-package-resolution-v1.schema.json` describes selected
+  packages, preserved path dependencies, dependency edges, and the ordered
+  resolver trace emitted for agent inspection.
 - `stage1/schemas/axiom.stage1.v1.schema.json` describes the shared JSON
   envelope emitted by `axiomc check`, `build`, `test`, and `caps` with
   `--json`.
@@ -192,16 +201,212 @@ Pass `--base-url` when the registry is behind a proxy or stable hostname;
 otherwise it derives a local URL from the bound address. Uploads remain a
 separate `axiomc publish` operation.
 
-## Registry And Publish Contract
+## Package Resolver v1
 
-The local manifest contract exposes publish metadata for future registry tooling while keeping dependency resolution local-only. Today, `axiomc` accepts local path dependencies and rejects registry dependency selectors:
+Package Resolver v1 preserves local path dependencies and adds one explicitly
+configured static registry source. A root manifest names the registry and the
+project-relative Package Trust policy files that authenticate it:
 
 ```toml
-[dependencies]
-core = { path = "deps/core" }
+[registry]
+name = "fixture"
+index = "file:///absolute/path/to/registry/index.json"
+trust_roots = "trust/roots.json"
+expectation = "trust/expectation.json"
+cache = ".axiom/cache"
+vendor = "vendor"
+
+[dependencies.local_util]
+path = "deps/local-util"
+version = "^0.4.0"
+
+[dependencies.core]
+registry = "fixture"
+namespace = "axiom"
+package = "core"
+version = "^1.2.3"
 ```
 
-Package identity is the pair in `[package]`. Publish metadata is optional and declarative only:
+`registry.name`, `registry.index`, `registry.trust_roots`, and
+`registry.expectation` are required. `registry.cache` and `registry.vendor` are
+optional project-relative roots and must not name the same path. A registry
+dependency must name that configured registry, a portable lowercase namespace,
+an optional published package name (defaulting to the dependency alias), and
+an exact or caret release version. Path and registry sources are mutually
+exclusive. Registry versions are strict `MAJOR.MINOR.PATCH` releases; wildcard,
+prerelease, build-metadata, range, and tilde selectors are rejected.
+
+The current transport is deliberately a local qualification surface:
+
+- `file://` reads a regular, non-symlink local index or artifact.
+- `http://` is limited to numeric loopback addresses for the checked local HTTP
+  registry fixture.
+- Redirects, transfer encoding, content encoding other than identity,
+  ambiguous lengths, oversized headers/bodies, and truncated responses fail
+  closed.
+- Public HTTPS transport and a hosted registry service are not implemented by
+  this resolver slice. A syntactically valid HTTPS index may be retained as
+  forward-compatible manifest data, but the current fetch transport rejects it.
+
+This is not an edition-selection mechanism. Resolver v1 records the current
+compatibility and edition policy as evidence; it does not choose an edition for
+a package.
+
+### Resolution and trust boundary
+
+The resolver first authenticates the exact Registry Index v2 bytes with
+Package Trust v1. Only an `AuthenticatedRegistryCatalog` can supply candidates.
+Its read-only catalog and release methods expose authenticated registry/source
+identities, current root and index positions, transcript digests, signer IDs,
+yank state, artifact digests, exact index bytes, and normalized paths for
+`package.axp`, `axiom.toml`, `provenance.json`, and `package.axp.sig`. Resolver
+code cannot construct or mutate authenticated release internals directly.
+
+Resolution allows one version for each canonical
+`(registry_identity, source_identity, namespace, package)` coordinate. It
+orders coordinates lexically, tries matching strict release versions in
+descending order, and uses authenticated release ID and target path lexical
+order as the final tie-break. Duplicate coordinate/version records are
+rejected. Exact and caret requirements, transitive edges, conflicts, yanks,
+candidate attempts, backtracks, and trace events all use fixed deterministic
+work budgets.
+
+Each decision records the dependency alias, requested constraint, selected
+coordinate, candidate disposition, and reason. An index signature failure,
+expired or rolled-back metadata, replay, duplicate coordinate or target path,
+source mismatch, incompatible constraints, work-budget exhaustion, or
+ineligible yanked candidate fails closed before package bytes become graph
+inputs. Fresh resolution never selects a yanked release. Locked replay may
+retain one only when every exact Package Trust, digest, transcript, and cache or
+vendor pin still verifies; `update` moves off it when a compatible non-yanked
+release exists.
+
+After candidate selection, the consumer fetches all four exact release
+artifacts and calls full Package Trust verification. The authenticated manifest
+is parsed from the verified bytes with `parse_manifest_exact`; it is never
+silently reread from a mutable filesystem path. Transitive dependency
+discovery therefore happens only after the containing release has been fully
+authenticated.
+
+### Lockfile v2
+
+Any graph containing a registry dependency requires `axiom.lock` version 2.
+Version 1 remains valid for path-only graphs. The v2 TOML contract contains:
+
+- `[compatibility]`: `contract`, `compiler`, and the recorded
+  `edition_policy`.
+- `roots`: sorted unique package IDs for every entry package whose dependency
+  closure forms the graph, including virtual-workspace members.
+- `[[registry]]`: manifest-local `name`/`source`, authenticated
+  `registry_identity`/`source_identity`, exact `trust_roots_sha256` and
+  `expectation_sha256`,
+  `current_root_version`/`current_root_sequence`/
+  `current_root_transcript_sha256`, exact `index_sha256`/
+  `index_transcript_sha256`, `index_generation`/`index_sequence`,
+  `index_snapshot_id`, and sorted unique `index_signer_key_ids`.
+- `[[package]]`: required `id`, `name`, `version`, `source`, and
+  `compatibility`. Registry records additionally require `registry`,
+  `namespace`, `archive_sha256`, `archive_length`, `manifest_sha256`,
+  `provenance_sha256`, `package_signature_sha256`, `publisher_identity`,
+  `verification_sha256`, sorted unique `signer_key_ids`, exact `cache_key`, and
+  `yanked_at_resolution`; path records must omit every registry evidence field.
+- `[[edge]]`: from/to package IDs, dependency alias, requested constraint,
+  path or registry source kind, and one closed stable reason:
+  `root_path_constraint`, `transitive_path_constraint`,
+  `highest_compatible`, `exact_locked_replay`, or
+  `trusted_yanked_locked_replay`.
+
+Parsing is strict and rejects unknown fields, duplicate identities, malformed
+versions or digests, and inconsistent graph edges. Lockfile replacement is an
+atomic write. `--locked` never performs resolution or changes the file; a
+missing, v1, stale, or altered lock for a registry graph is an error.
+
+The Rust boundary preserves version identity instead of decoding into a common
+lossy struct: `parse_lockfile_exact` and `load_lockfile` return
+`ParsedLockfile::V1` or `ParsedLockfile::V2`; `render_lockfile_v2`,
+`validate_lockfile_v2`, and `write_lockfile_v2_atomic` own v2 persistence;
+`validate_lockfile_version_for_manifest` enforces the registry/v2 gate; and
+`canonical_path_package_id`/`canonical_registry_package_id` define stable node
+IDs.
+
+### Cache, offline mode, and vendoring
+
+Registry packages enter the build graph only through verified immutable
+material. Archives are limited to 64 MiB, 4,096 files, 16 MiB per file,
+1,024-byte paths, and 64 path components. Absolute or parent paths, duplicate
+entries, symlinks, unsupported entry types, and extraction outside the
+transaction root are rejected.
+
+The content-addressed store shares immutable archive content by authenticated
+archive digest: the exact blob lives under `blobs/sha256/<archive-digest>` and
+the extracted tree under
+`trees/axiom-package-extractor-v1/sha256/<archive-digest>`. Package Trust and
+tree-integrity evidence lives under
+`evidence/sha256/<archive-digest>/<evidence-identity>/`, where the evidence
+identity binds the exact registry-index and verification-document digests.
+Atomic admission records live under
+`commits/sha256/<archive-digest>/<registry-index-digest>/<evidence-identity>.json`.
+The `axiom.package_tree_integrity.v1` record binds the extractor version and a
+path-sorted list of every file length and SHA-256 digest. Cache hits are
+selected by the lock's exact archive, registry-index, and verification digests
+and revalidated against the complete evidence and commit records; a matching
+directory name is not sufficient proof.
+
+`--locked --offline` performs no registry request and has no network fallback.
+It succeeds only when every locked release can be reconstructed from intact
+cache or vendor material and still passes the locked digest, identity, trust,
+and compatibility checks. Missing files, modified bytes, symlinks, traversal,
+duplicate archive paths, or stale trust/index pins fail closed.
+
+Vendoring copies the same verified immutable package material into a
+project-controlled snapshot under
+`snapshots/sha256/<vendor-manifest-digest>/`, then atomically replaces
+`CURRENT`. Within one snapshot, packages sharing an archive reuse
+`packages/sha256/<archive-digest>/{archive,tree}` while exact Package Trust
+evidence and commits remain isolated by evidence identity. Its canonical
+`axiom.vendor_manifest.v1` sorts package identities and binds every content
+key, archive digest, registry-index digest, verification digest, evidence
+identity, and tree-manifest digest. A vendor tree is not a trust bypass:
+locked and offline consumers reverify it exactly as they reverify the shared
+cache. Local path dependencies remain paths and are never copied into the
+registry store or vendor tree.
+
+The stable operator surface is:
+
+```bash
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- pkg fetch <path> --json
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- pkg update <path> --json
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- pkg update <path> --package core --json
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- pkg vendor <path> --out vendor --json
+cargo run --manifest-path stage1/Cargo.toml -p axiomc -- pkg graph <path> --json
+```
+
+`fetch` preserves every selection in an existing valid v2 lock while
+authenticating and caching its exact pins. For a registry graph with no lock or
+only v1, it performs the initial deterministic resolution and atomically writes
+v2. `update` explicitly re-resolves and atomically replaces v2; `--package`
+unlocks only that direct dependency while freezing all other selections, and
+fails with a deterministic conflict when the requested change needs a broader
+update. `vendor` materializes the locked graph at the configured vendor root or
+`--out` override. Machine-readable reports include the deterministic resolver
+trace, trust decision, cache/vendor disposition, and resulting package graph.
+
+The issue-level qualification gate is:
+
+```bash
+make stage1-package-resolver
+```
+
+It covers exact/caret and transitive resolution, conflicts and yanks, local
+HTTP fixture fetch, Package Trust tamper/replay rejection, content-addressed
+cache admission, locked-offline and vendor round trips, package-graph
+inspection, and supply-chain integration. Public hosted-registry operation
+remains outside this gate.
+
+## Publish metadata
+
+Package identity remains the `[package]` name/version pair. `[publish]` is
+optional metadata consumed by the separate local publication flow:
 
 ```toml
 [package]
@@ -215,21 +420,5 @@ include = ["src/**", "axiom.toml", "axiom.lock"]
 exclude = ["dist/**"]
 ```
 
-Future registry packages will need stable source and integrity metadata:
-
-- Package identity: `package.name` plus `package.version`.
-- Registry source: a named registry or URL source for non-local packages.
-- Checksums: content-addressed package archives, expected to use a tagged form
-  such as `sha256:<hex>`.
-- Publish metadata: include/exclude rules, target registry, archive checksum,
-  and provenance or signature references.
-
-Those registry fields are intentionally reserved. Until registry resolution
-exists, manifests must not contain root `[registry]`, `package.checksum`,
-`package.registry`, `package.source`, or dependency
-`checksum`/`registry`/`source` fields. Local dependency `version` constraints
-are accepted only with a local `path` and are validated against the dependency
-package version. The parser rejects reserved registry fields instead
-of silently treating a registry package as a local package. `[publish]` is
-accepted only as metadata; it does not make `axiomc` contact or upload to a
-remote registry.
+Resolver v1 does not turn `[publish]` into an upload client and does not
+implement a public hosted registry.

--- a/docs/production-language-readiness.json
+++ b/docs/production-language-readiness.json
@@ -487,15 +487,15 @@
       "requirement": "Registry dependencies resolve deterministically into trusted cache, lockfile v2, offline builds, and vendored sources.",
       "requiredForProduction": true,
       "targetTier": "production_qualified",
-      "currentTier": "syntax_only",
-      "status": "blocked",
+      "currentTier": "static_spike",
+      "status": "partial",
       "governingIssue": 1459,
       "blockerIssues": [1459],
       "dependencies": [1458, 1457],
-      "evidence": ["docs/package.md", "stage1/schemas/axiom.toml.schema.json"],
-      "validatingCommand": "make stage1-package-graph-boundary && make supply-chain",
+      "evidence": ["docs/package.md", "docs/compiler-package-graph.md", "docs/supply-chain.md", "stage1/crates/axiomc/src/manifest.rs", "stage1/crates/axiomc/src/lockfile.rs", "stage1/crates/axiomc/src/package_version.rs", "stage1/crates/axiomc/src/package_resolver.rs", "stage1/crates/axiomc/src/registry_client.rs", "stage1/crates/axiomc/src/package_trust.rs", "stage1/package-resolver/fixtures/lockfile-v2.json", "stage1/package-resolver/fixtures/resolution-v1.json", "stage1/schemas/axiom.toml.schema.json", "stage1/schemas/axiom-lockfile-v2.schema.json", "stage1/schemas/axiom-package-resolution-v1.schema.json"],
+      "validatingCommand": "make stage1-package-resolver && make stage1-package-graph-boundary && make supply-chain",
       "rustCaptureRisk": "high",
-      "agentInspectionImpact": "Explain requested and selected versions, trust, cache, and resolution decisions."
+      "agentInspectionImpact": "Explain canonical coordinates, requested and selected versions, candidate/yank decisions, trust pins, cache/vendor disposition, conflicts, and bounded resolution decisions. Current evidence is a local static/loopback registry spike; public hosted transport and edition selection remain out of scope."
     },
     {
       "id": "formatter_v1",

--- a/docs/production-language-roadmap.md
+++ b/docs/production-language-roadmap.md
@@ -104,8 +104,11 @@ make production-language-readiness-github
   MIR control-flow/resource pass.
 - The async, synchronization, network, HTTP, JSON, FFI, formatter, LSP, DAP,
   documentation, benchmark, package, and release surfaces are bootstrap-grade.
-- No executable persistence package, public dependency resolver, installable
-  release, or production workload qualification gate exists.
+- No executable persistence package, public hosted dependency resolver,
+  installable release, or production workload qualification gate exists.
+  Package Resolver v1 is a local static/file and loopback-fixture spike until
+  its fetch, locked-offline, vendor, graph, and supply-chain round trips pass
+  `make stage1-package-resolver`.
 
 ## Dependency-Ordered Execution
 
@@ -207,6 +210,13 @@ The safe first queue is:
 Do not dispatch #1427, #1468 children, snapshot, release publication, external
 network authority, provider ABI, structured-concurrency policy, or final
 production qualification past their human and dependency gates.
+
+Package Resolver v1 (#1459) is intentionally bounded to signed static registry
+metadata, regular local files, and numeric-loopback HTTP fixtures. It must
+record deterministic exact/caret/transitive selection, conflict/yank
+disposition, trust pins, content-addressed cache/vendor evidence, and package
+graph decisions. Public HTTPS/hosted registry operation and edition selection
+are separate work and must not be inferred from this row.
 
 ## Agent Execution Contract
 

--- a/docs/roadmap-status.md
+++ b/docs/roadmap-status.md
@@ -26,7 +26,7 @@ define completion.
   declared rows, but the backend can execute unsupported programs in the
   compiler process and emit replay binaries. #1434 therefore blocks any broad
   runtime-complete, production, or self-hosting claim.
-- The production-language ledger currently has 52 capability rows: 2 of 39
+- The production-language ledger currently has 52 capability rows: 3 of 39
   production-required rows meet their target evidence tier. The remaining
   rows are intentionally `partial` or `blocked`, not missing from the plan.
 - The compiler itself is not self-hosting. It remains predominantly Rust,
@@ -36,6 +36,12 @@ define completion.
   semantic diff, decisions, target contracts, and artifact generators are
   shipped foundations. Real-package and workspace Intent IR emission is
   available through `axiomc inspect intent <path> --json`.
+- Package Trust v1 is the resolver trust boundary. Package Resolver v1 (#1459)
+  is currently a local static/file and loopback-fixture spike covering registry
+  manifests, lockfile v2, authenticated catalog candidates, bounded transport,
+  content-addressed cache/vendor contracts, and deterministic decision
+  evidence. It remains `partial` until the CLI round trips and
+  `make stage1-package-resolver` prove the integrated runtime.
 
 ## Active Roadmap Families
 
@@ -52,12 +58,14 @@ define completion.
 | Snapshot bootstrap | #1428 | Human-gated release work | Pin the genesis snapshot and prove offline build/test, no Cargo after genesis, and fixpoint evidence. |
 | Unattended agent coding | #1417-#1424 | Ready for staged planning | Follow `docs/autonomous-agent-roadmap.md`; do not skip semantic authority, containment, evidence, or independent review. |
 | Repeatable autonomy validation | #1430 | Ready for implementation | Make the compiler-property fast check portable, repeatable, parallel-safe, and self-cleaning on macOS/BSD `mktemp`. |
+| Trusted package resolution | #1458-#1459 | Local resolver qualification active | Require signed static catalog authentication, full per-release verification, lockfile v2, atomic content-addressed storage, locked-offline/vendor round trips, deterministic traces, and package-graph inspection. Do not claim public hosted transport or edition selection. |
 | Repository branch hygiene | #1164 | Narrow maintenance remainder | Preserve protected/historical branches while reducing the remaining remote-branch inventory. |
 
 ## Readiness Commands
 
 ```bash
 make stage1-direct-native-runtime-abi
+make stage1-package-resolver
 make production-language-readiness-validate
 make production-language-readiness
 make production-language-readiness-github
@@ -70,8 +78,11 @@ make stage1-compiler-source-monoliths
 
 Expected current outcomes:
 
-- production-language ledger validation: green; readiness: red with 2 of 39
+- production-language ledger validation: green; readiness: red with 3 of 39
   required rows at target;
+- package resolver: partial until the local static/loopback fetch, update,
+  locked-offline, vendor, trust-tamper/replay, and graph-inspection fixtures pass
+  the resolver target;
 - direct-native ABI, command surface, Rust exit, and monolith ratchet:
   structurally green, but not a substitute for #1434 runtime truth;
 - self-hosting language entry readiness: red until the runtime foundation,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -61,6 +61,11 @@ implementation surfaces; see
 - Use complete Intent IR emission for real packages and workspaces (#1418) so
   semantic APIs share one canonical graph rather than partial,
   command-specific views.
+- Qualify Package Resolver v1 (#1459) as a local static/loopback registry
+  surface: deterministic registry dependency selection, lockfile v2,
+  Package-Trust-gated content-addressed cache, strict locked-offline replay,
+  vendoring, and inspectable resolver/package-graph decisions. Do not treat
+  this slice as a public hosted registry or edition-selection service.
 - Advance the [Autonomous Agent Execution Roadmap](autonomous-agent-roadmap.md)
   (#1417 and #1419-#1424) from typed authority through transactional execution,
   impact-aware evidence, independent review, delivery, and recovery.
@@ -70,8 +75,9 @@ implementation surfaces; see
 ## Longer-Term Work
 
 - Additional native targets beyond Linux x86-64 and macOS arm64 after #1455.
-- Hosted registry service ergonomics after trusted resolution, signatures,
-  lockfiles, and vendoring are qualified by #1458 and #1459.
+- Public HTTPS transport and hosted registry service ergonomics after trusted
+  local resolution, signatures, lockfiles, and vendoring are qualified by
+  #1458 and #1459.
 - Richer semantic generators and verifiers driven from complete Intent IR.
 - Policy-scoped unattended maintenance across multiple packages and
   repositories after the single-repository autonomy evaluation gate is green.

--- a/docs/supply-chain.md
+++ b/docs/supply-chain.md
@@ -6,6 +6,17 @@ surface for lockfile integrity, signed package verification when applicable,
 offline dependency verification, reproducible release build inputs, and SBOM
 emission.
 
+Package Resolver v1 has an additional issue-level qualification target:
+
+```bash
+make stage1-package-resolver
+```
+
+Run both targets for resolver changes. The resolver target validates AxiOM
+lockfile v2 and authenticated package material; `make supply-chain` continues
+to validate the temporary Rust-hosted implementation and its Cargo dependency
+closure.
+
 This gate verifies the temporary Rust-hosted toolchain. AxiOM package identity
 is still defined by `axiom.toml` and `axiom.lock`, not Cargo metadata. The
 package graph boundary fixture is checked separately with:
@@ -52,6 +63,74 @@ The target runs `scripts/ci/run-toolchain-supply-chain.sh`.
 - `make stage1-package-graph-boundary` proves the self-hosting package graph
   fixture is derived from `axiom.toml` and `axiom.lock` and rejects
   Cargo-derived graph outputs.
+- `make stage1-package-resolver` proves exact/caret and transitive selection,
+  deterministic conflict/yank behavior, trusted local fixture fetch,
+  content-addressed cache admission, locked-offline and vendor round trips,
+  resolver traces, and package-graph trust/cache decisions.
+
+## Package Resolver Supply-Chain Boundary
+
+Resolver candidates come only from an `AuthenticatedRegistryCatalog` produced
+from exact Registry Index v2 bytes. Index, root-transition, expiry, rollback,
+replay, identity, duplicate-coordinate, and duplicate-target failures are
+rejected before selection. Selected package bytes then pass full Package Trust
+verification before manifest parsing or extraction.
+
+The current registry transport is intentionally limited to regular
+non-symlink `file://` inputs and numeric-loopback `http://` fixtures. Redirects,
+chunked/transfer encoding, non-identity content encoding, ambiguous lengths,
+oversized or truncated responses, and non-loopback HTTP hosts fail closed.
+Public HTTPS transport and hosted registry operation are outside the v1 local
+qualification surface.
+
+The package archive and store enforce these bounds:
+
+- archive size: 64 MiB;
+- individual file size: 16 MiB;
+- file count: 4,096;
+- archive path: 1,024 bytes and 64 components;
+- no absolute paths, `..`, duplicates, symlinks, unsupported entry kinds, or
+  extraction outside the transaction root.
+
+The content-addressed layout is:
+
+```text
+blobs/sha256/<archive-digest>
+trees/axiom-package-extractor-v1/sha256/<archive-digest>/
+evidence/sha256/<archive-digest>/<evidence-identity>/
+  manifest
+  provenance
+  signature
+  registry-index
+  verification
+  integrity.json
+commits/sha256/<archive-digest>/<registry-index-digest>/<evidence-identity>.json
+```
+
+`integrity.json` is an `axiom.package_tree_integrity.v1` record binding the
+extractor version, archive digest, and a path-sorted list of extracted
+file lengths and SHA-256 digests. Installation writes a temporary transaction,
+verifies the complete tree, and publishes the commit marker last. Offline cache
+use selects the exact archive, registry-index, and verification digests from
+lockfile v2, then verifies the blob, tree, isolated evidence identity, and
+commit again; directory presence is never treated as trust.
+
+Vendor snapshots use
+`snapshots/sha256/<vendor-manifest-digest>/packages/sha256/<archive-digest>/`
+plus a canonical `axiom.vendor_manifest.v1` and an atomically replaced
+`CURRENT` pointer. Shared archive/tree bytes remain keyed by archive digest;
+per-verification evidence and commits are isolated below `evidence/` and
+`commits/` by the evidence identity. The manifest sorts package identities and
+binds each content key, archive digest, registry-index digest, verification
+digest, evidence identity, and tree-manifest digest. Vendor material is
+reverified against lockfile v2 and Package Trust evidence in offline mode.
+Local path dependencies are preserved as paths rather than copied into the
+registry store.
+
+Fresh resolution excludes yanked releases. A locked replay may retain a newly
+yanked release only when every exact trust, digest, transcript, and compatibility
+pin still verifies. This narrow replay rule supports reproducibility without
+allowing a fresh resolver to select a yanked package.
 
 ## Runner Contract
 
@@ -63,4 +142,6 @@ graph.
 Hosted registry service ownership and external trust-root operation remain
 outside this gate and are tracked separately by the hosted-registry roadmap
 issue. The local static registry verifies package authenticity and serves only
-an immutable in-memory snapshot of already verified bytes.
+an immutable in-memory snapshot of already verified bytes. Package Resolver v1
+does not claim public registry availability, external network transport, or
+edition selection.

--- a/scripts/ci/check-package-graph-boundary.py
+++ b/scripts/ci/check-package-graph-boundary.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -14,6 +15,18 @@ SCHEMA_VERSION = "axiom.compiler.package_graph.v1"
 CONTRACT = "compiler.package_graph"
 DEFAULT_SCHEMA = Path("stage1/compiler-contracts/schemas/axiom.compiler.package_graph.v1.schema.json")
 DEFAULT_SNAPSHOT = Path("stage1/compiler-contracts/snapshots/package-graph.json")
+DEFAULT_RUNTIME_SCHEMA = Path(
+    "stage1/compiler-contracts/schemas/axiom.compiler.package_graph.runtime.v1.schema.json"
+)
+DEFAULT_RUNTIME_SNAPSHOT = Path(
+    "stage1/compiler-contracts/snapshots/package-graph-runtime.json"
+)
+DEFAULT_MANIFEST_SCHEMA = Path("stage1/schemas/axiom.toml.schema.json")
+DEFAULT_MANIFEST_FIXTURE = Path("stage1/package-resolver/fixtures/manifest-registry.json")
+DEFAULT_LOCKFILE_V2_SCHEMA = Path("stage1/schemas/axiom-lockfile-v2.schema.json")
+DEFAULT_LOCKFILE_V2_FIXTURE = Path("stage1/package-resolver/fixtures/lockfile-v2.json")
+DEFAULT_RESOLUTION_SCHEMA = Path("stage1/schemas/axiom-package-resolution-v1.schema.json")
+DEFAULT_RESOLUTION_FIXTURE = Path("stage1/package-resolver/fixtures/resolution-v1.json")
 
 
 def load_json(path: Path) -> Any:
@@ -88,60 +101,143 @@ def require(condition: bool, message: str) -> None:
 
 
 def validate_against_schema(value: Any, schema: dict[str, Any]) -> None:
-    defs = schema.get("$defs", {})
-    validate_schema_node(value, schema, "$", defs)
+    errors = schema_errors(value, schema, schema)
+    require(not errors, errors[0] if errors else "schema validation failed")
 
 
-def validate_schema_node(value: Any, schema: dict[str, Any], path: str, defs: dict[str, Any]) -> None:
+def schema_type_matches(value: Any, expected: str) -> bool:
+    return {
+        "object": isinstance(value, dict),
+        "array": isinstance(value, list),
+        "string": isinstance(value, str),
+        "integer": isinstance(value, int) and not isinstance(value, bool),
+        "number": isinstance(value, (int, float)) and not isinstance(value, bool),
+        "boolean": isinstance(value, bool),
+        "null": value is None,
+    }.get(expected, False)
+
+
+def json_equal(left: Any, right: Any) -> bool:
+    if isinstance(left, bool) or isinstance(right, bool):
+        return isinstance(left, bool) and isinstance(right, bool) and left == right
+    if isinstance(left, (int, float)) and isinstance(right, (int, float)):
+        return left == right
+    return type(left) is type(right) and left == right
+
+
+def schema_errors(
+    value: Any,
+    schema: Any,
+    root: dict[str, Any],
+    path: str = "$",
+) -> list[str]:
+    if not isinstance(schema, dict):
+        return [f"{path} schema node must be an object"]
     if "$ref" in schema:
         ref = schema["$ref"]
         prefix = "#/$defs/"
-        require(ref.startswith(prefix), f"{path} uses unsupported schema ref {ref}")
+        if not isinstance(ref, str) or not ref.startswith(prefix):
+            return [f"{path} uses unsupported schema ref {ref!r}"]
         name = ref[len(prefix):]
-        require(name in defs, f"{path} references unknown schema def {name}")
-        validate_schema_node(value, defs[name], path, defs)
-        return
+        target = root.get("$defs", {}).get(name)
+        if not isinstance(target, dict):
+            return [f"{path} references unknown schema def {name}"]
+        return schema_errors(value, target, root, path)
 
-    if "const" in schema:
-        require(value == schema["const"], f"{path} must equal {schema['const']!r}")
+    errors: list[str] = []
+    expected = schema.get("type")
+    expected_types = expected if isinstance(expected, list) else [expected] if expected else []
+    if expected_types and not any(
+        isinstance(item, str) and schema_type_matches(value, item)
+        for item in expected_types
+    ):
+        return [f"{path} must have type {' or '.join(map(str, expected_types))}"]
 
-    if "enum" in schema:
-        require(value in schema["enum"], f"{path} must be one of {schema['enum']!r}")
+    if "const" in schema and not json_equal(value, schema["const"]):
+        errors.append(f"{path} must equal {schema['const']!r}")
+    if "enum" in schema and not any(json_equal(value, item) for item in schema["enum"]):
+        errors.append(f"{path} must be one of {schema['enum']!r}")
 
-    expected_type = schema.get("type")
-    if expected_type == "object":
-        require(isinstance(value, dict), f"{path} must be an object")
-        required = set(schema.get("required", []))
-        missing = sorted(required - set(value))
-        require(not missing, f"{path} is missing required fields: {', '.join(missing)}")
+    for keyword in ("allOf",):
+        branches = schema.get(keyword, [])
+        if isinstance(branches, list):
+            for branch in branches:
+                errors.extend(schema_errors(value, branch, root, path))
+    for keyword, expected_matches in (("oneOf", 1), ("anyOf", None)):
+        branches = schema.get(keyword)
+        if isinstance(branches, list):
+            matches = sum(not schema_errors(value, branch, root, path) for branch in branches)
+            if (expected_matches == 1 and matches != 1) or (
+                expected_matches is None and matches == 0
+            ):
+                errors.append(
+                    f"{path} must match "
+                    + ("exactly one" if expected_matches == 1 else "at least one")
+                    + f" {keyword} branch (matched {matches})"
+                )
+    if "not" in schema and not schema_errors(value, schema["not"], root, path):
+        errors.append(f"{path} must not match the forbidden schema")
+    if "if" in schema:
+        condition_matches = not schema_errors(value, schema["if"], root, path)
+        selected = schema.get("then") if condition_matches else schema.get("else")
+        if selected is not None:
+            errors.extend(schema_errors(value, selected, root, path))
+
+    if isinstance(value, dict):
+        required = schema.get("required", [])
+        if isinstance(required, list):
+            missing = sorted(set(required) - set(value))
+            if missing:
+                errors.append(f"{path} is missing required fields: {', '.join(missing)}")
         properties = schema.get("properties", {})
-        if schema.get("additionalProperties") is False:
+        if not isinstance(properties, dict):
+            properties = {}
+        additional = schema.get("additionalProperties")
+        if additional is False:
             unexpected = sorted(set(value) - set(properties))
-            require(not unexpected, f"{path} has unexpected fields: {', '.join(unexpected)}")
+            if unexpected:
+                errors.append(f"{path} has unexpected fields: {', '.join(unexpected)}")
         for key, nested in value.items():
             if key in properties:
-                validate_schema_node(nested, properties[key], f"{path}.{key}", defs)
-    elif expected_type == "array":
-        require(isinstance(value, list), f"{path} must be an array")
-        if "minItems" in schema:
-            require(len(value) >= schema["minItems"], f"{path} must have at least {schema['minItems']} items")
+                errors.extend(schema_errors(nested, properties[key], root, f"{path}.{key}"))
+            elif isinstance(additional, dict):
+                errors.extend(schema_errors(nested, additional, root, f"{path}.{key}"))
+
+    if isinstance(value, list):
+        minimum = schema.get("minItems")
+        maximum = schema.get("maxItems")
+        if isinstance(minimum, int) and len(value) < minimum:
+            errors.append(f"{path} must have at least {minimum} items")
+        if isinstance(maximum, int) and len(value) > maximum:
+            errors.append(f"{path} must have at most {maximum} items")
         if schema.get("uniqueItems") is True:
-            seen = {json.dumps(item, sort_keys=True) for item in value}
-            require(len(seen) == len(value), f"{path} items must be unique")
-        item_schema = schema.get("items")
-        if item_schema:
+            encoded = [json.dumps(item, sort_keys=True) for item in value]
+            if len(encoded) != len(set(encoded)):
+                errors.append(f"{path} items must be unique")
+        items = schema.get("items")
+        if isinstance(items, dict):
             for index, item in enumerate(value):
-                validate_schema_node(item, item_schema, f"{path}[{index}]", defs)
-    elif expected_type == "string":
-        require(isinstance(value, str), f"{path} must be a string")
-        if "minLength" in schema:
-            require(len(value) >= schema["minLength"], f"{path} must not be empty")
-    elif expected_type == "integer":
-        require(isinstance(value, int) and not isinstance(value, bool), f"{path} must be an integer")
-        if "minimum" in schema:
-            require(value >= schema["minimum"], f"{path} must be >= {schema['minimum']}")
-    elif expected_type is not None:
-        fail(f"{path} uses unsupported schema type {expected_type}")
+                errors.extend(schema_errors(item, items, root, f"{path}[{index}]"))
+
+    if isinstance(value, str):
+        minimum = schema.get("minLength")
+        maximum = schema.get("maxLength")
+        pattern = schema.get("pattern")
+        if isinstance(minimum, int) and len(value) < minimum:
+            errors.append(f"{path} must have at least {minimum} characters")
+        if isinstance(maximum, int) and len(value) > maximum:
+            errors.append(f"{path} must have at most {maximum} characters")
+        if isinstance(pattern, str) and re.search(pattern, value) is None:
+            errors.append(f"{path} must match {pattern!r}")
+
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        minimum = schema.get("minimum")
+        maximum = schema.get("maximum")
+        if isinstance(minimum, (int, float)) and value < minimum:
+            errors.append(f"{path} must be >= {minimum}")
+        if isinstance(maximum, (int, float)) and value > maximum:
+            errors.append(f"{path} must be <= {maximum}")
+    return errors
 
 
 def reject_cargo_fields(value: Any, path: str = "outputs") -> None:
@@ -181,19 +277,498 @@ def normalize_dependencies(raw_dependencies: dict[str, Any] | None) -> list[dict
     return normalized
 
 
+def package_key(value: dict[str, Any]) -> tuple[str, str, str, str]:
+    return (
+        str(value.get("registry", "")),
+        str(value.get("source", "")),
+        str(value.get("namespace", "")),
+        str(value.get("name", "")),
+    )
+
+
+def require_strict_order(values: list[Any], label: str) -> None:
+    require(
+        all(left < right for left, right in zip(values, values[1:])),
+        f"{label} must be strictly sorted and duplicate-free",
+    )
+
+
+def validate_lockfile_v2_fixture(lockfile: dict[str, Any]) -> None:
+    registries = lockfile["registry"]
+    require_strict_order([row["name"] for row in registries], "lockfile registries")
+    registry_names = {row["name"] for row in registries}
+    for registry in registries:
+        require(
+            re.fullmatch(r"[0-9a-f]{64}", registry["expectation_sha256"]) is not None,
+            f"registry {registry['name']} expectation digest must be lowercase SHA-256",
+        )
+        require_strict_order(
+            registry["index_signer_key_ids"],
+            f"registry {registry['name']} index signers",
+        )
+
+    packages = lockfile["package"]
+    require_strict_order([row["id"] for row in packages], "lockfile packages")
+    package_by_id = {row["id"]: row for row in packages}
+    for package in packages:
+        if package["source"].startswith("registry:"):
+            require(package["registry"] in registry_names, "registry package must name a lock registry")
+            require_strict_order(
+                package["signer_key_ids"],
+                f"package {package['id']} signers",
+            )
+            require(
+                package["cache_key"] == f"sha256:{package['archive_sha256']}",
+                f"package {package['id']} cache key must bind its archive digest",
+            )
+
+    source_rank = {"path": 0, "registry": 1}
+    reason_rank = {
+        "root_path_constraint": 0,
+        "transitive_path_constraint": 1,
+        "highest_compatible": 2,
+        "exact_locked_replay": 3,
+        "trusted_yanked_locked_replay": 4,
+    }
+    edge_keys = [
+        (
+            row["from"],
+            row["alias"],
+            row["to"],
+            row["requested"],
+            source_rank[row["source_kind"]],
+            reason_rank[row["reason"]],
+        )
+        for row in lockfile["edge"]
+    ]
+    require_strict_order(edge_keys, "lockfile dependency edges")
+    for edge in lockfile["edge"]:
+        require(edge["from"] in package_by_id, "lockfile edge source must exist")
+        require(edge["to"] in package_by_id, "lockfile edge target must exist")
+        expected_registry = edge["source_kind"] == "registry"
+        actual_registry = package_by_id[edge["to"]]["source"].startswith("registry:")
+        require(expected_registry == actual_registry, "lockfile edge source kind must match target")
+
+
+def validate_resolution_fixture(resolution: dict[str, Any]) -> None:
+    packages = resolution["packages"]
+    require_strict_order(
+        [package_key(row["package"]) for row in packages],
+        "resolved packages",
+    )
+    for package in packages:
+        require_strict_order(
+            package["signer_key_ids"],
+            f"resolved package {package_key(package['package'])} signers",
+        )
+        require(not package["yanked"], "fresh resolution fixture must not select a yank")
+    require(
+        any(event["event"] == "catalog_authenticated" for event in resolution["trace"]),
+        "resolver trace must show authenticated catalog input",
+    )
+    require(
+        any(
+            event["event"] == "candidate_rejected"
+            and event["reason"]["reason"] == "yanked"
+            for event in resolution["trace"]
+        ),
+        "resolver trace must explain a deterministic yank rejection",
+    )
+    require(
+        any(event["event"] == "candidate_verified" for event in resolution["trace"]),
+        "resolver trace must show Package Trust verification",
+    )
+    require(
+        any(event["event"] == "selected" for event in resolution["trace"]),
+        "resolver trace must show the selected release",
+    )
+
+
+def validate_runtime_package_graph_fixture(graph: dict[str, Any]) -> None:
+    packages = graph["packages"]
+    package_by_id = {
+        package["id"]: package for package in packages if isinstance(package.get("id"), str)
+    }
+    require(
+        len(package_by_id) == sum(isinstance(package.get("id"), str) for package in packages),
+        "runtime package graph package ids must be unique",
+    )
+    for package in packages:
+        identifier = package.get("id")
+        source = package.get("source")
+        is_registry = (
+            isinstance(identifier, str) and identifier.startswith("registry:")
+        ) or (isinstance(source, str) and source.startswith("registry:"))
+        if is_registry:
+            require(
+                isinstance(source, str) and source.startswith("registry:"),
+                "runtime registry packages must expose their canonical source",
+            )
+            require(
+                isinstance(package.get("trust"), dict),
+                "runtime registry packages must expose Package Trust evidence",
+            )
+            trust = package["trust"]
+            for field in ("index_sha256", "verification_sha256"):
+                require(
+                    isinstance(trust.get(field), str)
+                    and re.fullmatch(r"[0-9a-f]{64}", trust[field]) is not None,
+                    f"runtime registry package trust {field} must be exact lowercase SHA-256",
+                )
+            materialization = package.get("materialization")
+            require(
+                isinstance(materialization, dict)
+                and materialization.get("package_trust_verified") is True,
+                "runtime registry packages must expose verified materialization evidence",
+            )
+            lockfile = package.get("lockfile")
+            require(
+                isinstance(lockfile, dict)
+                and lockfile.get("version") == 2
+                and isinstance(lockfile.get("hash"), str)
+                and re.fullmatch(r"[0-9a-f]{64}", lockfile["hash"]) is not None,
+                "runtime registry packages must expose an exact SHA-256 lockfile v2 identity",
+            )
+
+        for dependency in package["dependencies"]:
+            package_id = dependency.get("package_id")
+            source_kind = dependency.get("source_kind")
+            is_registry_edge = source_kind == "registry" or (
+                isinstance(package_id, str) and package_id.startswith("registry:")
+            )
+            if not is_registry_edge:
+                continue
+            require(
+                all(
+                    isinstance(dependency.get(field), str) and dependency[field]
+                    for field in ("package_id", "source_kind", "requested", "reason")
+                ),
+                "runtime registry dependency edges must expose package_id, source_kind, requested, and reason",
+            )
+            require(
+                dependency["source_kind"] == "registry"
+                and dependency["package_id"].startswith("registry:"),
+                "runtime registry dependency edge identity must agree with source_kind",
+            )
+            require(
+                dependency["package_id"] in package_by_id,
+                "runtime registry dependency edge must target a package in the graph",
+            )
+
+
+def render_version(value: dict[str, Any]) -> str:
+    return f"{value['major']}.{value['minor']}.{value['patch']}"
+
+
+def render_requirement(value: dict[str, Any]) -> str:
+    prefix = {"exact": "", "caret": "^"}[value["kind"]]
+    return f"{prefix}{render_version(value['version'])}"
+
+
+def canonical_path_package_id(package: dict[str, Any]) -> str:
+    source = package["source"]
+    relative = "." if source == "path" else source.removeprefix("path:")
+    return f"path:{relative}#{package['name']}@{package['version']}"
+
+
+def canonical_registry_package_id(
+    registry: str,
+    namespace: str,
+    package: str,
+    version: str,
+) -> str:
+    return f"registry:{registry}/{namespace}/{package}@{version}"
+
+
+def validate_resolver_fixture_consistency(
+    manifest: dict[str, Any],
+    lockfile: dict[str, Any],
+    resolution: dict[str, Any],
+) -> None:
+    manifest_package = manifest["package"]
+    root_id = f"path:.#{manifest_package['name']}@{manifest_package['version']}"
+    require(
+        lockfile["roots"] == [root_id],
+        "lockfile roots must contain the canonical manifest root package identity",
+    )
+
+    lock_packages = {package["id"]: package for package in lockfile["package"]}
+    require(root_id in lock_packages, "manifest root package must exist in lockfile packages")
+    root_package = lock_packages[root_id]
+    require(
+        root_package["name"] == manifest_package["name"]
+        and root_package["version"] == manifest_package["version"]
+        and root_package["source"] == "path",
+        "lockfile root package identity must match the manifest package",
+    )
+    for package in lockfile["package"]:
+        if package["source"].startswith("path"):
+            require(
+                package["id"] == canonical_path_package_id(package),
+                f"lockfile path package {package['id']} must use its canonical package id",
+            )
+
+    manifest_registry = manifest["registry"]
+    lock_registries = {registry["name"]: registry for registry in lockfile["registry"]}
+    require(
+        set(lock_registries) == {manifest_registry["name"]},
+        "lockfile registry names must exactly match the manifest registry name",
+    )
+    lock_registry = lock_registries[manifest_registry["name"]]
+    require(
+        lock_registry["source"] == manifest_registry["index"],
+        "lockfile registry source must exactly match the manifest registry index",
+    )
+    require(
+        re.fullmatch(r"[0-9a-f]{64}", lock_registry["expectation_sha256"]) is not None,
+        "lockfile registry expectation_sha256 must be a lowercase SHA-256 digest",
+    )
+
+    resolved_by_key = {
+        package_key(package["package"]): package for package in resolution["packages"]
+    }
+    require(
+        len(resolved_by_key) == len(resolution["packages"]),
+        "resolution packages must have unique package coordinates",
+    )
+    resolved_ids: dict[tuple[str, str, str, str], str] = {}
+    for key, resolved in resolved_by_key.items():
+        registry, source, namespace, name = key
+        require(
+            registry == manifest_registry["name"],
+            "resolved package registry must match the manifest and lock registry name",
+        )
+        require(
+            source == lock_registry["source_identity"],
+            "resolved package source must match the authenticated lock registry source identity",
+        )
+        version = render_version(resolved["version"])
+        package_id = canonical_registry_package_id(registry, namespace, name, version)
+        require(
+            package_id in lock_packages,
+            f"resolved package {package_id} must exist in lockfile packages",
+        )
+        locked = lock_packages[package_id]
+        require(
+            locked["source"] == f"registry:{registry}/{namespace}/{name}"
+            and locked["registry"] == registry
+            and locked["namespace"] == namespace
+            and locked["name"] == name
+            and locked["version"] == version,
+            f"resolved package {package_id} must match its lockfile coordinates",
+        )
+        require(
+            locked["manifest_sha256"] == resolved["manifest_digest"],
+            f"resolved package {package_id} manifest digest must match the lockfile",
+        )
+        require(
+            locked["signer_key_ids"] == resolved["signer_key_ids"],
+            f"resolved package {package_id} signer identities must match the lockfile",
+        )
+        require(
+            locked["compatibility"]["contract"] == resolved["compatibility"]
+            and locked["compatibility"]["edition_policy"] == resolved["edition"],
+            f"resolved package {package_id} compatibility must match the lockfile",
+        )
+        resolved_ids[key] = package_id
+
+    locked_registry_ids = {
+        package["id"]
+        for package in lockfile["package"]
+        if package["source"].startswith("registry:")
+    }
+    require(
+        set(resolved_ids.values()) == locked_registry_ids,
+        "resolved package identities must exactly match registry lockfile packages",
+    )
+
+    def source_id(value: dict[str, Any] | None) -> str:
+        if value is None:
+            return root_id
+        key = package_key(value)
+        require(key in resolved_ids, "resolution edge source must be a selected package")
+        return resolved_ids[key]
+
+    expected_edges: set[tuple[str, str, str, str, str]] = set()
+    for edge in resolution["edges"]:
+        target_key = package_key(edge["to"])
+        require(target_key in resolved_ids, "resolution edge target must be a selected package")
+        selected = render_version(edge["selected"])
+        target = resolved_by_key[target_key]
+        require(
+            selected == render_version(target["version"]),
+            "resolution edge selected version must match its selected package",
+        )
+        expected_edges.add(
+            (
+                source_id(edge["from"]),
+                edge["alias"],
+                resolved_ids[target_key],
+                render_requirement(edge["requirement"]),
+                "registry",
+            )
+        )
+
+    for dependency in resolution["path_dependencies"]:
+        source = source_id(dependency["from"])
+        candidates = [
+            package
+            for package in lockfile["package"]
+            if package["source"] == f"path:{dependency['path']}"
+        ]
+        require(
+            len(candidates) == 1,
+            f"resolution path {dependency['path']} must identify one lockfile package",
+        )
+        lock_edge = next(
+            (
+                edge
+                for edge in lockfile["edge"]
+                if edge["from"] == source
+                and edge["alias"] == dependency["alias"]
+                and edge["to"] == candidates[0]["id"]
+            ),
+            None,
+        )
+        require(lock_edge is not None, "resolution path dependency must exist in lockfile edges")
+        expected_edges.add(
+            (
+                source,
+                dependency["alias"],
+                candidates[0]["id"],
+                lock_edge["requested"],
+                "path",
+            )
+        )
+
+    observed_edges = {
+        (
+            edge["from"],
+            edge["alias"],
+            edge["to"],
+            edge["requested"],
+            edge["source_kind"],
+        )
+        for edge in lockfile["edge"]
+    }
+    require(
+        observed_edges == expected_edges,
+        "resolution and lockfile dependency edges must match exactly",
+    )
+
+    manifest_dependencies = manifest.get("dependencies", {})
+    root_resolution_aliases = {
+        edge["alias"] for edge in resolution["edges"] if edge["from"] is None
+    } | {
+        dependency["alias"]
+        for dependency in resolution["path_dependencies"]
+        if dependency["from"] is None
+    }
+    root_lock_aliases = {
+        edge["alias"] for edge in lockfile["edge"] if edge["from"] == root_id
+    }
+    require(
+        set(manifest_dependencies) == root_resolution_aliases == root_lock_aliases,
+        "manifest, resolution, and lockfile root dependency aliases must match exactly",
+    )
+    for alias, dependency in manifest_dependencies.items():
+        if "registry" in dependency:
+            require(
+                dependency["registry"] == manifest_registry["name"],
+                f"manifest dependency {alias} must use the configured registry name",
+            )
+            matching = [
+                edge
+                for edge in resolution["edges"]
+                if edge["from"] is None and edge["alias"] == alias
+            ]
+            require(len(matching) == 1, f"manifest registry dependency {alias} must resolve once")
+            edge = matching[0]
+            require(
+                edge["to"]["registry"] == dependency["registry"]
+                and edge["to"]["namespace"] == dependency["namespace"]
+                and edge["to"]["name"] == dependency.get("package", alias)
+                and render_requirement(edge["requirement"]) == dependency["version"],
+                f"manifest registry dependency {alias} must match its resolution edge",
+            )
+        else:
+            matching = [
+                path
+                for path in resolution["path_dependencies"]
+                if path["from"] is None and path["alias"] == alias
+            ]
+            require(len(matching) == 1, f"manifest path dependency {alias} must resolve once")
+            require(
+                matching[0]["path"] == dependency["path"],
+                f"manifest path dependency {alias} must match its resolution path",
+            )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
     parser.add_argument("--snapshot", type=Path, default=DEFAULT_SNAPSHOT)
+    parser.add_argument("--runtime-schema", type=Path, default=DEFAULT_RUNTIME_SCHEMA)
+    parser.add_argument("--runtime-snapshot", type=Path, default=DEFAULT_RUNTIME_SNAPSHOT)
+    parser.add_argument("--manifest-schema", type=Path, default=DEFAULT_MANIFEST_SCHEMA)
+    parser.add_argument("--manifest-fixture", type=Path, default=DEFAULT_MANIFEST_FIXTURE)
+    parser.add_argument("--lockfile-v2-schema", type=Path, default=DEFAULT_LOCKFILE_V2_SCHEMA)
+    parser.add_argument("--lockfile-v2-fixture", type=Path, default=DEFAULT_LOCKFILE_V2_FIXTURE)
+    parser.add_argument("--resolution-schema", type=Path, default=DEFAULT_RESOLUTION_SCHEMA)
+    parser.add_argument("--resolution-fixture", type=Path, default=DEFAULT_RESOLUTION_FIXTURE)
     parser.add_argument("--json", action="store_true", help="emit a JSON validation result")
     args = parser.parse_args()
 
     schema = load_json(args.schema)
     snapshot = load_json(args.snapshot)
+    runtime_schema = load_json(args.runtime_schema)
+    runtime_snapshot = load_json(args.runtime_snapshot)
+    manifest_schema = load_json(args.manifest_schema)
+    manifest_fixture = load_json(args.manifest_fixture)
+    lockfile_v2_schema = load_json(args.lockfile_v2_schema)
+    lockfile_v2_fixture = load_json(args.lockfile_v2_fixture)
+    resolution_schema = load_json(args.resolution_schema)
+    resolution_fixture = load_json(args.resolution_fixture)
 
     require(schema.get("$id", "").endswith("/axiom.compiler.package_graph.v1.schema.json"), "schema $id must name package graph v1")
     require(schema.get("title") == "Axiom compiler package graph contract", "schema title changed unexpectedly")
+    require(
+        runtime_schema.get("$id", "").endswith(
+            "/axiom.compiler.package_graph.runtime.v1.schema.json"
+        ),
+        "runtime schema $id must name runtime package graph v1",
+    )
+    require(
+        runtime_schema.get("title") == "Axiom compiler runtime package graph",
+        "runtime schema title changed unexpectedly",
+    )
+    require(
+        manifest_schema.get("$id") == "https://axiom.omt.global/schemas/axiom.toml.schema.json",
+        "manifest schema $id mismatch",
+    )
+    require(
+        lockfile_v2_schema.get("$id")
+        == "https://axiom.omt.global/schemas/axiom-lockfile-v2.schema.json",
+        "lockfile v2 schema $id mismatch",
+    )
+    require(
+        resolution_schema.get("$id")
+        == "https://axiom.omt.global/schemas/axiom-package-resolution-v1.schema.json",
+        "package resolution schema $id mismatch",
+    )
     validate_against_schema(snapshot, schema)
+    validate_against_schema(runtime_snapshot, runtime_schema)
+    validate_against_schema(manifest_fixture, manifest_schema)
+    validate_against_schema(lockfile_v2_fixture, lockfile_v2_schema)
+    validate_against_schema(resolution_fixture, resolution_schema)
+    validate_lockfile_v2_fixture(lockfile_v2_fixture)
+    validate_resolution_fixture(resolution_fixture)
+    validate_runtime_package_graph_fixture(runtime_snapshot)
+    validate_resolver_fixture_consistency(
+        manifest_fixture,
+        lockfile_v2_fixture,
+        resolution_fixture,
+    )
     require(snapshot.get("schema_version") == SCHEMA_VERSION, "snapshot schema_version mismatch")
     require(snapshot.get("contract") == CONTRACT, "snapshot contract mismatch")
     reject_cargo_fields(snapshot.get("outputs", {}))
@@ -246,6 +821,7 @@ def main() -> int:
         "schema": SCHEMA_VERSION,
         "ok": True,
         "packages": len(packages),
+        "resolver_fixtures": 3,
         "fixture": str(args.snapshot),
     }
     if args.json:

--- a/scripts/ci/extract-public-contract-v1.py
+++ b/scripts/ci/extract-public-contract-v1.py
@@ -651,42 +651,111 @@ def extract(inventory_path: Path, policy_path: Path) -> dict[str, Any]:
         manifest_schema,
         parser_contract,
     )
-    surfaces.append(
-        surface(
-            "axiom://package/manifest",
-            "package",
-            public_surface_version("axiom://package/manifest"),
-            (
-                f"axiom.toml schema={manifest_schema.get('$id')}; "
-                f"semantic_digest={semantic_digest(manifest_projection)}; "
-                f"fields={','.join(sorted(manifest_properties))}; edition_selector=unavailable"
+    manifest_surface = surface(
+        "axiom://package/manifest",
+        "package",
+        public_surface_version("axiom://package/manifest"),
+        (
+            f"axiom.toml schema={manifest_schema.get('$id')}; "
+            f"semantic_digest={semantic_digest(manifest_projection)}; "
+            f"fields={','.join(sorted(manifest_properties))}; edition_selector=unavailable"
+        ),
+        [
+            manifest_schema_source,
+            source(
+                parser_contract_path,
+                "package_manifest_parser_contract",
+                "dependency_version_pattern,test_kinds,test_capabilities",
             ),
-            [
-                manifest_schema_source,
-                source(
-                    parser_contract_path,
-                    "package_manifest_parser_contract",
-                    "dependency_version_pattern,test_kinds,test_capabilities",
-                ),
-                manifest_parser_source,
-            ],
-        )
+            manifest_parser_source,
+        ],
     )
+    manifest_migration = entries["package_manifest"].get("migration")
+    if (
+        not isinstance(manifest_migration, dict)
+        or set(manifest_migration) != {"action"}
+        or not isinstance(manifest_migration.get("action"), str)
+        or not manifest_migration["action"].strip()
+    ):
+        raise ValueError("package manifest source entry must contain one migration action")
+    manifest_surface["migration"] = {"action": manifest_migration["action"].strip()}
+    surfaces.append(manifest_surface)
 
     lock_path = entry_path(entries, "lockfile")
     lock = tomllib.loads(lock_path.read_text(encoding="utf-8"))
     lock_version = lock.get("version")
     if not isinstance(lock_version, int) or lock_version < 1:
         raise ValueError("canonical axiom.lock fixture must declare a positive numeric version")
-    surfaces.append(
-        surface(
-            "axiom://package/lockfile",
-            "package",
-            public_surface_version("axiom://package/lockfile"),
-            f"axiom.lock format={lock_version}; records=package(name,version,source)",
-            [source(lock_path, "lockfile_format", "version,package[*]")],
+    lock_v2_schema_value = entries["lockfile"].get("schema_v2")
+    lock_v2_fixture_value = entries["lockfile"].get("fixture_v2")
+    lock_implementation_value = entries["lockfile"].get("implementation")
+    if not all(
+        isinstance(value, str) and value
+        for value in (
+            lock_v2_schema_value,
+            lock_v2_fixture_value,
+            lock_implementation_value,
         )
+    ):
+        raise ValueError(
+            "lockfile source entry must name schema_v2, fixture_v2, and implementation"
+        )
+    lock_v2_schema_path = ROOT / lock_v2_schema_value
+    lock_v2_fixture_path = ROOT / lock_v2_fixture_value
+    lock_implementation_path = ROOT / lock_implementation_value
+    lock_v2_schema = load_object(lock_v2_schema_path)
+    lock_v2_fixture = load_object(lock_v2_fixture_path)
+    if lock_v2_fixture.get("version") != 2:
+        raise ValueError("canonical axiom.lock v2 fixture must declare version 2")
+    lock_v2_properties = lock_v2_schema.get("properties")
+    if not isinstance(lock_v2_properties, dict):
+        raise ValueError("axiom.lock v2 schema must define top-level properties")
+    expected_v2_fields = ["compatibility", "edge", "package", "registry", "roots", "version"]
+    if sorted(lock_v2_properties) != expected_v2_fields:
+        raise ValueError("axiom.lock v2 schema has an unexpected top-level field set")
+    lock_v2_projection = {
+        "schema": lock_v2_schema,
+        "fixture": lock_v2_fixture,
+    }
+    lock_surface = surface(
+        "axiom://package/lockfile",
+        "package",
+        public_surface_version("axiom://package/lockfile"),
+        (
+            f"axiom.lock formats={lock_version},2; "
+            "v1_records=package(name,version,source); "
+            f"v2_fields={','.join(expected_v2_fields)}; "
+            f"v2_semantic_digest={semantic_digest(lock_v2_projection)}"
+        ),
+        [
+            source(lock_path, "lockfile_v1_format", "version,package[*]"),
+            source(
+                lock_v2_schema_path,
+                "lockfile_v2_schema",
+                "$id,required,properties,$defs",
+            ),
+            source(
+                lock_v2_fixture_path,
+                "lockfile_v2_fixture",
+                "version,compatibility,roots,registry,package,edge",
+            ),
+            source(
+                lock_implementation_path,
+                "lockfile_runtime_parity",
+                "LockfileV2 and validate_lockfile_v2",
+            ),
+        ],
     )
+    lock_migration = entries["lockfile"].get("migration")
+    if (
+        not isinstance(lock_migration, dict)
+        or set(lock_migration) != {"action"}
+        or not isinstance(lock_migration.get("action"), str)
+        or not lock_migration["action"].strip()
+    ):
+        raise ValueError("lockfile source entry must contain one non-empty migration action")
+    lock_surface["migration"] = {"action": lock_migration["action"].strip()}
+    surfaces.append(lock_surface)
 
     abi_path = entry_path(entries, "logical_abi")
     abi = load_object(abi_path)
@@ -802,6 +871,25 @@ def extract(inventory_path: Path, policy_path: Path) -> dict[str, Any]:
     )
 
     surfaces.sort(key=lambda item: (KIND_RANK[item["kind"]], item["id"]))
+    surface_migrations = inventory.get("surface_migrations", {})
+    if not isinstance(surface_migrations, dict):
+        raise ValueError("source inventory surface_migrations must be an object")
+    surface_by_id = {item["id"]: item for item in surfaces}
+    for identifier, migration in surface_migrations.items():
+        if identifier not in surface_by_id:
+            raise ValueError(f"surface migration references unknown surface {identifier}")
+        if (
+            not isinstance(migration, dict)
+            or set(migration) != {"action"}
+            or not isinstance(migration.get("action"), str)
+            or not migration["action"].strip()
+        ):
+            raise ValueError(
+                f"surface migration for {identifier} must contain one non-empty action"
+            )
+        surface_by_id[identifier]["migration"] = {
+            "action": migration["action"].strip()
+        }
     observed = {item["kind"] for item in surfaces}
     missing = set(KINDS) - observed
     if missing:

--- a/scripts/ci/report-compiler-source-monoliths.py
+++ b/scripts/ci/report-compiler-source-monoliths.py
@@ -41,6 +41,7 @@ BOUNDARY_MAP: dict[str, list[str]] = {
     "model.rs": ["compiler.hir"],
     "new_project.rs": ["compiler.commands"],
     "ownership.rs": ["compiler.hir"],
+    "package_trust.rs": ["compiler.package_trust"],
     "properties.rs": ["compiler.hir"],
     "reachability.rs": ["compiler.hir"],
     "project.rs": ["compiler.package_graph", "compiler.commands", "compiler.evidence"],

--- a/scripts/ci/run-fast-checks.sh
+++ b/scripts/ci/run-fast-checks.sh
@@ -88,6 +88,7 @@ python3 "$script_repo_root/scripts/ci/check-production-language-readiness.py" \
   --json --validate-only >/dev/null
 bash "$script_repo_root/scripts/ci/test-check-production-language-readiness.sh"
 bash "$script_repo_root/scripts/ci/test-check-direct-native-runtime-abi.sh"
+python3 "$script_repo_root/scripts/ci/check-package-graph-boundary.py" --json >/dev/null
 bash "$script_repo_root/scripts/ci/test-check-package-graph-boundary.sh"
 bash "$script_repo_root/scripts/ci/test-check-diagnostics-syntax-boundary.sh"
 bash "$script_repo_root/scripts/ci/test-check-command-lsp-boundary.sh"

--- a/scripts/ci/run-toolchain-supply-chain.sh
+++ b/scripts/ci/run-toolchain-supply-chain.sh
@@ -18,6 +18,15 @@ bash "$repo_root/scripts/ci/test-check-package-trust-contract.sh"
 cargo test --manifest-path "$manifest_path" -p axiomc --locked --lib package_trust::tests
 cargo test --manifest-path "$manifest_path" -p axiomc --locked --lib registry::tests
 cargo test --manifest-path "$manifest_path" -p axiomc --locked --test package_trust_cli
+cargo test --manifest-path "$manifest_path" -p axiomc --locked --lib package_version::tests
+cargo test --manifest-path "$manifest_path" -p axiomc --locked --lib package_resolver::tests
+cargo test --manifest-path "$manifest_path" -p axiomc --locked --lib registry_client::tests
+cargo test --manifest-path "$manifest_path" -p axiomc --locked --lib package_archive::tests
+cargo test --manifest-path "$manifest_path" -p axiomc --locked --lib package_store::tests
+cargo test --manifest-path "$manifest_path" -p axiomc --locked --lib package_manager::tests
+cargo test --manifest-path "$manifest_path" -p axiomc --locked --test package_resolver_cli
+python3 "$repo_root/scripts/ci/check-package-graph-boundary.py" --json
+bash "$repo_root/scripts/ci/test-check-package-graph-boundary.sh"
 
 if [[ -f "$repo_root/package-lock.json" ]]; then
   if ! command -v npm >/dev/null 2>&1; then

--- a/scripts/ci/test-check-compatibility-v1.py
+++ b/scripts/ci/test-check-compatibility-v1.py
@@ -203,23 +203,34 @@ def main() -> int:
         "axiom://schema/axiom-quality-policy-v1",
         "axiom://schema/axiom-quality-report-v1",
     }
+    new_package_resolver_ids = {
+        "axiom://schema/axiom.compiler.package_graph.runtime.v1",
+        "axiom://schema/axiom-lockfile-v2",
+        "axiom://schema/axiom-package-resolution-v1",
+    }
     new_public_schema_ids = new_package_trust_ids | new_main_schema_ids | new_quality_schema_ids
+    new_schema_ids = new_package_trust_ids | new_main_schema_ids | new_package_resolver_ids
     modified_schema_ids = {
         "axiom://schema/axiom-build-lowering-evidence-v1",
         "axiom://schema/axiom.stage1.command",
         "axiom://schema/axiom.stage1.v1",
     }
     assert len(baseline_ids) == 52, "accepted baseline must remain the frozen 52-surface ratchet"
-    assert len(current_ids) == 63, "current contract must include five package trust schemas, two quality schemas, Provider ABI, Semantic MIR, runtime lifecycle, and persistent LSP schemas"
+    assert len(current_ids) == 66, "current contract must include package trust, quality, Provider ABI, Semantic MIR, runtime lifecycle, persistent LSP, and package resolver schemas"
     assert set(baseline_ids) < set(current_ids)
-    assert set(current_ids) - set(baseline_ids) == new_public_schema_ids
-    assert current_payload["contract_version"] == "0.3.0"
+    assert set(current_ids) - set(baseline_ids) == new_public_schema_ids | new_package_resolver_ids
+    assert current_payload["contract_version"] == "0.4.0"
     current_cli = surface(current_payload, "axiom://cli/axiomc")
-    assert current_cli["version"] == "0.2.0"
+    assert current_cli["version"] == "0.3.0"
+    current_stage1_schema = surface(current_payload, "axiom://schema/axiom.stage1.v1")
+    assert current_stage1_schema["version"] == "0.2.0"
+    compatibility_doc = (ROOT / "docs/compatibility-v1.md").read_text(encoding="utf-8")
+    assert f"current source contract is version `{current_payload['contract_version']}` with {len(current_ids)} surfaces" in compatibility_doc
+    assert f"CLI surface is version `{current_cli['version']}`" in compatibility_doc
     current_commands = (
         current_cli["signature"].split("; ", maxsplit=1)[0].split("=")[1].split(",")
     )
-    assert "pkg verify" in current_commands
+    assert {"pkg fetch", "pkg update", "pkg vendor", "pkg verify"} <= set(current_commands)
     canonical = run(
         BASELINE,
         CURRENT,
@@ -229,12 +240,17 @@ def main() -> int:
     assert canonical.returncode == 0, canonical.stdout + canonical.stderr
     canonical_report = json.loads(canonical.stdout)
     assert canonical_report["summary"] == {
-        "additive": 11,
-        "breaking": 4,
+        "additive": 14,
+        "breaking": 7,
         "compatible": 0,
         "deprecated": 0,
     }
-    expected_changed_ids = new_public_schema_ids | modified_schema_ids | {"axiom://cli/axiomc"}
+    expected_changed_ids = new_public_schema_ids | new_package_resolver_ids | modified_schema_ids | {
+        "axiom://cli/axiomc",
+        "axiom://package/lockfile",
+        "axiom://package/manifest",
+        "axiom://schema/axiom.toml",
+    }
     assert {
         item["surface_id"] for item in canonical_report["changes"]
     } == expected_changed_ids
@@ -243,7 +259,7 @@ def main() -> int:
         and item["severity"] == "additive"
         and item["surface_kind"] == "schema"
         for item in canonical_report["changes"]
-        if item["surface_id"] in new_package_trust_ids
+        if item["surface_id"] in new_schema_ids
     )
     cli_change = next(
         item
@@ -254,10 +270,12 @@ def main() -> int:
     assert cli_change["severity"] == "breaking"
     assert cli_change["surface_kind"] == "cli"
     assert cli_change["migration"] == (
-        "Existing command invocations require no changes. To adopt Package Trust v1 "
-        "verification, invoke axiomc pkg verify with the exact artifact and trust "
-        "metadata paths plus --json, then handle exit 0 as trusted, exit 1 as rejected, "
-        "and exit 2 as an operational failure."
+        "Existing command invocations require no changes. To adopt registry dependencies, "
+        "run axiomc pkg fetch to create the v2 lock and verified cache, use axiomc pkg "
+        "update for explicit re-resolution, and run axiomc pkg vendor before "
+        "cache-independent locked offline builds. Package Trust v1 remains available "
+        "through axiomc pkg verify with exact artifact and trust metadata paths plus "
+        "--json."
     )
     for identifier in modified_schema_ids:
         schema_change = next(
@@ -270,7 +288,12 @@ def main() -> int:
         f"axiom://schema/{path.name.removesuffix('.schema.json')}"
         for path in (ROOT / "stage1/compiler-contracts/schemas").glob("*.schema.json")
     }
-    assert compiler_schema_ids - new_main_schema_ids <= set(baseline_ids)
+    assert compiler_schema_ids <= set(current_ids)
+    assert compiler_schema_ids - set(baseline_ids) == (
+        new_main_schema_ids - {"axiom://schema/axiom.lsp.v1"}
+    ) | {
+        "axiom://schema/axiom.compiler.package_graph.runtime.v1"
+    }
     with tempfile.TemporaryDirectory() as temporary:
         directory = Path(temporary)
         for identifier in baseline_ids:

--- a/scripts/ci/test-check-package-graph-boundary.sh
+++ b/scripts/ci/test-check-package-graph-boundary.sh
@@ -5,6 +5,7 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 script="$repo_root/scripts/ci/check-package-graph-boundary.py"
 temp_dir="$(mktemp -d)"
 trap 'rm -rf "$temp_dir"' EXIT
+cd "$repo_root"
 
 python3 "$script" --json >"$temp_dir/result.json"
 
@@ -39,6 +40,175 @@ if python3 "$script" --snapshot "$temp_dir/unexpected-field.json" >"$temp_dir/un
 fi
 
 grep -q "unexpected fields" "$temp_dir/unexpected.err"
+
+python3 - "$repo_root/stage1/compiler-contracts/snapshots/package-graph-runtime.json" "$temp_dir/runtime-unexpected.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    payload = json.load(handle)
+
+payload["packages"][0]["unexpected"] = "drift"
+
+with open(sys.argv[2], "w", encoding="utf-8") as handle:
+    json.dump(payload, handle)
+PY
+
+if python3 "$script" --runtime-snapshot "$temp_dir/runtime-unexpected.json" >"$temp_dir/runtime-unexpected.out" 2>"$temp_dir/runtime-unexpected.err"; then
+  echo "expected schema-invalid runtime package graph output to fail" >&2
+  exit 1
+fi
+
+grep -q "unexpected fields" "$temp_dir/runtime-unexpected.err"
+
+python3 - "$repo_root/stage1/compiler-contracts/snapshots/package-graph-runtime.json" "$temp_dir/runtime-v2-short-hash.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    payload = json.load(handle)
+
+registry_package = next(
+    package
+    for package in payload["packages"]
+    if str(package.get("id", "")).startswith("registry:")
+)
+registry_package["lockfile"]["hash"] = "1" * 16
+
+with open(sys.argv[2], "w", encoding="utf-8") as handle:
+    json.dump(payload, handle)
+PY
+
+if python3 "$script" --runtime-snapshot "$temp_dir/runtime-v2-short-hash.json" >"$temp_dir/runtime-v2-short-hash.out" 2>"$temp_dir/runtime-v2-short-hash.err"; then
+  echo "expected runtime lockfile v2 with a legacy short hash to fail" >&2
+  exit 1
+fi
+
+grep -Fq "must match '^[0-9a-f]{64}$'" "$temp_dir/runtime-v2-short-hash.err"
+
+python3 - "$repo_root/stage1/compiler-contracts/snapshots/package-graph-runtime.json" "$temp_dir" <<'PY'
+import copy
+import json
+import sys
+from pathlib import Path
+
+snapshot_path, output_dir = map(Path, sys.argv[1:])
+payload = json.loads(snapshot_path.read_text(encoding="utf-8"))
+registry_package = next(
+    package
+    for package in payload["packages"]
+    if str(package.get("id", "")).startswith("registry:")
+)
+registry_edge = next(
+    dependency
+    for package in payload["packages"]
+    for dependency in package["dependencies"]
+    if dependency.get("source_kind") == "registry"
+)
+
+for field in ("source", "trust", "materialization"):
+    mutated = copy.deepcopy(payload)
+    target = next(
+        package
+        for package in mutated["packages"]
+        if package.get("id") == registry_package["id"]
+    )
+    target.pop(field)
+    (output_dir / f"runtime-package-missing-{field}.json").write_text(
+        json.dumps(mutated, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+for field in ("index_sha256", "verification_sha256"):
+    mutated = copy.deepcopy(payload)
+    target = next(
+        package
+        for package in mutated["packages"]
+        if package.get("id") == registry_package["id"]
+    )
+    target["trust"].pop(field)
+    (output_dir / f"runtime-trust-missing-{field}.json").write_text(
+        json.dumps(mutated, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+missing_version = copy.deepcopy(payload)
+next(
+    package
+    for package in missing_version["packages"]
+    if package.get("id") == registry_package["id"]
+)["lockfile"].pop("version")
+(output_dir / "runtime-registry-lock-missing-version.json").write_text(
+    json.dumps(missing_version, indent=2, sort_keys=True) + "\n",
+    encoding="utf-8",
+)
+
+v1_lock = copy.deepcopy(payload)
+v1_target = next(
+    package
+    for package in v1_lock["packages"]
+    if package.get("id") == registry_package["id"]
+)
+v1_target["lockfile"]["version"] = 1
+v1_target["lockfile"]["hash"] = "1" * 16
+(output_dir / "runtime-registry-lock-v1.json").write_text(
+    json.dumps(v1_lock, indent=2, sort_keys=True) + "\n",
+    encoding="utf-8",
+)
+
+for field in ("package_id", "source_kind", "requested", "reason"):
+    mutated = copy.deepcopy(payload)
+    target = next(
+        dependency
+        for package in mutated["packages"]
+        for dependency in package["dependencies"]
+        if dependency.get("package_id") == registry_edge["package_id"]
+    )
+    target.pop(field)
+    (output_dir / f"runtime-edge-missing-{field}.json").write_text(
+        json.dumps(mutated, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+PY
+
+for field in source trust materialization; do
+  name="runtime-package-missing-$field"
+  if python3 "$script" --runtime-snapshot "$temp_dir/$name.json" >"$temp_dir/$name.out" 2>"$temp_dir/$name.err"; then
+    echo "expected runtime registry package without $field to fail" >&2
+    exit 1
+  fi
+  grep -Fq "missing required fields: $field" "$temp_dir/$name.err"
+done
+
+for field in index_sha256 verification_sha256; do
+  name="runtime-trust-missing-$field"
+  if python3 "$script" --runtime-snapshot "$temp_dir/$name.json" >"$temp_dir/$name.out" 2>"$temp_dir/$name.err"; then
+    echo "expected runtime registry trust without $field to fail" >&2
+    exit 1
+  fi
+  grep -Fq "missing required fields: $field" "$temp_dir/$name.err"
+done
+
+if python3 "$script" --runtime-snapshot "$temp_dir/runtime-registry-lock-missing-version.json" >"$temp_dir/runtime-registry-lock-missing-version.out" 2>"$temp_dir/runtime-registry-lock-missing-version.err"; then
+  echo "expected runtime registry package without lock version to fail" >&2
+  exit 1
+fi
+grep -Fq "missing required fields: version" "$temp_dir/runtime-registry-lock-missing-version.err"
+
+if python3 "$script" --runtime-snapshot "$temp_dir/runtime-registry-lock-v1.json" >"$temp_dir/runtime-registry-lock-v1.out" 2>"$temp_dir/runtime-registry-lock-v1.err"; then
+  echo "expected runtime registry package with lock version 1 to fail" >&2
+  exit 1
+fi
+grep -Eq "must equal 2|must match '\\^\\[0-9a-f\\]\\{64\\}\\$'" "$temp_dir/runtime-registry-lock-v1.err"
+
+for field in package_id source_kind requested reason; do
+  name="runtime-edge-missing-$field"
+  if python3 "$script" --runtime-snapshot "$temp_dir/$name.json" >"$temp_dir/$name.out" 2>"$temp_dir/$name.err"; then
+    echo "expected runtime registry edge without $field to fail" >&2
+    exit 1
+  fi
+  grep -Fq "missing required fields: $field" "$temp_dir/$name.err"
+done
 
 python3 - "$repo_root/stage1/compiler-contracts/snapshots/package-graph.json" "$temp_dir/cargo-derived.json" <<'PY'
 import json
@@ -79,5 +249,128 @@ if python3 "$script" --snapshot "$temp_dir/stale-lockfile.json" >"$temp_dir/stal
 fi
 
 grep -q "lockfile_integrity packages" "$temp_dir/stale.err"
+
+python3 - \
+  "$repo_root/stage1/package-resolver/fixtures/manifest-registry.json" \
+  "$repo_root/stage1/package-resolver/fixtures/lockfile-v2.json" \
+  "$repo_root/stage1/package-resolver/fixtures/resolution-v1.json" \
+  "$temp_dir" <<'PY'
+import copy
+import json
+import sys
+from pathlib import Path
+
+manifest_path, lock_path, resolution_path, output_dir = map(Path, sys.argv[1:])
+output_dir.mkdir(parents=True, exist_ok=True)
+
+with manifest_path.open(encoding="utf-8") as handle:
+    manifest = json.load(handle)
+with lock_path.open(encoding="utf-8") as handle:
+    lockfile = json.load(handle)
+with resolution_path.open(encoding="utf-8") as handle:
+    resolution = json.load(handle)
+
+
+def write(name, value):
+    with (output_dir / name).open("w", encoding="utf-8") as handle:
+        json.dump(value, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+registry_name = copy.deepcopy(manifest)
+registry_name["registry"]["name"] = "other"
+registry_name["dependencies"]["core"]["registry"] = "other"
+write("resolver-manifest-registry-name.json", registry_name)
+
+registry_source = copy.deepcopy(lockfile)
+registry_source["registry"][0]["source"] = "file:///registry/other-index.json"
+write("resolver-lock-registry-source.json", registry_source)
+
+root_drift = copy.deepcopy(lockfile)
+root_drift["roots"] = [
+    next(
+        package["id"]
+        for package in root_drift["package"]
+        if package["source"].startswith("registry:")
+    )
+]
+write("resolver-lock-root.json", root_drift)
+
+package_id = copy.deepcopy(lockfile)
+registry_package = next(
+    package for package in package_id["package"] if package["source"].startswith("registry:")
+)
+old_id = registry_package["id"]
+registry_package["id"] = "registry:fixture/axiom/core@1.2.4"
+for edge in package_id["edge"]:
+    if edge["to"] == old_id:
+        edge["to"] = registry_package["id"]
+write("resolver-lock-package-id.json", package_id)
+
+edge_drift = copy.deepcopy(lockfile)
+next(edge for edge in edge_drift["edge"] if edge["alias"] == "core")["requested"] = "^1.2.1"
+write("resolver-lock-edge.json", edge_drift)
+
+expectation_digest = copy.deepcopy(lockfile)
+expectation_digest["registry"][0]["expectation_sha256"] = "not-a-digest"
+write("resolver-lock-expectation.json", expectation_digest)
+
+source_identity = copy.deepcopy(resolution)
+
+
+def replace_source(value):
+    if isinstance(value, dict):
+        if {"registry", "source", "namespace", "name"}.issubset(value):
+            value["source"] = "registry:other-source"
+        for nested in value.values():
+            replace_source(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            replace_source(nested)
+
+
+replace_source(source_identity)
+write("resolver-resolution-source.json", source_identity)
+PY
+
+expect_resolver_failure() {
+  local name="$1"
+  local expected="$2"
+  shift 2
+  if python3 "$script" "$@" >"$temp_dir/$name.out" 2>"$temp_dir/$name.err"; then
+    echo "expected resolver fixture drift case $name to fail" >&2
+    exit 1
+  fi
+  grep -Fq "$expected" "$temp_dir/$name.err"
+}
+
+expect_resolver_failure \
+  resolver-manifest-registry-name \
+  "lockfile registry names must exactly match the manifest registry name" \
+  --manifest-fixture "$temp_dir/resolver-manifest-registry-name.json"
+expect_resolver_failure \
+  resolver-lock-registry-source \
+  "lockfile registry source must exactly match the manifest registry index" \
+  --lockfile-v2-fixture "$temp_dir/resolver-lock-registry-source.json"
+expect_resolver_failure \
+  resolver-lock-root \
+  "lockfile roots must contain the canonical manifest root package identity" \
+  --lockfile-v2-fixture "$temp_dir/resolver-lock-root.json"
+expect_resolver_failure \
+  resolver-lock-package-id \
+  "resolved package registry:fixture/axiom/core@1.2.3 must exist in lockfile packages" \
+  --lockfile-v2-fixture "$temp_dir/resolver-lock-package-id.json"
+expect_resolver_failure \
+  resolver-lock-edge \
+  "resolution and lockfile dependency edges must match exactly" \
+  --lockfile-v2-fixture "$temp_dir/resolver-lock-edge.json"
+expect_resolver_failure \
+  resolver-lock-expectation \
+  "expectation_sha256" \
+  --lockfile-v2-fixture "$temp_dir/resolver-lock-expectation.json"
+expect_resolver_failure \
+  resolver-resolution-source \
+  "resolved package source must match the authenticated lock registry source identity" \
+  --resolution-fixture "$temp_dir/resolver-resolution-source.json"
 
 echo "check-package-graph-boundary regression cases passed"

--- a/scripts/ci/test-report-compiler-source-monoliths.py
+++ b/scripts/ci/test-report-compiler-source-monoliths.py
@@ -42,6 +42,7 @@ class CompilerSourceMonolithTests(unittest.TestCase):
             write_lines(source_root / "cranelift_backend.rs", 5)
             write_lines(source_root / "diagnostics.rs", 1)
             write_lines(source_root / "hir.rs", 3)
+            write_lines(source_root / "package_trust.rs", 2)
             hir_dir = source_root / "hir"
             hir_dir.mkdir()
             write_lines(hir_dir / "generics.rs", 2)
@@ -57,14 +58,14 @@ class CompilerSourceMonolithTests(unittest.TestCase):
             write_lines(hir_dir / "symbols.rs", 1)
             write_lines(hir_dir / "types.rs", 1)
 
-            report = compiler_source_monoliths.build_report(source_root, top=15)
+            report = compiler_source_monoliths.build_report(source_root, top=16)
 
         self.assertEqual(report["schema_version"], "axiom.compiler_source.monoliths.v0")
         self.assertEqual(report["collected_at"], "2026-06-21T10:00:00Z")
-        self.assertEqual(report["summary"]["total_files"], 15)
-        self.assertEqual(report["summary"]["total_lines"], 22)
+        self.assertEqual(report["summary"]["total_files"], 16)
+        self.assertEqual(report["summary"]["total_lines"], 24)
         self.assertEqual(report["summary"]["largest_file_lines"], 5)
-        self.assertEqual(report["summary"]["top_file_lines"], 22)
+        self.assertEqual(report["summary"]["top_file_lines"], 24)
         self.assertEqual(report["summary"]["top_file_line_share"], 1.0)
         boundaries_by_suffix = {
             Path(item["path"]).as_posix().removeprefix(source_root.as_posix() + "/"): item[
@@ -76,6 +77,9 @@ class CompilerSourceMonolithTests(unittest.TestCase):
             boundaries_by_suffix["cranelift_backend.rs"], ["compiler.backend.native"]
         )
         self.assertEqual(boundaries_by_suffix["diagnostics.rs"], ["compiler.diagnostics"])
+        self.assertEqual(
+            boundaries_by_suffix["package_trust.rs"], ["compiler.package_trust"]
+        )
         for path in [
             "hir.rs",
             "hir/capabilities.rs",

--- a/scripts/ci/test-toolchain-supply-chain.sh
+++ b/scripts/ci/test-toolchain-supply-chain.sh
@@ -143,19 +143,45 @@ grep -Fq 'cargo test --manifest-path "$manifest_path" -p axiomc --locked --test 
   exit 1
 }
 
+for resolver_test in \
+  'package_version::tests' \
+  'package_resolver::tests' \
+  'registry_client::tests' \
+  'package_archive::tests' \
+  'package_store::tests' \
+  'package_manager::tests' \
+  '--test package_resolver_cli'; do
+  grep -Fq -- "$resolver_test" "$script" || {
+    echo "supply-chain script must run the Package Resolver v1 test: $resolver_test" >&2
+    exit 1
+  }
+done
+
+grep -Fq 'check-package-graph-boundary.py" --json' "$script" || {
+  echo "supply-chain script must run the Package Graph boundary checker" >&2
+  exit 1
+}
+
+grep -Fq 'test-check-package-graph-boundary.sh' "$script" || {
+  echo "supply-chain script must run the Package Graph boundary regression suite" >&2
+  exit 1
+}
+
 if ! awk '
   /test-check-package-trust-contract\.sh/ { contract = NR }
   /--locked --lib package_trust::tests/ { core = NR }
   /--locked --lib registry::tests/ { registry = NR }
   /--locked --test package_trust_cli/ { cli = NR }
+  /package_version::tests/ { resolver = NR }
+  /test-check-package-graph-boundary\.sh/ { graph = NR }
   /cargo vet --manifest-path/ { vet = NR }
   /cargo build --manifest-path/ { build = NR }
   END {
     exit !(contract < core && core < registry && registry < cli &&
-           cli < vet && cli < build)
+           cli < resolver && resolver < graph && graph < vet && vet < build)
   }
 ' "$script"; then
-  echo "Package Trust Rust suites must run after contract checks and before vet/build" >&2
+  echo "Package Trust and Package Resolver suites must run after contract checks and before vet/build" >&2
   exit 1
 fi
 

--- a/stage1/compatibility/cli-surface-v1.json
+++ b/stage1/compatibility/cli-surface-v1.json
@@ -31,7 +31,10 @@
     "new",
     "parse",
     "pkg",
+    "pkg fetch",
     "pkg graph",
+    "pkg update",
+    "pkg vendor",
     "pkg verify",
     "publish",
     "registry-index",
@@ -65,6 +68,6 @@
     "failure": "nonzero"
   },
   "migration": {
-    "action": "Existing command invocations require no changes. To adopt Package Trust v1 verification, invoke axiomc pkg verify with the exact artifact and trust metadata paths plus --json, then handle exit 0 as trusted, exit 1 as rejected, and exit 2 as an operational failure."
+    "action": "Existing command invocations require no changes. To adopt registry dependencies, run axiomc pkg fetch to create the v2 lock and verified cache, use axiomc pkg update for explicit re-resolution, and run axiomc pkg vendor before cache-independent locked offline builds. Package Trust v1 remains available through axiomc pkg verify with exact artifact and trust metadata paths plus --json."
   }
 }

--- a/stage1/compatibility/fixtures/current/contract.json
+++ b/stage1/compatibility/fixtures/current/contract.json
@@ -122,7 +122,7 @@
           "path": "stage1/crates/axiomc/src/lockfile.rs",
           "role": "lockfile_runtime_parity",
           "selector": "LockfileV2 and validate_lockfile_v2",
-          "sha256": "7b15384d7d5299b51915fb4f985d83971bf5e7c4c7f8788728839682e85c73dc"
+          "sha256": "5d8d4422b12408dac5d4711948522d39e95863b51c538e1fd8d5777f1de28606"
         },
         {
           "path": "stage1/package-resolver/fixtures/lockfile-v2.json",

--- a/stage1/compatibility/fixtures/current/contract.json
+++ b/stage1/compatibility/fixtures/current/contract.json
@@ -10,7 +10,7 @@
       "sha256": "0a7df662030a201d7953255a50ad4a5355758bc0626faa44ba879cd1d4eee00f"
     }
   },
-  "contract_version": "0.3.0",
+  "contract_version": "0.4.0",
   "edition": {
     "id": "2026",
     "source": {
@@ -72,15 +72,15 @@
       "id": "axiom://cli/axiomc",
       "kind": "cli",
       "migration": {
-        "action": "Existing command invocations require no changes. To adopt Package Trust v1 verification, invoke axiomc pkg verify with the exact artifact and trust metadata paths plus --json, then handle exit 0 as trusted, exit 1 as rejected, and exit 2 as an operational failure."
+        "action": "Existing command invocations require no changes. To adopt registry dependencies, run axiomc pkg fetch to create the v2 lock and verified cache, use axiomc pkg update for explicit re-resolution, and run axiomc pkg vendor before cache-independent locked offline builds. Package Trust v1 remains available through axiomc pkg verify with exact artifact and trust metadata paths plus --json."
       },
-      "signature": "commands=bench,build,caps,caps diff,check,dap,doc,doctor,evidence,explain,fmt,generate,generate openapi,generate policy,generate runbook,generate sql,generate terraform,inspect,inspect artifacts,inspect effects,inspect graph,inspect intent,inspect symbols,lsp,migrate,mutation-report,new,parse,pkg,pkg graph,pkg verify,publish,registry-index,registry-serve,registry-validate,repair-plan,repl,run,semantic-diff,task-contract,test,trace,verification-plan,verify; command_semantic_digest=eb9bfe7d1fdd4d572ec7f0d33aa8c5e455c1cc8b13507daf52b634791bf6a98b; flags_status=experimental_partial; flags=--json is the versioned machine envelope opt-in where the command publishes JSON; command-specific optional flags remain additive.; exit=0 means the requested operation completed successfully; nonzero means diagnostics or an operational failure.; json=axiom.stage1.v1 for governed stage1 command payloads; command-specific schemas retain their own AxiOM schema IDs.",
+      "signature": "commands=bench,build,caps,caps diff,check,dap,doc,doctor,evidence,explain,fmt,generate,generate openapi,generate policy,generate runbook,generate sql,generate terraform,inspect,inspect artifacts,inspect effects,inspect graph,inspect intent,inspect symbols,lsp,migrate,mutation-report,new,parse,pkg,pkg fetch,pkg graph,pkg update,pkg vendor,pkg verify,publish,registry-index,registry-serve,registry-validate,repair-plan,repl,run,semantic-diff,task-contract,test,trace,verification-plan,verify; command_semantic_digest=af506b3fccca2c0b539655a6966fe364eaf25c9d486d30f3930ed5be963754ed; flags_status=experimental_partial; flags=--json is the versioned machine envelope opt-in where the command publishes JSON; command-specific optional flags remain additive.; exit=0 means the requested operation completed successfully; nonzero means diagnostics or an operational failure.; json=axiom.stage1.v1 for governed stage1 command payloads; command-specific schemas retain their own AxiOM schema IDs.",
       "sources": [
         {
           "path": "stage1/compatibility/cli-surface-v1.json",
           "role": "cli_public_surface",
           "selector": "command_paths,flags,exit_status,migration",
-          "sha256": "8972e6b09446133fefd800feae3214f26fd79766886e8232056f9dea473978e6"
+          "sha256": "07bbb71adee957f8137ffa45e8a76ed13cfb06e5bbe26d7e5bd245b414bd6409"
         },
         {
           "path": "stage1/compiler-contracts/schemas/axiom.stage1.command.schema.json",
@@ -92,37 +92,61 @@
           "path": "stage1/compiler-contracts/snapshots/capability-ledger.json",
           "role": "cli_top_level_parity",
           "selector": "commands[*].name",
-          "sha256": "d2e2a51a4874447b20d6bf5908f74b4c9cde2c8703c1d7fa2239483446a2c1e5"
+          "sha256": "b19f222c3fc1c4835cbc661b57cb430e1beaa7a4e1cabb7d356b9b4207e16178"
         },
         {
           "path": "stage1/crates/axiomc/src/main.rs",
           "role": "cli_command_graph_parity",
           "selector": "Command and nested command variant names",
-          "sha256": "f91ec6858dfea119ba89031989665237c0c6f9b4c1c36a75665c7c678ab06ef1"
+          "sha256": "af28b41a8db43be2b8df05259edbe800da349a895347754f240fda64af4494e9"
+        }
+      ],
+      "stability": "experimental",
+      "version": "0.3.0"
+    },
+    {
+      "id": "axiom://package/lockfile",
+      "kind": "package",
+      "migration": {
+        "action": "Path-only axiom.lock version 1 files remain supported. Before using registry dependencies, run axiomc pkg fetch without --locked to authenticate the registry graph and atomically replace the valid v1 file with axiom.lock version 2; thereafter use --locked --offline for exact cache or vendor replay."
+      },
+      "signature": "axiom.lock formats=1,2; v1_records=package(name,version,source); v2_fields=compatibility,edge,package,registry,roots,version; v2_semantic_digest=b67c3004db840786b81e1fe1fdc7fe63759b02fe4d3403f98029d4c7ce032875",
+      "sources": [
+        {
+          "path": "stage1/compatibility/fixtures/current/axiom.lock",
+          "role": "lockfile_v1_format",
+          "selector": "version,package[*]",
+          "sha256": "b84320f39f44d45319d8efd29d612922227bb8ed30111c2291df1f2ec98e1ea1"
+        },
+        {
+          "path": "stage1/crates/axiomc/src/lockfile.rs",
+          "role": "lockfile_runtime_parity",
+          "selector": "LockfileV2 and validate_lockfile_v2",
+          "sha256": "7b15384d7d5299b51915fb4f985d83971bf5e7c4c7f8788728839682e85c73dc"
+        },
+        {
+          "path": "stage1/package-resolver/fixtures/lockfile-v2.json",
+          "role": "lockfile_v2_fixture",
+          "selector": "version,compatibility,roots,registry,package,edge",
+          "sha256": "14ccb2579de4fc15e85dd2aa3217f068508fc32984de90dfab76ad8a20431d25"
+        },
+        {
+          "path": "stage1/schemas/axiom-lockfile-v2.schema.json",
+          "role": "lockfile_v2_schema",
+          "selector": "$id,required,properties,$defs",
+          "sha256": "d44a9455abdad5481647ca1fc17e23749b8f3930791b74d074622ad69a7ce821"
         }
       ],
       "stability": "experimental",
       "version": "0.2.0"
     },
     {
-      "id": "axiom://package/lockfile",
-      "kind": "package",
-      "signature": "axiom.lock format=1; records=package(name,version,source)",
-      "sources": [
-        {
-          "path": "stage1/compatibility/fixtures/current/axiom.lock",
-          "role": "lockfile_format",
-          "selector": "version,package[*]",
-          "sha256": "b84320f39f44d45319d8efd29d612922227bb8ed30111c2291df1f2ec98e1ea1"
-        }
-      ],
-      "stability": "experimental",
-      "version": "0.1.0"
-    },
-    {
       "id": "axiom://package/manifest",
       "kind": "package",
-      "signature": "axiom.toml schema=https://axiom.omt.global/schemas/axiom.toml.schema.json; semantic_digest=4887c917589982835dbecc5c3ef80657151df795384e7f3d3296f0028ad7da44; fields=build,capabilities,dependencies,package,publish,runtime,tests,workspace; edition_selector=unavailable",
+      "migration": {
+        "action": "Existing path dependencies remain valid. Registry consumers add one root [registry] table with index, trust_roots, and expectation paths, then use the closed registry dependency form with registry, namespace, package, and an exact or caret version requirement before running axiomc pkg fetch."
+      },
+      "signature": "axiom.toml schema=https://axiom.omt.global/schemas/axiom.toml.schema.json; semantic_digest=fe45690ed5f1217eb0a3461e106573f13d1159d2d694843f9be3c08ba0099b6d; fields=build,capabilities,dependencies,package,publish,registry,runtime,tests,workspace; edition_selector=unavailable",
       "sources": [
         {
           "path": "stage1/compatibility/manifest-parser-contract-v1.json",
@@ -134,17 +158,17 @@
           "path": "stage1/crates/axiomc/src/manifest.rs",
           "role": "package_manifest_parser_parity",
           "selector": "RawManifest and closed nested manifest structures",
-          "sha256": "42a7342967a349740ab926cda964573918bfb81a953576070def305b7cbf4f5d"
+          "sha256": "f32ccf07ed766e9882418d311252b9c959725f37145723f6c9aeab2e46e09bef"
         },
         {
           "path": "stage1/schemas/axiom.toml.schema.json",
           "role": "package_manifest_schema",
           "selector": "$id,properties",
-          "sha256": "8fb6c6060461c8209bb2153382f17333b390f8ba4468027c7d395bf7f59cce36"
+          "sha256": "de567ce7d89ae36558c21922ea61d661f9f372ccd194365bfba5d7d4b756147f"
         }
       ],
       "stability": "experimental",
-      "version": "0.1.0"
+      "version": "0.2.0"
     },
     {
       "id": "axiom://abi/direct-native",
@@ -471,6 +495,21 @@
       "version": "0.1.0"
     },
     {
+      "id": "axiom://schema/axiom-lockfile-v2",
+      "kind": "schema",
+      "signature": "published schema id=https://axiom.omt.global/schemas/axiom-lockfile-v2.schema.json; semantic_digest=3424594f8680260992489db04b9c6c8b33b9481405fe7b57f642d61de8d7ebe0",
+      "sources": [
+        {
+          "path": "stage1/schemas/axiom-lockfile-v2.schema.json",
+          "role": "published_schema",
+          "selector": "$id,properties.schema_version.const",
+          "sha256": "d44a9455abdad5481647ca1fc17e23749b8f3930791b74d074622ad69a7ce821"
+        }
+      ],
+      "stability": "experimental",
+      "version": "0.1.0"
+    },
+    {
       "id": "axiom://schema/axiom-migration-plan-v1",
       "kind": "schema",
       "signature": "published schema id=https://axiom.omt.global/schemas/axiom-migration-plan-v1.schema.json; semantic_digest=1518655714913cf15ebb972a5c75ac44d58e1d8b218e62960e4c7444160b3692; envelope=axiom.migration_plan.v1",
@@ -480,6 +519,21 @@
           "role": "published_schema",
           "selector": "$id,properties.schema_version.const",
           "sha256": "04743eba1c1fce01897584889ccb3be27d25663a9d61c62a182b26407d30bb1d"
+        }
+      ],
+      "stability": "experimental",
+      "version": "0.1.0"
+    },
+    {
+      "id": "axiom://schema/axiom-package-resolution-v1",
+      "kind": "schema",
+      "signature": "published schema id=https://axiom.omt.global/schemas/axiom-package-resolution-v1.schema.json; semantic_digest=9c24007cb13342afdade9ad9476dc8a61f751821c71875eea806664cc0055484; envelope=axiom.package_resolution.v1",
+      "sources": [
+        {
+          "path": "stage1/schemas/axiom-package-resolution-v1.schema.json",
+          "role": "published_schema",
+          "selector": "$id,properties.schema_version.const",
+          "sha256": "8dc630ab260a6afd397ca0d0aab70f985f6b6de8ec6ebe701577154db90db233"
         }
       ],
       "stability": "experimental",
@@ -861,6 +915,21 @@
       "version": "0.1.0"
     },
     {
+      "id": "axiom://schema/axiom.compiler.package_graph.runtime.v1",
+      "kind": "schema",
+      "signature": "published schema id=https://omt-global.github.io/axiom/schemas/axiom.compiler.package_graph.runtime.v1.schema.json; semantic_digest=dc2b6a6aceaf28537fb85c72c76bbf6a805e78f6abe9dd43a20f561152d7ecd3; envelope=axiom.compiler.package_graph.runtime.v1",
+      "sources": [
+        {
+          "path": "stage1/compiler-contracts/schemas/axiom.compiler.package_graph.runtime.v1.schema.json",
+          "role": "published_schema",
+          "selector": "$id,properties.schema_version.const",
+          "sha256": "707ee3a51df91c3aefee6f56400c9396b4a20f94b59b73c6d8920201847e54ef"
+        }
+      ],
+      "stability": "experimental",
+      "version": "0.1.0"
+    },
+    {
       "id": "axiom://schema/axiom.compiler.package_graph.v1",
       "kind": "schema",
       "signature": "published schema id=https://omt-global.github.io/axiom/schemas/axiom.compiler.package_graph.v1.schema.json; semantic_digest=95e1b46d56ad3b842a9280c2e4fdf6044db220bd99442f1fe7df40a819ca7f5e; envelope=axiom.compiler.package_graph.v1",
@@ -987,15 +1056,15 @@
       "id": "axiom://schema/axiom.stage1.v1",
       "kind": "schema",
       "migration": {
-        "action": "Update consumers to understand the new diagnostic and lowering fields before consuming axiom.stage1.v1 envelopes."
+        "action": "Update consumers to understand the new diagnostic and lowering fields plus the optional structured trace and resolver fields before consuming axiom.stage1.v1 envelopes."
       },
-      "signature": "published schema id=https://axiom.omt.global/schemas/axiom.stage1.v1.schema.json; semantic_digest=a86e98c6693d21c7d4613a5f77930a82beaa41c3e1e8f4b566f70c52ff117326; envelope=axiom.stage1.v1",
+      "signature": "published schema id=https://axiom.omt.global/schemas/axiom.stage1.v1.schema.json; semantic_digest=417176c8832c77f390d1487dd84afe16b1ee04175ed612a64e62ee32378cdf93; envelope=axiom.stage1.v1",
       "sources": [
         {
           "path": "stage1/schemas/axiom.stage1.v1.schema.json",
           "role": "published_schema",
           "selector": "$id,properties.schema_version.const",
-          "sha256": "717476ad335ddc4243ec1d747ffe041cc1b30372758e819a4bbb29873e831a67"
+          "sha256": "9970368648e147e199942df3c0202be397e5e3284241bb1f670938004fb96c78"
         }
       ],
       "stability": "experimental",
@@ -1004,17 +1073,20 @@
     {
       "id": "axiom://schema/axiom.toml",
       "kind": "schema",
-      "signature": "published schema id=https://axiom.omt.global/schemas/axiom.toml.schema.json; semantic_digest=4b082a2037f1d1579235773ed158f67c05b151f737c9bdf72e55b76f2be425cb",
+      "migration": {
+        "action": "Existing path-only manifests remain valid. To adopt registry dependencies, add the root registry configuration and use the closed registry dependency object documented by the 0.2 schema, then run axiomc pkg fetch to create axiom.lock version 2."
+      },
+      "signature": "published schema id=https://axiom.omt.global/schemas/axiom.toml.schema.json; semantic_digest=e0d385251a6ba1c8aae6ff2641e89cb5e29d8ceba0d724f07bf7ba2f7a621e8a",
       "sources": [
         {
           "path": "stage1/schemas/axiom.toml.schema.json",
           "role": "published_schema",
           "selector": "$id,properties.schema_version.const",
-          "sha256": "8fb6c6060461c8209bb2153382f17333b390f8ba4468027c7d395bf7f59cce36"
+          "sha256": "de567ce7d89ae36558c21922ea61d661f9f372ccd194365bfba5d7d4b756147f"
         }
       ],
       "stability": "experimental",
-      "version": "0.1.0"
+      "version": "0.2.0"
     },
     {
       "id": "axiom://artifact/envelope",

--- a/stage1/compatibility/source-inventory-v1.json
+++ b/stage1/compatibility/source-inventory-v1.json
@@ -1,10 +1,12 @@
 {
   "schema_version": "axiom.compatibility_source_inventory.v1",
-  "contract_version": "0.3.0",
+  "contract_version": "0.4.0",
   "surface_versions": {
     "default": "0.1.0",
     "overrides": {
-      "axiom://cli/axiomc": "0.2.0",
+      "axiom://cli/axiomc": "0.3.0",
+      "axiom://package/lockfile": "0.2.0",
+      "axiom://package/manifest": "0.2.0",
       "axiom://schema/axiom-build-lowering-evidence-v1": "0.2.0",
       "axiom://schema/axiom-package-signature-v1": "0.2.0",
       "axiom://schema/axiom-package-verification-expectation-v1": "0.2.0",
@@ -12,7 +14,8 @@
       "axiom://schema/axiom-registry-index-v2": "0.2.0",
       "axiom://schema/axiom.stage1.command": "0.2.0",
       "axiom://schema/axiom.stage1.v1": "0.2.0",
-      "axiom://schema/axiom-trust-roots-v1": "0.2.0"
+      "axiom://schema/axiom-trust-roots-v1": "0.2.0",
+      "axiom://schema/axiom.toml": "0.2.0"
     }
   },
   "surface_migrations": {
@@ -23,7 +26,10 @@
       "action": "Update consumers to understand the new diagnostic and lowering fields before consuming axiom.stage1.command envelopes."
     },
     "axiom://schema/axiom.stage1.v1": {
-      "action": "Update consumers to understand the new diagnostic and lowering fields before consuming axiom.stage1.v1 envelopes."
+      "action": "Update consumers to understand the new diagnostic and lowering fields plus the optional structured trace and resolver fields before consuming axiom.stage1.v1 envelopes."
+    },
+    "axiom://schema/axiom.toml": {
+      "action": "Existing path-only manifests remain valid. To adopt registry dependencies, add the root registry configuration and use the closed registry dependency object documented by the 0.2 schema, then run axiomc pkg fetch to create axiom.lock version 2."
     }
   },
   "snapshot_id": "axiom://compatibility/current-source-contract",
@@ -60,12 +66,21 @@
       "path": "stage1/schemas/axiom.toml.schema.json",
       "extractor": "package_manifest",
       "implementation": "stage1/crates/axiomc/src/manifest.rs",
-      "parser_contract": "stage1/compatibility/manifest-parser-contract-v1.json"
+      "parser_contract": "stage1/compatibility/manifest-parser-contract-v1.json",
+      "migration": {
+        "action": "Existing path dependencies remain valid. Registry consumers add one root [registry] table with index, trust_roots, and expectation paths, then use the closed registry dependency form with registry, namespace, package, and an exact or caret version requirement before running axiomc pkg fetch."
+      }
     },
     {
       "kind": "package",
       "path": "stage1/compatibility/fixtures/current/axiom.lock",
-      "extractor": "lockfile"
+      "extractor": "lockfile",
+      "schema_v2": "stage1/schemas/axiom-lockfile-v2.schema.json",
+      "fixture_v2": "stage1/package-resolver/fixtures/lockfile-v2.json",
+      "implementation": "stage1/crates/axiomc/src/lockfile.rs",
+      "migration": {
+        "action": "Path-only axiom.lock version 1 files remain supported. Before using registry dependencies, run axiomc pkg fetch without --locked to authenticate the registry graph and atomically replace the valid v1 file with axiom.lock version 2; thereafter use --locked --offline for exact cache or vendor replay."
+      }
     },
     {
       "kind": "abi",

--- a/stage1/compiler-contracts/schemas/axiom.compiler.package_graph.runtime.v1.schema.json
+++ b/stage1/compiler-contracts/schemas/axiom.compiler.package_graph.runtime.v1.schema.json
@@ -1,0 +1,538 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://omt-global.github.io/axiom/schemas/axiom.compiler.package_graph.runtime.v1.schema.json",
+  "title": "Axiom compiler runtime package graph",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "contract",
+    "manifest",
+    "packages"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "axiom.compiler.package_graph.runtime.v1"
+    },
+    "contract": {
+      "const": "compiler.package_graph.runtime"
+    },
+    "manifest": {
+      "$ref": "#/$defs/path"
+    },
+    "packages": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/package"
+      }
+    }
+  },
+  "$defs": {
+    "path": {
+      "type": "string",
+      "minLength": 1
+    },
+    "nullableString": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "package": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "root",
+        "manifest",
+        "name",
+        "version",
+        "workspace_only",
+        "entrypoint",
+        "capabilities",
+        "dependencies",
+        "members",
+        "lockfile"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "root": {
+          "$ref": "#/$defs/path"
+        },
+        "manifest": {
+          "$ref": "#/$defs/path"
+        },
+        "name": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "version": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "trust": {
+          "$ref": "#/$defs/trust"
+        },
+        "materialization": {
+          "$ref": "#/$defs/materialization"
+        },
+        "workspace_only": {
+          "type": "boolean"
+        },
+        "entrypoint": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "capabilities": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/capability"
+          }
+        },
+        "dependencies": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/dependency"
+          }
+        },
+        "members": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/member"
+          }
+        },
+        "lockfile": {
+          "$ref": "#/$defs/lockfile"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "anyOf": [
+              {
+                "required": [
+                  "id"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "pattern": "^registry:"
+                  }
+                }
+              },
+              {
+                "required": [
+                  "source"
+                ],
+                "properties": {
+                  "source": {
+                    "type": "string",
+                    "pattern": "^registry:"
+                  }
+                }
+              }
+            ]
+          },
+          "then": {
+            "required": [
+              "source",
+              "trust",
+              "materialization",
+              "lockfile"
+            ],
+            "properties": {
+              "source": {
+                "type": "string",
+                "pattern": "^registry:"
+              },
+              "materialization": {
+                "allOf": [
+                  {
+                    "$ref": "#/$defs/materialization"
+                  },
+                  {
+                    "properties": {
+                      "package_trust_verified": {
+                        "const": true
+                      }
+                    }
+                  }
+                ]
+              },
+              "lockfile": {
+                "allOf": [
+                  {
+                    "$ref": "#/$defs/lockfile"
+                  },
+                  {
+                    "required": [
+                      "version",
+                      "hash"
+                    ],
+                    "properties": {
+                      "version": {
+                        "const": 2
+                      },
+                      "hash": {
+                        "$ref": "#/$defs/sha256"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "dependency": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "path",
+        "package"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "path": {
+          "$ref": "#/$defs/path"
+        },
+        "package": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "package_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_kind": {
+          "enum": [
+            "path",
+            "registry"
+          ]
+        },
+        "requested": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "required": [
+              "source_kind"
+            ],
+            "properties": {
+              "source_kind": {
+                "const": "registry"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "package_id",
+              "source_kind",
+              "requested",
+              "reason"
+            ],
+            "properties": {
+              "package_id": {
+                "type": "string",
+                "pattern": "^registry:"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": [
+              "package_id"
+            ],
+            "properties": {
+              "package_id": {
+                "type": "string",
+                "pattern": "^registry:"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "package_id",
+              "source_kind",
+              "requested",
+              "reason"
+            ],
+            "properties": {
+              "source_kind": {
+                "const": "registry"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "member": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "package"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/$defs/path"
+        },
+        "package": {
+          "$ref": "#/$defs/nullableString"
+        }
+      }
+    },
+    "lockfile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "status"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/$defs/path"
+        },
+        "status": {
+          "enum": [
+            "current",
+            "stale"
+          ]
+        },
+        "version": {
+          "enum": [
+            1,
+            2
+          ]
+        },
+        "hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{16}([0-9a-f]{48})?$"
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "required": [
+              "version"
+            ],
+            "properties": {
+              "version": {
+                "const": 1
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "hash": {
+                "type": "string",
+                "pattern": "^[0-9a-f]{16}$"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": [
+              "version"
+            ],
+            "properties": {
+              "version": {
+                "const": 2
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "hash"
+            ],
+            "properties": {
+              "hash": {
+                "$ref": "#/$defs/sha256"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "capability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "enabled",
+        "description"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "deny_by_default": {
+          "type": "boolean"
+        },
+        "allowed": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "configured_root": {
+          "type": "string"
+        },
+        "effective_root": {
+          "$ref": "#/$defs/path"
+        },
+        "package_root": {
+          "$ref": "#/$defs/path"
+        },
+        "unsafe_unrestricted": {
+          "type": "boolean"
+        },
+        "unsafe_opt_in": {
+          "type": "boolean"
+        },
+        "unsafe_rationale": {
+          "type": "string"
+        },
+        "owner": {
+          "type": "string"
+        },
+        "rationale": {
+          "type": "string"
+        }
+      }
+    },
+    "trust": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "registry",
+        "registry_identity",
+        "source_identity",
+        "publisher_identity",
+        "archive_sha256",
+        "manifest_sha256",
+        "provenance_sha256",
+        "package_signature_sha256",
+        "index_sha256",
+        "verification_sha256",
+        "signer_key_ids",
+        "index_generation",
+        "index_sequence",
+        "index_transcript_sha256"
+      ],
+      "properties": {
+        "registry": {
+          "type": "string",
+          "minLength": 1
+        },
+        "registry_identity": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_identity": {
+          "type": "string",
+          "minLength": 1
+        },
+        "publisher_identity": {
+          "type": "string",
+          "minLength": 1
+        },
+        "archive_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "manifest_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "provenance_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "package_signature_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "index_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "verification_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "signer_key_ids": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "index_generation": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "index_sequence": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "index_transcript_sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "materialization": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source",
+        "content_key",
+        "package_trust_verified"
+      ],
+      "properties": {
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content_key": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "package_trust_verified": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/stage1/compiler-contracts/snapshots/capability-ledger.json
+++ b/stage1/compiler-contracts/snapshots/capability-ledger.json
@@ -972,8 +972,20 @@
     },
     {
       "evidenceTier": "static_spike",
+      "name": "https://axiom.omt.global/schemas/axiom-lockfile-v2.schema.json",
+      "source": "stage1/schemas/axiom-lockfile-v2.schema.json",
+      "status": "checked"
+    },
+    {
+      "evidenceTier": "static_spike",
       "name": "https://axiom.omt.global/schemas/axiom-migration-plan-v1.schema.json",
       "source": "stage1/schemas/axiom-migration-plan-v1.schema.json",
+      "status": "checked"
+    },
+    {
+      "evidenceTier": "static_spike",
+      "name": "https://axiom.omt.global/schemas/axiom-package-resolution-v1.schema.json",
+      "source": "stage1/schemas/axiom-package-resolution-v1.schema.json",
       "status": "checked"
     },
     {
@@ -1148,6 +1160,12 @@
       "evidenceTier": "static_spike",
       "name": "https://omt-global.github.io/axiom/schemas/axiom.compiler.mir_backend.v1.schema.json",
       "source": "stage1/compiler-contracts/schemas/axiom.compiler.mir_backend.v1.schema.json",
+      "status": "checked"
+    },
+    {
+      "evidenceTier": "static_spike",
+      "name": "https://omt-global.github.io/axiom/schemas/axiom.compiler.package_graph.runtime.v1.schema.json",
+      "source": "stage1/compiler-contracts/schemas/axiom.compiler.package_graph.runtime.v1.schema.json",
       "status": "checked"
     },
     {
@@ -1840,11 +1858,11 @@
       "direct_runtime": 2,
       "production_qualified": 0,
       "scaffold": 5,
-      "static_spike": 215,
+      "static_spike": 218,
       "unsupported": 5
     },
     "runtimeAbiRows": 34,
-    "schemas": 56,
+    "schemas": 59,
     "stdlibFunctions": 299,
     "stdlibModules": 34,
     "supportedNativeBackend": "cranelift"

--- a/stage1/compiler-contracts/snapshots/package-graph-runtime.json
+++ b/stage1/compiler-contracts/snapshots/package-graph-runtime.json
@@ -1,0 +1,83 @@
+{
+  "schema_version": "axiom.compiler.package_graph.runtime.v1",
+  "contract": "compiler.package_graph.runtime",
+  "manifest": "/workspace/axiom.toml",
+  "packages": [
+    {
+      "id": "path:.#app@0.1.0",
+      "root": "/workspace",
+      "manifest": "/workspace/axiom.toml",
+      "name": "app",
+      "version": "0.1.0",
+      "source": "path",
+      "materialization": {
+        "source": "path",
+        "content_key": null,
+        "package_trust_verified": true
+      },
+      "workspace_only": false,
+      "entrypoint": "/workspace/src/main.ax",
+      "capabilities": [],
+      "dependencies": [
+        {
+          "name": "dep",
+          "path": "/cache/sha256-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "package": "dep",
+          "package_id": "registry:default/acme/dep@1.2.3",
+          "source_kind": "registry",
+          "requested": "^1.2.0",
+          "reason": "highest_compatible"
+        }
+      ],
+      "members": [],
+      "lockfile": {
+        "path": "/workspace/axiom.lock",
+        "status": "current",
+        "version": 2,
+        "hash": "1111111111111111111111111111111111111111111111111111111111111111"
+      }
+    },
+    {
+      "id": "registry:default/acme/dep@1.2.3",
+      "root": "/cache/sha256-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "manifest": "/cache/sha256-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/axiom.toml",
+      "name": "dep",
+      "version": "1.2.3",
+      "source": "registry:default/acme/dep",
+      "trust": {
+        "registry": "default",
+        "registry_identity": "registry.example",
+        "source_identity": "registry-source.example",
+        "publisher_identity": "publisher.example",
+        "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "manifest_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "provenance_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "package_signature_sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+        "index_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+        "verification_sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+        "signer_key_ids": [
+          "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+        ],
+        "index_generation": 1,
+        "index_sequence": 2,
+        "index_transcript_sha256": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+      },
+      "materialization": {
+        "source": "cache",
+        "content_key": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "package_trust_verified": true
+      },
+      "workspace_only": false,
+      "entrypoint": "/cache/sha256-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/src/lib.ax",
+      "capabilities": [],
+      "dependencies": [],
+      "members": [],
+      "lockfile": {
+        "path": "/workspace/axiom.lock",
+        "status": "current",
+        "version": 2,
+        "hash": "1111111111111111111111111111111111111111111111111111111111111111"
+      }
+    }
+  ]
+}

--- a/stage1/crates/axiomc/src/diagnostics.rs
+++ b/stage1/crates/axiomc/src/diagnostics.rs
@@ -1,4 +1,6 @@
+use crate::package_resolver::TraceEvent;
 use serde::Serialize;
+use serde_json::Value;
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct DiagnosticRepair {
@@ -28,6 +30,10 @@ pub struct Diagnostic {
     pub related: Vec<Diagnostic>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub repair: Option<DiagnosticRepair>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub trace: Vec<TraceEvent>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolver: Option<Value>,
 }
 
 impl Diagnostic {
@@ -44,6 +50,8 @@ impl Diagnostic {
             end_column: None,
             related: Vec::new(),
             repair: None,
+            trace: Vec::new(),
+            resolver: None,
         }
     }
 
@@ -107,6 +115,16 @@ impl Diagnostic {
             edit: edit.map(Into::into),
             command: command.map(Into::into),
         });
+        self
+    }
+
+    pub fn with_package_resolution(
+        mut self,
+        trace: Vec<TraceEvent>,
+        resolver: Option<Value>,
+    ) -> Self {
+        self.trace = trace;
+        self.resolver = resolver;
         self
     }
 

--- a/stage1/crates/axiomc/src/intent_ir.rs
+++ b/stage1/crates/axiomc/src/intent_ir.rs
@@ -31,7 +31,9 @@ pub struct IntentIrDocument {
 
 impl IntentIrDocument {
     pub fn contains_node(&self, id: &str) -> bool {
-        self.nodes.binary_search_by(|node| node.id.as_str().cmp(id)).is_ok()
+        self.nodes
+            .binary_search_by(|node| node.id.as_str().cmp(id))
+            .is_ok()
     }
 
     pub fn node_id(&self, kind: &str, name: &str) -> Option<&str> {
@@ -241,16 +243,18 @@ fn emit_package(
 
     for (alias, dependency) in &manifest.dependencies {
         let id = child_id(&package, "dependency", alias);
-        graph.node(node(
-            &id,
-            "Dependency",
-            alias,
-            None,
-            object([
-                ("path", json!(normalize_text_path(&dependency.path))),
-                ("version", json!(dependency.version)),
-            ]),
-        ));
+        let mut metadata = object([("version", json!(dependency.version))]);
+        if let Some(path) = dependency.path_source() {
+            metadata.insert("source".into(), json!("path"));
+            metadata.insert("path".into(), json!(normalize_text_path(path)));
+        }
+        if let Some(registry) = dependency.registry_source() {
+            metadata.insert("source".into(), json!("registry"));
+            metadata.insert("registry".into(), json!(registry.registry));
+            metadata.insert("namespace".into(), json!(registry.namespace));
+            metadata.insert("package".into(), json!(registry.package));
+        }
+        graph.node(node(&id, "Dependency", alias, None, metadata));
         graph.edge(&package, "depends_on", &id);
     }
 
@@ -624,7 +628,10 @@ fn emit_decisions(
     graph: &mut Graph,
 ) -> Result<(), Diagnostic> {
     let mut paths = Vec::new();
-    for directory in [package_root.join("decisions"), package_root.join(".axiom/decisions")] {
+    for directory in [
+        package_root.join("decisions"),
+        package_root.join(".axiom/decisions"),
+    ] {
         if directory.is_dir() {
             paths.extend(regular_files(&directory)?);
         }
@@ -763,16 +770,15 @@ fn axiom_files(root: &Path) -> Result<Vec<PathBuf>, Diagnostic> {
         let entries = fs::read_dir(&directory)
             .map_err(|error| io_error("intent_ir_read_dir", &directory, error))?;
         for entry in entries {
-            let entry = entry
-                .map_err(|error| io_error("intent_ir_read_dir", &directory, error))?;
+            let entry = entry.map_err(|error| io_error("intent_ir_read_dir", &directory, error))?;
             let path = entry.path();
             if path.is_dir() {
                 let skipped = matches!(
                     path.file_name().and_then(|value| value.to_str()),
                     Some(".git" | "target")
                 );
-                let nested_package = path != root
-                    && path.join(crate::manifest::MANIFEST_FILENAME).is_file();
+                let nested_package =
+                    path != root && path.join(crate::manifest::MANIFEST_FILENAME).is_file();
                 if !skipped && !nested_package {
                     pending.push(path);
                 }
@@ -848,6 +854,7 @@ fn io_error(code: &'static str, path: &Path, error: std::io::Error) -> Diagnosti
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::tempdir;
 
     #[test]
     fn segments_are_stable_and_schema_safe() {
@@ -864,5 +871,60 @@ mod tests {
             normalize_text_path(r"src\\nested\\main.ax"),
             "src/nested/main.ax"
         );
+    }
+
+    #[test]
+    fn dependency_nodes_distinguish_path_and_registry_sources() {
+        let dir = tempdir().expect("tempdir");
+        let root = dir.path();
+        fs::create_dir_all(root.join("src")).expect("create source");
+        fs::write(
+            root.join(crate::manifest::MANIFEST_FILENAME),
+            r#"[package]
+name = "intent-dependencies"
+version = "0.1.0"
+
+[registry]
+name = "default"
+index = "file:///registry/index.json"
+trust_roots = "registry/trust-roots.json"
+expectation = "registry/expectation.json"
+
+[dependencies.local]
+path = "deps/local"
+version = "*"
+
+[dependencies.remote]
+registry = "default"
+namespace = "acme"
+package = "remote-core"
+version = "^1.2.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+"#,
+        )
+        .expect("write manifest");
+        fs::write(root.join("src/main.ax"), "print \"intent\"\n").expect("write source");
+
+        let document = emit_intent_ir(root).expect("emit intent IR");
+        let local = document
+            .nodes
+            .iter()
+            .find(|node| node.kind == "Dependency" && node.name == "local")
+            .expect("path dependency node");
+        assert_eq!(local.metadata.get("source"), Some(&json!("path")));
+        assert_eq!(local.metadata.get("path"), Some(&json!("deps/local")));
+        let remote = document
+            .nodes
+            .iter()
+            .find(|node| node.kind == "Dependency" && node.name == "remote")
+            .expect("registry dependency node");
+        assert_eq!(remote.metadata.get("source"), Some(&json!("registry")));
+        assert_eq!(remote.metadata.get("registry"), Some(&json!("default")));
+        assert_eq!(remote.metadata.get("namespace"), Some(&json!("acme")));
+        assert_eq!(remote.metadata.get("package"), Some(&json!("remote-core")));
+        assert!(!remote.metadata.contains_key("path"));
     }
 }

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -1,5 +1,6 @@
-pub mod agent_task; pub mod bounded_executor;
+pub mod agent_task;
 pub(crate) mod borrowck;
+pub mod bounded_executor;
 #[path = "project/build_contract.rs"]
 pub mod build_contract;
 pub mod codegen;
@@ -13,12 +14,23 @@ pub mod intent_ir;
 pub mod json_contract;
 pub mod lockfile;
 pub mod lsp;
-pub mod manifest; pub mod migration_plan;
+pub mod manifest;
+pub mod migration_plan;
 pub mod mir;
 pub mod new_project;
+pub mod package_archive;
+pub mod package_manager;
+pub mod package_resolver;
+pub mod package_store;
 pub mod package_trust;
+pub mod package_version;
 pub mod project;
 pub mod registry;
+pub mod registry_client;
 pub mod stdlib;
-pub mod syntax; pub mod transactional_workspace; pub mod verification_planner;
-#[cfg(test)] #[path = "../tests/support/lib_unit.rs"] mod tests;
+pub mod syntax;
+#[cfg(test)]
+#[path = "../tests/support/lib_unit.rs"]
+mod tests;
+pub mod transactional_workspace;
+pub mod verification_planner;

--- a/stage1/crates/axiomc/src/lockfile.rs
+++ b/stage1/crates/axiomc/src/lockfile.rs
@@ -1,9 +1,21 @@
 use crate::diagnostics::Diagnostic;
-use crate::manifest::{DependencySpec, Manifest, load_manifest, lockfile_path, manifest_path};
+use crate::manifest::{
+    DependencySpec, Manifest, is_supported_registry_index_url, load_manifest, lockfile_path,
+    manifest_path,
+};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
-use std::fs;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Read, Write};
 use std::path::{Component, Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+pub const LOCKFILE_V1_VERSION: u32 = 1;
+pub const LOCKFILE_V2_VERSION: u32 = 2;
+pub const REGISTRY_LOCKFILE_V2_REQUIRED: &str = "registry dependency graphs require axiom.lock version 2 under --locked; regenerate it with `axiomc pkg update`";
+const MAX_LOCKFILE_BYTES: usize = 4 * 1024 * 1024;
+static LOCKFILE_TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
@@ -20,9 +32,1273 @@ pub struct LockedPackage {
     pub source: String,
 }
 
+/// A strictly parsed lockfile without erasing its version-specific contract.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParsedLockfile {
+    V1(Lockfile),
+    V2(LockfileV2),
+}
+
+impl ParsedLockfile {
+    pub fn version(&self) -> u32 {
+        match self {
+            Self::V1(lockfile) => lockfile.version,
+            Self::V2(lockfile) => lockfile.version,
+        }
+    }
+
+    pub fn as_v1(&self) -> Option<&Lockfile> {
+        match self {
+            Self::V1(lockfile) => Some(lockfile),
+            Self::V2(_) => None,
+        }
+    }
+
+    pub fn as_v2(&self) -> Option<&LockfileV2> {
+        match self {
+            Self::V1(_) => None,
+            Self::V2(lockfile) => Some(lockfile),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct LockfileV2 {
+    pub version: u32,
+    pub compatibility: LockedCompatibilityEvidence,
+    /// Entry packages whose dependency closures form the complete graph.
+    pub roots: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub registry: Vec<LockedRegistryV2>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub package: Vec<LockedPackageV2>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub edge: Vec<LockedDependencyEdgeV2>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct LockedCompatibilityEvidence {
+    pub contract: String,
+    pub compiler: String,
+    pub edition_policy: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct LockedRegistryV2 {
+    pub name: String,
+    pub source: String,
+    pub registry_identity: String,
+    pub source_identity: String,
+    /// SHA-256 of the exact trust-roots envelope bytes.
+    pub trust_roots_sha256: String,
+    /// SHA-256 of the exact verification-expectation bytes.
+    pub expectation_sha256: String,
+    /// Pins for the current candidate root authenticated from that envelope.
+    pub current_root_version: u64,
+    pub current_root_sequence: u64,
+    pub current_root_transcript_sha256: String,
+    pub index_sha256: String,
+    pub index_transcript_sha256: String,
+    pub index_generation: u64,
+    pub index_sequence: u64,
+    pub index_snapshot_id: String,
+    pub index_signer_key_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct LockedPackageV2 {
+    pub id: String,
+    pub name: String,
+    pub version: String,
+    pub source: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub registry: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub namespace: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub archive_sha256: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub archive_length: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub manifest_sha256: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provenance_sha256: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub package_signature_sha256: Option<String>,
+    /// SHA-256 of the exact Package Trust verification-result bytes.
+    ///
+    /// Together with the registry index digest this selects one immutable
+    /// evidence version for the content-addressed archive.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verification_sha256: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub publisher_identity: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub signer_key_ids: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub yanked_at_resolution: Option<bool>,
+    pub compatibility: LockedCompatibilityEvidence,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum LockedDependencySourceKind {
+    Path,
+    Registry,
+}
+
+impl LockedDependencySourceKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Path => "path",
+            Self::Registry => "registry",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum LockedDependencyReason {
+    RootPathConstraint,
+    TransitivePathConstraint,
+    HighestCompatible,
+    ExactLockedReplay,
+    TrustedYankedLockedReplay,
+}
+
+impl LockedDependencyReason {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::RootPathConstraint => "root_path_constraint",
+            Self::TransitivePathConstraint => "transitive_path_constraint",
+            Self::HighestCompatible => "highest_compatible",
+            Self::ExactLockedReplay => "exact_locked_replay",
+            Self::TrustedYankedLockedReplay => "trusted_yanked_locked_replay",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct LockedDependencyEdgeV2 {
+    pub from: String,
+    pub to: String,
+    pub alias: String,
+    pub requested: String,
+    pub source_kind: LockedDependencySourceKind,
+    pub reason: LockedDependencyReason,
+}
+
+pub fn parse_lockfile_exact(
+    content: &[u8],
+    source_path: &Path,
+) -> Result<ParsedLockfile, Diagnostic> {
+    if content.len() > MAX_LOCKFILE_BYTES {
+        return Err(lockfile_error(
+            source_path,
+            format!(
+                "axiom.lock exceeds the {} byte parsing limit",
+                MAX_LOCKFILE_BYTES
+            ),
+        ));
+    }
+    let content = std::str::from_utf8(content)
+        .map_err(|err| lockfile_error(source_path, format!("axiom.lock is not UTF-8: {err}")))?;
+    let value: toml::Value = toml::from_str(content)
+        .map_err(|err| lockfile_error(source_path, format!("invalid axiom.lock: {err}")))?;
+    let version = value
+        .as_table()
+        .and_then(|table| table.get("version"))
+        .and_then(toml::Value::as_integer)
+        .and_then(|value| u32::try_from(value).ok())
+        .ok_or_else(|| {
+            lockfile_error(
+                source_path,
+                "invalid axiom.lock: version must be an unsigned integer",
+            )
+        })?;
+    match version {
+        LOCKFILE_V1_VERSION => {
+            let lockfile: Lockfile = toml::from_str(content).map_err(|err| {
+                lockfile_error(source_path, format!("invalid axiom.lock v1: {err}"))
+            })?;
+            validate_lockfile_v1_model(&lockfile, source_path)?;
+            Ok(ParsedLockfile::V1(lockfile))
+        }
+        LOCKFILE_V2_VERSION => {
+            let lockfile: LockfileV2 = toml::from_str(content).map_err(|err| {
+                lockfile_error(source_path, format!("invalid axiom.lock v2: {err}"))
+            })?;
+            validate_lockfile_v2_at(&lockfile, source_path)?;
+            Ok(ParsedLockfile::V2(lockfile))
+        }
+        other => Err(lockfile_error(
+            source_path,
+            format!(
+                "unsupported axiom.lock version {other}; supported versions are {LOCKFILE_V1_VERSION} and {LOCKFILE_V2_VERSION}"
+            ),
+        )),
+    }
+}
+
+pub fn load_lockfile(project_root: &Path) -> Result<ParsedLockfile, Diagnostic> {
+    load_lockfile_with_sha256(project_root).map(|(lockfile, _sha256)| lockfile)
+}
+
+/// Securely load, parse, and hash the exact bytes of `axiom.lock`.
+///
+/// The digest and parsed model are derived from the same bounded descriptor
+/// read so callers can carry an exact validated lock identity without racing a
+/// second filesystem read.
+pub fn load_lockfile_with_sha256(
+    project_root: &Path,
+) -> Result<(ParsedLockfile, String), Diagnostic> {
+    let path = lockfile_path(project_root);
+    let content = read_lockfile_bounded(&path)?;
+    let sha256 = format!("{:x}", Sha256::digest(&content));
+    let lockfile = parse_lockfile_exact(&content, &path)?;
+    Ok((lockfile, sha256))
+}
+
+#[cfg(unix)]
+fn open_lockfile_no_follow(path: &Path) -> io::Result<File> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    OpenOptions::new()
+        .read(true)
+        // O_NOFOLLOW closes the final-component symlink race, O_NONBLOCK
+        // prevents a swapped FIFO from blocking before descriptor validation,
+        // and O_CLOEXEC avoids inheritance into compiler subprocesses.
+        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_CLOEXEC)
+        .open(path)
+}
+
+#[cfg(windows)]
+fn open_lockfile_no_follow(path: &Path) -> io::Result<File> {
+    use std::os::windows::fs::OpenOptionsExt;
+
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    OpenOptions::new()
+        .read(true)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn open_lockfile_no_follow(_path: &Path) -> io::Result<File> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "secure axiom.lock loading requires descriptor-level no-follow support",
+    ))
+}
+
+fn read_lockfile_bounded(path: &Path) -> Result<Vec<u8>, Diagnostic> {
+    try_read_lockfile_bounded(path)?.ok_or_else(|| {
+        lockfile_error(
+            path,
+            "failed to securely open axiom.lock: file does not exist",
+        )
+    })
+}
+
+fn try_read_lockfile_bounded(path: &Path) -> Result<Option<Vec<u8>>, Diagnostic> {
+    let mut file = match open_lockfile_no_follow(path) {
+        Ok(file) => file,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => {
+            return Err(lockfile_error(
+                path,
+                format!("failed to securely open axiom.lock: {err}"),
+            ));
+        }
+    };
+    let metadata = file.metadata().map_err(|err| {
+        lockfile_error(path, format!("failed to inspect opened axiom.lock: {err}"))
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(lockfile_error(
+            path,
+            "axiom.lock must be a regular non-symlink file",
+        ));
+    }
+    if metadata.len() > MAX_LOCKFILE_BYTES as u64 {
+        return Err(lockfile_error(
+            path,
+            format!(
+                "axiom.lock exceeds the {} byte parsing limit",
+                MAX_LOCKFILE_BYTES
+            ),
+        ));
+    }
+
+    let mut content = Vec::with_capacity(metadata.len() as usize);
+    (&mut file)
+        .take(MAX_LOCKFILE_BYTES as u64 + 1)
+        .read_to_end(&mut content)
+        .map_err(|err| lockfile_error(path, format!("failed to read opened axiom.lock: {err}")))?;
+    if content.len() > MAX_LOCKFILE_BYTES {
+        return Err(lockfile_error(
+            path,
+            format!(
+                "axiom.lock exceeds the {} byte parsing limit",
+                MAX_LOCKFILE_BYTES
+            ),
+        ));
+    }
+    Ok(Some(content))
+}
+
+fn exact_lockfile_sha256(path: &Path) -> Result<Option<String>, Diagnostic> {
+    try_read_lockfile_bounded(path)
+        .map(|content| content.map(|content| format!("{:x}", Sha256::digest(content))))
+}
+
+pub fn render_lockfile_v2(lockfile: &LockfileV2) -> Result<String, Diagnostic> {
+    validate_lockfile_v2(lockfile)?;
+    let mut rendered = toml::to_string_pretty(lockfile).map_err(|err| {
+        Diagnostic::new("lockfile", format!("failed to render axiom.lock v2: {err}"))
+    })?;
+    if !rendered.ends_with('\n') {
+        rendered.push('\n');
+    }
+    Ok(rendered)
+}
+
+pub fn validate_lockfile_v2(lockfile: &LockfileV2) -> Result<(), Diagnostic> {
+    validate_lockfile_v2_at(lockfile, Path::new("axiom.lock"))
+}
+
+pub fn write_lockfile_v2_atomic(
+    project_root: &Path,
+    lockfile: &LockfileV2,
+) -> Result<(), Diagnostic> {
+    let target = lockfile_path(project_root);
+    let expected_sha256 = exact_lockfile_sha256(&target)?;
+    write_lockfile_v2_atomic_cas(project_root, lockfile, expected_sha256.as_deref())
+}
+
+/// Atomically replace `axiom.lock` only if its exact bytes still match the
+/// caller's previously observed state.
+///
+/// `Some(digest)` requires an existing lockfile with that lowercase SHA-256;
+/// `None` requires the lockfile to remain absent.
+pub fn write_lockfile_v2_atomic_cas(
+    project_root: &Path,
+    lockfile: &LockfileV2,
+    expected_sha256: Option<&str>,
+) -> Result<(), Diagnostic> {
+    write_lockfile_v2_atomic_cas_impl(project_root, lockfile, expected_sha256, || Ok(()))
+}
+
+fn write_lockfile_v2_atomic_cas_impl(
+    project_root: &Path,
+    lockfile: &LockfileV2,
+    expected_sha256: Option<&str>,
+    before_compare: impl FnOnce() -> Result<(), Diagnostic>,
+) -> Result<(), Diagnostic> {
+    let target = lockfile_path(project_root);
+    if let Some(expected_sha256) = expected_sha256 {
+        validate_sha256(&target, "expected axiom.lock SHA-256", expected_sha256)?;
+    }
+    let rendered = render_lockfile_v2(lockfile)?;
+    let parent = target.parent().unwrap_or(project_root);
+    let mut temporary = None;
+    for _ in 0..64 {
+        let sequence = LOCKFILE_TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let candidate = parent.join(format!(
+            ".axiom.lock.tmp.{}.{}",
+            std::process::id(),
+            sequence
+        ));
+        match OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&candidate)
+        {
+            Ok(file) => {
+                temporary = Some((candidate, file));
+                break;
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(err) => {
+                return Err(lockfile_error(
+                    &target,
+                    format!("failed to create temporary axiom.lock: {err}"),
+                ));
+            }
+        }
+    }
+    let Some((temporary_path, mut temporary_file)) = temporary else {
+        return Err(lockfile_error(
+            &target,
+            "failed to allocate a unique temporary axiom.lock",
+        ));
+    };
+    let result = (|| {
+        temporary_file
+            .write_all(rendered.as_bytes())
+            .map_err(|err| {
+                lockfile_error(
+                    &target,
+                    format!("failed to write temporary axiom.lock: {err}"),
+                )
+            })?;
+        temporary_file.sync_all().map_err(|err| {
+            lockfile_error(
+                &target,
+                format!("failed to sync temporary axiom.lock: {err}"),
+            )
+        })?;
+        drop(temporary_file);
+        before_compare()?;
+        let observed_sha256 = exact_lockfile_sha256(&target)?;
+        let unchanged = match (expected_sha256, observed_sha256.as_deref()) {
+            (None, None) => true,
+            (Some(expected), Some(observed)) => expected == observed,
+            _ => false,
+        };
+        if !unchanged {
+            return Err(lockfile_error(
+                &target,
+                "axiom.lock changed while package resolution was in progress; refusing to overwrite it",
+            ));
+        }
+        fs::rename(&temporary_path, &target).map_err(|err| {
+            lockfile_error(&target, format!("failed to replace axiom.lock: {err}"))
+        })?;
+        if let Ok(directory) = fs::File::open(parent) {
+            directory.sync_all().map_err(|err| {
+                lockfile_error(
+                    &target,
+                    format!("failed to sync axiom.lock directory: {err}"),
+                )
+            })?;
+        }
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary_path);
+    }
+    result
+}
+
+pub fn validate_lockfile_version_for_manifest(
+    manifest: &Manifest,
+    lockfile: &ParsedLockfile,
+) -> Result<(), Diagnostic> {
+    let has_registry_dependency = manifest
+        .dependencies
+        .values()
+        .any(DependencySpec::is_registry);
+    if has_registry_dependency && !matches!(lockfile, ParsedLockfile::V2(_)) {
+        return Err(Diagnostic::new("lockfile", REGISTRY_LOCKFILE_V2_REQUIRED));
+    }
+    if !has_registry_dependency && matches!(lockfile, ParsedLockfile::V2(_)) {
+        // A v2 lock remains valid for path-only graphs; this is required for a
+        // stable migration and for workspaces that temporarily remove their
+        // last registry dependency.
+        return Ok(());
+    }
+    Ok(())
+}
+
+pub fn canonical_registry_package_id(
+    registry: &str,
+    namespace: &str,
+    package: &str,
+    version: &str,
+) -> String {
+    format!("registry:{registry}/{namespace}/{package}@{version}")
+}
+
+pub fn canonical_path_package_id(source: &str, package: &str, version: &str) -> String {
+    let source = source.strip_prefix("path:").unwrap_or(source);
+    let source = if source == "path" || source.is_empty() {
+        "."
+    } else {
+        source
+    };
+    format!("path:{source}#{package}@{version}")
+}
+
+fn validate_lockfile_v1_model(lockfile: &Lockfile, path: &Path) -> Result<(), Diagnostic> {
+    if lockfile.version != LOCKFILE_V1_VERSION {
+        return Err(lockfile_error(
+            path,
+            format!("axiom.lock v1 parser received version {}", lockfile.version),
+        ));
+    }
+    let mut names = BTreeSet::new();
+    for package in &lockfile.package {
+        require_nonempty(path, "package.name", &package.name)?;
+        require_nonempty(path, "package.version", &package.version)?;
+        validate_path_source(path, &package.source)?;
+        if !names.insert(package.name.as_str()) {
+            return Err(lockfile_error(
+                path,
+                format!("duplicate axiom.lock v1 package name {:?}", package.name),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_lockfile_v2_at(lockfile: &LockfileV2, path: &Path) -> Result<(), Diagnostic> {
+    if lockfile.version != LOCKFILE_V2_VERSION {
+        return Err(lockfile_error(
+            path,
+            format!(
+                "axiom.lock v2 requires version {LOCKFILE_V2_VERSION}, got {}",
+                lockfile.version
+            ),
+        ));
+    }
+    validate_compatibility(path, "compatibility", &lockfile.compatibility)?;
+
+    let registry_names = lockfile
+        .registry
+        .iter()
+        .map(|registry| registry.name.as_str())
+        .collect::<Vec<_>>();
+    require_strictly_sorted(path, "registry records", &registry_names)?;
+    let mut registry_identities = BTreeSet::new();
+    for registry in &lockfile.registry {
+        validate_coordinate(path, "registry.name", &registry.name)?;
+        if !is_supported_registry_index_url(&registry.source) {
+            return Err(lockfile_error(
+                path,
+                format!(
+                    "registry {:?} has unsupported or non-canonical source {:?}",
+                    registry.name, registry.source
+                ),
+            ));
+        }
+        require_nonempty(
+            path,
+            "registry.registry_identity",
+            &registry.registry_identity,
+        )?;
+        require_nonempty(path, "registry.source_identity", &registry.source_identity)?;
+        validate_sha256(
+            path,
+            "registry.trust_roots_sha256",
+            &registry.trust_roots_sha256,
+        )?;
+        validate_sha256(
+            path,
+            "registry.expectation_sha256",
+            &registry.expectation_sha256,
+        )?;
+        validate_sha256(
+            path,
+            "registry.current_root_transcript_sha256",
+            &registry.current_root_transcript_sha256,
+        )?;
+        validate_sha256(path, "registry.index_sha256", &registry.index_sha256)?;
+        validate_sha256(
+            path,
+            "registry.index_transcript_sha256",
+            &registry.index_transcript_sha256,
+        )?;
+        if registry.current_root_version == 0
+            || registry.current_root_sequence == 0
+            || registry.index_generation == 0
+            || registry.index_sequence == 0
+        {
+            return Err(lockfile_error(
+                path,
+                format!(
+                    "registry {:?} root/index version and sequence pins must be greater than zero",
+                    registry.name
+                ),
+            ));
+        }
+        require_nonempty(
+            path,
+            "registry.index_snapshot_id",
+            &registry.index_snapshot_id,
+        )?;
+        if registry.index_signer_key_ids.is_empty() {
+            return Err(lockfile_error(
+                path,
+                format!(
+                    "registry {:?} index_signer_key_ids must not be empty",
+                    registry.name
+                ),
+            ));
+        }
+        require_strictly_sorted(
+            path,
+            "registry index_signer_key_ids",
+            &registry
+                .index_signer_key_ids
+                .iter()
+                .map(String::as_str)
+                .collect::<Vec<_>>(),
+        )?;
+        for signer in &registry.index_signer_key_ids {
+            validate_key_id(path, "registry.index_signer_key_ids", signer)?;
+        }
+        if !registry_identities.insert((
+            registry.registry_identity.as_str(),
+            registry.source_identity.as_str(),
+        )) {
+            return Err(lockfile_error(
+                path,
+                "duplicate registry/source identity pair",
+            ));
+        }
+    }
+    let configured_registries = lockfile
+        .registry
+        .iter()
+        .map(|registry| registry.name.as_str())
+        .collect::<BTreeSet<_>>();
+
+    let package_ids = lockfile
+        .package
+        .iter()
+        .map(|package| package.id.as_str())
+        .collect::<Vec<_>>();
+    require_strictly_sorted(path, "package records", &package_ids)?;
+    let known_packages = package_ids.iter().copied().collect::<BTreeSet<_>>();
+    let mut registry_coordinates = BTreeSet::new();
+    for package in &lockfile.package {
+        validate_locked_package_v2(path, package, &configured_registries)?;
+        if let (Some(registry), Some(namespace)) =
+            (package.registry.as_deref(), package.namespace.as_deref())
+            && !registry_coordinates.insert((registry, namespace, package.name.as_str()))
+        {
+            return Err(lockfile_error(
+                path,
+                format!(
+                    "axiom.lock v2 selects multiple versions for registry coordinate {registry}/{namespace}/{}",
+                    package.name
+                ),
+            ));
+        }
+    }
+    if lockfile.roots.is_empty() {
+        return Err(lockfile_error(
+            path,
+            "axiom.lock v2 roots must contain at least one entry package id",
+        ));
+    }
+    require_strictly_sorted(
+        path,
+        "root package ids",
+        &lockfile
+            .roots
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>(),
+    )?;
+    for root in &lockfile.roots {
+        if !known_packages.contains(root.as_str()) {
+            return Err(lockfile_error(
+                path,
+                format!("axiom.lock v2 root {root:?} is absent from package records"),
+            ));
+        }
+        let root_package = lockfile
+            .package
+            .binary_search_by(|package| package.id.as_str().cmp(root.as_str()))
+            .ok()
+            .map(|index| &lockfile.package[index])
+            .expect("known root package id was checked above");
+        if !root_package.source.starts_with("path") {
+            return Err(lockfile_error(
+                path,
+                format!("axiom.lock v2 root {root:?} must identify a path package"),
+            ));
+        }
+    }
+
+    let edge_keys = lockfile.edge.iter().map(edge_order_key).collect::<Vec<_>>();
+    require_strictly_sorted(path, "dependency edge records", &edge_keys)?;
+    let mut aliases = BTreeSet::new();
+    for edge in &lockfile.edge {
+        if !known_packages.contains(edge.from.as_str())
+            || !known_packages.contains(edge.to.as_str())
+        {
+            return Err(lockfile_error(
+                path,
+                format!(
+                    "dependency edge {:?} -> {:?} references a package id absent from axiom.lock",
+                    edge.from, edge.to
+                ),
+            ));
+        }
+        validate_portable_name(path, "edge.alias", &edge.alias)?;
+        validate_constraint(path, "edge.requested", &edge.requested, true)?;
+        if !aliases.insert((edge.from.as_str(), edge.alias.as_str())) {
+            return Err(lockfile_error(
+                path,
+                format!(
+                    "duplicate dependency alias {:?} from package {:?}",
+                    edge.alias, edge.from
+                ),
+            ));
+        }
+        let target = lockfile
+            .package
+            .binary_search_by(|package| package.id.as_str().cmp(edge.to.as_str()))
+            .ok()
+            .map(|index| &lockfile.package[index])
+            .expect("known package id was checked above");
+        match edge.source_kind {
+            LockedDependencySourceKind::Path if !target.source.starts_with("path") => {
+                return Err(lockfile_error(
+                    path,
+                    format!(
+                        "path dependency edge {:?} targets non-path source {:?}",
+                        edge.alias, target.source
+                    ),
+                ));
+            }
+            LockedDependencySourceKind::Registry if !target.source.starts_with("registry:") => {
+                return Err(lockfile_error(
+                    path,
+                    format!(
+                        "registry dependency edge {:?} targets non-registry source {:?}",
+                        edge.alias, target.source
+                    ),
+                ));
+            }
+            _ => {}
+        }
+        if !locked_version_matches(&edge.requested, &target.version) {
+            return Err(lockfile_error(
+                path,
+                format!(
+                    "dependency edge {:?} requests {:?}, which does not select locked version {:?}",
+                    edge.alias, edge.requested, target.version
+                ),
+            ));
+        }
+        match (edge.source_kind, edge.reason) {
+            (LockedDependencySourceKind::Path, LockedDependencyReason::RootPathConstraint)
+                if lockfile
+                    .roots
+                    .binary_search_by(|root| root.as_str().cmp(edge.from.as_str()))
+                    .is_ok() => {}
+            (
+                LockedDependencySourceKind::Path,
+                LockedDependencyReason::TransitivePathConstraint,
+            ) => {}
+            (
+                LockedDependencySourceKind::Registry,
+                LockedDependencyReason::HighestCompatible
+                | LockedDependencyReason::ExactLockedReplay,
+            ) if target.yanked_at_resolution == Some(false) => {}
+            (
+                LockedDependencySourceKind::Registry,
+                LockedDependencyReason::TrustedYankedLockedReplay,
+            ) if target.yanked_at_resolution == Some(true) => {}
+            _ => {
+                return Err(lockfile_error(
+                    path,
+                    format!(
+                        "dependency edge {:?} has reason {:?} inconsistent with its source and yank evidence",
+                        edge.alias, edge.reason
+                    ),
+                ));
+            }
+        }
+    }
+    validate_acyclic_v2_graph(path, lockfile)?;
+    validate_connected_v2_graph(path, lockfile)?;
+    Ok(())
+}
+
+fn validate_acyclic_v2_graph(path: &Path, lockfile: &LockfileV2) -> Result<(), Diagnostic> {
+    let mut incoming = lockfile
+        .package
+        .iter()
+        .map(|package| (package.id.as_str(), 0usize))
+        .collect::<BTreeMap<_, _>>();
+    let mut outgoing = BTreeMap::<&str, Vec<&str>>::new();
+    for edge in &lockfile.edge {
+        *incoming
+            .get_mut(edge.to.as_str())
+            .expect("edge package ids were validated before cycle detection") += 1;
+        outgoing
+            .entry(edge.from.as_str())
+            .or_default()
+            .push(edge.to.as_str());
+    }
+
+    let mut ready = incoming
+        .iter()
+        .filter_map(|(package, degree)| (*degree == 0).then_some(*package))
+        .collect::<BTreeSet<_>>();
+    let mut visited = 0usize;
+    while let Some(package) = ready.iter().next().copied() {
+        ready.remove(package);
+        visited += 1;
+        for target in outgoing.get(package).into_iter().flatten() {
+            let degree = incoming
+                .get_mut(target)
+                .expect("edge package ids were validated before cycle detection");
+            *degree -= 1;
+            if *degree == 0 {
+                ready.insert(target);
+            }
+        }
+    }
+
+    if visited == incoming.len() {
+        return Ok(());
+    }
+    let cycle_members = incoming
+        .into_iter()
+        .filter_map(|(package, degree)| (degree > 0).then_some(package))
+        .collect::<Vec<_>>();
+    Err(lockfile_error(
+        path,
+        format!(
+            "axiom.lock v2 dependency graph contains a cycle involving {}",
+            cycle_members.join(", ")
+        ),
+    ))
+}
+
+fn validate_connected_v2_graph(path: &Path, lockfile: &LockfileV2) -> Result<(), Diagnostic> {
+    let mut reachable = lockfile
+        .roots
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    loop {
+        let before = reachable.len();
+        for edge in &lockfile.edge {
+            if reachable.contains(edge.from.as_str()) {
+                reachable.insert(edge.to.as_str());
+            }
+        }
+        if reachable.len() == before {
+            break;
+        }
+    }
+    if reachable.len() != lockfile.package.len() {
+        let orphan = lockfile
+            .package
+            .iter()
+            .find(|package| !reachable.contains(package.id.as_str()))
+            .map(|package| package.id.as_str())
+            .unwrap_or("<unknown>");
+        return Err(lockfile_error(
+            path,
+            format!("axiom.lock v2 contains orphan package record {orphan:?}"),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_locked_package_v2(
+    path: &Path,
+    package: &LockedPackageV2,
+    configured_registries: &BTreeSet<&str>,
+) -> Result<(), Diagnostic> {
+    validate_portable_name(path, "package.name", &package.name)?;
+    validate_compatibility(path, "package.compatibility", &package.compatibility)?;
+    if package.source == "path" || package.source.starts_with("path:") {
+        validate_exact_version(path, "package.version", &package.version)?;
+        validate_path_source(path, &package.source)?;
+        let expected = canonical_path_package_id(&package.source, &package.name, &package.version);
+        if package.id != expected {
+            return Err(lockfile_error(
+                path,
+                format!(
+                    "path package id {:?} is not canonical; expected {expected:?}",
+                    package.id
+                ),
+            ));
+        }
+        if package.registry.is_some()
+            || package.namespace.is_some()
+            || package.archive_sha256.is_some()
+            || package.archive_length.is_some()
+            || package.manifest_sha256.is_some()
+            || package.provenance_sha256.is_some()
+            || package.package_signature_sha256.is_some()
+            || package.verification_sha256.is_some()
+            || package.publisher_identity.is_some()
+            || !package.signer_key_ids.is_empty()
+            || package.cache_key.is_some()
+            || package.yanked_at_resolution.is_some()
+        {
+            return Err(lockfile_error(
+                path,
+                format!(
+                    "path package {:?} must not contain registry trust evidence",
+                    package.id
+                ),
+            ));
+        }
+        return Ok(());
+    }
+
+    let Some(source_coordinates) = package.source.strip_prefix("registry:") else {
+        return Err(lockfile_error(
+            path,
+            format!(
+                "package {:?} has invalid source {:?}",
+                package.id, package.source
+            ),
+        ));
+    };
+    validate_coordinate(path, "package.name", &package.name)?;
+    validate_exact_version(path, "package.version", &package.version)?;
+    let registry = required_option(path, "package.registry", package.registry.as_deref())?;
+    let namespace = required_option(path, "package.namespace", package.namespace.as_deref())?;
+    validate_coordinate(path, "package.registry", registry)?;
+    validate_coordinate(path, "package.namespace", namespace)?;
+    if !configured_registries.contains(registry) {
+        return Err(lockfile_error(
+            path,
+            format!(
+                "package {:?} references missing registry record {registry:?}",
+                package.id
+            ),
+        ));
+    }
+    let expected_source = format!("registry:{registry}/{namespace}/{}", package.name);
+    if source_coordinates != expected_source.trim_start_matches("registry:") {
+        return Err(lockfile_error(
+            path,
+            format!(
+                "registry package source {:?} is not canonical; expected {expected_source:?}",
+                package.source
+            ),
+        ));
+    }
+    let expected_id =
+        canonical_registry_package_id(registry, namespace, &package.name, &package.version);
+    if package.id != expected_id {
+        return Err(lockfile_error(
+            path,
+            format!(
+                "registry package id {:?} is not canonical; expected {expected_id:?}",
+                package.id
+            ),
+        ));
+    }
+    let archive_sha256 = required_option(
+        path,
+        "package.archive_sha256",
+        package.archive_sha256.as_deref(),
+    )?;
+    validate_sha256(path, "package.archive_sha256", archive_sha256)?;
+    if package.archive_length == Some(0) || package.archive_length.is_none() {
+        return Err(lockfile_error(
+            path,
+            "registry package archive_length must be greater than zero",
+        ));
+    }
+    if package
+        .archive_length
+        .is_some_and(|length| length > 64 * 1024 * 1024)
+    {
+        return Err(lockfile_error(
+            path,
+            "registry package archive_length exceeds the 64 MiB package archive limit",
+        ));
+    }
+    for (field, digest) in [
+        (
+            "package.manifest_sha256",
+            package.manifest_sha256.as_deref(),
+        ),
+        (
+            "package.provenance_sha256",
+            package.provenance_sha256.as_deref(),
+        ),
+        (
+            "package.package_signature_sha256",
+            package.package_signature_sha256.as_deref(),
+        ),
+        (
+            "package.verification_sha256",
+            package.verification_sha256.as_deref(),
+        ),
+    ] {
+        validate_sha256(path, field, required_option(path, field, digest)?)?;
+    }
+    require_nonempty(
+        path,
+        "package.publisher_identity",
+        required_option(
+            path,
+            "package.publisher_identity",
+            package.publisher_identity.as_deref(),
+        )?,
+    )?;
+    if package.signer_key_ids.is_empty() {
+        return Err(lockfile_error(
+            path,
+            "registry package signer_key_ids must not be empty",
+        ));
+    }
+    require_strictly_sorted(
+        path,
+        "package signer_key_ids",
+        &package
+            .signer_key_ids
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>(),
+    )?;
+    for signer in &package.signer_key_ids {
+        validate_key_id(path, "package.signer_key_ids", signer)?;
+    }
+    let cache_key = required_option(path, "package.cache_key", package.cache_key.as_deref())?;
+    let expected_cache_key = format!("sha256:{archive_sha256}");
+    if cache_key != expected_cache_key {
+        return Err(lockfile_error(
+            path,
+            format!("package.cache_key must equal the content address {expected_cache_key:?}"),
+        ));
+    }
+    if package.yanked_at_resolution.is_none() {
+        return Err(lockfile_error(
+            path,
+            "registry package yanked_at_resolution must be recorded",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_compatibility(
+    path: &Path,
+    field: &str,
+    evidence: &LockedCompatibilityEvidence,
+) -> Result<(), Diagnostic> {
+    require_nonempty(path, &format!("{field}.contract"), &evidence.contract)?;
+    require_nonempty(path, &format!("{field}.compiler"), &evidence.compiler)?;
+    require_nonempty(
+        path,
+        &format!("{field}.edition_policy"),
+        &evidence.edition_policy,
+    )
+}
+
+fn edge_order_key(
+    edge: &LockedDependencyEdgeV2,
+) -> (
+    &str,
+    &str,
+    &str,
+    &str,
+    LockedDependencySourceKind,
+    LockedDependencyReason,
+) {
+    (
+        edge.from.as_str(),
+        edge.alias.as_str(),
+        edge.to.as_str(),
+        edge.requested.as_str(),
+        edge.source_kind,
+        edge.reason,
+    )
+}
+
+fn require_strictly_sorted<T: Ord + std::fmt::Debug>(
+    path: &Path,
+    label: &str,
+    values: &[T],
+) -> Result<(), Diagnostic> {
+    if values.windows(2).all(|pair| pair[0] < pair[1]) {
+        Ok(())
+    } else {
+        Err(lockfile_error(
+            path,
+            format!("{label} must be strictly sorted and duplicate-free"),
+        ))
+    }
+}
+
+fn validate_path_source(path: &Path, source: &str) -> Result<(), Diagnostic> {
+    if source == "path" {
+        return Ok(());
+    }
+    let Some(relative) = source.strip_prefix("path:") else {
+        return Err(lockfile_error(
+            path,
+            format!("path package has invalid source {source:?}"),
+        ));
+    };
+    if relative.is_empty()
+        || relative == "."
+        || relative.contains('\\')
+        || Path::new(relative).is_absolute()
+        || Path::new(relative)
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+        || normalize_dependency_source(relative) != relative
+    {
+        return Err(lockfile_error(
+            path,
+            format!("path source {source:?} is not portable and canonical"),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_sha256(path: &Path, field: &str, digest: &str) -> Result<(), Diagnostic> {
+    if digest.len() == 64
+        && digest
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        Ok(())
+    } else {
+        Err(lockfile_error(
+            path,
+            format!("{field} must contain exactly 64 lowercase hexadecimal characters"),
+        ))
+    }
+}
+
+fn validate_key_id(path: &Path, field: &str, key_id: &str) -> Result<(), Diagnostic> {
+    let Some(digest) = key_id.strip_prefix("sha256:") else {
+        return Err(lockfile_error(
+            path,
+            format!("{field} entries must use sha256:<64 lowercase hex> key ids"),
+        ));
+    };
+    validate_sha256(path, field, digest)
+}
+
+fn validate_coordinate(path: &Path, field: &str, value: &str) -> Result<(), Diagnostic> {
+    let mut chars = value.chars();
+    let valid = value.len() <= 256
+        && chars
+            .next()
+            .is_some_and(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit())
+        && chars.all(|ch| {
+            ch.is_ascii_lowercase() || ch.is_ascii_digit() || matches!(ch, '-' | '_' | '.')
+        });
+    if valid {
+        Ok(())
+    } else {
+        Err(lockfile_error(
+            path,
+            format!("{field} must be a portable lowercase coordinate"),
+        ))
+    }
+}
+
+fn validate_portable_name(path: &Path, field: &str, value: &str) -> Result<(), Diagnostic> {
+    let valid = !value.is_empty()
+        && value.len() <= 256
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'));
+    if valid {
+        Ok(())
+    } else {
+        Err(lockfile_error(
+            path,
+            format!("{field} must be a portable ASCII name"),
+        ))
+    }
+}
+
+fn validate_constraint(
+    path: &Path,
+    field: &str,
+    value: &str,
+    allow_wildcard: bool,
+) -> Result<(), Diagnostic> {
+    if allow_wildcard && value == "*" {
+        return Ok(());
+    }
+    validate_exact_version(path, field, value.strip_prefix('^').unwrap_or(value))
+}
+
+fn locked_version_matches(constraint: &str, version: &str) -> bool {
+    if constraint == "*" || constraint == version {
+        return true;
+    }
+    let Some(base) = constraint.strip_prefix('^').and_then(parse_version_triplet) else {
+        return false;
+    };
+    let Some(selected) = parse_version_triplet(version) else {
+        return false;
+    };
+    if base.0 == 0 && base.1 == 0 {
+        selected.0 == 0 && selected.1 == 0 && selected.2 == base.2
+    } else if base.0 == 0 {
+        selected.0 == 0 && selected.1 == base.1 && selected >= base
+    } else {
+        selected.0 == base.0 && selected >= base
+    }
+}
+
+fn parse_version_triplet(value: &str) -> Option<(u64, u64, u64)> {
+    let mut parts = value.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next()?.parse().ok()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    Some((major, minor, patch))
+}
+
+fn validate_exact_version(path: &Path, field: &str, value: &str) -> Result<(), Diagnostic> {
+    let parts = value.split('.').collect::<Vec<_>>();
+    let numeric = parts.len() == 3
+        && parts.iter().all(|part| {
+            !part.is_empty()
+                && part.bytes().all(|byte| byte.is_ascii_digit())
+                && (*part == "0" || !part.starts_with('0'))
+        });
+    if numeric {
+        Ok(())
+    } else {
+        Err(lockfile_error(
+            path,
+            format!("{field} must be a canonical MAJOR.MINOR.PATCH version"),
+        ))
+    }
+}
+
+fn required_option<'a>(
+    path: &Path,
+    field: &str,
+    value: Option<&'a str>,
+) -> Result<&'a str, Diagnostic> {
+    value
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| lockfile_error(path, format!("missing or empty {field}")))
+}
+
+fn require_nonempty(path: &Path, field: &str, value: &str) -> Result<(), Diagnostic> {
+    if value.is_empty() || value.trim() != value {
+        Err(lockfile_error(
+            path,
+            format!("{field} must be non-empty without surrounding whitespace"),
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn lockfile_error(path: &Path, message: impl Into<String>) -> Diagnostic {
+    Diagnostic::new("lockfile", message).with_path(path.display().to_string())
+}
+
 pub fn expected_lockfile(manifest: &Manifest) -> Lockfile {
     Lockfile {
-        version: 1,
+        version: LOCKFILE_V1_VERSION,
         package: manifest
             .package
             .as_ref()
@@ -41,6 +1317,14 @@ pub fn expected_lockfile_for_project(
     project_root: &Path,
     manifest: &Manifest,
 ) -> Result<Lockfile, Diagnostic> {
+    if manifest
+        .dependencies
+        .values()
+        .any(DependencySpec::is_registry)
+    {
+        return Err(Diagnostic::new("lockfile", REGISTRY_LOCKFILE_V2_REQUIRED)
+            .with_path(lockfile_path(project_root).display().to_string()));
+    }
     let project_root = normalize_path(project_root);
     let mut package = expected_lockfile(manifest).package;
     let mut visited = BTreeSet::from([project_root.clone()]);
@@ -66,7 +1350,7 @@ pub fn expected_lockfile_for_project(
         });
     }
     Ok(Lockfile {
-        version: 1,
+        version: LOCKFILE_V1_VERSION,
         package,
     })
 }
@@ -85,8 +1369,17 @@ pub fn render_lockfile_for_project(
 }
 
 pub fn validate_lockfile(project_root: &Path, manifest: &Manifest) -> Result<(), Diagnostic> {
-    let expected = expected_lockfile_for_project(project_root, manifest)?;
-    validate_lockfile_packages(project_root, &expected.package)
+    let lockfile = load_lockfile(project_root)?;
+    validate_lockfile_version_for_manifest(manifest, &lockfile)?;
+    match lockfile {
+        ParsedLockfile::V1(lockfile) => {
+            let expected = expected_lockfile_for_project(project_root, manifest)?;
+            compare_v1_lockfile(project_root, &lockfile, &expected)
+        }
+        ParsedLockfile::V2(lockfile) => {
+            validate_v2_against_manifest(project_root, manifest, &lockfile)
+        }
+    }
 }
 
 pub fn validate_lockfile_packages(
@@ -94,18 +1387,29 @@ pub fn validate_lockfile_packages(
     packages: &[LockedPackage],
 ) -> Result<(), Diagnostic> {
     let path = lockfile_path(project_root);
-    let content = std::fs::read_to_string(&path).map_err(|err| {
+    let content = std::fs::read(&path).map_err(|err| {
         Diagnostic::new("lockfile", format!("failed to read axiom.lock: {err}"))
             .with_path(path.display().to_string())
     })?;
-    let lockfile: Lockfile = toml::from_str(&content).map_err(|err| {
-        Diagnostic::new("lockfile", format!("invalid axiom.lock: {err}"))
-            .with_path(path.display().to_string())
-    })?;
+    let ParsedLockfile::V1(lockfile) = parse_lockfile_exact(&content, &path)? else {
+        return Err(lockfile_error(
+            &path,
+            "validate_lockfile_packages requires axiom.lock version 1",
+        ));
+    };
     let expected = Lockfile {
-        version: 1,
+        version: LOCKFILE_V1_VERSION,
         package: packages.to_vec(),
     };
+    compare_v1_lockfile(project_root, &lockfile, &expected)
+}
+
+fn compare_v1_lockfile(
+    project_root: &Path,
+    lockfile: &Lockfile,
+    expected: &Lockfile,
+) -> Result<(), Diagnostic> {
+    let path = lockfile_path(project_root);
     if lockfile != expected {
         let detail = lockfile_mismatch_detail(&lockfile, &expected);
         return Err(
@@ -117,6 +1421,84 @@ pub fn validate_lockfile_packages(
             )
             .with_path(path.display().to_string()),
         );
+    }
+    Ok(())
+}
+
+fn validate_v2_against_manifest(
+    project_root: &Path,
+    manifest: &Manifest,
+    lockfile: &LockfileV2,
+) -> Result<(), Diagnostic> {
+    let path = lockfile_path(project_root);
+    if let Some(registry) = &manifest.registry {
+        let Some(locked_registry) = lockfile
+            .registry
+            .iter()
+            .find(|entry| entry.name == registry.name)
+        else {
+            return Err(lockfile_error(
+                &path,
+                format!(
+                    "axiom.lock v2 is missing configured registry {:?}",
+                    registry.name
+                ),
+            ));
+        };
+        if locked_registry.source != registry.index {
+            return Err(lockfile_error(
+                &path,
+                format!(
+                    "configured registry source changed (axiom.lock has {:?}; axiom.toml expects {:?})",
+                    locked_registry.source, registry.index
+                ),
+            ));
+        }
+    }
+    let root_id = manifest
+        .package
+        .as_ref()
+        .map(|package| canonical_path_package_id("path", &package.name, &package.version));
+    for (alias, dependency) in &manifest.dependencies {
+        let matching_edges = lockfile
+            .edge
+            .iter()
+            .filter(|edge| {
+                edge.alias == *alias
+                    && root_id
+                        .as_deref()
+                        .is_none_or(|root_id| edge.from == root_id)
+            })
+            .collect::<Vec<_>>();
+        if matching_edges.is_empty() {
+            return Err(lockfile_error(
+                &path,
+                format!("axiom.lock v2 is missing dependency edge for alias {alias:?}"),
+            ));
+        }
+        if matching_edges.len() > 1 {
+            return Err(lockfile_error(
+                &path,
+                format!("axiom.lock v2 has ambiguous dependency edges for alias {alias:?}"),
+            ));
+        }
+        let edge = matching_edges[0];
+        let expected_kind = if dependency.is_registry() {
+            LockedDependencySourceKind::Registry
+        } else {
+            LockedDependencySourceKind::Path
+        };
+        if edge.source_kind != expected_kind
+            || dependency
+                .version
+                .as_deref()
+                .is_some_and(|version| edge.requested != version)
+        {
+            return Err(lockfile_error(
+                &path,
+                format!("axiom.lock v2 dependency decision for alias {alias:?} is stale"),
+            ));
+        }
     }
     Ok(())
 }
@@ -178,7 +1560,11 @@ fn dependency_root(
     project_root: &Path,
     spec: &DependencySpec,
 ) -> Result<PathBuf, Diagnostic> {
-    let dependency_root = normalize_path(project_root.join(&spec.path));
+    let path_source = spec.path_source().ok_or_else(|| {
+        Diagnostic::new("lockfile", REGISTRY_LOCKFILE_V2_REQUIRED)
+            .with_path(lockfile_path(root_project_root).display().to_string())
+    })?;
+    let dependency_root = normalize_path(project_root.join(path_source));
     let canonical_project_root = canonicalize_path(project_root, "dependency source package")?;
     let canonical_dependency_root = canonicalize_path(&dependency_root, "dependency path")?;
     let canonical_root_project_root = canonicalize_path(root_project_root, "package root")?;
@@ -411,6 +1797,97 @@ mod tests {
         .expect("write lockfile fixture");
     }
 
+    fn digest(byte: char) -> String {
+        std::iter::repeat_n(byte, 64).collect()
+    }
+
+    fn key_id(byte: char) -> String {
+        format!("sha256:{}", digest(byte))
+    }
+
+    fn compatibility() -> LockedCompatibilityEvidence {
+        LockedCompatibilityEvidence {
+            contract: "compatibility-v1".to_string(),
+            compiler: "axiomc-0.3.0".to_string(),
+            edition_policy: "2026-policy-only".to_string(),
+        }
+    }
+
+    fn sample_lockfile_v2() -> LockfileV2 {
+        let root_id = canonical_path_package_id("path", "app", "1.0.0");
+        let dependency_id = canonical_registry_package_id("primary", "acme", "math", "1.2.3");
+        LockfileV2 {
+            version: LOCKFILE_V2_VERSION,
+            compatibility: compatibility(),
+            roots: vec![root_id.clone()],
+            registry: vec![LockedRegistryV2 {
+                name: "primary".to_string(),
+                source: "https://registry.example.test/index.json".to_string(),
+                registry_identity: "https://registry.example.test".to_string(),
+                source_identity: "https://registry.example.test/index.json".to_string(),
+                trust_roots_sha256: digest('1'),
+                expectation_sha256: digest('9'),
+                current_root_version: 4,
+                current_root_sequence: 9,
+                current_root_transcript_sha256: digest('2'),
+                index_sha256: digest('3'),
+                index_transcript_sha256: digest('4'),
+                index_generation: 7,
+                index_sequence: 11,
+                index_snapshot_id: "snapshot-7-11".to_string(),
+                index_signer_key_ids: vec![key_id('a'), key_id('b')],
+            }],
+            package: vec![
+                LockedPackageV2 {
+                    id: root_id.clone(),
+                    name: "app".to_string(),
+                    version: "1.0.0".to_string(),
+                    source: "path".to_string(),
+                    registry: None,
+                    namespace: None,
+                    archive_sha256: None,
+                    archive_length: None,
+                    manifest_sha256: None,
+                    provenance_sha256: None,
+                    package_signature_sha256: None,
+                    verification_sha256: None,
+                    publisher_identity: None,
+                    signer_key_ids: Vec::new(),
+                    cache_key: None,
+                    yanked_at_resolution: None,
+                    compatibility: compatibility(),
+                },
+                LockedPackageV2 {
+                    id: dependency_id.clone(),
+                    name: "math".to_string(),
+                    version: "1.2.3".to_string(),
+                    source: "registry:primary/acme/math".to_string(),
+                    registry: Some("primary".to_string()),
+                    namespace: Some("acme".to_string()),
+                    archive_sha256: Some(digest('5')),
+                    archive_length: Some(1234),
+                    manifest_sha256: Some(digest('6')),
+                    provenance_sha256: Some(digest('7')),
+                    package_signature_sha256: Some(digest('8')),
+                    verification_sha256: Some(digest('0')),
+                    publisher_identity: Some("https://publisher.example.test/acme".to_string()),
+                    signer_key_ids: vec![key_id('c'), key_id('d')],
+                    cache_key: Some(format!("sha256:{}", digest('5'))),
+                    yanked_at_resolution: Some(false),
+                    compatibility: compatibility(),
+                },
+            ],
+            edge: vec![LockedDependencyEdgeV2 {
+                from: root_id,
+                to: dependency_id,
+                alias: "math".to_string(),
+                requested: "^1.2.0".to_string(),
+                source_kind: LockedDependencySourceKind::Registry,
+                reason: LockedDependencyReason::HighestCompatible,
+            }],
+        }
+    }
+
     #[test]
     fn lockfile_rejects_unknown_top_level_field() {
         let toml = "version = 1\nextra = \"tamper\"\n\n[[package]]\nname = \"demo\"\nversion = \"0.1.0\"\nsource = \"path\"\n";
@@ -556,6 +2033,793 @@ mod tests {
             error
                 .message
                 .contains("locked version \"0.9.0\" from source \"path:deps/old\"")
+        );
+    }
+
+    #[test]
+    fn lockfile_v2_roundtrips_with_exact_replay_pins() {
+        let lockfile = sample_lockfile_v2();
+        let rendered = render_lockfile_v2(&lockfile).expect("render v2");
+        assert!(rendered.contains("roots = [\"path:.#app@1.0.0\"]"));
+        assert!(rendered.contains("trust_roots_sha256"));
+        assert!(rendered.contains("expectation_sha256"));
+        assert!(rendered.contains("current_root_transcript_sha256"));
+        assert!(rendered.contains("index_snapshot_id = \"snapshot-7-11\""));
+        assert!(rendered.contains("index_signer_key_ids"));
+        assert!(rendered.contains("verification_sha256"));
+        let parsed = parse_lockfile_exact(rendered.as_bytes(), Path::new("fixture/axiom.lock"))
+            .expect("parse rendered v2");
+        assert_eq!(parsed, ParsedLockfile::V2(lockfile.clone()));
+        let ParsedLockfile::V2(parsed) = parsed else {
+            panic!("expected v2");
+        };
+        assert_eq!(
+            render_lockfile_v2(&parsed).expect("rerender v2"),
+            rendered,
+            "v2 rendering must be deterministic"
+        );
+    }
+
+    #[test]
+    fn lockfile_v2_rejects_archive_above_runtime_limit() {
+        let mut lockfile = sample_lockfile_v2();
+        lockfile.package[1].archive_length = Some(64 * 1024 * 1024 + 1);
+        let error = validate_lockfile_v2(&lockfile).expect_err("oversized archive must fail");
+        assert!(
+            error.message.contains("64 MiB package archive limit"),
+            "unexpected diagnostic: {error:?}"
+        );
+    }
+
+    #[test]
+    fn lockfile_v2_accepts_multiple_explicit_workspace_roots() {
+        let mut lockfile = sample_lockfile_v2();
+        let workspace_root_id = canonical_path_package_id("path:members/tool", "tool", "1.0.0");
+        let utility_id = canonical_path_package_id("path:deps/util", "util", "1.0.0");
+        let path_package = |id: String, name: &str, source: &str| LockedPackageV2 {
+            id,
+            name: name.to_owned(),
+            version: "1.0.0".to_owned(),
+            source: source.to_owned(),
+            registry: None,
+            namespace: None,
+            archive_sha256: None,
+            archive_length: None,
+            manifest_sha256: None,
+            provenance_sha256: None,
+            package_signature_sha256: None,
+            verification_sha256: None,
+            publisher_identity: None,
+            signer_key_ids: Vec::new(),
+            cache_key: None,
+            yanked_at_resolution: None,
+            compatibility: compatibility(),
+        };
+        lockfile.package.push(path_package(
+            workspace_root_id.clone(),
+            "tool",
+            "path:members/tool",
+        ));
+        lockfile
+            .package
+            .push(path_package(utility_id.clone(), "util", "path:deps/util"));
+        lockfile
+            .package
+            .sort_by(|left, right| left.id.cmp(&right.id));
+        lockfile.roots.push(workspace_root_id.clone());
+        lockfile.roots.sort();
+        lockfile.edge.push(LockedDependencyEdgeV2 {
+            from: workspace_root_id,
+            to: utility_id,
+            alias: "util".to_owned(),
+            requested: "1.0.0".to_owned(),
+            source_kind: LockedDependencySourceKind::Path,
+            reason: LockedDependencyReason::RootPathConstraint,
+        });
+        lockfile
+            .edge
+            .sort_by(|left, right| edge_order_key(left).cmp(&edge_order_key(right)));
+
+        validate_lockfile_v2(&lockfile).expect("multiple explicit roots should validate");
+
+        let mut missing_root = lockfile.clone();
+        missing_root
+            .roots
+            .push("path:missing#missing@1.0.0".to_owned());
+        missing_root.roots.sort();
+        assert!(
+            validate_lockfile_v2(&missing_root)
+                .expect_err("unknown root must fail")
+                .message
+                .contains("absent from package records")
+        );
+    }
+
+    #[test]
+    fn lockfile_v2_rejects_order_digest_and_dangling_edge_tamper() {
+        let mut unsorted = sample_lockfile_v2();
+        unsorted.package[1].signer_key_ids.reverse();
+        assert!(
+            validate_lockfile_v2(&unsorted)
+                .expect_err("unsorted signer ids")
+                .message
+                .contains("strictly sorted")
+        );
+
+        let mut malformed_digest = sample_lockfile_v2();
+        malformed_digest.registry[0].index_sha256 = "ABC".to_string();
+        assert!(
+            validate_lockfile_v2(&malformed_digest)
+                .expect_err("malformed digest")
+                .message
+                .contains("64 lowercase hexadecimal")
+        );
+
+        let mut malformed_verification = sample_lockfile_v2();
+        malformed_verification.package[1].verification_sha256 = Some("A".repeat(64));
+        assert!(
+            validate_lockfile_v2(&malformed_verification)
+                .expect_err("uppercase verification digest")
+                .message
+                .contains("64 lowercase hexadecimal")
+        );
+
+        let mut missing_verification = sample_lockfile_v2();
+        missing_verification.package[1].verification_sha256 = None;
+        assert!(
+            validate_lockfile_v2(&missing_verification)
+                .expect_err("missing verification digest")
+                .message
+                .contains("missing or empty package.verification_sha256")
+        );
+
+        let mut dangling = sample_lockfile_v2();
+        dangling.edge[0].to = "registry:primary/acme/missing@1.0.0".to_string();
+        assert!(
+            validate_lockfile_v2(&dangling)
+                .expect_err("dangling edge")
+                .message
+                .contains("absent from axiom.lock")
+        );
+    }
+
+    #[test]
+    fn lockfile_v2_rejects_invalid_source_combinations_and_duplicate_aliases() {
+        let mut path_with_registry_evidence = sample_lockfile_v2();
+        path_with_registry_evidence.package[0].archive_sha256 = Some(digest('e'));
+        assert!(
+            validate_lockfile_v2(&path_with_registry_evidence)
+                .expect_err("path trust evidence")
+                .message
+                .contains("must not contain registry trust evidence")
+        );
+
+        let mut path_with_verification_evidence = sample_lockfile_v2();
+        path_with_verification_evidence.package[0].verification_sha256 = Some(digest('e'));
+        assert!(
+            validate_lockfile_v2(&path_with_verification_evidence)
+                .expect_err("path verification evidence")
+                .message
+                .contains("must not contain registry trust evidence")
+        );
+
+        let mut duplicate_alias = sample_lockfile_v2();
+        let mut second = duplicate_alias.edge[0].clone();
+        second.to = duplicate_alias.package[0].id.clone();
+        second.requested = "1.0.0".to_string();
+        second.source_kind = LockedDependencySourceKind::Path;
+        second.reason = LockedDependencyReason::RootPathConstraint;
+        duplicate_alias.edge.push(second);
+        duplicate_alias
+            .edge
+            .sort_by(|left, right| edge_order_key(left).cmp(&edge_order_key(right)));
+        assert!(
+            validate_lockfile_v2(&duplicate_alias)
+                .expect_err("duplicate alias")
+                .message
+                .contains("duplicate dependency alias")
+        );
+    }
+
+    #[test]
+    fn lockfile_v2_rejects_noncanonical_path_sources_and_versions() {
+        for source in [
+            "path:",
+            "path:.",
+            "path:./child",
+            "path:../outside",
+            "path:child/../outside",
+            "path:/absolute",
+            "path:child\\nested",
+            "path:child//nested",
+            "path:child/",
+        ] {
+            let mut lockfile = sample_lockfile_v2();
+            lockfile.package[0].source = source.to_string();
+            lockfile.package[0].id = canonical_path_package_id(
+                source,
+                &lockfile.package[0].name,
+                &lockfile.package[0].version,
+            );
+            lockfile.roots[0] = lockfile.package[0].id.clone();
+            lockfile.edge[0].from = lockfile.package[0].id.clone();
+            assert!(
+                validate_lockfile_v2(&lockfile)
+                    .expect_err("noncanonical path source must fail")
+                    .message
+                    .contains("not portable and canonical"),
+                "runtime accepted or misdiagnosed {source:?}"
+            );
+        }
+
+        let mut invalid_version = sample_lockfile_v2();
+        invalid_version.package[0].version = "1.0".to_string();
+        assert!(
+            validate_lockfile_v2(&invalid_version)
+                .expect_err("non-release path version must fail")
+                .message
+                .contains("canonical MAJOR.MINOR.PATCH version"),
+        );
+    }
+
+    #[test]
+    fn lockfile_v2_rejects_unknown_dependency_reason() {
+        let rendered = render_lockfile_v2(&sample_lockfile_v2()).expect("render v2");
+        let tampered = rendered.replace(
+            "reason = \"highest_compatible\"",
+            "reason = \"network_was_fast\"",
+        );
+        let error = parse_lockfile_exact(tampered.as_bytes(), Path::new("axiom.lock"))
+            .expect_err("unknown reason must fail");
+        assert!(
+            error.message.contains("unknown variant") && error.message.contains("network_was_fast"),
+            "unexpected error: {}",
+            error.message
+        );
+    }
+
+    #[test]
+    fn lockfile_v2_rejects_constraint_yank_and_orphan_inconsistency() {
+        let mut incompatible = sample_lockfile_v2();
+        incompatible.edge[0].requested = "^2.0.0".to_string();
+        assert!(
+            validate_lockfile_v2(&incompatible)
+                .expect_err("incompatible selected version")
+                .message
+                .contains("does not select locked version")
+        );
+
+        let mut yanked_without_replay = sample_lockfile_v2();
+        yanked_without_replay.package[1].yanked_at_resolution = Some(true);
+        assert!(
+            validate_lockfile_v2(&yanked_without_replay)
+                .expect_err("yanked selection reason mismatch")
+                .message
+                .contains("inconsistent with its source and yank evidence")
+        );
+
+        let mut orphaned = sample_lockfile_v2();
+        let mut orphan = orphaned.package[0].clone();
+        orphan.name = "orphan".to_string();
+        orphan.source = "path:deps/orphan".to_string();
+        orphan.id = canonical_path_package_id(&orphan.source, &orphan.name, &orphan.version);
+        orphaned.package.push(orphan);
+        orphaned
+            .package
+            .sort_by(|left, right| left.id.cmp(&right.id));
+        assert!(
+            validate_lockfile_v2(&orphaned)
+                .expect_err("orphan package")
+                .message
+                .contains("orphan package record")
+        );
+    }
+
+    #[test]
+    fn lockfile_v2_rejects_multiple_versions_for_one_registry_coordinate() {
+        let mut lockfile = sample_lockfile_v2();
+        let mut second = lockfile.package[1].clone();
+        second.version = "1.2.4".to_string();
+        second.id = canonical_registry_package_id("primary", "acme", "math", "1.2.4");
+        lockfile.package.push(second);
+        lockfile
+            .package
+            .sort_by(|left, right| left.id.cmp(&right.id));
+
+        let rendered = toml::to_string_pretty(&lockfile).expect("serialize tampered lockfile");
+        let error = parse_lockfile_exact(rendered.as_bytes(), Path::new("axiom.lock"))
+            .expect_err("duplicate registry coordinate must fail strict parsing");
+        assert!(
+            error
+                .message
+                .contains("selects multiple versions for registry coordinate primary/acme/math"),
+            "unexpected diagnostic: {error:?}"
+        );
+    }
+
+    #[test]
+    fn lockfile_v2_rejects_path_and_registry_dependency_cycles() {
+        let mut path_cycle = sample_lockfile_v2();
+        let utility_id = canonical_path_package_id("path:deps/util", "util", "1.0.0");
+        path_cycle.package.push(LockedPackageV2 {
+            id: utility_id.clone(),
+            name: "util".to_string(),
+            version: "1.0.0".to_string(),
+            source: "path:deps/util".to_string(),
+            registry: None,
+            namespace: None,
+            archive_sha256: None,
+            archive_length: None,
+            manifest_sha256: None,
+            provenance_sha256: None,
+            package_signature_sha256: None,
+            verification_sha256: None,
+            publisher_identity: None,
+            signer_key_ids: Vec::new(),
+            cache_key: None,
+            yanked_at_resolution: None,
+            compatibility: compatibility(),
+        });
+        path_cycle
+            .package
+            .sort_by(|left, right| left.id.cmp(&right.id));
+        path_cycle.edge.extend([
+            LockedDependencyEdgeV2 {
+                from: path_cycle.roots[0].clone(),
+                to: utility_id.clone(),
+                alias: "util".to_string(),
+                requested: "1.0.0".to_string(),
+                source_kind: LockedDependencySourceKind::Path,
+                reason: LockedDependencyReason::RootPathConstraint,
+            },
+            LockedDependencyEdgeV2 {
+                from: utility_id,
+                to: path_cycle.roots[0].clone(),
+                alias: "app".to_string(),
+                requested: "1.0.0".to_string(),
+                source_kind: LockedDependencySourceKind::Path,
+                reason: LockedDependencyReason::TransitivePathConstraint,
+            },
+        ]);
+        path_cycle
+            .edge
+            .sort_by(|left, right| edge_order_key(left).cmp(&edge_order_key(right)));
+        let rendered = toml::to_string_pretty(&path_cycle).expect("serialize path cycle");
+        assert!(
+            parse_lockfile_exact(rendered.as_bytes(), Path::new("axiom.lock"))
+                .expect_err("path cycle must fail strict parsing")
+                .message
+                .contains("dependency graph contains a cycle")
+        );
+
+        let mut registry_cycle = sample_lockfile_v2();
+        let registry_id = registry_cycle.package[1].id.clone();
+        registry_cycle.edge.push(LockedDependencyEdgeV2 {
+            from: registry_id.clone(),
+            to: registry_id,
+            alias: "self".to_string(),
+            requested: "1.2.3".to_string(),
+            source_kind: LockedDependencySourceKind::Registry,
+            reason: LockedDependencyReason::ExactLockedReplay,
+        });
+        registry_cycle
+            .edge
+            .sort_by(|left, right| edge_order_key(left).cmp(&edge_order_key(right)));
+        assert!(
+            validate_lockfile_v2(&registry_cycle)
+                .expect_err("registry cycle must fail")
+                .message
+                .contains("dependency graph contains a cycle")
+        );
+    }
+
+    #[test]
+    fn lockfile_v2_accepts_dag_diamonds_across_multiple_roots() {
+        let mut lockfile = sample_lockfile_v2();
+        lockfile.registry.clear();
+        lockfile.package.truncate(1);
+        lockfile.edge.clear();
+        let path_package = |name: &str, source: &str| LockedPackageV2 {
+            id: canonical_path_package_id(source, name, "1.0.0"),
+            name: name.to_string(),
+            version: "1.0.0".to_string(),
+            source: source.to_string(),
+            registry: None,
+            namespace: None,
+            archive_sha256: None,
+            archive_length: None,
+            manifest_sha256: None,
+            provenance_sha256: None,
+            package_signature_sha256: None,
+            verification_sha256: None,
+            publisher_identity: None,
+            signer_key_ids: Vec::new(),
+            cache_key: None,
+            yanked_at_resolution: None,
+            compatibility: compatibility(),
+        };
+        let tool = path_package("tool", "path:tools/tool");
+        let left = path_package("left", "path:deps/left");
+        let right = path_package("right", "path:deps/right");
+        let leaf = path_package("leaf", "path:deps/leaf");
+        lockfile.roots.push(tool.id.clone());
+        lockfile.roots.sort();
+        lockfile
+            .package
+            .extend([tool.clone(), left.clone(), right.clone(), leaf.clone()]);
+        lockfile
+            .package
+            .sort_by(|left, right| left.id.cmp(&right.id));
+        lockfile.edge.extend([
+            LockedDependencyEdgeV2 {
+                from: lockfile.roots[0].clone(),
+                to: left.id.clone(),
+                alias: "left".to_string(),
+                requested: "1.0.0".to_string(),
+                source_kind: LockedDependencySourceKind::Path,
+                reason: LockedDependencyReason::RootPathConstraint,
+            },
+            LockedDependencyEdgeV2 {
+                from: lockfile.roots[0].clone(),
+                to: right.id.clone(),
+                alias: "right".to_string(),
+                requested: "1.0.0".to_string(),
+                source_kind: LockedDependencySourceKind::Path,
+                reason: LockedDependencyReason::RootPathConstraint,
+            },
+            LockedDependencyEdgeV2 {
+                from: tool.id,
+                to: right.id.clone(),
+                alias: "right".to_string(),
+                requested: "1.0.0".to_string(),
+                source_kind: LockedDependencySourceKind::Path,
+                reason: LockedDependencyReason::RootPathConstraint,
+            },
+            LockedDependencyEdgeV2 {
+                from: left.id,
+                to: leaf.id.clone(),
+                alias: "leaf".to_string(),
+                requested: "1.0.0".to_string(),
+                source_kind: LockedDependencySourceKind::Path,
+                reason: LockedDependencyReason::TransitivePathConstraint,
+            },
+            LockedDependencyEdgeV2 {
+                from: right.id,
+                to: leaf.id,
+                alias: "leaf".to_string(),
+                requested: "1.0.0".to_string(),
+                source_kind: LockedDependencySourceKind::Path,
+                reason: LockedDependencyReason::TransitivePathConstraint,
+            },
+        ]);
+        lockfile
+            .edge
+            .sort_by(|left, right| edge_order_key(left).cmp(&edge_order_key(right)));
+
+        validate_lockfile_v2(&lockfile).expect("multiple-root DAG diamond should validate");
+    }
+
+    #[test]
+    fn load_either_preserves_v1_and_requires_v2_for_registry_graphs() {
+        let v1 =
+            b"version = 1\n\n[[package]]\nname = \"app\"\nversion = \"1.0.0\"\nsource = \"path\"\n";
+        let parsed =
+            parse_lockfile_exact(v1, Path::new("axiom.lock")).expect("strict v1 should parse");
+        assert!(matches!(parsed, ParsedLockfile::V1(_)));
+
+        let manifest = crate::manifest::parse_manifest_exact(
+            br#"
+[package]
+name = "app"
+version = "1.0.0"
+
+[registry]
+name = "primary"
+index = "https://registry.example.test/index.json"
+trust_roots = "roots.json"
+expectation = "expectation.json"
+
+[dependencies.math]
+registry = "primary"
+namespace = "acme"
+version = "^1.2.0"
+"#,
+            Path::new("axiom.toml"),
+        )
+        .expect("registry manifest");
+        let error = validate_lockfile_version_for_manifest(&manifest, &parsed)
+            .expect_err("registry graph with v1 must fail");
+        assert_eq!(error.message, REGISTRY_LOCKFILE_V2_REQUIRED);
+    }
+
+    #[test]
+    fn lockfile_v2_rejects_hostname_loopback_and_accepts_numeric_loopback() {
+        let mut lockfile = sample_lockfile_v2();
+        lockfile.registry[0].source = "http://localhost:8080/index.json".to_string();
+        assert!(
+            validate_lockfile_v2(&lockfile)
+                .expect_err("hostname loopback must fail")
+                .message
+                .contains("unsupported or non-canonical source")
+        );
+
+        lockfile.registry[0].source = "http://127.0.0.1:8080/index.json".to_string();
+        validate_lockfile_v2(&lockfile).expect("numeric IPv4 loopback should validate");
+
+        lockfile.registry[0].source = "http://[::1]:8080/index.json".to_string();
+        validate_lockfile_v2(&lockfile).expect("numeric IPv6 loopback should validate");
+    }
+
+    #[test]
+    fn resolver_url_schemas_reject_hostname_and_malformed_numeric_loopback() {
+        let manifest_schema: serde_json::Value =
+            serde_json::from_str(include_str!("../../../schemas/axiom.toml.schema.json"))
+                .expect("parse manifest schema");
+        let manifest_validator =
+            jsonschema::validator_for(&manifest_schema).expect("compile manifest schema");
+        let manifest_fixture: serde_json::Value = serde_json::from_str(include_str!(
+            "../../../package-resolver/fixtures/manifest-registry.json"
+        ))
+        .expect("parse manifest fixture");
+        assert!(manifest_validator.is_valid(&manifest_fixture));
+
+        for invalid in [
+            "http://localhost:8080/index.json",
+            "http://192.0.2.1:8080/index.json",
+            "http://127.0.0.999:8080/index.json",
+            "http://127.0.0.1:99999/index.json",
+        ] {
+            let mut value = manifest_fixture.clone();
+            value["registry"]["index"] = serde_json::Value::String(invalid.to_string());
+            assert!(
+                !manifest_validator.is_valid(&value),
+                "manifest schema accepted invalid registry URL {invalid:?}"
+            );
+        }
+        for valid in [
+            "http://127.0.0.1:8080/index.json",
+            "http://127.255.255.255:65535/index.json",
+            "http://[::1]:8080/index.json",
+        ] {
+            let mut value = manifest_fixture.clone();
+            value["registry"]["index"] = serde_json::Value::String(valid.to_string());
+            assert!(
+                manifest_validator.is_valid(&value),
+                "manifest schema rejected numeric loopback URL {valid:?}"
+            );
+        }
+
+        let lock_schema: serde_json::Value = serde_json::from_str(include_str!(
+            "../../../schemas/axiom-lockfile-v2.schema.json"
+        ))
+        .expect("parse lockfile schema");
+        let lock_validator =
+            jsonschema::validator_for(&lock_schema).expect("compile lockfile schema");
+        let lock_fixture: serde_json::Value = serde_json::from_str(include_str!(
+            "../../../package-resolver/fixtures/lockfile-v2.json"
+        ))
+        .expect("parse lockfile fixture");
+        assert!(lock_validator.is_valid(&lock_fixture));
+
+        for invalid in [
+            "http://localhost:8080/index.json",
+            "http://192.0.2.1:8080/index.json",
+            "http://127.0.0.999:8080/index.json",
+            "http://127.0.0.1:99999/index.json",
+        ] {
+            let mut value = lock_fixture.clone();
+            value["registry"][0]["source"] = serde_json::Value::String(invalid.to_string());
+            assert!(
+                !lock_validator.is_valid(&value),
+                "lockfile schema accepted invalid registry URL {invalid:?}"
+            );
+        }
+        for valid in [
+            "http://127.0.0.1:8080/index.json",
+            "http://127.255.255.255:65535/index.json",
+            "http://[::1]:8080/index.json",
+        ] {
+            let mut value = lock_fixture.clone();
+            value["registry"][0]["source"] = serde_json::Value::String(valid.to_string());
+            assert!(
+                lock_validator.is_valid(&value),
+                "lockfile schema rejected numeric loopback URL {valid:?}"
+            );
+        }
+
+        let mut invalid_version = lock_fixture.clone();
+        invalid_version["package"][0]["version"] = serde_json::json!("1.0");
+        assert!(
+            !lock_validator.is_valid(&invalid_version),
+            "lockfile schema accepted a non-release path-package version"
+        );
+        for invalid in [
+            "path:",
+            "path:.",
+            "path:./child",
+            "path:../outside",
+            "path:child/../outside",
+            "path:/absolute",
+            "path:child\\nested",
+            "path:child//nested",
+            "path:child/",
+        ] {
+            let mut value = lock_fixture.clone();
+            value["package"][0]["source"] = serde_json::Value::String(invalid.to_string());
+            assert!(
+                !lock_validator.is_valid(&value),
+                "lockfile schema accepted non-canonical path source {invalid:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn bounded_lock_load_returns_digest_of_exact_v1_bytes() {
+        let dir = tempdir().expect("tempdir");
+        let content =
+            b"version = 1\n\n[[package]]\nname = \"app\"\nversion = \"1.0.0\"\nsource = \"path\"\n";
+        fs::write(lockfile_path(dir.path()), content).expect("write v1 lockfile");
+        let (loaded, sha256) =
+            load_lockfile_with_sha256(dir.path()).expect("load bounded v1 lockfile");
+        assert!(matches!(loaded, ParsedLockfile::V1(_)));
+        assert_eq!(
+            sha256,
+            "284c411ba5cdff2ad7703951b23acef592150ca832b61ff263c24b46f21084d4"
+        );
+        assert_eq!(
+            load_lockfile(dir.path()).expect("compatibility loader"),
+            loaded
+        );
+    }
+
+    #[test]
+    fn bounded_lock_load_rejects_oversized_files_before_parsing() {
+        let dir = tempdir().expect("tempdir");
+        fs::write(
+            lockfile_path(dir.path()),
+            vec![b' '; MAX_LOCKFILE_BYTES + 1],
+        )
+        .expect("write oversized lockfile");
+        let error =
+            load_lockfile_with_sha256(dir.path()).expect_err("oversized lockfile must fail");
+        assert!(
+            error
+                .message
+                .contains("exceeds the 4194304 byte parsing limit"),
+            "unexpected diagnostic: {error:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bounded_lock_load_rejects_final_component_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempdir().expect("tempdir");
+        let real = dir.path().join("real.lock");
+        fs::write(
+            &real,
+            b"version = 1\n\n[[package]]\nname = \"app\"\nversion = \"1.0.0\"\nsource = \"path\"\n",
+        )
+        .expect("write real lockfile");
+        symlink(&real, lockfile_path(dir.path())).expect("create lockfile symlink");
+        let error =
+            load_lockfile_with_sha256(dir.path()).expect_err("lockfile symlink must fail closed");
+        assert!(
+            error.message.contains("failed to securely open axiom.lock"),
+            "unexpected diagnostic: {error:?}"
+        );
+    }
+
+    #[test]
+    fn atomic_write_preserves_existing_lockfile_when_validation_fails() {
+        let dir = tempdir().expect("tempdir");
+        let path = lockfile_path(dir.path());
+        fs::write(&path, "original lockfile\n").expect("write original");
+        let mut invalid = sample_lockfile_v2();
+        invalid.registry[0].index_generation = 0;
+        let error =
+            write_lockfile_v2_atomic(dir.path(), &invalid).expect_err("invalid v2 must not write");
+        assert!(error.message.contains("greater than zero"));
+        assert_eq!(
+            fs::read_to_string(&path).expect("read preserved lock"),
+            "original lockfile\n"
+        );
+        assert!(fs::read_dir(dir.path()).expect("read dir").all(|entry| {
+            !entry
+                .expect("dir entry")
+                .file_name()
+                .to_string_lossy()
+                .starts_with(".axiom.lock.tmp.")
+        }));
+    }
+
+    #[test]
+    fn conditional_atomic_write_requires_expected_presence_and_digest() {
+        let dir = tempdir().expect("tempdir");
+        let path = lockfile_path(dir.path());
+        let first = sample_lockfile_v2();
+        write_lockfile_v2_atomic_cas(dir.path(), &first, None)
+            .expect("expected-absence write should create lockfile");
+        let original = fs::read(&path).expect("read original lockfile");
+        let (_loaded, original_sha256) =
+            load_lockfile_with_sha256(dir.path()).expect("load original lock identity");
+
+        let mut replacement = first.clone();
+        replacement.compatibility.compiler = "axiomc-0.3.1".to_string();
+        for package in &mut replacement.package {
+            package.compatibility.compiler = "axiomc-0.3.1".to_string();
+        }
+        let error = write_lockfile_v2_atomic_cas(dir.path(), &replacement, None)
+            .expect_err("expected absence must reject an existing lockfile");
+        assert!(error.message.contains("changed while package resolution"));
+        assert_eq!(fs::read(&path).expect("read preserved lockfile"), original);
+
+        write_lockfile_v2_atomic_cas(dir.path(), &replacement, Some(&original_sha256))
+            .expect("matching digest should replace lockfile");
+        let replaced = fs::read(&path).expect("read replaced lockfile");
+        assert_ne!(replaced, original);
+
+        let error = write_lockfile_v2_atomic_cas(dir.path(), &first, Some(&original_sha256))
+            .expect_err("stale digest must reject a changed lockfile");
+        assert!(error.message.contains("changed while package resolution"));
+        assert_eq!(
+            fs::read(&path).expect("read preserved replacement"),
+            replaced
+        );
+        assert!(fs::read_dir(dir.path()).expect("read dir").all(|entry| {
+            !entry
+                .expect("dir entry")
+                .file_name()
+                .to_string_lossy()
+                .starts_with(".axiom.lock.tmp.")
+        }));
+    }
+
+    #[test]
+    fn conditional_atomic_write_compares_immediately_before_replace() {
+        let dir = tempdir().expect("tempdir");
+        let path = lockfile_path(dir.path());
+        let original = sample_lockfile_v2();
+        write_lockfile_v2_atomic(dir.path(), &original).expect("write original lockfile");
+        let (_loaded, original_sha256) =
+            load_lockfile_with_sha256(dir.path()).expect("load original identity");
+        let concurrent = b"concurrent operator edit\n";
+
+        let error = write_lockfile_v2_atomic_cas_impl(
+            dir.path(),
+            &original,
+            Some(&original_sha256),
+            || {
+                fs::write(&path, concurrent).map_err(|err| {
+                    lockfile_error(&path, format!("failed to simulate concurrent edit: {err}"))
+                })
+            },
+        )
+        .expect_err("concurrent edit immediately before compare must fail closed");
+        assert!(error.message.contains("changed while package resolution"));
+        assert_eq!(
+            fs::read(&path).expect("read concurrent edit"),
+            concurrent,
+            "CAS failure must preserve the concurrent writer's bytes"
+        );
+        assert!(fs::read_dir(dir.path()).expect("read dir").all(|entry| {
+            !entry
+                .expect("dir entry")
+                .file_name()
+                .to_string_lossy()
+                .starts_with(".axiom.lock.tmp.")
+        }));
+    }
+
+    #[test]
+    fn atomic_write_commits_a_strict_v2_lockfile() {
+        let dir = tempdir().expect("tempdir");
+        let expected = sample_lockfile_v2();
+        write_lockfile_v2_atomic(dir.path(), &expected).expect("atomic write");
+        assert_eq!(
+            load_lockfile(dir.path()).expect("load written lock"),
+            ParsedLockfile::V2(expected)
         );
     }
 }

--- a/stage1/crates/axiomc/src/lockfile.rs
+++ b/stage1/crates/axiomc/src/lockfile.rs
@@ -534,17 +534,14 @@ fn validate_lockfile_v1_model(lockfile: &Lockfile, path: &Path) -> Result<(), Di
             format!("axiom.lock v1 parser received version {}", lockfile.version),
         ));
     }
-    let mut names = BTreeSet::new();
     for package in &lockfile.package {
         require_nonempty(path, "package.name", &package.name)?;
         require_nonempty(path, "package.version", &package.version)?;
-        validate_path_source(path, &package.source)?;
-        if !names.insert(package.name.as_str()) {
-            return Err(lockfile_error(
-                path,
-                format!("duplicate axiom.lock v1 package name {:?}", package.name),
-            ));
-        }
+        // v1 lockfiles are workspace-relative and may contain multiple
+        // packages with the same name from different dependency trees. Keep
+        // their legacy source syntax intact; the canonical/portable source
+        // contract belongs to v2.
+        validate_path_source_v1(path, &package.source)?;
     }
     Ok(())
 }
@@ -1146,6 +1143,25 @@ fn validate_path_source(path: &Path, source: &str) -> Result<(), Diagnostic> {
         return Err(lockfile_error(
             path,
             format!("path source {source:?} is not portable and canonical"),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_path_source_v1(path: &Path, source: &str) -> Result<(), Diagnostic> {
+    if source == "path" {
+        return Ok(());
+    }
+    let Some(relative) = source.strip_prefix("path:") else {
+        return Err(lockfile_error(
+            path,
+            format!("path package has invalid source {source:?}"),
+        ));
+    };
+    if relative.is_empty() {
+        return Err(lockfile_error(
+            path,
+            format!("path package has invalid source {source:?}"),
         ));
     }
     Ok(())

--- a/stage1/crates/axiomc/src/lsp.rs
+++ b/stage1/crates/axiomc/src/lsp.rs
@@ -332,7 +332,7 @@ impl LspServer {
             match analyze_package_for_lsp(root, &overlays) {
                 Ok(modules) => {
                     for module in modules {
-                        let uri = uri_for_path(&module.path);
+                        let uri = workspace_uri_for_path(&module.path, &documents);
                         let source = documents.get(&uri).cloned().unwrap_or_else(|| {
                             fs::read_to_string(&module.path).unwrap_or_default()
                         });
@@ -345,7 +345,7 @@ impl LspServer {
                             module
                                 .imports
                                 .iter()
-                                .map(|path| uri_for_path(path))
+                                .map(|path| workspace_uri_for_path(path, &documents))
                                 .collect(),
                         );
                         resolved.insert(uri);
@@ -356,8 +356,8 @@ impl LspServer {
                         .path
                         .as_deref()
                         .map(Path::new)
-                        .map(uri_for_path)
-                        .unwrap_or_else(|| uri_for_path(root));
+                        .map(|path| workspace_uri_for_path(path, &documents))
+                        .unwrap_or_else(|| workspace_uri_for_path(root, &documents));
                     diagnostics.entry(uri).or_default().push(diagnostic);
                 }
             }
@@ -769,6 +769,21 @@ fn uri_for_path(path: &Path) -> String {
         "workspace file paths must be absolute"
     );
     format!("file://{}", percent_encode_path(path))
+}
+
+fn workspace_uri_for_path(path: &Path, documents: &BTreeMap<String, String>) -> String {
+    let direct = uri_for_path(path);
+    if documents.contains_key(&direct) {
+        return direct;
+    }
+    let Ok(canonical) = fs::canonicalize(path) else {
+        return direct;
+    };
+    documents
+        .keys()
+        .find(|uri| fs::canonicalize(path_for_uri(uri)).ok().as_ref() == Some(&canonical))
+        .cloned()
+        .unwrap_or(direct)
 }
 
 fn percent_encode_path(path: &str) -> String {

--- a/stage1/crates/axiomc/src/main.rs
+++ b/stage1/crates/axiomc/src/main.rs
@@ -3,8 +3,8 @@ use axiomc::dap;
 use axiomc::diagnostic_catalog::{DiagnosticCodeInfo, diagnostic_code_info};
 use axiomc::diagnostics::Diagnostic;
 use axiomc::doctor::{doctor_report, doctor_text};
-use axiomc::json_contract;
 use axiomc::intent_ir::{IntentIrDocument, emit_intent_ir};
+use axiomc::json_contract;
 use axiomc::lockfile::{expected_lockfile_for_project, validate_lockfile};
 use axiomc::lsp;
 use axiomc::manifest::{
@@ -14,6 +14,9 @@ use axiomc::manifest::{
 #[cfg(test)]
 use axiomc::new_project::create_project;
 use axiomc::new_project::{WorkloadTemplate, create_project_with_template};
+use axiomc::package_manager::{
+    PackageManagerError, fetch_packages, update_packages, vendor_packages,
+};
 use axiomc::package_trust::{
     Ed25519Signer, PackageArtifacts, PackageInputFailure, PackageTrustInput, PackageVerification,
     RegistryIndexEnvelope, TrustRootsEnvelope, VerificationExpectation, input_failure_verification,
@@ -24,9 +27,9 @@ use axiomc::package_trust::{
 use axiomc::project::{
     BuildOptions, BuildOutput, CheckOptions, RunLimits, RunOptions, TestOptions, TestOutput,
     build_project_with_options, capability_sbom, check_project_with_options,
-    documentation_packages, list_project_tests_with_options, package_graph_metadata, project_capabilities,
-    run_project_report_with_limits, run_project_report_with_options, run_project_tests_with_options, run_project_with_options,
-    trace_provenance,
+    documentation_packages, list_project_tests_with_options, package_graph_metadata,
+    project_capabilities, run_project_report_with_limits, run_project_report_with_options,
+    run_project_tests_with_options, run_project_with_options, trace_provenance,
 };
 use axiomc::registry::{
     PublishOptions, RegistryIndexOptions, RegistryServeOptions, load_registry_index,
@@ -48,12 +51,13 @@ use std::os::unix::ffi::OsStrExt;
 use std::path::{Component, Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
+mod agent_task_cli;
 mod benchmark;
 mod formatter;
-mod intent_ir_cli; mod migration_plan_cli;
-mod agent_task_cli;
-mod verification_planner_cli;
 mod formatter_cli;
+mod intent_ir_cli;
+mod migration_plan_cli;
+mod verification_planner_cli;
 use formatter::FormatRange;
 #[derive(Debug, Parser)]
 #[command(name = "axiomc", about = "Axiom stage1 bootstrap compiler")]
@@ -196,7 +200,13 @@ enum Command {
         json: bool,
     },
     /// Compile an approved specification into a bounded, read-only task contract.
-    TaskContract { spec: PathBuf, #[arg(long, default_value = ".")] project: PathBuf, #[arg(long)] json: bool },
+    TaskContract {
+        spec: PathBuf,
+        #[arg(long, default_value = ".")]
+        project: PathBuf,
+        #[arg(long)]
+        json: bool,
+    },
     /// Emit semantic evidence requirements and observed test evidence.
     Evidence {
         path: PathBuf,
@@ -220,7 +230,22 @@ enum Command {
         json: bool,
     },
     /// Map semantic impact to exact-head evidence, or evaluate a result set.
-    VerificationPlan { before: PathBuf, after: PathBuf, #[arg(long)] diff: PathBuf, #[arg(long, default_value = ".")] project: PathBuf, #[arg(long)] source_head: String, #[arg(long)] delivered_head: String, #[arg(long)] results: Option<PathBuf>, #[arg(long)] json: bool },
+    VerificationPlan {
+        before: PathBuf,
+        after: PathBuf,
+        #[arg(long)]
+        diff: PathBuf,
+        #[arg(long, default_value = ".")]
+        project: PathBuf,
+        #[arg(long)]
+        source_head: String,
+        #[arg(long)]
+        delivered_head: String,
+        #[arg(long)]
+        results: Option<PathBuf>,
+        #[arg(long)]
+        json: bool,
+    },
     /// Inspect project metadata for agent tooling.
     Inspect {
         #[command(subcommand)]
@@ -305,7 +330,12 @@ enum Command {
         json: bool,
     },
     /// Build a deterministic, plan-only edition migration from a Compatibility v1 report.
-    Migrate { #[arg(long)] report: PathBuf, #[arg(long)] json: bool },
+    Migrate {
+        #[arg(long)]
+        report: PathBuf,
+        #[arg(long)]
+        json: bool,
+    },
     /// Start a small stage1 scratch REPL backed by axiomc check/run.
     Repl {
         /// Emit an axiom.stage1.v1 JSON envelope for agent/tool consumption.
@@ -511,6 +541,33 @@ enum PkgCommand {
         #[arg(long)]
         json: bool,
     },
+    /// Authenticate and cache exact locked packages, creating axiom.lock v2 on first resolution.
+    Fetch {
+        path: PathBuf,
+        /// Emit an axiom.stage1.v1 JSON envelope for agent/tool consumption.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Re-resolve authenticated registry packages and update axiom.lock v2.
+    Update {
+        path: PathBuf,
+        /// Update only the named direct dependency.
+        #[arg(long)]
+        package: Option<String>,
+        /// Emit an axiom.stage1.v1 JSON envelope for agent/tool consumption.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Materialize the locked registry graph into a deterministic vendor tree.
+    Vendor {
+        path: PathBuf,
+        /// Override the manifest-configured vendor directory.
+        #[arg(long)]
+        out: Option<PathBuf>,
+        /// Emit an axiom.stage1.v1 JSON envelope for agent/tool consumption.
+        #[arg(long)]
+        json: bool,
+    },
     /// Verify a delivered package against Package Trust v1 metadata and exact artifact bytes.
     Verify {
         /// Exact package archive bytes to authenticate.
@@ -704,13 +761,11 @@ fn main() {
             };
             if json {
                 match run_project_report_with_options(&path, &options) {
-                    Ok(output) => {
-                        print_json_output_or_error(
-                            "run",
-                            &json_contract::run_success(&path, &output),
-                            output.exit_code,
-                        )
-                    }
+                    Ok(output) => print_json_output_or_error(
+                        "run",
+                        &json_contract::run_success(&path, &output),
+                        output.exit_code,
+                    ),
                     Err(error) => print_error("run", error, true),
                 }
             } else {
@@ -946,7 +1001,11 @@ fn main() {
             }
             Err(error) => print_error("repair-plan", error, json),
         },
-        Command::TaskContract { spec, project, json } => agent_task_cli::run(&project, &spec, json),
+        Command::TaskContract {
+            spec,
+            project,
+            json,
+        } => agent_task_cli::run(&project, &spec, json),
         Command::Evidence { path, json } => match evidence_report(&path) {
             Ok(report) => {
                 if json {
@@ -1008,7 +1067,25 @@ fn main() {
             }
             Err(error) => print_error("semantic-diff", error, json),
         },
-        Command::VerificationPlan { before, after, diff, project, source_head, delivered_head, results, json } => verification_planner_cli::run(&before, &after, &diff, &project, &source_head, &delivered_head, results.as_deref(), json),
+        Command::VerificationPlan {
+            before,
+            after,
+            diff,
+            project,
+            source_head,
+            delivered_head,
+            results,
+            json,
+        } => verification_planner_cli::run(
+            &before,
+            &after,
+            &diff,
+            &project,
+            &source_head,
+            &delivered_head,
+            results.as_deref(),
+            json,
+        ),
         Command::Inspect { command } => match command {
             InspectCommand::Intent { path, json } => intent_ir_cli::run(&path, json),
             InspectCommand::Symbols { path, json } => match inspect_symbols(&path) {
@@ -1173,6 +1250,45 @@ fn main() {
                 }
                 Err(error) => print_error("pkg graph", error, json),
             },
+            PkgCommand::Fetch { path, json } => match fetch_packages(&path) {
+                Ok(report) => {
+                    if json {
+                        print_json("pkg fetch", &report)
+                    } else {
+                        eprintln!("{}", report.summary);
+                        0
+                    }
+                }
+                Err(error) => print_package_manager_error("pkg fetch", error, json),
+            },
+            PkgCommand::Update {
+                path,
+                package,
+                json,
+            } => match update_packages(&path, package.as_deref()) {
+                Ok(report) => {
+                    if json {
+                        print_json("pkg update", &report)
+                    } else {
+                        eprintln!("{}", report.summary);
+                        0
+                    }
+                }
+                Err(error) => print_package_manager_error("pkg update", error, json),
+            },
+            PkgCommand::Vendor { path, out, json } => {
+                match vendor_packages(&path, out.as_deref()) {
+                    Ok(report) => {
+                        if json {
+                            print_json("pkg vendor", &report)
+                        } else {
+                            eprintln!("{}", report.summary);
+                            0
+                        }
+                    }
+                    Err(error) => print_package_manager_error("pkg vendor", error, json),
+                }
+            }
             PkgCommand::Verify {
                 archive,
                 manifest,
@@ -1787,6 +1903,33 @@ fn print_error(command: &str, error: Diagnostic, json: bool) -> i32 {
             eprintln!("{related}");
         }
     }
+    1
+}
+
+fn package_manager_diagnostic(error: PackageManagerError) -> Diagnostic {
+    Diagnostic::new("package", error.message)
+        .with_code(error.code)
+        .with_package_resolution(error.trace, error.resolver)
+}
+
+fn print_package_manager_error(command: &str, error: PackageManagerError, json: bool) -> i32 {
+    if !json {
+        return print_error(command, package_manager_diagnostic(error), false);
+    }
+
+    let PackageManagerError {
+        code,
+        message,
+        trace,
+        resolver,
+    } = error;
+    let diagnostic = Diagnostic::new("package", message)
+        .with_code(code)
+        .with_package_resolution(trace.clone(), resolver.clone());
+    let mut payload = json_contract::error(command, &diagnostic);
+    payload["trace"] = serde_json::json!(trace);
+    payload["resolver"] = resolver.unwrap_or(serde_json::Value::Null);
+    println!("{payload}");
     1
 }
 
@@ -2808,12 +2951,14 @@ fn collect_semantic_declarations(
             .with_path(file.display().to_string())
         })?;
         let program = parse_program(&source, &file)?;
-        axioms.extend(program.axioms.iter().map(|axiom| DeclaredAxiom {
-            id: intent
-                .node_id("Axiom", &axiom.name)
-                .unwrap_or(&intent.package)
-                .to_owned(),
-            name: axiom.name.clone(),
+        axioms.extend(program.axioms.iter().map(|axiom| {
+            DeclaredAxiom {
+                id: intent
+                    .node_id("Axiom", &axiom.name)
+                    .unwrap_or(&intent.package)
+                    .to_owned(),
+                name: axiom.name.clone(),
+            }
         }));
         capabilities.extend(program.semantic_capabilities.iter().map(|capability| {
             DeclaredSemanticCapability {
@@ -7324,13 +7469,8 @@ fn run_doc_tests_with_limits(
             .map_err(|err| Diagnostic::new("doctest", format!("failed to write lockfile: {err}")))?;
         fs::write(temp.path().join("src/main.ax"), &test.code)
             .map_err(|err| Diagnostic::new("doctest", format!("failed to write source: {err}")))?;
-        let output = run_project_report_with_limits(
-            temp.path(),
-            &RunOptions::default(),
-            limits,
-        )
-        .map_err(
-            |err| {
+        let output = run_project_report_with_limits(temp.path(), &RunOptions::default(), limits)
+            .map_err(|err| {
                 Diagnostic::new(
                     "doctest",
                     format!("doctest `{}` failed: {}", test.id, err.message),
@@ -7338,8 +7478,7 @@ fn run_doc_tests_with_limits(
                 .with_code("doctest_failed")
                 .with_path(test.source.clone())
                 .with_span(test.line, 1)
-            },
-        )?;
+            })?;
         if output.exit_code != 0 {
             return Err(Diagnostic::new(
                 "doctest",
@@ -7406,9 +7545,12 @@ fn render_markdown_docs(items: &[DocItem]) -> String {
 }
 
 fn render_doc_markdown_line(line: &str, links: &[DocLink]) -> String {
-    render_doc_links(line, links, |text| text.to_string(), |link| {
-        format!("[{}](#{})", link.target, link.resolved_id)
-    })
+    render_doc_links(
+        line,
+        links,
+        |text| text.to_string(),
+        |link| format!("[{}](#{})", link.target, link.resolved_id),
+    )
 }
 
 fn render_doc_html_line(line: &str, links: &[DocLink]) -> String {
@@ -7945,7 +8087,21 @@ fn inspect_package_nodes(
         .iter()
         .map(|(name, spec)| PackageEdge {
             name: name.clone(),
-            path: project.join(&spec.path).display().to_string(),
+            path: spec.path_source().map_or_else(
+                || {
+                    let registry = spec
+                        .registry_source()
+                        .expect("manifest dependencies have exactly one source");
+                    format!(
+                        "registry:{}/{}/{}@{}",
+                        registry.registry,
+                        registry.namespace,
+                        registry.package,
+                        spec.version.as_deref().unwrap_or("<missing>")
+                    )
+                },
+                |path| project.join(path).display().to_string(),
+            ),
         })
         .collect::<Vec<_>>();
     let workspace_members = manifest
@@ -7983,7 +8139,10 @@ fn inspect_module_nodes(
     let dependencies = manifest
         .dependencies
         .iter()
-        .map(|(name, spec)| (name.as_str(), project.join(&spec.path).join("src")))
+        .filter_map(|(name, spec)| {
+            spec.path_source()
+                .map(|path| (name.as_str(), project.join(path).join("src")))
+        })
         .collect::<HashMap<_, _>>();
     let stdlib = inspect_stdlib_module_set();
     let mut modules = Vec::new();
@@ -8752,14 +8911,37 @@ mod tests {
     #[test]
     fn json_flags_describe_agent_envelope_in_help() {
         for path in [
-            &["parse"][..], &["check"], &["build"], &["run"], &["trace"], &["test"],
-            &["caps"], &["repair-plan"], &["evidence"], &["verify"], &["semantic-diff"],
-            &["explain"], &["doctor"], &["fmt"], &["doc"], &["bench"],
-            &["mutation-report"], &["repl"], &["inspect", "symbols"], &["inspect", "graph"],
-            &["inspect", "effects"], &["inspect", "artifacts"], &["generate", "openapi"],
-            &["generate", "policy"], &["generate", "sql"], &["generate", "terraform"],
+            &["parse"][..],
+            &["check"],
+            &["build"],
+            &["run"],
+            &["trace"],
+            &["test"],
+            &["caps"],
+            &["repair-plan"],
+            &["evidence"],
+            &["verify"],
+            &["semantic-diff"],
+            &["explain"],
+            &["doctor"],
+            &["fmt"],
+            &["doc"],
+            &["bench"],
+            &["mutation-report"],
+            &["repl"],
+            &["inspect", "symbols"],
+            &["inspect", "graph"],
+            &["inspect", "effects"],
+            &["inspect", "artifacts"],
+            &["generate", "openapi"],
+            &["generate", "policy"],
+            &["generate", "sql"],
+            &["generate", "terraform"],
             &["generate", "runbook"],
             &["pkg", "graph"],
+            &["pkg", "fetch"],
+            &["pkg", "update"],
+            &["pkg", "vendor"],
         ] {
             let help = subcommand_help(path);
             assert!(help.contains("--json"), "{path:?} should list --json");
@@ -9150,8 +9332,7 @@ return "ok"
         fs::write(&path, br#"{"_type":"first","_type":"duplicate"}"#)
             .expect("write duplicate-key provenance");
 
-        let error =
-            load_registry_json_value(&path, "publish", "provenance statement").unwrap_err();
+        let error = load_registry_json_value(&path, "publish", "provenance statement").unwrap_err();
 
         assert!(
             error.message.contains("duplicate"),
@@ -9161,8 +9342,7 @@ return "ok"
 
     #[test]
     fn package_verification_writer_rejects_schema_invalid_result_before_output() {
-        let mut verdict =
-            input_failure_verification(PackageInputFailure::MissingOrUnreadable);
+        let mut verdict = input_failure_verification(PackageInputFailure::MissingOrUnreadable);
         verdict.decision = "unknown".to_owned();
         let mut output = Vec::new();
 
@@ -9187,8 +9367,7 @@ return "ok"
             }
         }
 
-        let verdict =
-            input_failure_verification(PackageInputFailure::MissingOrUnreadable);
+        let verdict = input_failure_verification(PackageInputFailure::MissingOrUnreadable);
 
         assert_eq!(
             write_package_verification_to(&verdict, &mut FailingWriter),
@@ -9208,6 +9387,57 @@ return "ok"
             }
             other => panic!("expected pkg graph command, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn package_resolution_commands_parse_explicit_project_and_options() {
+        let fetch = Cli::parse_from(["axiomc", "pkg", "fetch", "demo", "--json"]);
+        assert!(matches!(
+            fetch.command,
+            Command::Pkg {
+                command: PkgCommand::Fetch { path, json: true },
+            } if path == PathBuf::from("demo")
+        ));
+
+        let update = Cli::parse_from([
+            "axiomc",
+            "pkg",
+            "update",
+            "demo",
+            "--package",
+            "parser",
+            "--json",
+        ]);
+        assert!(matches!(
+            update.command,
+            Command::Pkg {
+                command: PkgCommand::Update {
+                    path,
+                    package: Some(package),
+                    json: true,
+                },
+            } if path == PathBuf::from("demo") && package == "parser"
+        ));
+
+        let vendor = Cli::parse_from([
+            "axiomc",
+            "pkg",
+            "vendor",
+            "demo",
+            "--out",
+            "third-party",
+            "--json",
+        ]);
+        assert!(matches!(
+            vendor.command,
+            Command::Pkg {
+                command: PkgCommand::Vendor {
+                    path,
+                    out: Some(out),
+                    json: true,
+                },
+            } if path == PathBuf::from("demo") && out == PathBuf::from("third-party")
+        ));
     }
 
     #[test]
@@ -11304,8 +11534,11 @@ print serve("127.0.0.1:0", selected_route, 1)
         let dir = tempfile::tempdir().expect("tempdir");
         let project = dir.path().join("doc-contained");
         fs::create_dir_all(project.join("src")).expect("mkdir");
-        fs::write(project.join("src/main.ax"), "/// Main.\npub fn main(): int {\nreturn 0\n}\n")
-            .expect("write source");
+        fs::write(
+            project.join("src/main.ax"),
+            "/// Main.\npub fn main(): int {\nreturn 0\n}\n",
+        )
+        .expect("write source");
 
         let outside = dir.path().join("outside-docs");
         let error = generate_docs(&project, &outside, true).expect_err("reject outside output");
@@ -11318,8 +11551,11 @@ print serve("127.0.0.1:0", selected_route, 1)
         let dir = tempfile::tempdir().expect("tempdir");
         let project = dir.path().join("doc-relative-escape");
         fs::create_dir_all(project.join("src")).expect("mkdir");
-        fs::write(project.join("src/main.ax"), "/// Main.\npub fn main(): int {\nreturn 0\n}\n")
-            .expect("write source");
+        fs::write(
+            project.join("src/main.ax"),
+            "/// Main.\npub fn main(): int {\nreturn 0\n}\n",
+        )
+        .expect("write source");
 
         let outside = project.join("../outside-docs");
         let error = generate_docs(&project, &outside, true).expect_err("reject outside output");
@@ -11341,8 +11577,11 @@ print serve("127.0.0.1:0", selected_route, 1)
         let outside = dir.path().join("outside-docs");
         fs::create_dir_all(project.join("src")).expect("mkdir project src");
         fs::create_dir_all(&outside).expect("mkdir outside");
-        fs::write(project.join("src/main.ax"), "/// Main.\npub fn main(): int {\nreturn 0\n}\n")
-            .expect("write source");
+        fs::write(
+            project.join("src/main.ax"),
+            "/// Main.\npub fn main(): int {\nreturn 0\n}\n",
+        )
+        .expect("write source");
         std::os::unix::fs::symlink(&outside, project.join("docs")).expect("symlink docs");
         let canonical_project = project.canonicalize().expect("canonical project");
 
@@ -11371,8 +11610,11 @@ print serve("127.0.0.1:0", selected_route, 1)
         let outside = dir.path().join("outside.md");
         fs::create_dir_all(project.join("src")).expect("mkdir project src");
         fs::create_dir_all(project.join("docs/axiom")).expect("mkdir docs");
-        fs::write(project.join("src/main.ax"), "/// Main.\npub fn main(): int {\nreturn 0\n}\n")
-            .expect("write source");
+        fs::write(
+            project.join("src/main.ax"),
+            "/// Main.\npub fn main(): int {\nreturn 0\n}\n",
+        )
+        .expect("write source");
         write_doc_test_manifest(&project, "doc-file-symlink");
         fs::write(&outside, "do not overwrite").expect("write outside");
         std::os::unix::fs::symlink(&outside, project.join("docs/axiom/index.md"))
@@ -11407,8 +11649,11 @@ print serve("127.0.0.1:0", selected_route, 1)
         let outside = dir.path().join("outside.html");
         fs::create_dir_all(project.join("src")).expect("mkdir project src");
         fs::create_dir_all(project.join("dist/docs")).expect("mkdir docs");
-        fs::write(project.join("src/main.ax"), "/// Main.\npub fn main(): int {\nreturn 0\n}\n")
-            .expect("write source");
+        fs::write(
+            project.join("src/main.ax"),
+            "/// Main.\npub fn main(): int {\nreturn 0\n}\n",
+        )
+        .expect("write source");
         write_doc_test_manifest(&project, "doc-md-stale-html-symlink");
         fs::write(&outside, "do not overwrite").expect("write outside");
         std::os::unix::fs::symlink(&outside, project.join("dist/docs/index.html"))
@@ -11434,8 +11679,11 @@ print serve("127.0.0.1:0", selected_route, 1)
         let outside = dir.path().join("missing.html");
         fs::create_dir_all(project.join("src")).expect("mkdir project src");
         fs::create_dir_all(project.join("dist/docs")).expect("mkdir docs");
-        fs::write(project.join("src/main.ax"), "/// Main.\npub fn main(): int {\nreturn 0\n}\n")
-            .expect("write source");
+        fs::write(
+            project.join("src/main.ax"),
+            "/// Main.\npub fn main(): int {\nreturn 0\n}\n",
+        )
+        .expect("write source");
         write_doc_test_manifest(&project, "doc-md-broken-html-symlink");
         std::os::unix::fs::symlink(&outside, project.join("dist/docs/index.html"))
             .expect("symlink index html");

--- a/stage1/crates/axiomc/src/manifest.rs
+++ b/stage1/crates/axiomc/src/manifest.rs
@@ -5,6 +5,8 @@ use std::path::{Path, PathBuf};
 
 pub const MANIFEST_FILENAME: &str = "axiom.toml";
 pub const LOCK_FILENAME: &str = "axiom.lock";
+pub const DEFAULT_PACKAGE_CACHE_DIR: &str = ".axiom/cache";
+pub const DEFAULT_PACKAGE_VENDOR_DIR: &str = "vendor";
 pub const KNOWN_CAPABILITIES: [CapabilityKind; 9] = [
     CapabilityKind::Fs,
     CapabilityKind::FsWrite,
@@ -21,6 +23,7 @@ pub const KNOWN_CAPABILITIES: [CapabilityKind; 9] = [
 pub struct Manifest {
     pub package: Option<PackageSection>,
     pub publish: Option<PublishSection>,
+    pub registry: Option<RegistryConfig>,
     pub dependencies: BTreeMap<String, DependencySpec>,
     pub workspace: Option<WorkspaceSection>,
     pub build: BuildSection,
@@ -44,6 +47,34 @@ pub struct PublishSection {
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RegistryConfig {
+    /// Stable manifest-local name used by dependency selectors and lockfiles.
+    pub name: String,
+    /// Exact registry-index endpoint.
+    pub index: String,
+    /// Project-relative Package Trust root metadata.
+    pub trust_roots: String,
+    /// Project-relative Package Trust verification expectation.
+    pub expectation: String,
+    /// Optional project-relative content-addressed cache root.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache: Option<String>,
+    /// Optional project-relative vendored package root.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vendor: Option<String>,
+}
+
+impl RegistryConfig {
+    pub fn cache_root(&self) -> &str {
+        self.cache.as_deref().unwrap_or(DEFAULT_PACKAGE_CACHE_DIR)
+    }
+
+    pub fn vendor_root(&self) -> &str {
+        self.vendor.as_deref().unwrap_or(DEFAULT_PACKAGE_VENDOR_DIR)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct WorkspaceSection {
     pub members: Vec<String>,
 }
@@ -62,9 +93,39 @@ pub struct RuntimeConfig {
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct DependencySpec {
-    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub registry: Option<RegistryDependencySpec>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RegistryDependencySpec {
+    /// Stable name of the root `[registry]` entry.
+    pub registry: String,
+    pub namespace: String,
+    /// Published package name. Defaults to the dependency alias.
+    pub package: String,
+}
+
+impl DependencySpec {
+    pub fn is_path(&self) -> bool {
+        self.path.is_some()
+    }
+
+    pub fn is_registry(&self) -> bool {
+        self.registry.is_some()
+    }
+
+    pub fn path_source(&self) -> Option<&str> {
+        self.path.as_deref()
+    }
+
+    pub fn registry_source(&self) -> Option<&RegistryDependencySpec> {
+        self.registry.as_ref()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -248,7 +309,7 @@ struct RawManifest {
     runtime: Option<RawRuntimeConfig>,
     tests: Option<Vec<RawTestTarget>>,
     capabilities: Option<RawCapabilityConfig>,
-    registry: Option<toml::Value>,
+    registry: Option<RawRegistryConfig>,
     publish: Option<RawPublishSection>,
 }
 
@@ -294,8 +355,21 @@ struct RawDependencyDetail {
     path: Option<String>,
     version: Option<String>,
     checksum: Option<toml::Value>,
-    registry: Option<toml::Value>,
+    registry: Option<String>,
+    namespace: Option<String>,
+    package: Option<String>,
     source: Option<toml::Value>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawRegistryConfig {
+    name: Option<String>,
+    index: Option<String>,
+    trust_roots: Option<String>,
+    expectation: Option<String>,
+    cache: Option<String>,
+    vendor: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -379,18 +453,34 @@ fn is_false(value: &bool) -> bool {
 
 pub fn load_manifest(project_root: &Path) -> Result<Manifest, Diagnostic> {
     let path = manifest_path(project_root);
-    let content = std::fs::read_to_string(&path).map_err(|err| {
+    let content = std::fs::read(&path).map_err(|err| {
         Diagnostic::new(
             "manifest",
             format!("failed to read {}: {err}", MANIFEST_FILENAME),
         )
         .with_path(path.display().to_string())
     })?;
-    let raw: RawManifest = toml::from_str(&content).map_err(|err| {
-        Diagnostic::new("manifest", format!("invalid {MANIFEST_FILENAME}: {err}"))
-            .with_path(path.display().to_string())
+    parse_manifest_exact(&content, &path)
+}
+
+/// Parse a manifest from the exact authenticated bytes supplied by a caller.
+///
+/// Registry resolution must use this entrypoint only after Package Trust has
+/// authenticated the containing release. It deliberately does not reread a
+/// filesystem path, closing the authenticate-then-reread gap.
+pub fn parse_manifest_exact(content: &[u8], source_path: &Path) -> Result<Manifest, Diagnostic> {
+    let content = std::str::from_utf8(content).map_err(|err| {
+        Diagnostic::new(
+            "manifest",
+            format!("invalid {MANIFEST_FILENAME}: manifest is not UTF-8: {err}"),
+        )
+        .with_path(source_path.display().to_string())
     })?;
-    normalize_manifest(raw, &path)
+    let raw: RawManifest = toml::from_str(content).map_err(|err| {
+        Diagnostic::new("manifest", format!("invalid {MANIFEST_FILENAME}: {err}"))
+            .with_path(source_path.display().to_string())
+    })?;
+    normalize_manifest(raw, source_path)
 }
 
 pub fn manifest_path(project_root: &Path) -> PathBuf {
@@ -575,8 +665,8 @@ impl CapabilityKind {
 }
 
 fn normalize_manifest(raw: RawManifest, path: &Path) -> Result<Manifest, Diagnostic> {
-    validate_reserved_root_publish_fields(&raw, path)?;
     let publish = normalize_publish(raw.publish, path)?;
+    let registry = normalize_registry(raw.registry, path)?;
     let workspace = normalize_workspace(raw.workspace, path)?;
     let package = normalize_package(raw.package, workspace.is_some(), path)?;
     let raw_build = raw.build;
@@ -595,7 +685,11 @@ fn normalize_manifest(raw: RawManifest, path: &Path) -> Result<Manifest, Diagnos
     validate_relative_path(path, "build.entry", &entry)?;
     validate_relative_path(path, "build.out_dir", &out_dir)?;
     let runtime = normalize_runtime(raw.runtime, path)?;
-    let dependencies = normalize_dependencies(raw.dependencies.unwrap_or_default(), path)?;
+    let dependencies = normalize_dependencies(
+        raw.dependencies.unwrap_or_default(),
+        registry.as_ref(),
+        path,
+    )?;
     let tests = normalize_tests(raw.tests.unwrap_or_default(), path)?;
     let capabilities = raw.capabilities.unwrap_or_default();
     let fs_root =
@@ -630,6 +724,7 @@ fn normalize_manifest(raw: RawManifest, path: &Path) -> Result<Manifest, Diagnos
     Ok(Manifest {
         package,
         publish,
+        registry,
         dependencies,
         workspace,
         build: BuildSection { entry, out_dir },
@@ -677,13 +772,6 @@ fn normalize_runtime(
     })
 }
 
-fn validate_reserved_root_publish_fields(raw: &RawManifest, path: &Path) -> Result<(), Diagnostic> {
-    if raw.registry.is_some() {
-        return Err(reserved_manifest_field(path, "[registry]"));
-    }
-    Ok(())
-}
-
 fn normalize_publish(
     raw_publish: Option<RawPublishSection>,
     path: &Path,
@@ -719,13 +807,69 @@ fn normalize_publish(
     }))
 }
 
+fn normalize_registry(
+    raw_registry: Option<RawRegistryConfig>,
+    path: &Path,
+) -> Result<Option<RegistryConfig>, Diagnostic> {
+    let Some(raw_registry) = raw_registry else {
+        return Ok(None);
+    };
+    let name = required_field(raw_registry.name, path, "registry.name")?;
+    validate_stable_registry_name(path, "registry.name", &name)?;
+    let index = required_field(raw_registry.index, path, "registry.index")?;
+    validate_registry_source(path, "registry.index", &index)?;
+    let trust_roots = required_field(raw_registry.trust_roots, path, "registry.trust_roots")?;
+    validate_relative_path(path, "registry.trust_roots", &trust_roots)?;
+    let expectation = required_field(raw_registry.expectation, path, "registry.expectation")?;
+    validate_relative_path(path, "registry.expectation", &expectation)?;
+    let cache =
+        normalize_optional_materialization_root(path, "registry.cache", raw_registry.cache)?;
+    let vendor =
+        normalize_optional_materialization_root(path, "registry.vendor", raw_registry.vendor)?;
+    let effective_cache = cache.as_deref().unwrap_or(DEFAULT_PACKAGE_CACHE_DIR);
+    let effective_vendor = vendor.as_deref().unwrap_or(DEFAULT_PACKAGE_VENDOR_DIR);
+    validate_distinct_materialization_roots(path, effective_cache, effective_vendor)?;
+    Ok(Some(RegistryConfig {
+        name,
+        index,
+        trust_roots,
+        expectation,
+        cache,
+        vendor,
+    }))
+}
+
+fn validate_stable_registry_name(
+    path: &Path,
+    field_name: &str,
+    value: &str,
+) -> Result<(), Diagnostic> {
+    let mut chars = value.chars();
+    let valid = value.len() <= 64
+        && chars
+            .next()
+            .is_some_and(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit())
+        && chars.all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-' || ch == '_');
+    if valid {
+        Ok(())
+    } else {
+        Err(Diagnostic::new(
+            "manifest",
+            format!("{field_name} must be a stable lowercase ASCII name of at most 64 characters"),
+        )
+        .with_path(path.display().to_string()))
+    }
+}
+
 fn validate_registry_source(path: &Path, field_name: &str, value: &str) -> Result<(), Diagnostic> {
-    if is_valid_registry_url(value) {
+    if is_supported_registry_index_url(value) {
         return Ok(());
     }
     Err(Diagnostic::new(
         "manifest",
-        format!("{field_name} must be a valid https:// or file:// registry source"),
+        format!(
+            "{field_name} must be a valid https:// or file:// registry source (or an http:// loopback fixture source)"
+        ),
     )
     .with_path(path.display().to_string()))
 }
@@ -1137,6 +1281,7 @@ fn required_field(
 
 fn normalize_dependencies(
     raw_dependencies: BTreeMap<String, RawDependencySpec>,
+    registry_config: Option<&RegistryConfig>,
     path: &Path,
 ) -> Result<BTreeMap<String, DependencySpec>, Diagnostic> {
     let mut dependencies = BTreeMap::new();
@@ -1149,11 +1294,14 @@ fn normalize_dependencies(
         }
         match raw_spec {
             RawDependencySpec::Path(value) => {
+                let value =
+                    required_field(Some(value), path, &format!("dependencies.{name}.path"))?;
                 validate_dependency_path(path, &format!("dependencies.{name}.path"), &value)?;
                 dependencies.insert(
                     name,
                     DependencySpec {
-                        path: value,
+                        path: Some(value),
+                        registry: None,
                         version: None,
                     },
                 );
@@ -1166,39 +1314,139 @@ fn normalize_dependencies(
                         &format!("dependencies.{name}.checksum"),
                     ));
                 }
-                if detail.registry.is_some() {
-                    return Err(reserved_manifest_field(
-                        path,
-                        &format!("dependencies.{name}.registry"),
-                    ));
-                }
                 if detail.source.is_some() {
                     return Err(reserved_manifest_field(
                         path,
                         &format!("dependencies.{name}.source"),
                     ));
                 }
-                if detail.path.is_none() && detail.version.is_some() {
-                    return Err(reserved_manifest_field(
-                        path,
-                        &format!("dependencies.{name}.version"),
-                    ));
+                let source_prefix = format!("dependencies.{name}");
+                match (detail.path, detail.registry) {
+                    (Some(raw_path), None) => {
+                        if detail.namespace.is_some() || detail.package.is_some() {
+                            return Err(Diagnostic::new(
+                                "manifest",
+                                format!(
+                                    "{source_prefix} path dependencies must not declare namespace or package"
+                                ),
+                            )
+                            .with_path(path.display().to_string()));
+                        }
+                        let raw_path =
+                            required_field(Some(raw_path), path, &format!("{source_prefix}.path"))?;
+                        validate_dependency_path(
+                            path,
+                            &format!("{source_prefix}.path"),
+                            &raw_path,
+                        )?;
+                        let version = normalize_dependency_version(
+                            path,
+                            &format!("{source_prefix}.version"),
+                            detail.version,
+                            true,
+                        )?;
+                        dependencies.insert(
+                            name,
+                            DependencySpec {
+                                path: Some(raw_path),
+                                registry: None,
+                                version,
+                            },
+                        );
+                    }
+                    (None, Some(registry_name)) => {
+                        let registry_name = required_field(
+                            Some(registry_name),
+                            path,
+                            &format!("{source_prefix}.registry"),
+                        )?;
+                        let Some(registry_config) = registry_config else {
+                            return Err(Diagnostic::new(
+                                "manifest",
+                                format!(
+                                    "{source_prefix}.registry requires a root [registry] configuration"
+                                ),
+                            )
+                            .with_path(path.display().to_string()));
+                        };
+                        if registry_name != registry_config.name {
+                            return Err(Diagnostic::new(
+                                "manifest",
+                                format!(
+                                    "{source_prefix}.registry names {registry_name:?}, but the configured registry is {:?}",
+                                    registry_config.name
+                                ),
+                            )
+                            .with_path(path.display().to_string()));
+                        }
+                        let namespace = required_field(
+                            detail.namespace,
+                            path,
+                            &format!("{source_prefix}.namespace"),
+                        )?;
+                        validate_registry_coordinate_segment(
+                            path,
+                            &format!("{source_prefix}.namespace"),
+                            &namespace,
+                        )?;
+                        let package = detail.package.unwrap_or_else(|| name.clone());
+                        let package = required_field(
+                            Some(package),
+                            path,
+                            &format!("{source_prefix}.package"),
+                        )?;
+                        validate_registry_coordinate_segment(
+                            path,
+                            &format!("{source_prefix}.package"),
+                            &package,
+                        )?;
+                        let version = normalize_dependency_version(
+                            path,
+                            &format!("{source_prefix}.version"),
+                            detail.version,
+                            false,
+                        )?
+                        .ok_or_else(|| {
+                            Diagnostic::new(
+                                "manifest",
+                                format!(
+                                    "missing or empty {source_prefix}.version; registry dependencies require an exact or caret version"
+                                ),
+                            )
+                            .with_path(path.display().to_string())
+                        })?;
+                        dependencies.insert(
+                            name,
+                            DependencySpec {
+                                path: None,
+                                registry: Some(RegistryDependencySpec {
+                                    registry: registry_name,
+                                    namespace,
+                                    package,
+                                }),
+                                version: Some(version),
+                            },
+                        );
+                    }
+                    (Some(_), Some(_)) => {
+                        return Err(Diagnostic::new(
+                            "manifest",
+                            format!(
+                                "{source_prefix} must declare exactly one source kind: path or registry"
+                            ),
+                        )
+                        .with_path(path.display().to_string()));
+                    }
+                    (None, None) => {
+                        return Err(Diagnostic::new(
+                            "manifest",
+                            format!(
+                                "{source_prefix} must declare exactly one source kind: path or registry"
+                            ),
+                        )
+                        .with_path(path.display().to_string()));
+                    }
                 }
-                let raw_path =
-                    required_field(detail.path, path, &format!("dependencies.{name}.path"))?;
-                validate_dependency_path(path, &format!("dependencies.{name}.path"), &raw_path)?;
-                let version = normalize_dependency_version(
-                    path,
-                    &format!("dependencies.{name}.version"),
-                    detail.version,
-                )?;
-                dependencies.insert(
-                    name,
-                    DependencySpec {
-                        path: raw_path,
-                        version,
-                    },
-                );
             }
         };
     }
@@ -1209,13 +1457,47 @@ fn normalize_dependency_version(
     path: &Path,
     field_name: &str,
     version: Option<String>,
+    allow_wildcard: bool,
 ) -> Result<Option<String>, Diagnostic> {
     let Some(version) = version else {
         return Ok(None);
     };
     let version = required_field(Some(version), path, field_name)?;
     validate_version_constraint(path, field_name, &version)?;
+    if !allow_wildcard && version == "*" {
+        return Err(Diagnostic::new(
+            "manifest",
+            format!(
+                "{field_name} must be an exact MAJOR.MINOR.PATCH version or a caret constraint"
+            ),
+        )
+        .with_path(path.display().to_string()));
+    }
     Ok(Some(version))
+}
+
+fn validate_registry_coordinate_segment(
+    path: &Path,
+    field_name: &str,
+    value: &str,
+) -> Result<(), Diagnostic> {
+    let mut chars = value.chars();
+    let valid = value.len() <= 128
+        && chars
+            .next()
+            .is_some_and(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit())
+        && chars.all(|ch| {
+            ch.is_ascii_lowercase() || ch.is_ascii_digit() || matches!(ch, '-' | '_' | '.')
+        });
+    if valid {
+        Ok(())
+    } else {
+        Err(Diagnostic::new(
+            "manifest",
+            format!("{field_name} must be a portable lowercase package coordinate"),
+        )
+        .with_path(path.display().to_string()))
+    }
 }
 
 fn validate_version_constraint(
@@ -1357,9 +1639,12 @@ fn normalize_test_kind(
     }
 }
 
-fn is_valid_registry_url(registry: &str) -> bool {
+pub fn is_supported_registry_index_url(registry: &str) -> bool {
     if let Some(rest) = registry.strip_prefix("https://") {
-        return is_valid_https_registry_url(rest);
+        return is_valid_network_registry_url(rest, false);
+    }
+    if let Some(rest) = registry.strip_prefix("http://") {
+        return is_valid_network_registry_url(rest, true);
     }
     if let Some(path) = registry.strip_prefix("file://") {
         return is_valid_file_registry_url(path);
@@ -1367,7 +1652,7 @@ fn is_valid_registry_url(registry: &str) -> bool {
     false
 }
 
-fn is_valid_https_registry_url(rest: &str) -> bool {
+fn is_valid_network_registry_url(rest: &str, require_loopback: bool) -> bool {
     let authority_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
     let authority = &rest[..authority_end];
     let suffix = &rest[authority_end..];
@@ -1390,13 +1675,24 @@ fn is_valid_https_registry_url(rest: &str) -> bool {
         }
     }
 
-    if host.starts_with('[') || host.ends_with(']') {
-        return is_valid_ipv6_authority_host(host);
+    let valid_host = if host.starts_with('[') || host.ends_with(']') {
+        is_valid_ipv6_authority_host(host)
+    } else if host.parse::<std::net::Ipv4Addr>().is_ok() {
+        true
+    } else {
+        is_valid_registry_host(host)
+    };
+    valid_host && (!require_loopback || is_loopback_registry_host(host))
+}
+
+fn is_loopback_registry_host(host: &str) -> bool {
+    if let Ok(address) = host.parse::<std::net::Ipv4Addr>() {
+        return address.is_loopback();
     }
-    if host.parse::<std::net::Ipv4Addr>().is_ok() {
-        return true;
-    }
-    is_valid_registry_host(host)
+    host.strip_prefix('[')
+        .and_then(|value| value.strip_suffix(']'))
+        .and_then(|value| value.parse::<std::net::Ipv6Addr>().ok())
+        .is_some_and(|address| address.is_loopback())
 }
 
 fn split_registry_authority(authority: &str) -> (Option<&str>, Option<&str>) {
@@ -1466,6 +1762,69 @@ fn normalize_optional_relative_path(
     let value = required_field(Some(value), path, field_name)?;
     validate_relative_path(path, field_name, &value)?;
     Ok(Some(value))
+}
+
+fn normalize_optional_materialization_root(
+    path: &Path,
+    field_name: &str,
+    value: Option<String>,
+) -> Result<Option<String>, Diagnostic> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    normalize_project_relative_materialization_root(path, field_name, &value).map(Some)
+}
+
+/// Normalize a portable materialization root without touching the filesystem.
+///
+/// Package-manager overrides use this helper to share the manifest's lexical
+/// safety policy before resolving the returned path against the project root.
+pub(crate) fn normalize_project_relative_materialization_root(
+    path: &Path,
+    field_name: &str,
+    value: &str,
+) -> Result<String, Diagnostic> {
+    let value = required_field(Some(value.to_owned()), path, field_name)?;
+    validate_relative_path(path, field_name, &value)?;
+    if value.contains('\\') {
+        return Err(Diagnostic::new(
+            "manifest",
+            format!("{field_name} must use portable '/' path separators"),
+        )
+        .with_path(path.display().to_string()));
+    }
+
+    let normalized = value
+        .split('/')
+        .filter(|component| !component.is_empty() && *component != ".")
+        .collect::<Vec<_>>()
+        .join("/");
+    if normalized.is_empty() {
+        return Err(Diagnostic::new(
+            "manifest",
+            format!("{field_name} must identify a path below the project root"),
+        )
+        .with_path(path.display().to_string()));
+    }
+    Ok(normalized)
+}
+
+/// Reject cache/vendor aliases after both roots have been lexically normalized
+/// and any omitted manifest values have been replaced by their defaults.
+pub(crate) fn validate_distinct_materialization_roots(
+    path: &Path,
+    effective_cache: &str,
+    effective_vendor: &str,
+) -> Result<(), Diagnostic> {
+    if effective_cache == effective_vendor {
+        Err(Diagnostic::new(
+            "manifest",
+            "registry.cache and registry.vendor must use different paths",
+        )
+        .with_path(path.display().to_string()))
+    } else {
+        Ok(())
+    }
 }
 
 fn validate_relative_path(path: &Path, field_name: &str, value: &str) -> Result<(), Diagnostic> {
@@ -1626,12 +1985,10 @@ entry = "src/integration.ax"
 kind = "integration"
 "#,
         );
-        assert!(
-            load_manifest(unknown_kind.path())
-                .expect_err("unpublished test kind must fail")
-                .message
-                .contains("tests[0].kind must be one of")
-        );
+        assert!(load_manifest(unknown_kind.path())
+            .expect_err("unpublished test kind must fail")
+            .message
+            .contains("tests[0].kind must be one of"));
 
         for capability in KNOWN_CAPABILITIES {
             let unsupported_capability = write_manifest(&format!(
@@ -1685,12 +2042,10 @@ path = "../dep"
 version = "^01.2.3"
 "#,
         );
-        assert!(
-            load_manifest(noncanonical_dependency.path())
-                .expect_err("leading-zero dependency version must fail")
-                .message
-                .contains("MAJOR.MINOR.PATCH")
-        );
+        assert!(load_manifest(noncanonical_dependency.path())
+            .expect_err("leading-zero dependency version must fail")
+            .message
+            .contains("MAJOR.MINOR.PATCH"));
     }
 
     #[test]
@@ -1944,23 +2299,269 @@ checksum = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abc
     }
 
     #[test]
-    fn still_reserves_dependency_registry_resolution_fields() {
+    fn accepts_registry_configuration_and_dependency_alias_default() {
         let dir = write_manifest(
             r#"
 [package]
 name = "demo"
 version = "0.1.0"
 
+[registry]
+name = "primary"
+index = "https://registry.example.test/index.json"
+trust_roots = "trust/roots.json"
+expectation = "trust/expectation.json"
+cache = ".axiom/cache"
+vendor = "vendor"
+
 [dependencies.dep]
-path = "dep"
-registry = "https://registry.example.test/index"
+registry = "primary"
+namespace = "acme"
+version = "^1.2.3"
 "#,
         );
-        let error = load_manifest(dir.path()).expect_err("dependency registry should be reserved");
-        assert!(
-            error
-                .message
-                .contains("dependencies.dep.registry is reserved")
+        let manifest = load_manifest(dir.path()).expect("registry dependency should parse");
+        let registry = manifest.registry.expect("root registry");
+        assert_eq!(registry.name, "primary");
+        assert_eq!(registry.cache.as_deref(), Some(".axiom/cache"));
+        let dependency = &manifest.dependencies["dep"];
+        assert!(dependency.is_registry());
+        assert!(!dependency.is_path());
+        assert_eq!(
+            dependency.registry_source().expect("registry").package,
+            "dep"
         );
+        assert_eq!(dependency.version.as_deref(), Some("^1.2.3"));
+    }
+
+    #[test]
+    fn rejects_registry_materialization_roots_equal_to_effective_defaults() {
+        for (label, roots) in [
+            ("explicit cache versus default vendor", "cache = \"vendor\""),
+            (
+                "default cache versus explicit vendor",
+                "vendor = \".axiom/cache\"",
+            ),
+        ] {
+            let dir = write_manifest(&format!(
+                r#"
+[package]
+name = "demo"
+version = "0.1.0"
+
+[registry]
+name = "primary"
+index = "https://registry.example.test/index.json"
+trust_roots = "trust/roots.json"
+expectation = "trust/expectation.json"
+{roots}
+"#
+            ));
+            let error = load_manifest(dir.path()).expect_err(label);
+            assert!(
+                error
+                    .message
+                    .contains("registry.cache and registry.vendor must use different paths"),
+                "unexpected {label} error: {}",
+                error.message
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_lexical_aliases_for_registry_materialization_roots() {
+        for (label, cache, vendor) in [
+            ("leading current directory", "./vendor", "vendor"),
+            (
+                "redundant separators and suffix",
+                "packages//materialized",
+                "packages/materialized/.",
+            ),
+        ] {
+            let dir = write_manifest(&format!(
+                r#"
+[package]
+name = "demo"
+version = "0.1.0"
+
+[registry]
+name = "primary"
+index = "https://registry.example.test/index.json"
+trust_roots = "trust/roots.json"
+expectation = "trust/expectation.json"
+cache = "{cache}"
+vendor = "{vendor}"
+"#
+            ));
+            let error = load_manifest(dir.path()).expect_err(label);
+            assert!(
+                error
+                    .message
+                    .contains("registry.cache and registry.vendor must use different paths"),
+                "unexpected {label} error: {}",
+                error.message
+            );
+        }
+    }
+
+    #[test]
+    fn normalizes_valid_distinct_registry_materialization_roots() {
+        let dir = write_manifest(
+            r#"
+[package]
+name = "demo"
+version = "0.1.0"
+
+[registry]
+name = "primary"
+index = "https://registry.example.test/index.json"
+trust_roots = "trust/roots.json"
+expectation = "trust/expectation.json"
+cache = "./.axiom//cache/."
+vendor = "./vendor//packages/."
+"#,
+        );
+        let manifest = load_manifest(dir.path()).expect("distinct roots should parse");
+        let registry = manifest.registry.expect("root registry");
+        assert_eq!(registry.cache.as_deref(), Some(".axiom/cache"));
+        assert_eq!(registry.vendor.as_deref(), Some("vendor/packages"));
+        assert_eq!(registry.cache_root(), ".axiom/cache");
+        assert_eq!(registry.vendor_root(), "vendor/packages");
+    }
+
+    #[test]
+    fn rejects_nonportable_registry_materialization_roots() {
+        for (label, cache, expected) in [
+            ("parent traversal", "../cache", "parent traversal"),
+            ("absolute path", "/tmp/cache", "must be relative"),
+            (
+                "backslash separator",
+                r"nested\cache",
+                "portable '/' path separators",
+            ),
+        ] {
+            let dir = write_manifest(&format!(
+                r#"
+[package]
+name = "demo"
+version = "0.1.0"
+
+[registry]
+name = "primary"
+index = "https://registry.example.test/index.json"
+trust_roots = "trust/roots.json"
+expectation = "trust/expectation.json"
+cache = '{cache}'
+"#
+            ));
+            let error = load_manifest(dir.path()).expect_err(label);
+            assert!(
+                error.message.contains(expected),
+                "unexpected {label} error: {}",
+                error.message
+            );
+        }
+    }
+
+    #[test]
+    fn registry_dependency_requires_exactly_one_source_kind() {
+        for (label, dependency) in [
+            (
+                "both",
+                "path = \"dep\"\nregistry = \"primary\"\nnamespace = \"acme\"\nversion = \"1.2.3\"",
+            ),
+            ("neither", "version = \"1.2.3\""),
+        ] {
+            let dir = write_manifest(&format!(
+                r#"
+[package]
+name = "demo"
+version = "0.1.0"
+
+[registry]
+name = "primary"
+index = "https://registry.example.test/index.json"
+trust_roots = "trust/roots.json"
+expectation = "trust/expectation.json"
+
+[dependencies.dep]
+{dependency}
+"#
+            ));
+            let error = load_manifest(dir.path()).expect_err(label);
+            assert!(
+                error.message.contains("exactly one source kind"),
+                "unexpected {label} error: {}",
+                error.message
+            );
+        }
+    }
+
+    #[test]
+    fn registry_http_is_limited_to_loopback_fixtures() {
+        for accepted in [
+            "http://127.0.0.42:8080/index.json",
+            "http://[::1]:8080/index.json",
+            "https://registry.example.test/index.json",
+            "file:///tmp/axiom-registry/index.json",
+        ] {
+            let dir = write_manifest(&format!(
+                r#"
+[package]
+name = "demo"
+version = "0.1.0"
+
+[registry]
+name = "fixture"
+index = "{accepted}"
+trust_roots = "roots.json"
+expectation = "expectation.json"
+"#
+            ));
+            load_manifest(dir.path())
+                .unwrap_or_else(|error| panic!("{accepted} should parse: {error:?}"));
+        }
+
+        for rejected in [
+            "http://localhost:8080/index.json",
+            "http://registry.example.test/index.json",
+            "http://192.0.2.10/index.json",
+            "http://localhost@example.test/index.json",
+        ] {
+            let dir = write_manifest(&format!(
+                r#"
+[package]
+name = "demo"
+version = "0.1.0"
+
+[registry]
+name = "fixture"
+index = "{rejected}"
+trust_roots = "roots.json"
+expectation = "expectation.json"
+"#
+            ));
+            let error = load_manifest(dir.path()).expect_err(rejected);
+            assert!(error.message.contains("loopback fixture source"));
+        }
+    }
+
+    #[test]
+    fn exact_byte_parser_never_rereads_source_path() {
+        let source = Path::new("/authenticated/release/axiom.toml");
+        let manifest = parse_manifest_exact(
+            b"[package]\nname = \"trusted\"\nversion = \"1.2.3\"\n",
+            source,
+        )
+        .expect("exact bytes should parse");
+        assert_eq!(manifest.package.expect("package").name, "trusted");
+
+        let error = parse_manifest_exact(&[0xff, 0xfe], source)
+            .expect_err("non-UTF-8 authenticated bytes must fail closed");
+        assert_eq!(
+            error.path.as_deref(),
+            Some(source.to_string_lossy().as_ref())
+        );
+        assert!(error.message.contains("not UTF-8"));
     }
 }

--- a/stage1/crates/axiomc/src/new_project.rs
+++ b/stage1/crates/axiomc/src/new_project.rs
@@ -83,6 +83,7 @@ pub fn create_project_with_template(
             version: String::from("0.1.0"),
         }),
         publish: None,
+        registry: None,
         dependencies: BTreeMap::new(),
         workspace: None,
         build: BuildSection {

--- a/stage1/crates/axiomc/src/package_archive.rs
+++ b/stage1/crates/axiomc/src/package_archive.rs
@@ -1,0 +1,1085 @@
+//! Strict parser and filesystem materializer for `AXIOM_PACKAGE_ARCHIVE_V1`.
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::BTreeSet;
+use std::fmt;
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use unicode_normalization::UnicodeNormalization;
+
+pub const ARCHIVE_MAGIC: &[u8] = b"AXIOM_PACKAGE_ARCHIVE_V1\n";
+pub const EXTRACTOR_VERSION: &str = "axiom-package-extractor-v1";
+pub const TREE_INTEGRITY_SCHEMA: &str = "axiom.package_tree_integrity.v1";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ArchiveLimits {
+    pub max_archive_bytes: usize,
+    pub max_file_bytes: usize,
+    pub max_files: usize,
+    pub max_directories: usize,
+    pub max_tree_entries: usize,
+    pub max_path_bytes: usize,
+    pub max_path_components: usize,
+}
+
+impl Default for ArchiveLimits {
+    fn default() -> Self {
+        Self {
+            max_archive_bytes: 64 * 1024 * 1024,
+            max_file_bytes: 16 * 1024 * 1024,
+            max_files: 4_096,
+            max_directories: 4_096,
+            max_tree_entries: 8_192,
+            max_path_bytes: 1_024,
+            max_path_components: 64,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ArchiveError {
+    pub code: &'static str,
+    pub message: String,
+}
+
+impl ArchiveError {
+    fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for ArchiveError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for ArchiveError {}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ArchiveEntry {
+    pub path: String,
+    pub bytes: Vec<u8>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ParsedArchive {
+    pub archive_sha256: String,
+    pub entries: Vec<ArchiveEntry>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TreeFileRecord {
+    pub path: String,
+    pub length: u64,
+    pub sha256: String,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TreeIntegrityManifest {
+    pub schema_version: String,
+    pub extractor_version: String,
+    pub archive_sha256: String,
+    pub files: Vec<TreeFileRecord>,
+}
+
+pub fn parse_archive(
+    bytes: &[u8],
+    expected_sha256: &str,
+    limits: ArchiveLimits,
+) -> Result<ParsedArchive, ArchiveError> {
+    validate_sha256(expected_sha256, "expected archive digest")?;
+    if bytes.len() > limits.max_archive_bytes {
+        return Err(ArchiveError::new(
+            "archive_too_large",
+            format!(
+                "archive is {} bytes; limit is {}",
+                bytes.len(),
+                limits.max_archive_bytes
+            ),
+        ));
+    }
+    let archive_sha256 = sha256_hex(bytes);
+    if archive_sha256 != expected_sha256 {
+        return Err(ArchiveError::new(
+            "archive_digest_mismatch",
+            format!("expected {expected_sha256}, computed {archive_sha256}"),
+        ));
+    }
+    if !bytes.starts_with(ARCHIVE_MAGIC) {
+        return Err(ArchiveError::new(
+            "archive_magic_invalid",
+            "archive does not begin with AXIOM_PACKAGE_ARCHIVE_V1",
+        ));
+    }
+
+    let mut cursor = ARCHIVE_MAGIC.len();
+    let mut extracted_bytes = 0usize;
+    let mut entries = Vec::new();
+    let mut paths = BTreeSet::new();
+    let mut directories = BTreeSet::new();
+    let mut previous_path: Option<String> = None;
+    while cursor < bytes.len() {
+        if entries.len() == limits.max_files {
+            return Err(ArchiveError::new(
+                "archive_file_count_exceeded",
+                format!("archive contains more than {} files", limits.max_files),
+            ));
+        }
+        let remaining = &bytes[cursor..];
+        let newline = remaining
+            .iter()
+            .position(|byte| *byte == b'\n')
+            .ok_or_else(|| {
+                ArchiveError::new("archive_header_truncated", "file header has no newline")
+            })?;
+        if newline > limits.max_path_bytes.saturating_add(64) {
+            return Err(ArchiveError::new(
+                "archive_header_too_large",
+                "file header exceeds its deterministic bound",
+            ));
+        }
+        let header = std::str::from_utf8(&remaining[..newline]).map_err(|_| {
+            ArchiveError::new("archive_header_invalid", "file header is not valid UTF-8")
+        })?;
+        let body = header
+            .strip_prefix("--- file ")
+            .and_then(|header| header.strip_suffix(" ---"))
+            .ok_or_else(|| {
+                ArchiveError::new(
+                    "archive_header_invalid",
+                    format!("malformed file header at byte {cursor}"),
+                )
+            })?;
+        let (path, length_text) = body.rsplit_once(' ').ok_or_else(|| {
+            ArchiveError::new(
+                "archive_header_invalid",
+                "file header must contain a path and byte length",
+            )
+        })?;
+        validate_archive_path(path, limits)?;
+        if length_text.is_empty()
+            || (length_text.len() > 1 && length_text.starts_with('0'))
+            || !length_text.bytes().all(|byte| byte.is_ascii_digit())
+        {
+            return Err(ArchiveError::new(
+                "archive_length_invalid",
+                format!("non-canonical byte length for {path:?}"),
+            ));
+        }
+        let length = length_text.parse::<usize>().map_err(|_| {
+            ArchiveError::new(
+                "archive_length_invalid",
+                format!("byte length for {path:?} does not fit usize"),
+            )
+        })?;
+        if length > limits.max_file_bytes {
+            return Err(ArchiveError::new(
+                "archive_file_too_large",
+                format!(
+                    "{path:?} is {length} bytes; per-file limit is {}",
+                    limits.max_file_bytes
+                ),
+            ));
+        }
+        extracted_bytes = extracted_bytes.checked_add(length).ok_or_else(|| {
+            ArchiveError::new("archive_size_overflow", "extracted byte count overflowed")
+        })?;
+        if extracted_bytes > limits.max_archive_bytes {
+            return Err(ArchiveError::new(
+                "archive_total_bytes_exceeded",
+                "sum of extracted file bytes exceeds the archive limit",
+            ));
+        }
+        if !paths.insert(path.to_owned()) {
+            return Err(ArchiveError::new(
+                "archive_duplicate_path",
+                format!("duplicate archive path {path:?}"),
+            ));
+        }
+        if previous_path
+            .as_deref()
+            .is_some_and(|previous| previous >= path)
+        {
+            return Err(ArchiveError::new(
+                "archive_path_order_invalid",
+                "archive paths must be strictly increasing",
+            ));
+        }
+        reject_file_directory_collision(path, &paths)?;
+        let mut prefix = String::new();
+        for component in path
+            .split('/')
+            .take(path.split('/').count().saturating_sub(1))
+        {
+            if !prefix.is_empty() {
+                prefix.push('/');
+            }
+            prefix.push_str(component);
+            directories.insert(prefix.clone());
+        }
+        if directories.len() > limits.max_directories
+            || paths.len().saturating_add(directories.len()) > limits.max_tree_entries
+        {
+            return Err(ArchiveError::new(
+                "archive_tree_entries_exceeded",
+                "archive implies more filesystem entries than the extraction budget",
+            ));
+        }
+
+        cursor = cursor
+            .checked_add(newline + 1)
+            .ok_or_else(|| ArchiveError::new("archive_size_overflow", "cursor overflowed"))?;
+        let end = cursor
+            .checked_add(length)
+            .ok_or_else(|| ArchiveError::new("archive_size_overflow", "file extent overflowed"))?;
+        if end > bytes.len() {
+            return Err(ArchiveError::new(
+                "archive_content_truncated",
+                format!("{path:?} declares {length} bytes beyond end of archive"),
+            ));
+        }
+        let content = bytes[cursor..end].to_vec();
+        cursor = end;
+        if !content.ends_with(b"\n") {
+            if bytes.get(cursor) != Some(&b'\n') {
+                return Err(ArchiveError::new(
+                    "archive_separator_missing",
+                    format!("{path:?} is not followed by the canonical newline separator"),
+                ));
+            }
+            cursor += 1;
+        }
+        previous_path = Some(path.to_owned());
+        entries.push(ArchiveEntry {
+            path: path.to_owned(),
+            bytes: content,
+        });
+    }
+
+    Ok(ParsedArchive {
+        archive_sha256,
+        entries,
+    })
+}
+
+pub fn extract_archive(
+    archive: &ParsedArchive,
+    destination: &Path,
+) -> Result<TreeIntegrityManifest, ArchiveError> {
+    let manifest = expected_tree_integrity(archive)?;
+    fs::create_dir(destination).map_err(|error| {
+        ArchiveError::new(
+            "extraction_root_create_failed",
+            format!("failed to create {}: {error}", destination.display()),
+        )
+    })?;
+    let result = (|| {
+        sync_directory(destination)?;
+        sync_parent_directory(destination)?;
+        let mut directories_to_sync = BTreeSet::from([destination.to_path_buf()]);
+        let mut previous: Option<&str> = None;
+        for entry in &archive.entries {
+            validate_archive_path(&entry.path, ArchiveLimits::default())?;
+            if previous.is_some_and(|path| path >= entry.path.as_str()) {
+                return Err(ArchiveError::new(
+                    "archive_path_order_invalid",
+                    "parsed archive entries must remain strictly ordered",
+                ));
+            }
+            let target = safe_join(destination, &entry.path)?;
+            let parent = target.parent().ok_or_else(|| {
+                ArchiveError::new("archive_path_invalid", "archive file has no parent")
+            })?;
+            ensure_directories(destination, parent, &mut directories_to_sync)?;
+            let mut file = open_new_nofollow(&target)?;
+            file.write_all(&entry.bytes).map_err(|error| {
+                ArchiveError::new(
+                    "extraction_write_failed",
+                    format!("failed to write {}: {error}", target.display()),
+                )
+            })?;
+            file.sync_all().map_err(|error| {
+                ArchiveError::new(
+                    "extraction_sync_failed",
+                    format!("failed to sync {}: {error}", target.display()),
+                )
+            })?;
+            sync_directory(parent)?;
+            previous = Some(&entry.path);
+        }
+        let mut directories = directories_to_sync.into_iter().collect::<Vec<_>>();
+        directories.sort_by_key(|path| std::cmp::Reverse(path.components().count()));
+        for directory in directories {
+            sync_directory(&directory)?;
+        }
+        sync_parent_directory(destination)?;
+        verify_tree(destination, &manifest)?;
+        Ok(manifest)
+    })();
+    if result.is_err() {
+        let _ = fs::remove_dir_all(destination);
+    }
+    result
+}
+
+pub fn expected_tree_integrity(
+    archive: &ParsedArchive,
+) -> Result<TreeIntegrityManifest, ArchiveError> {
+    validate_sha256(&archive.archive_sha256, "archive digest")?;
+    let limits = ArchiveLimits::default();
+    if archive.entries.len() > limits.max_files {
+        return Err(ArchiveError::new(
+            "archive_file_count_exceeded",
+            "parsed archive exceeds the extraction file-count limit",
+        ));
+    }
+    let mut files = Vec::with_capacity(archive.entries.len());
+    let mut previous: Option<&str> = None;
+    for entry in &archive.entries {
+        validate_archive_path(&entry.path, ArchiveLimits::default())?;
+        if previous.is_some_and(|path| path >= entry.path.as_str()) {
+            return Err(ArchiveError::new(
+                "archive_path_order_invalid",
+                "parsed archive entries must remain strictly ordered",
+            ));
+        }
+        files.push(TreeFileRecord {
+            path: entry.path.clone(),
+            length: entry.bytes.len() as u64,
+            sha256: sha256_hex(&entry.bytes),
+        });
+        previous = Some(&entry.path);
+    }
+    let manifest = TreeIntegrityManifest {
+        schema_version: TREE_INTEGRITY_SCHEMA.to_owned(),
+        extractor_version: EXTRACTOR_VERSION.to_owned(),
+        archive_sha256: archive.archive_sha256.clone(),
+        files,
+    };
+    validate_integrity_manifest(&manifest)?;
+    Ok(manifest)
+}
+
+pub fn verify_tree(root: &Path, manifest: &TreeIntegrityManifest) -> Result<(), ArchiveError> {
+    verify_tree_with_limits(root, manifest, ArchiveLimits::default())
+}
+
+pub fn verify_tree_with_limits(
+    root: &Path,
+    manifest: &TreeIntegrityManifest,
+    limits: ArchiveLimits,
+) -> Result<(), ArchiveError> {
+    validate_integrity_manifest(manifest)?;
+    let metadata = fs::symlink_metadata(root).map_err(|error| {
+        ArchiveError::new(
+            "tree_unavailable",
+            format!("failed to stat {}: {error}", root.display()),
+        )
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(ArchiveError::new(
+            "tree_root_invalid",
+            "tree root must be a non-symlink directory",
+        ));
+    }
+    let mut scan = TreeScan {
+        files: Vec::with_capacity(manifest.files.len()),
+        total_bytes: 0,
+        entries: 0,
+        directories: 0,
+    };
+    collect_tree_files(root, root, 0, limits, &mut scan)?;
+    let mut actual = scan.files;
+    actual.sort_by(|left, right| left.path.cmp(&right.path));
+    if actual != manifest.files {
+        return Err(ArchiveError::new(
+            "tree_integrity_mismatch",
+            "tree paths, lengths, or file digests differ from integrity manifest",
+        ));
+    }
+    Ok(())
+}
+
+pub fn integrity_manifest_bytes(manifest: &TreeIntegrityManifest) -> Result<Vec<u8>, ArchiveError> {
+    validate_integrity_manifest(manifest)?;
+    let mut bytes = serde_json::to_vec(manifest).map_err(|error| {
+        ArchiveError::new(
+            "integrity_manifest_invalid",
+            format!("failed to render integrity manifest: {error}"),
+        )
+    })?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+pub fn integrity_manifest_sha256(manifest: &TreeIntegrityManifest) -> Result<String, ArchiveError> {
+    Ok(sha256_hex(&integrity_manifest_bytes(manifest)?))
+}
+
+pub fn safe_join(root: &Path, relative: &str) -> Result<PathBuf, ArchiveError> {
+    validate_archive_path(relative, ArchiveLimits::default())?;
+    let mut joined = root.to_path_buf();
+    for component in relative.split('/') {
+        joined.push(component);
+    }
+    Ok(joined)
+}
+
+fn validate_integrity_manifest(manifest: &TreeIntegrityManifest) -> Result<(), ArchiveError> {
+    if manifest.schema_version != TREE_INTEGRITY_SCHEMA
+        || manifest.extractor_version != EXTRACTOR_VERSION
+    {
+        return Err(ArchiveError::new(
+            "integrity_manifest_version_invalid",
+            "tree integrity schema or extractor version is unsupported",
+        ));
+    }
+    validate_sha256(&manifest.archive_sha256, "integrity archive digest")?;
+    let limits = ArchiveLimits::default();
+    if manifest.files.len() > limits.max_files {
+        return Err(ArchiveError::new(
+            "integrity_file_count_exceeded",
+            "integrity manifest exceeds file-count limit",
+        ));
+    }
+    let mut previous: Option<&str> = None;
+    let mut total_bytes = 0u64;
+    let mut directories = BTreeSet::new();
+    for file in &manifest.files {
+        validate_archive_path(&file.path, limits)?;
+        validate_sha256(&file.sha256, "tree file digest")?;
+        if file.length > limits.max_file_bytes as u64 {
+            return Err(ArchiveError::new(
+                "integrity_file_too_large",
+                format!("integrity entry {:?} exceeds file limit", file.path),
+            ));
+        }
+        total_bytes = total_bytes.checked_add(file.length).ok_or_else(|| {
+            ArchiveError::new(
+                "integrity_total_bytes_exceeded",
+                "integrity file lengths overflowed",
+            )
+        })?;
+        if total_bytes > limits.max_archive_bytes as u64 {
+            return Err(ArchiveError::new(
+                "integrity_total_bytes_exceeded",
+                "integrity file lengths exceed the total tree limit",
+            ));
+        }
+        if previous.is_some_and(|path| path >= file.path.as_str()) {
+            return Err(ArchiveError::new(
+                "integrity_path_order_invalid",
+                "integrity file paths must be strictly increasing",
+            ));
+        }
+        let components = file.path.split('/').collect::<Vec<_>>();
+        let mut prefix = String::new();
+        for component in components.iter().take(components.len().saturating_sub(1)) {
+            if !prefix.is_empty() {
+                prefix.push('/');
+            }
+            prefix.push_str(component);
+            directories.insert(prefix.clone());
+            if directories.len() > limits.max_directories
+                || manifest.files.len().saturating_add(directories.len()) > limits.max_tree_entries
+            {
+                return Err(ArchiveError::new(
+                    "integrity_tree_entries_exceeded",
+                    "integrity manifest implies too many filesystem entries",
+                ));
+            }
+        }
+        previous = Some(&file.path);
+    }
+    Ok(())
+}
+
+fn validate_archive_path(path: &str, limits: ArchiveLimits) -> Result<(), ArchiveError> {
+    if path.is_empty()
+        || path.starts_with('/')
+        || path.ends_with('/')
+        || path.contains('\\')
+        || path.contains('\0')
+    {
+        return Err(ArchiveError::new(
+            "archive_path_invalid",
+            format!("unsafe archive path {path:?}"),
+        ));
+    }
+    if path.as_bytes().len() > limits.max_path_bytes {
+        return Err(ArchiveError::new(
+            "archive_path_too_long",
+            format!("archive path exceeds {} bytes", limits.max_path_bytes),
+        ));
+    }
+    if path.nfc().collect::<String>() != path {
+        return Err(ArchiveError::new(
+            "archive_path_noncanonical",
+            format!("archive path is not NFC-normalized: {path:?}"),
+        ));
+    }
+    let components = path.split('/').collect::<Vec<_>>();
+    if components.len() > limits.max_path_components {
+        return Err(ArchiveError::new(
+            "archive_path_too_deep",
+            format!(
+                "archive path exceeds {} components",
+                limits.max_path_components
+            ),
+        ));
+    }
+    if components.iter().any(|component| {
+        component.is_empty()
+            || *component == "."
+            || *component == ".."
+            || component.contains(':')
+            || component.chars().any(char::is_control)
+    }) {
+        return Err(ArchiveError::new(
+            "archive_path_noncanonical",
+            format!("archive path has an unsafe component: {path:?}"),
+        ));
+    }
+    Ok(())
+}
+
+fn reject_file_directory_collision(
+    path: &str,
+    paths: &BTreeSet<String>,
+) -> Result<(), ArchiveError> {
+    let mut prefix = String::new();
+    for component in path
+        .split('/')
+        .take(path.split('/').count().saturating_sub(1))
+    {
+        if !prefix.is_empty() {
+            prefix.push('/');
+        }
+        prefix.push_str(component);
+        if paths.contains(&prefix) {
+            return Err(ArchiveError::new(
+                "archive_path_collision",
+                format!("{prefix:?} is both a file and a directory"),
+            ));
+        }
+    }
+    if paths
+        .range(format!("{path}/")..)
+        .next()
+        .is_some_and(|candidate| candidate.starts_with(&format!("{path}/")))
+    {
+        return Err(ArchiveError::new(
+            "archive_path_collision",
+            format!("{path:?} is both a file and a directory"),
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_directories(
+    root: &Path,
+    parent: &Path,
+    directories_to_sync: &mut BTreeSet<PathBuf>,
+) -> Result<(), ArchiveError> {
+    let relative = parent.strip_prefix(root).map_err(|_| {
+        ArchiveError::new(
+            "extraction_escape",
+            "archive parent escaped extraction root",
+        )
+    })?;
+    let mut current = root.to_path_buf();
+    for component in relative.components() {
+        current.push(component);
+        directories_to_sync.insert(current.clone());
+        match fs::symlink_metadata(&current) {
+            Ok(metadata) => {
+                if metadata.file_type().is_symlink() || !metadata.is_dir() {
+                    return Err(ArchiveError::new(
+                        "extraction_parent_invalid",
+                        format!("{} is not a safe directory", current.display()),
+                    ));
+                }
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                fs::create_dir(&current).map_err(|error| {
+                    ArchiveError::new(
+                        "extraction_directory_create_failed",
+                        format!("failed to create {}: {error}", current.display()),
+                    )
+                })?;
+                sync_directory(&current)?;
+                sync_parent_directory(&current)?;
+            }
+            Err(error) => {
+                return Err(ArchiveError::new(
+                    "extraction_parent_unavailable",
+                    format!("failed to stat {}: {error}", current.display()),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn open_new_nofollow(path: &Path) -> Result<File, ArchiveError> {
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+        options.mode(0o600);
+    }
+    options.open(path).map_err(|error| {
+        ArchiveError::new(
+            "extraction_file_create_failed",
+            format!("failed to create {}: {error}", path.display()),
+        )
+    })
+}
+
+fn open_read_nofollow(path: &Path) -> Result<File, ArchiveError> {
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+        let metadata = fs::symlink_metadata(path).map_err(|error| {
+            ArchiveError::new(
+                "tree_file_unavailable",
+                format!("failed to inspect {}: {error}", path.display()),
+            )
+        })?;
+        if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+            return Err(ArchiveError::new(
+                "tree_symlink_rejected",
+                format!("tree file is a reparse point: {}", path.display()),
+            ));
+        }
+    }
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK);
+    }
+    let file = options.open(path).map_err(|error| {
+        ArchiveError::new(
+            "tree_file_unavailable",
+            format!("failed to open {}: {error}", path.display()),
+        )
+    })?;
+    let metadata = file.metadata().map_err(|error| {
+        ArchiveError::new(
+            "tree_file_unavailable",
+            format!("failed to inspect open file {}: {error}", path.display()),
+        )
+    })?;
+    if !metadata.is_file() {
+        return Err(ArchiveError::new(
+            "tree_entry_type_rejected",
+            format!("tree entry is not a regular file: {}", path.display()),
+        ));
+    }
+    Ok(file)
+}
+
+struct TreeScan {
+    files: Vec<TreeFileRecord>,
+    total_bytes: u64,
+    entries: usize,
+    directories: usize,
+}
+
+fn collect_tree_files(
+    root: &Path,
+    directory: &Path,
+    depth: usize,
+    limits: ArchiveLimits,
+    scan: &mut TreeScan,
+) -> Result<(), ArchiveError> {
+    if depth > limits.max_path_components {
+        return Err(ArchiveError::new(
+            "tree_depth_exceeded",
+            "tree exceeds maximum path depth",
+        ));
+    }
+    let entries = fs::read_dir(directory).map_err(|error| {
+        ArchiveError::new(
+            "tree_read_failed",
+            format!("failed to read {}: {error}", directory.display()),
+        )
+    })?;
+    for entry in entries {
+        let entry =
+            entry.map_err(|error| ArchiveError::new("tree_read_failed", error.to_string()))?;
+        scan.entries = scan.entries.checked_add(1).ok_or_else(|| {
+            ArchiveError::new("tree_entry_count_exceeded", "tree entry count overflowed")
+        })?;
+        if scan.entries > limits.max_tree_entries {
+            return Err(ArchiveError::new(
+                "tree_entry_count_exceeded",
+                "tree exceeds maximum filesystem entry count",
+            ));
+        }
+        let path = entry.path();
+        let metadata = fs::symlink_metadata(&path).map_err(|error| {
+            ArchiveError::new(
+                "tree_stat_failed",
+                format!("failed to stat {}: {error}", path.display()),
+            )
+        })?;
+        if metadata.file_type().is_symlink() {
+            return Err(ArchiveError::new(
+                "tree_symlink_rejected",
+                format!("tree contains symlink {}", path.display()),
+            ));
+        }
+        if metadata.is_dir() {
+            scan.directories = scan.directories.checked_add(1).ok_or_else(|| {
+                ArchiveError::new(
+                    "tree_directory_count_exceeded",
+                    "tree directory count overflowed",
+                )
+            })?;
+            if scan.directories > limits.max_directories {
+                return Err(ArchiveError::new(
+                    "tree_directory_count_exceeded",
+                    "tree exceeds maximum directory count",
+                ));
+            }
+            collect_tree_files(root, &path, depth + 1, limits, scan)?;
+            continue;
+        }
+        if !metadata.is_file() {
+            return Err(ArchiveError::new(
+                "tree_entry_type_rejected",
+                format!("tree contains non-regular entry {}", path.display()),
+            ));
+        }
+        if metadata.len() > limits.max_file_bytes as u64 {
+            return Err(ArchiveError::new(
+                "tree_file_too_large",
+                format!("tree file exceeds limit: {}", path.display()),
+            ));
+        }
+        if scan.files.len() == limits.max_files {
+            return Err(ArchiveError::new(
+                "tree_file_count_exceeded",
+                "tree exceeds maximum file count",
+            ));
+        }
+        scan.total_bytes = scan
+            .total_bytes
+            .checked_add(metadata.len())
+            .ok_or_else(|| {
+                ArchiveError::new("tree_total_bytes_exceeded", "tree byte count overflowed")
+            })?;
+        if scan.total_bytes > limits.max_archive_bytes as u64 {
+            return Err(ArchiveError::new(
+                "tree_total_bytes_exceeded",
+                "tree exceeds maximum cumulative file bytes",
+            ));
+        }
+        let relative = path
+            .strip_prefix(root)
+            .map_err(|_| ArchiveError::new("tree_path_invalid", "tree path escaped root"))?;
+        let relative = relative
+            .components()
+            .map(|component| {
+                component.as_os_str().to_str().ok_or_else(|| {
+                    ArchiveError::new("tree_path_invalid", "tree path is not valid UTF-8")
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?
+            .join("/");
+        validate_archive_path(&relative, limits)?;
+        scan.files.push(TreeFileRecord {
+            path: relative,
+            length: metadata.len(),
+            sha256: hash_file(&path, metadata.len())?,
+        });
+    }
+    Ok(())
+}
+
+fn hash_file(path: &Path, expected_length: u64) -> Result<String, ArchiveError> {
+    let file = open_read_nofollow(path)?;
+    let mut hasher = Sha256::new();
+    let copied = std::io::copy(
+        &mut file.take(expected_length.saturating_add(1)),
+        &mut hasher,
+    )
+    .map_err(|error| {
+        ArchiveError::new(
+            "tree_file_read_failed",
+            format!("failed to read {}: {error}", path.display()),
+        )
+    })?;
+    if copied != expected_length {
+        return Err(ArchiveError::new(
+            "tree_file_raced",
+            format!("{} changed while being verified", path.display()),
+        ));
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn sync_directory(path: &Path) -> Result<(), ArchiveError> {
+    File::open(path)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|error| {
+            ArchiveError::new(
+                "extraction_sync_failed",
+                format!("failed to sync {}: {error}", path.display()),
+            )
+        })
+}
+
+fn sync_parent_directory(path: &Path) -> Result<(), ArchiveError> {
+    let parent = path.parent().ok_or_else(|| {
+        ArchiveError::new(
+            "extraction_sync_failed",
+            format!("{} has no parent directory", path.display()),
+        )
+    })?;
+    sync_directory(parent)
+}
+
+fn validate_sha256(value: &str, label: &str) -> Result<(), ArchiveError> {
+    if value.len() != 64
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(ArchiveError::new(
+            "sha256_invalid",
+            format!("{label} must be 64 lowercase hexadecimal characters"),
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn sha256_hex(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn archive(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut bytes = ARCHIVE_MAGIC.to_vec();
+        for (path, content) in entries {
+            bytes.extend_from_slice(format!("--- file {path} {} ---\n", content.len()).as_bytes());
+            bytes.extend_from_slice(content);
+            if !content.ends_with(b"\n") {
+                bytes.push(b'\n');
+            }
+        }
+        bytes
+    }
+
+    fn parse(bytes: &[u8]) -> Result<ParsedArchive, ArchiveError> {
+        parse_archive(bytes, &sha256_hex(bytes), ArchiveLimits::default())
+    }
+
+    #[test]
+    fn parses_extracts_and_reverifies_deterministic_archive() {
+        let bytes = archive(&[
+            ("axiom.toml", b"[package]\nname = \"demo\"\n"),
+            ("src/main.ax", b"fn main() {}"),
+        ]);
+        let parsed = parse(&bytes).unwrap();
+        let temp = tempfile::tempdir().unwrap();
+        let tree = temp.path().join("tree");
+        let manifest = extract_archive(&parsed, &tree).unwrap();
+        verify_tree(&tree, &manifest).unwrap();
+        assert_eq!(fs::read(tree.join("src/main.ax")).unwrap(), b"fn main() {}");
+        assert_eq!(manifest.files.len(), 2);
+        assert_eq!(
+            integrity_manifest_bytes(&manifest).unwrap(),
+            integrity_manifest_bytes(&manifest).unwrap()
+        );
+    }
+
+    #[test]
+    fn rejects_unsafe_duplicate_and_noncanonical_paths() {
+        for path in [
+            "../escape",
+            "/absolute",
+            "a\\b",
+            "a\0b",
+            "a//b",
+            "a/./b",
+            "C:/absolute",
+            "e\u{301}.txt",
+        ] {
+            let bytes = archive(&[(path, b"x")]);
+            assert!(parse(&bytes).is_err(), "{path:?}");
+        }
+        let duplicate = archive(&[("a", b"x"), ("a", b"y")]);
+        assert_eq!(
+            parse(&duplicate).unwrap_err().code,
+            "archive_duplicate_path"
+        );
+        let collision = archive(&[("a", b"x"), ("a/b", b"y")]);
+        assert_eq!(
+            parse(&collision).unwrap_err().code,
+            "archive_path_collision"
+        );
+        let unsorted = archive(&[("b", b"x"), ("a", b"y")]);
+        assert_eq!(
+            parse(&unsorted).unwrap_err().code,
+            "archive_path_order_invalid"
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_lengths_truncation_trailing_garbage_and_bounds() {
+        for bytes in [
+            b"AXIOM_PACKAGE_ARCHIVE_V1\n--- file a 01 ---\nx\n".to_vec(),
+            b"AXIOM_PACKAGE_ARCHIVE_V1\n--- file a 3 ---\nx\n".to_vec(),
+            b"AXIOM_PACKAGE_ARCHIVE_V1\ntrailing".to_vec(),
+        ] {
+            assert!(parse(&bytes).is_err());
+        }
+        let bytes = archive(&[("a", b"xx")]);
+        let limits = ArchiveLimits {
+            max_file_bytes: 1,
+            ..ArchiveLimits::default()
+        };
+        assert_eq!(
+            parse_archive(&bytes, &sha256_hex(&bytes), limits)
+                .unwrap_err()
+                .code,
+            "archive_file_too_large"
+        );
+
+        let nested = archive(&[("a/b", b"x")]);
+        let limits = ArchiveLimits {
+            max_directories: 0,
+            ..ArchiveLimits::default()
+        };
+        assert_eq!(
+            parse_archive(&nested, &sha256_hex(&nested), limits)
+                .unwrap_err()
+                .code,
+            "archive_tree_entries_exceeded"
+        );
+    }
+
+    #[test]
+    fn digest_mismatch_is_rejected_before_extraction() {
+        let bytes = archive(&[("a", b"x")]);
+        assert_eq!(
+            parse_archive(&bytes, &"0".repeat(64), ArchiveLimits::default())
+                .unwrap_err()
+                .code,
+            "archive_digest_mismatch"
+        );
+    }
+
+    #[test]
+    fn offline_verification_rejects_tampering_and_extra_files() {
+        let bytes = archive(&[("a", b"x")]);
+        let parsed = parse(&bytes).unwrap();
+        let temp = tempfile::tempdir().unwrap();
+        let tree = temp.path().join("tree");
+        let manifest = extract_archive(&parsed, &tree).unwrap();
+        fs::write(tree.join("a"), b"tampered").unwrap();
+        assert_eq!(
+            verify_tree(&tree, &manifest).unwrap_err().code,
+            "tree_integrity_mismatch"
+        );
+        fs::write(tree.join("a"), b"x").unwrap();
+        fs::write(tree.join("extra"), b"x").unwrap();
+        assert_eq!(
+            verify_tree(&tree, &manifest).unwrap_err().code,
+            "tree_integrity_mismatch"
+        );
+    }
+
+    #[test]
+    fn offline_verification_enforces_aggregate_tree_resource_limits() {
+        let bytes = archive(&[("a", b"x"), ("dir/b", b"y")]);
+        let parsed = parse(&bytes).unwrap();
+        let temp = tempfile::tempdir().unwrap();
+        let tree = temp.path().join("tree");
+        let manifest = extract_archive(&parsed, &tree).unwrap();
+
+        let byte_limits = ArchiveLimits {
+            max_archive_bytes: 1,
+            ..ArchiveLimits::default()
+        };
+        assert_eq!(
+            verify_tree_with_limits(&tree, &manifest, byte_limits)
+                .unwrap_err()
+                .code,
+            "tree_total_bytes_exceeded"
+        );
+
+        let entry_limits = ArchiveLimits {
+            max_tree_entries: 2,
+            ..ArchiveLimits::default()
+        };
+        assert_eq!(
+            verify_tree_with_limits(&tree, &manifest, entry_limits)
+                .unwrap_err()
+                .code,
+            "tree_entry_count_exceeded"
+        );
+
+        let directory_limits = ArchiveLimits {
+            max_directories: 0,
+            ..ArchiveLimits::default()
+        };
+        assert_eq!(
+            verify_tree_with_limits(&tree, &manifest, directory_limits)
+                .unwrap_err()
+                .code,
+            "tree_directory_count_exceeded"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn offline_verification_rejects_symlinks() {
+        use std::os::unix::fs::symlink;
+        let bytes = archive(&[("a", b"x")]);
+        let parsed = parse(&bytes).unwrap();
+        let temp = tempfile::tempdir().unwrap();
+        let tree = temp.path().join("tree");
+        let manifest = extract_archive(&parsed, &tree).unwrap();
+        fs::remove_file(tree.join("a")).unwrap();
+        symlink("/dev/null", tree.join("a")).unwrap();
+        assert_eq!(
+            verify_tree(&tree, &manifest).unwrap_err().code,
+            "tree_symlink_rejected"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn nofollow_reader_rejects_fifo_without_blocking() {
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let fifo = temp.path().join("tree-fifo");
+        let fifo_name = CString::new(fifo.as_os_str().as_bytes()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(fifo_name.as_ptr(), 0o600) }, 0);
+        assert_eq!(
+            open_read_nofollow(&fifo).unwrap_err().code,
+            "tree_entry_type_rejected"
+        );
+    }
+}

--- a/stage1/crates/axiomc/src/package_manager.rs
+++ b/stage1/crates/axiomc/src/package_manager.rs
@@ -1,0 +1,4482 @@
+//! High-level package resolution, trusted transport, and materialization bridge.
+//!
+//! `PackageManager` owns the manifest/lock pairing for one project. Transport
+//! is supplied only to operations that are allowed to fetch bytes; locked
+//! materialization and vendoring deliberately have no transport handle.
+
+use crate::diagnostics::Diagnostic;
+use crate::lockfile::{
+    LOCKFILE_V2_VERSION, LockedCompatibilityEvidence, LockedDependencyEdgeV2,
+    LockedDependencyReason, LockedDependencySourceKind, LockedPackage, LockedPackageV2,
+    LockedRegistryV2, Lockfile, LockfileV2, ParsedLockfile, canonical_path_package_id,
+    canonical_registry_package_id, load_lockfile_with_sha256,
+    validate_lockfile_version_for_manifest, write_lockfile_v2_atomic_cas,
+};
+#[cfg(test)]
+use crate::lockfile::{load_lockfile, write_lockfile_v2_atomic};
+use crate::manifest::{
+    DEFAULT_PACKAGE_CACHE_DIR, DEFAULT_PACKAGE_VENDOR_DIR, DependencySpec, Manifest,
+    RegistryConfig, load_manifest, lockfile_path, manifest_path,
+    normalize_project_relative_materialization_root, parse_manifest_exact,
+};
+use crate::package_archive::{ArchiveLimits, parse_archive};
+use crate::package_resolver::{
+    AuthenticatedCatalog as ResolverCatalog, CandidateRejection, CatalogCandidate, Dependency,
+    LockedSelection, PackageKey, PathDependency, RegistryDependency, Resolution, ResolutionMode,
+    ResolveError, ResolveRequest, ResolverLimits, ResolverSource, SourceFailure, TraceEvent,
+    VerifiedCandidate, resolve_packages,
+};
+use crate::package_store::{
+    CachedPackage, PackageStore, StoreError, VendorPackage, VendorSnapshot, VerifiedArtifacts,
+    read_bounded_regular_file,
+};
+use crate::package_trust::{
+    AuthenticatedRegistryCatalog, AuthenticatedRegistryRelease, PackageArtifacts,
+    PackageTrustInput, PackageVerification, TrustRootsEnvelope, VerificationExpectation,
+    authenticate_registry_catalog, parse_package_signature_json, parse_registry_index_json,
+    parse_trust_roots_json, parse_verification_expectation_json,
+    verification_expectation_for_authenticated_release, verify_package_with_artifacts,
+};
+use crate::package_version::{ReleaseVersion, VersionRequirement};
+use crate::registry_client::{
+    MAX_PACKAGE_ARCHIVE_BODY_BYTES, RegistryClient, RegistryClientError,
+    resolve_registry_artifact_url,
+};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::fmt;
+use std::fs::OpenOptions;
+use std::io::Write;
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+const MAX_TRUST_DOCUMENT_BYTES: usize = 8 * 1024 * 1024;
+const MAX_CANDIDATE_DOWNLOAD_BYTES: usize = 256 * 1024 * 1024;
+
+pub const PACKAGE_OPERATION_REPORT_SCHEMA: &str = "axiom.package_operation_report.v1";
+pub const MATERIALIZED_PACKAGE_GRAPH_SCHEMA: &str = "axiom.materialized_package_graph.v1";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PackageOperation {
+    Fetch,
+    Update,
+    Vendor,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct FetchOptions<'a> {
+    pub transport: &'a RegistryClient,
+    pub resolver_limits: ResolverLimits,
+}
+
+impl<'a> FetchOptions<'a> {
+    pub fn new(transport: &'a RegistryClient) -> Self {
+        Self {
+            transport,
+            resolver_limits: ResolverLimits::default(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct UpdateOptions<'a> {
+    pub transport: &'a RegistryClient,
+    pub package: Option<String>,
+    pub resolver_limits: ResolverLimits,
+}
+
+impl<'a> UpdateOptions<'a> {
+    pub fn new(transport: &'a RegistryClient) -> Self {
+        Self {
+            transport,
+            package: None,
+            resolver_limits: ResolverLimits::default(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct VendorOptions {
+    pub out: Option<PathBuf>,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct MaterializeOptions {
+    /// Prefer an intact vendor snapshot over the content-addressed cache.
+    pub prefer_vendor: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct PackageOperationReport {
+    pub schema_version: String,
+    pub operation: PackageOperation,
+    pub project: String,
+    pub lockfile: String,
+    pub packages: Vec<MaterializedPackage>,
+    pub graph: MaterializedPackageGraph,
+    pub trace: Vec<TraceEvent>,
+    pub transport_used: bool,
+    pub summary: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct MaterializedPackageGraph {
+    pub schema_version: String,
+    pub lockfile_sha256: String,
+    pub roots: Vec<String>,
+    pub packages: Vec<MaterializedPackage>,
+    pub edges: Vec<MaterializedDependencyEdge>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct MaterializedPackage {
+    pub id: String,
+    pub name: String,
+    pub version: String,
+    pub source: String,
+    pub root: String,
+    #[serde(skip)]
+    pub verified_archive: Option<Arc<[u8]>>,
+    #[serde(skip)]
+    pub verified_manifest: Option<Arc<[u8]>>,
+    pub trust: Option<PackageTrustEvidence>,
+    pub materialization: MaterializationEvidence,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct MaterializedDependencyEdge {
+    pub from: String,
+    pub to: String,
+    pub alias: String,
+    pub requested: String,
+    pub source_kind: String,
+    pub reason: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct PackageTrustEvidence {
+    pub registry: String,
+    pub registry_identity: String,
+    pub source_identity: String,
+    pub publisher_identity: String,
+    pub archive_sha256: String,
+    pub manifest_sha256: String,
+    pub provenance_sha256: String,
+    pub package_signature_sha256: String,
+    pub signer_key_ids: Vec<String>,
+    pub index_sha256: String,
+    pub index_generation: u64,
+    pub index_sequence: u64,
+    pub index_transcript_sha256: String,
+    pub verification_sha256: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct MaterializationEvidence {
+    pub source: String,
+    pub content_key: Option<String>,
+    pub package_trust_verified: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct PackageManagerError {
+    pub code: String,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub trace: Vec<TraceEvent>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolver: Option<serde_json::Value>,
+}
+
+impl PackageManagerError {
+    fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            code: code.into(),
+            message: message.into(),
+            trace: Vec::new(),
+            resolver: None,
+        }
+    }
+
+    fn from_source(failure: SourceFailure) -> Self {
+        Self::new(failure.code, failure.message)
+    }
+}
+
+impl fmt::Display for PackageManagerError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for PackageManagerError {}
+
+#[derive(Clone, Debug)]
+pub struct PackageManager {
+    project_root: PathBuf,
+    manifest: Manifest,
+}
+
+#[derive(Clone, Debug)]
+struct VerifiedDownload {
+    release: AuthenticatedRegistryRelease,
+    verification_bytes: Vec<u8>,
+    archive: Arc<[u8]>,
+    manifest: Arc<[u8]>,
+    provenance: Vec<u8>,
+    package_signature_bytes: Vec<u8>,
+    registry_index_bytes: Arc<[u8]>,
+}
+
+struct OnlineResolverSource<'a> {
+    transport: &'a RegistryClient,
+    registry: RegistryConfig,
+    trust_roots_bytes: Vec<u8>,
+    expectation_bytes: Vec<u8>,
+    trust_roots: TrustRootsEnvelope,
+    expectation: VerificationExpectation,
+    catalog: AuthenticatedRegistryCatalog,
+    index_bytes: Arc<[u8]>,
+    candidate_download_bytes: usize,
+    downloads: BTreeMap<(PackageKey, ReleaseVersion, String), VerifiedDownload>,
+}
+
+#[derive(Clone, Debug)]
+struct LocalPackage {
+    id: String,
+    source: String,
+    root: PathBuf,
+    manifest: Manifest,
+}
+
+#[derive(Clone, Debug)]
+struct LocalGraph {
+    roots: Vec<String>,
+    packages: Vec<LocalPackage>,
+    path_edges: Vec<LockedDependencyEdgeV2>,
+    registry_edges: Vec<(String, RegistryDependency)>,
+    resolver_dependencies: Vec<Dependency>,
+}
+
+#[derive(Clone, Debug)]
+struct MaterializedRoot {
+    path: PathBuf,
+    source: String,
+    content_key: Option<String>,
+    verified_archive: Option<Arc<[u8]>>,
+    verified_manifest: Option<Arc<[u8]>>,
+}
+
+#[derive(Clone, Debug)]
+struct OfflineTrustContext {
+    registry: RegistryConfig,
+    trust_roots: TrustRootsEnvelope,
+    expectation: VerificationExpectation,
+}
+
+struct OnlineResolution<'a> {
+    source: OnlineResolverSource<'a>,
+    local: LocalGraph,
+    resolution: Resolution,
+    previous: Option<LockfileV2>,
+    frozen: BTreeMap<PackageKey, LockedSelection>,
+    mode: ResolutionMode,
+    expected_lock_sha256: Option<String>,
+}
+
+#[derive(Debug)]
+struct PreviousLockState {
+    lockfile: Option<LockfileV2>,
+    expected_sha256: Option<String>,
+}
+
+struct PackageOperationLock {
+    path: PathBuf,
+    file: std::fs::File,
+}
+
+impl PackageOperationLock {
+    fn acquire(project_root: &Path) -> Result<Self, PackageManagerError> {
+        let path = project_root.join(".axiom-package-operation.lock");
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+        let mut file = options.open(&path).map_err(|error| {
+            PackageManagerError::new(
+                if error.kind() == std::io::ErrorKind::AlreadyExists {
+                    "package_operation_in_progress"
+                } else {
+                    "package_operation_lock_failed"
+                },
+                format!(
+                    "failed to acquire package operation lock {}: {error}",
+                    path.display()
+                ),
+            )
+        })?;
+        file.write_all(format!("pid={}\n", std::process::id()).as_bytes())
+            .and_then(|()| file.sync_all())
+            .map_err(|error| {
+                let _ = std::fs::remove_file(&path);
+                PackageManagerError::new(
+                    "package_operation_lock_failed",
+                    format!(
+                        "failed to persist package operation lock {}: {error}",
+                        path.display()
+                    ),
+                )
+            })?;
+        Ok(Self { path, file })
+    }
+}
+
+impl Drop for PackageOperationLock {
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            let owned = self.file.metadata();
+            let current = std::fs::symlink_metadata(&self.path);
+            if owned
+                .ok()
+                .zip(current.ok())
+                .is_some_and(|(owned, current)| {
+                    owned.dev() == current.dev() && owned.ino() == current.ino()
+                })
+            {
+                let _ = std::fs::remove_file(&self.path);
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
+impl PackageManager {
+    pub fn open(project_root: &Path) -> Result<Self, PackageManagerError> {
+        let project_root = std::fs::canonicalize(project_root).map_err(|error| {
+            PackageManagerError::new(
+                "project_unavailable",
+                format!(
+                    "failed to open package project {}: {error}",
+                    project_root.display()
+                ),
+            )
+        })?;
+        let manifest = load_manifest(&project_root)
+            .map_err(|error| PackageManagerError::new("manifest_invalid", error.to_string()))?;
+        Ok(Self {
+            project_root,
+            manifest,
+        })
+    }
+
+    pub fn project_root(&self) -> &Path {
+        &self.project_root
+    }
+
+    pub fn manifest(&self) -> &Manifest {
+        &self.manifest
+    }
+
+    pub fn fetch(
+        &self,
+        options: FetchOptions<'_>,
+    ) -> Result<PackageOperationReport, PackageManagerError> {
+        let _operation_lock = PackageOperationLock::acquire(&self.project_root)?;
+        let previous = self.optional_v2_lockfile()?;
+        if let Some(report) = self.finish_path_only_operation(
+            PackageOperation::Fetch,
+            None,
+            previous.expected_sha256.as_deref(),
+        )? {
+            return Ok(report);
+        }
+        let mode = if previous.lockfile.is_some() {
+            ResolutionMode::Locked
+        } else {
+            ResolutionMode::Fresh
+        };
+        let resolved = self.resolve_online(
+            options.transport,
+            options.resolver_limits,
+            mode,
+            previous.lockfile,
+            previous.expected_sha256,
+            None,
+        )?;
+        self.finish_online(PackageOperation::Fetch, resolved, true)
+    }
+
+    pub fn update(
+        &self,
+        options: UpdateOptions<'_>,
+    ) -> Result<PackageOperationReport, PackageManagerError> {
+        let _operation_lock = PackageOperationLock::acquire(&self.project_root)?;
+        let previous = self.optional_v2_lockfile()?;
+        if let Some(report) = self.finish_path_only_operation(
+            PackageOperation::Update,
+            options.package.as_deref(),
+            previous.expected_sha256.as_deref(),
+        )? {
+            return Ok(report);
+        }
+        let resolved = self.resolve_online(
+            options.transport,
+            options.resolver_limits,
+            ResolutionMode::Update,
+            previous.lockfile,
+            previous.expected_sha256,
+            options.package.as_deref(),
+        )?;
+        self.finish_online(PackageOperation::Update, resolved, true)
+    }
+
+    fn finish_path_only_operation(
+        &self,
+        operation: PackageOperation,
+        update_target: Option<&str>,
+        expected_lock_sha256: Option<&str>,
+    ) -> Result<Option<PackageOperationReport>, PackageManagerError> {
+        let fallback = RegistryConfig {
+            name: "path-only".to_owned(),
+            index: "file:///path-only/index.json".to_owned(),
+            trust_roots: "unused".to_owned(),
+            expectation: "unused".to_owned(),
+            cache: None,
+            vendor: None,
+        };
+        let registry = self.manifest.registry.as_ref().unwrap_or(&fallback);
+        let local = collect_local_graph(&self.project_root, &self.manifest, registry, "path-only")?;
+        if !local.registry_edges.is_empty() {
+            return Ok(None);
+        }
+        if let Some(target) = update_target {
+            return Err(PackageManagerError::new(
+                "update_target_invalid",
+                format!("targeted update {target:?} requires a direct registry dependency"),
+            ));
+        }
+        let lockfile = build_path_only_lockfile(&local)?;
+        let roots = local_materialized_roots(&local);
+        write_lockfile_v2_atomic_cas(&self.project_root, &lockfile, expected_lock_sha256)
+            .map_err(lockfile_write_error)?;
+        let (written, lockfile_sha256) = self.required_v2_lockfile()?;
+        if written != lockfile {
+            return Err(PackageManagerError::new(
+                "lockfile_write_mismatch",
+                "reloaded path-only lock differs from the exact lock model written",
+            ));
+        }
+        let graph = materialized_graph(&lockfile, &lockfile_sha256, &roots, &lockfile.roots)?;
+        Ok(Some(operation_report(
+            operation,
+            &self.project_root,
+            &lockfile_path(&self.project_root),
+            graph,
+            Vec::new(),
+            false,
+        )))
+    }
+
+    pub fn vendor(
+        &self,
+        options: VendorOptions,
+    ) -> Result<PackageOperationReport, PackageManagerError> {
+        let _operation_lock = PackageOperationLock::acquire(&self.project_root)?;
+        let (lockfile, lockfile_sha256) = self.required_v2_lockfile()?;
+        let local = verify_locked_local_graph(&self.project_root, &self.manifest, &lockfile)?;
+        if !lockfile_has_registry_packages(&lockfile) {
+            let roots = local_materialized_roots(&local);
+            let graph = materialized_graph(&lockfile, &lockfile_sha256, &roots, &lockfile.roots)?;
+            return Ok(operation_report(
+                PackageOperation::Vendor,
+                &self.project_root,
+                &lockfile_path(&self.project_root),
+                graph,
+                Vec::new(),
+                false,
+            ));
+        }
+        let trust = offline_trust_context(&self.project_root, &self.manifest, &lockfile)?;
+        let store = self.package_store()?;
+        let mut roots = local_materialized_roots(&local);
+        let mut retained_verified_bytes = 0usize;
+        for package in lockfile
+            .package
+            .iter()
+            .filter(|package| package.registry.is_some())
+        {
+            let registry = locked_registry_for_package(&lockfile, package)?;
+            let archive_sha256 = locked_archive_sha256(package)?;
+            let materialized = store
+                .load_verified_exact(
+                    archive_sha256,
+                    &registry.index_sha256,
+                    locked_verification_sha256(package)?,
+                )
+                .map_err(store_error)?;
+            verify_cached_against_lock(&materialized, package, registry)?;
+            verify_offline_package_trust(&materialized, package, registry, &lockfile, &trust)?;
+        }
+        let vendor_packages = locked_vendor_packages(&lockfile)?;
+        let vendor_root = self.vendor_root(options.out.as_deref())?;
+        let snapshot = store
+            .vendor_snapshot(&vendor_root, &vendor_packages)
+            .map_err(store_error)?;
+        verify_vendor_against_lock(&snapshot, &lockfile)?;
+        for package in lockfile
+            .package
+            .iter()
+            .filter(|package| package.registry.is_some())
+        {
+            let registry = locked_registry_for_package(&lockfile, package)?;
+            let materialized = snapshot
+                .package(&package.id)
+                .map_err(store_error)?
+                .ok_or_else(|| {
+                    PackageManagerError::new(
+                        "vendor_lock_mismatch",
+                        format!("verified vendor snapshot lacks {}", package.id),
+                    )
+                })?;
+            verify_cached_against_lock(&materialized, package, registry)?;
+            verify_offline_package_trust(&materialized, package, registry, &lockfile, &trust)?;
+            let tree = snapshot.package_tree(&package.id).ok_or_else(|| {
+                PackageManagerError::new(
+                    "vendor_lock_mismatch",
+                    format!("verified vendor snapshot lacks a tree for {}", package.id),
+                )
+            })?;
+            let (verified_archive, verified_manifest) = retain_verified_materialization_bytes(
+                &mut retained_verified_bytes,
+                materialized.artifacts.archive,
+                materialized.artifacts.manifest,
+            )?;
+            roots.insert(
+                package.id.clone(),
+                MaterializedRoot {
+                    path: tree,
+                    source: "vendor".to_owned(),
+                    content_key: package.cache_key.clone(),
+                    verified_archive: Some(verified_archive),
+                    verified_manifest: Some(verified_manifest),
+                },
+            );
+        }
+        let graph = materialized_graph(&lockfile, &lockfile_sha256, &roots, &lockfile.roots)?;
+        Ok(operation_report(
+            PackageOperation::Vendor,
+            &self.project_root,
+            &lockfile_path(&self.project_root),
+            graph,
+            Vec::new(),
+            false,
+        ))
+    }
+
+    pub fn materialize_locked(
+        &self,
+        options: MaterializeOptions,
+    ) -> Result<MaterializedPackageGraph, PackageManagerError> {
+        let (lockfile, lockfile_sha256) = self.required_v2_lockfile()?;
+        let local = verify_locked_local_graph(&self.project_root, &self.manifest, &lockfile)?;
+        if !lockfile_has_registry_packages(&lockfile) {
+            let roots = local_materialized_roots(&local);
+            return materialized_graph(&lockfile, &lockfile_sha256, &roots, &lockfile.roots);
+        }
+        let trust = offline_trust_context(&self.project_root, &self.manifest, &lockfile)?;
+        let store = self.package_store()?;
+        let mut roots = local_materialized_roots(&local);
+        let mut retained_verified_bytes = 0usize;
+        let vendor_packages = locked_vendor_packages(&lockfile)?;
+        let vendor_root = self.vendor_root(None)?;
+        let use_vendor = options.prefer_vendor || vendor_snapshot_is_present(&vendor_root)?;
+        if use_vendor {
+            let snapshot =
+                PackageStore::verify_vendor_snapshot_exact(&vendor_root, &vendor_packages)
+                    .map_err(store_error)?;
+            verify_vendor_against_lock(&snapshot, &lockfile)?;
+            for package in lockfile
+                .package
+                .iter()
+                .filter(|package| package.registry.is_some())
+            {
+                let registry = locked_registry_for_package(&lockfile, package)?;
+                let materialized = snapshot
+                    .package(&package.id)
+                    .map_err(store_error)?
+                    .ok_or_else(|| {
+                        PackageManagerError::new(
+                            "vendor_lock_mismatch",
+                            format!("verified vendor snapshot lacks {}", package.id),
+                        )
+                    })?;
+                verify_cached_against_lock(&materialized, package, registry)?;
+                verify_offline_package_trust(&materialized, package, registry, &lockfile, &trust)?;
+                let tree = snapshot.package_tree(&package.id).ok_or_else(|| {
+                    PackageManagerError::new(
+                        "vendor_lock_mismatch",
+                        format!("verified vendor snapshot lacks a tree for {}", package.id),
+                    )
+                })?;
+                let (verified_archive, verified_manifest) = retain_verified_materialization_bytes(
+                    &mut retained_verified_bytes,
+                    materialized.artifacts.archive,
+                    materialized.artifacts.manifest,
+                )?;
+                roots.insert(
+                    package.id.clone(),
+                    MaterializedRoot {
+                        path: tree,
+                        source: "vendor".to_owned(),
+                        content_key: package.cache_key.clone(),
+                        verified_archive: Some(verified_archive),
+                        verified_manifest: Some(verified_manifest),
+                    },
+                );
+            }
+        } else {
+            for package in lockfile
+                .package
+                .iter()
+                .filter(|package| package.registry.is_some())
+            {
+                let registry = locked_registry_for_package(&lockfile, package)?;
+                let materialized = store
+                    .load_verified_exact(
+                        locked_archive_sha256(package)?,
+                        &registry.index_sha256,
+                        locked_verification_sha256(package)?,
+                    )
+                    .map_err(store_error)?;
+                verify_cached_against_lock(&materialized, package, registry)?;
+                verify_offline_package_trust(&materialized, package, registry, &lockfile, &trust)?;
+                let (verified_archive, verified_manifest) = retain_verified_materialization_bytes(
+                    &mut retained_verified_bytes,
+                    materialized.artifacts.archive,
+                    materialized.artifacts.manifest,
+                )?;
+                roots.insert(
+                    package.id.clone(),
+                    MaterializedRoot {
+                        path: materialized.tree,
+                        source: "cache".to_owned(),
+                        content_key: package.cache_key.clone(),
+                        verified_archive: Some(verified_archive),
+                        verified_manifest: Some(verified_manifest),
+                    },
+                );
+            }
+        }
+        materialized_graph(&lockfile, &lockfile_sha256, &roots, &lockfile.roots)
+    }
+
+    fn optional_v2_lockfile(&self) -> Result<PreviousLockState, PackageManagerError> {
+        let path = lockfile_path(&self.project_root);
+        match std::fs::symlink_metadata(&path) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(PreviousLockState {
+                    lockfile: None,
+                    expected_sha256: None,
+                });
+            }
+            Err(error) => {
+                return Err(PackageManagerError::new(
+                    "lockfile_invalid",
+                    format!("failed to inspect {}: {error}", path.display()),
+                ));
+            }
+            Ok(_) => {}
+        }
+        let (parsed, expected_sha256) = load_lockfile_with_sha256(&self.project_root)
+            .map_err(|error| PackageManagerError::new("lockfile_invalid", error.to_string()))?;
+        match parsed {
+            // Fetch/update are the explicit migration boundary from a valid
+            // path-only v1 lock to a registry-capable v2 lock. The v2 file is
+            // written only after resolution, trust verification, and cache
+            // admission all succeed.
+            ParsedLockfile::V1(lockfile) => {
+                self.validate_v1_migration_lockfile(&lockfile)?;
+                Ok(PreviousLockState {
+                    lockfile: None,
+                    expected_sha256: Some(expected_sha256),
+                })
+            }
+            ParsedLockfile::V2(lockfile) => {
+                validate_lockfile_version_for_manifest(
+                    &self.manifest,
+                    &ParsedLockfile::V2(lockfile.clone()),
+                )
+                .map_err(|error| PackageManagerError::new("lockfile_invalid", error.to_string()))?;
+                Ok(PreviousLockState {
+                    lockfile: Some(lockfile),
+                    expected_sha256: Some(expected_sha256),
+                })
+            }
+        }
+    }
+
+    fn required_v2_lockfile(&self) -> Result<(LockfileV2, String), PackageManagerError> {
+        let (parsed, sha256) = load_lockfile_with_sha256(&self.project_root)
+            .map_err(|error| PackageManagerError::new("lockfile_unavailable", error.to_string()))?;
+        validate_lockfile_version_for_manifest(&self.manifest, &parsed)
+            .map_err(|error| PackageManagerError::new("lockfile_invalid", error.to_string()))?;
+        match parsed {
+            ParsedLockfile::V2(lockfile) => Ok((lockfile, sha256)),
+            ParsedLockfile::V1(_) => Err(PackageManagerError::new(
+                "lockfile_v2_required",
+                "locked package materialization requires axiom.lock version 2",
+            )),
+        }
+    }
+
+    fn validate_v1_migration_lockfile(
+        &self,
+        lockfile: &Lockfile,
+    ) -> Result<(), PackageManagerError> {
+        let fallback = RegistryConfig {
+            name: "path-only".to_owned(),
+            index: "file:///path-only/index.json".to_owned(),
+            trust_roots: "unused".to_owned(),
+            expectation: "unused".to_owned(),
+            cache: None,
+            vendor: None,
+        };
+        let registry = self.manifest.registry.as_ref().unwrap_or(&fallback);
+        let local =
+            collect_local_graph(&self.project_root, &self.manifest, registry, "v1-migration")?;
+        let expected = local
+            .packages
+            .iter()
+            .map(|package| {
+                let section = package.manifest.package.as_ref().ok_or_else(|| {
+                    PackageManagerError::new(
+                        "path_package_missing",
+                        format!(
+                            "path package {} has no [package] section",
+                            package.root.display()
+                        ),
+                    )
+                })?;
+                Ok(LockedPackage {
+                    name: section.name.clone(),
+                    version: section.version.clone(),
+                    source: package.source.clone(),
+                })
+            })
+            .collect::<Result<Vec<_>, PackageManagerError>>()?;
+        if lockfile.package != expected {
+            return Err(PackageManagerError::new(
+                "stale_v1_lockfile",
+                "axiom.lock v1 does not match the current path package graph; repair it before registry migration",
+            ));
+        }
+        Ok(())
+    }
+
+    fn resolve_online<'a>(
+        &self,
+        transport: &'a RegistryClient,
+        limits: ResolverLimits,
+        mode: ResolutionMode,
+        previous: Option<LockfileV2>,
+        expected_lock_sha256: Option<String>,
+        target: Option<&str>,
+    ) -> Result<OnlineResolution<'a>, PackageManagerError> {
+        let mut source = self.online_source(
+            transport,
+            (mode != ResolutionMode::Fresh)
+                .then_some(previous.as_ref())
+                .flatten(),
+        )?;
+        if mode == ResolutionMode::Update
+            && let Some(lockfile) = previous.as_ref()
+        {
+            validate_update_registry_continuity(lockfile, &source)?;
+        }
+        if mode == ResolutionMode::Locked {
+            let lockfile = previous.as_ref().ok_or_else(|| {
+                PackageManagerError::new(
+                    "lockfile_v2_required",
+                    "locked fetch requires axiom.lock version 2",
+                )
+            })?;
+            validate_locked_registry(lockfile, &source)?;
+        }
+        let local = collect_local_graph(
+            &self.project_root,
+            &self.manifest,
+            &source.registry,
+            source.catalog.source_identity(),
+        )?;
+        let locked = previous
+            .as_ref()
+            .map(|lockfile| locked_selections(lockfile, source.catalog.source_identity()))
+            .transpose()?
+            .unwrap_or_default();
+        let mut frozen = BTreeMap::new();
+        let target_key = if let Some(target) = target {
+            let matches = local
+                .registry_edges
+                .iter()
+                .filter(|(_, dependency)| {
+                    dependency.alias == target || dependency.package.name == target
+                })
+                .map(|(_, dependency)| dependency.package.clone())
+                .collect::<BTreeSet<_>>();
+            if matches.len() != 1 {
+                return Err(PackageManagerError::new(
+                    "update_target_invalid",
+                    format!(
+                        "targeted update {target:?} must identify exactly one direct registry dependency"
+                    ),
+                ));
+            }
+            matches.into_iter().next()
+        } else {
+            None
+        };
+        if mode == ResolutionMode::Locked {
+            frozen = locked.clone();
+        } else if let Some(target_key) = &target_key {
+            frozen.extend(
+                locked
+                    .iter()
+                    .filter(|(key, _)| *key != target_key)
+                    .map(|(key, selection)| (key.clone(), selection.clone())),
+            );
+        }
+        let request = ResolveRequest {
+            dependencies: local.resolver_dependencies.clone(),
+            locked: locked.clone(),
+            frozen: frozen.clone(),
+            mode,
+            limits,
+        };
+        let resolution = resolve_packages(&mut source, request)
+            .map_err(|error| map_resolve_error(error, !frozen.is_empty()))?;
+        validate_frozen_downloads(previous.as_ref(), &frozen, &resolution, &source)?;
+        retain_selected_downloads(&mut source, &resolution);
+        if let Some(target_key) = target_key
+            && let Some(previous) = locked.get(&target_key)
+            && resolution
+                .packages
+                .iter()
+                .any(|package| package.package == target_key && package.version == previous.version)
+            && resolution.trace.iter().any(trace_is_frozen_mismatch)
+        {
+            return Err(PackageManagerError::new(
+                "broader_update_required",
+                format!(
+                    "updating {} requires changing another locked package; run an untargeted update",
+                    target_key
+                ),
+            ));
+        }
+        let resolved = OnlineResolution {
+            source,
+            local,
+            resolution,
+            previous,
+            frozen,
+            mode,
+            expected_lock_sha256,
+        };
+        if resolved.mode == ResolutionMode::Locked {
+            let previous = resolved.previous.as_ref().ok_or_else(|| {
+                PackageManagerError::new(
+                    "lockfile_v2_required",
+                    "locked resolution completed without an axiom.lock v2 input",
+                )
+            })?;
+            if !same_dependency_edge_set(&resolved_dependency_edges(&resolved)?, &previous.edge) {
+                return Err(PackageManagerError::new(
+                    "locked_dependency_mismatch",
+                    "resolved dependency edge set differs from exact axiom.lock pins",
+                ));
+            }
+        }
+        Ok(resolved)
+    }
+
+    fn finish_online(
+        &self,
+        operation: PackageOperation,
+        resolved: OnlineResolution<'_>,
+        transport_used: bool,
+    ) -> Result<PackageOperationReport, PackageManagerError> {
+        let lockfile = build_resolved_lockfile(&resolved)?;
+        let store = self.package_store()?;
+        let mut roots = local_materialized_roots(&resolved.local);
+        let mut retained_verified_bytes = 0usize;
+        for selected in &resolved.resolution.packages {
+            let download = selected_download(&resolved.source, selected)?;
+            let package_id = canonical_registry_package_id(
+                &selected.package.registry,
+                &selected.package.namespace,
+                &selected.package.name,
+                &selected.version.to_string(),
+            );
+            let locked = lockfile
+                .package
+                .iter()
+                .find(|package| package.id == package_id)
+                .ok_or_else(|| {
+                    PackageManagerError::new(
+                        "resolution_incomplete",
+                        format!("selected package {package_id} is absent from the new lockfile"),
+                    )
+                })?;
+            let registry = locked_registry_for_package(&lockfile, locked)?;
+            if sha256_hex(&download.verification_bytes) != locked_verification_sha256(locked)? {
+                return Err(PackageManagerError::new(
+                    "locked_package_mismatch",
+                    format!(
+                        "Package Trust verification evidence differs from exact lock pins for {}",
+                        locked.id
+                    ),
+                ));
+            }
+            let cached = store
+                .admit(VerifiedArtifacts {
+                    archive_sha256: download.release.archive_sha256(),
+                    archive: &download.archive,
+                    manifest: &download.manifest,
+                    provenance: &download.provenance,
+                    signature: &download.package_signature_bytes,
+                    registry_index: &download.registry_index_bytes,
+                    verification: &download.verification_bytes,
+                })
+                .map_err(store_error)?;
+            verify_cached_against_lock(&cached, locked, registry)?;
+            let (verified_archive, verified_manifest) = retain_verified_materialization_bytes(
+                &mut retained_verified_bytes,
+                cached.artifacts.archive,
+                cached.artifacts.manifest,
+            )?;
+            roots.insert(
+                locked.id.clone(),
+                MaterializedRoot {
+                    path: cached.tree,
+                    source: "cache".to_owned(),
+                    content_key: locked.cache_key.clone(),
+                    verified_archive: Some(verified_archive),
+                    verified_manifest: Some(verified_manifest),
+                },
+            );
+        }
+        write_lockfile_v2_atomic_cas(
+            &self.project_root,
+            &lockfile,
+            resolved.expected_lock_sha256.as_deref(),
+        )
+        .map_err(lockfile_write_error)?;
+        let (written, lockfile_sha256) = self.required_v2_lockfile()?;
+        if written != lockfile {
+            return Err(PackageManagerError::new(
+                "lockfile_write_mismatch",
+                "reloaded resolved lock differs from the exact lock model written",
+            ));
+        }
+        let graph = materialized_graph(&lockfile, &lockfile_sha256, &roots, &lockfile.roots)?;
+        Ok(operation_report(
+            operation,
+            &self.project_root,
+            &lockfile_path(&self.project_root),
+            graph,
+            resolved.resolution.trace.clone(),
+            transport_used,
+        ))
+    }
+
+    fn package_store(&self) -> Result<PackageStore, PackageManagerError> {
+        let configured = self
+            .manifest
+            .registry
+            .as_ref()
+            .and_then(|registry| registry.cache.as_deref())
+            .unwrap_or(DEFAULT_PACKAGE_CACHE_DIR);
+        self.validate_storage_path_collision(Path::new(configured), None)?;
+        PackageStore::open_anchored(&self.project_root, Path::new(configured)).map_err(store_error)
+    }
+
+    fn vendor_root(&self, out: Option<&Path>) -> Result<PathBuf, PackageManagerError> {
+        let configured = out
+            .map(Path::to_path_buf)
+            .or_else(|| {
+                self.manifest
+                    .registry
+                    .as_ref()
+                    .and_then(|registry| registry.vendor.as_deref())
+                    .map(PathBuf::from)
+            })
+            .unwrap_or_else(|| PathBuf::from(DEFAULT_PACKAGE_VENDOR_DIR));
+        let configured = if configured.is_absolute() {
+            configured
+        } else {
+            let value = configured.to_str().ok_or_else(|| {
+                PackageManagerError::new("vendor_root_invalid", "vendor root must be valid UTF-8")
+            })?;
+            PathBuf::from(
+                normalize_project_relative_materialization_root(
+                    &manifest_path(&self.project_root),
+                    "pkg vendor --out",
+                    value,
+                )
+                .map_err(|error| {
+                    PackageManagerError::new("vendor_root_invalid", error.to_string())
+                })?,
+            )
+        };
+        let cache = Path::new(
+            self.manifest
+                .registry
+                .as_ref()
+                .and_then(|registry| registry.cache.as_deref())
+                .unwrap_or(DEFAULT_PACKAGE_CACHE_DIR),
+        );
+        self.validate_storage_path_collision(cache, Some(&configured))?;
+        if configured.is_absolute() {
+            let parent = configured.parent().ok_or_else(|| {
+                PackageManagerError::new(
+                    "vendor_root_invalid",
+                    "absolute vendor override has no parent directory",
+                )
+            })?;
+            let parent = std::fs::canonicalize(parent).map_err(|error| {
+                PackageManagerError::new(
+                    "vendor_root_invalid",
+                    format!(
+                        "failed to canonicalize vendor override parent {}: {error}",
+                        parent.display()
+                    ),
+                )
+            })?;
+            let name = configured.file_name().ok_or_else(|| {
+                PackageManagerError::new(
+                    "vendor_root_invalid",
+                    "absolute vendor override must name a directory below its parent",
+                )
+            })?;
+            PackageStore::prepare_anchored_root(&parent, Path::new(name)).map_err(store_error)
+        } else {
+            PackageStore::prepare_anchored_root(&self.project_root, &configured)
+                .map_err(store_error)
+        }
+    }
+
+    fn validate_storage_path_collision(
+        &self,
+        cache: &Path,
+        vendor_override: Option<&Path>,
+    ) -> Result<(), PackageManagerError> {
+        let vendor = vendor_override
+            .map(Path::to_path_buf)
+            .or_else(|| {
+                self.manifest
+                    .registry
+                    .as_ref()
+                    .and_then(|registry| registry.vendor.as_deref())
+                    .map(PathBuf::from)
+            })
+            .unwrap_or_else(|| PathBuf::from(DEFAULT_PACKAGE_VENDOR_DIR));
+        let effective = |configured: &Path| {
+            if configured.is_absolute() {
+                normalize_lexical_path(configured)
+            } else {
+                normalize_lexical_path(&self.project_root.join(configured))
+            }
+        };
+        if effective(cache) == effective(&vendor) {
+            return Err(PackageManagerError::new(
+                "package_storage_path_collision",
+                format!(
+                    "effective package cache and vendor roots both resolve to {}",
+                    effective(cache).display()
+                ),
+            ));
+        }
+        Ok(())
+    }
+
+    fn online_source<'a>(
+        &self,
+        transport: &'a RegistryClient,
+        previous: Option<&LockfileV2>,
+    ) -> Result<OnlineResolverSource<'a>, PackageManagerError> {
+        let registry = self.manifest.registry.clone().ok_or_else(|| {
+            PackageManagerError::new(
+                "registry_missing",
+                "registry dependencies require a root [registry] configuration",
+            )
+        })?;
+        let trust_roots_path = self.project_root.join(&registry.trust_roots);
+        let expectation_path = self.project_root.join(&registry.expectation);
+        let trust_roots_bytes = read_bounded_file(&trust_roots_path, MAX_TRUST_DOCUMENT_BYTES)
+            .map_err(|message| PackageManagerError::new("trust_roots_unavailable", message))?;
+        let expectation_bytes = read_bounded_file(&expectation_path, MAX_TRUST_DOCUMENT_BYTES)
+            .map_err(|message| PackageManagerError::new("expectation_unavailable", message))?;
+        if let Some(previous) = previous {
+            validate_previous_trust_documents(
+                previous,
+                &registry,
+                &trust_roots_bytes,
+                &expectation_bytes,
+            )?;
+        }
+        let trust_roots = parse_trust_roots_json(&trust_roots_bytes)
+            .map_err(|error| PackageManagerError::new("trust_roots_invalid", error.to_string()))?;
+        let mut expectation = parse_verification_expectation_json(&expectation_bytes)
+            .map_err(|error| PackageManagerError::new("expectation_invalid", error.to_string()))?;
+        let index_bytes = transport.fetch(&registry.index).map_err(transport_error)?;
+        if let Some(previous) = previous {
+            advance_expectation_from_lock(&mut expectation, previous, &registry)?;
+        }
+        let catalog = authenticate_registry_catalog(&index_bytes, &trust_roots, &expectation)
+            .map_err(|error| {
+                PackageManagerError::new("registry_catalog_rejected", error.reason_codes.join(", "))
+            })?;
+        let index_bytes: Arc<[u8]> = Arc::from(index_bytes);
+        Ok(OnlineResolverSource {
+            transport,
+            registry,
+            trust_roots_bytes,
+            expectation_bytes,
+            trust_roots,
+            expectation,
+            catalog,
+            index_bytes,
+            candidate_download_bytes: 0,
+            downloads: BTreeMap::new(),
+        })
+    }
+}
+
+impl ResolverSource for OnlineResolverSource<'_> {
+    fn authenticate_catalog(
+        &mut self,
+        package: &PackageKey,
+    ) -> Result<ResolverCatalog, SourceFailure> {
+        self.require_catalog_identity(package)?;
+        let mut candidates = Vec::new();
+        for release in self.catalog.releases().iter().filter(|release| {
+            release.namespace() == package.namespace && release.name() == package.name
+        }) {
+            let version = ReleaseVersion::parse(release.version()).map_err(|error| {
+                SourceFailure::new(
+                    "catalog_version_invalid",
+                    format!(
+                        "authenticated release {}/{} has unsupported version: {error}",
+                        release.namespace(),
+                        release.name()
+                    ),
+                )
+            })?;
+            candidates.push(CatalogCandidate {
+                version,
+                yanked: release.yanked(),
+                release_id: release.target_path().to_owned(),
+            });
+        }
+        Ok(ResolverCatalog::new(
+            package.clone(),
+            candidates,
+            sha256_hex(self.catalog.exact_index_bytes()),
+        ))
+    }
+
+    fn verify_candidate(
+        &mut self,
+        catalog: &ResolverCatalog,
+        candidate: &CatalogCandidate,
+    ) -> Result<VerifiedCandidate, SourceFailure> {
+        self.require_catalog_identity(catalog.package())?;
+        let version = candidate.version.to_string();
+        let release = self
+            .catalog
+            .release(
+                &catalog.package().namespace,
+                &catalog.package().name,
+                &version,
+            )
+            .filter(|release| release.target_path() == candidate.release_id)
+            .cloned()
+            .ok_or_else(|| {
+                SourceFailure::new(
+                    "release_identity_mismatch",
+                    format!(
+                        "authenticated catalog does not contain {} at release identity {:?}",
+                        catalog.package(),
+                        candidate.release_id
+                    ),
+                )
+            })?;
+        let paths = release.artifact_paths();
+        let archive = self.fetch_package_archive(&paths.archive, release.archive_length())?;
+        let manifest_bytes = self.fetch_artifact(&paths.manifest)?;
+        let provenance = self.fetch_artifact(&paths.provenance)?;
+        let package_signature_bytes = self.fetch_artifact(&paths.package_signature)?;
+        let package_signature = parse_package_signature_json(&package_signature_bytes)
+            .map_err(|error| SourceFailure::new("package_signature_invalid", error.to_string()))?;
+        let release_expectation = verification_expectation_for_authenticated_release(
+            &self.expectation,
+            &self.catalog,
+            &release,
+        )
+        .map_err(|error| {
+            SourceFailure::new("release_expectation_invalid", error.reason_codes.join(", "))
+        })?;
+        let registry_index = parse_registry_index_json(self.catalog.exact_index_bytes())
+            .map_err(|error| SourceFailure::new("registry_index_invalid", error.to_string()))?;
+        let verification = verify_package_with_artifacts(
+            &PackageTrustInput {
+                package_signature: package_signature.clone(),
+                trust_roots: self.trust_roots.clone(),
+                registry_index,
+                verification_expectation: release_expectation,
+            },
+            PackageArtifacts {
+                archive: Some(&archive),
+                manifest: Some(&manifest_bytes),
+                provenance: Some(&provenance),
+            },
+        );
+        if verification.decision != "trusted" {
+            return Err(SourceFailure::new(
+                "package_trust_rejected",
+                format!(
+                    "{} rejected: {}",
+                    catalog.package(),
+                    verification.reason_codes.join(", ")
+                ),
+            ));
+        }
+        let manifest = parse_manifest_exact(&manifest_bytes, Path::new("authenticated/axiom.toml"))
+            .map_err(|error| SourceFailure::new("package_manifest_invalid", error.to_string()))?;
+        validate_authenticated_archive_contract(
+            &archive,
+            release.archive_sha256(),
+            &manifest_bytes,
+            &manifest,
+        )?;
+        let package_section = manifest.package.as_ref().ok_or_else(|| {
+            SourceFailure::new(
+                "package_identity_mismatch",
+                "authenticated registry manifest has no [package] section",
+            )
+        })?;
+        if package_section.name != catalog.package().name || package_section.version != version {
+            return Err(SourceFailure::new(
+                "package_identity_mismatch",
+                format!(
+                    "authenticated manifest identifies {}@{}, expected {}@{}",
+                    package_section.name,
+                    package_section.version,
+                    catalog.package().name,
+                    version
+                ),
+            ));
+        }
+        let dependencies =
+            manifest_dependencies(&manifest, &self.registry, self.catalog.source_identity())?;
+        let mut signer_key_ids = verification
+            .signers
+            .iter()
+            .map(|signer| signer.key_id.clone())
+            .collect::<Vec<_>>();
+        signer_key_ids.sort();
+        signer_key_ids.dedup();
+        let compatibility = current_compatibility()
+            .map_err(|error| SourceFailure::new(error.code, error.message))?;
+        let verified = VerifiedCandidate {
+            package: catalog.package().clone(),
+            version: candidate.version,
+            release_id: candidate.release_id.clone(),
+            dependencies,
+            manifest_digest: release.manifest_sha256().to_owned(),
+            signer_key_ids,
+            edition: compatibility.edition_policy.clone(),
+            compatibility: compatibility.contract.clone(),
+        };
+        let verification_bytes = serde_json::to_vec(&verification).map_err(|error| {
+            SourceFailure::new(
+                "package_verification_invalid",
+                format!("failed to serialize Package Trust evidence: {error}"),
+            )
+        })?;
+        self.downloads.insert(
+            (
+                verified.package.clone(),
+                verified.version,
+                verified.release_id.clone(),
+            ),
+            VerifiedDownload {
+                release,
+                verification_bytes,
+                archive: Arc::from(archive),
+                manifest: Arc::from(manifest_bytes),
+                provenance,
+                package_signature_bytes,
+                registry_index_bytes: self.index_bytes.clone(),
+            },
+        );
+        Ok(verified)
+    }
+
+    fn discard_candidate(&mut self, candidate: &CatalogCandidate) {
+        self.downloads.retain(|(_, version, release_id), _| {
+            *version != candidate.version || release_id != &candidate.release_id
+        });
+    }
+}
+
+fn validate_authenticated_archive_contract(
+    archive_bytes: &[u8],
+    expected_sha256: &str,
+    authenticated_manifest_bytes: &[u8],
+    manifest: &Manifest,
+) -> Result<(), SourceFailure> {
+    let archive = parse_archive(archive_bytes, expected_sha256, ArchiveLimits::default())
+        .map_err(|error| SourceFailure::new(error.code, error.message))?;
+    let embedded_manifest = archive
+        .entries
+        .iter()
+        .find(|entry| entry.path == "axiom.toml")
+        .ok_or_else(|| {
+            SourceFailure::new(
+                "archive_manifest_missing",
+                "authenticated package archive does not contain axiom.toml",
+            )
+        })?;
+    if embedded_manifest.bytes != authenticated_manifest_bytes {
+        return Err(SourceFailure::new(
+            "archive_manifest_mismatch",
+            "archive axiom.toml differs from the separately authenticated manifest bytes",
+        ));
+    }
+    if manifest.workspace.is_some() {
+        return Err(SourceFailure::new(
+            "registry_workspace_unsupported",
+            "registry packages may not contain a [workspace] manifest",
+        ));
+    }
+    let entry = manifest.build.entry.as_str();
+    if !entry.ends_with(".ax") {
+        return Err(SourceFailure::new(
+            "registry_build_entry_invalid",
+            format!("registry package build.entry {entry:?} must name an .ax file"),
+        ));
+    }
+    if !archive
+        .entries
+        .iter()
+        .any(|archive_entry| archive_entry.path == entry)
+    {
+        return Err(SourceFailure::new(
+            "registry_build_entry_missing",
+            format!(
+                "registry package build.entry {entry:?} is absent from the authenticated archive"
+            ),
+        ));
+    }
+    Ok(())
+}
+
+impl OnlineResolverSource<'_> {
+    fn require_catalog_identity(&self, package: &PackageKey) -> Result<(), SourceFailure> {
+        if package.registry != self.registry.name
+            || package.source != self.catalog.source_identity()
+        {
+            return Err(SourceFailure::new(
+                "registry_identity_mismatch",
+                format!(
+                    "package source {} does not match authenticated registry {}@{}",
+                    package,
+                    self.registry.name,
+                    self.catalog.source_identity()
+                ),
+            ));
+        }
+        Ok(())
+    }
+
+    fn fetch_artifact(&mut self, relative_path: &str) -> Result<Vec<u8>, SourceFailure> {
+        let url = resolve_registry_artifact_url(&self.registry.index, relative_path)
+            .map_err(source_transport_error)?;
+        let bytes = self.transport.fetch(&url).map_err(source_transport_error)?;
+        self.charge_candidate_bytes(bytes.len())?;
+        Ok(bytes)
+    }
+
+    fn fetch_package_archive(
+        &mut self,
+        relative_path: &str,
+        authenticated_length: u64,
+    ) -> Result<Vec<u8>, SourceFailure> {
+        let authenticated_length = validate_authenticated_archive_length(authenticated_length)?;
+        let url = resolve_registry_artifact_url(&self.registry.index, relative_path)
+            .map_err(source_transport_error)?;
+        let bytes = self
+            .transport
+            .fetch_package_archive(&url)
+            .map_err(source_transport_error)?;
+        if bytes.len() != authenticated_length {
+            return Err(SourceFailure::new(
+                "archive_length_mismatch",
+                format!(
+                    "downloaded archive has {} bytes, authenticated catalog requires {authenticated_length}",
+                    bytes.len()
+                ),
+            ));
+        }
+        self.charge_candidate_bytes(bytes.len())?;
+        Ok(bytes)
+    }
+
+    fn charge_candidate_bytes(&mut self, bytes: usize) -> Result<(), SourceFailure> {
+        self.candidate_download_bytes =
+            charged_candidate_bytes(self.candidate_download_bytes, bytes)?;
+        Ok(())
+    }
+}
+
+fn validate_authenticated_archive_length(length: u64) -> Result<usize, SourceFailure> {
+    if length == 0 || length > MAX_PACKAGE_ARCHIVE_BODY_BYTES as u64 {
+        return Err(SourceFailure::new(
+            "archive_length_out_of_bounds",
+            format!(
+                "authenticated archive length {length} exceeds the {} byte package limit",
+                MAX_PACKAGE_ARCHIVE_BODY_BYTES
+            ),
+        ));
+    }
+    usize::try_from(length).map_err(|_| {
+        SourceFailure::new(
+            "archive_length_out_of_bounds",
+            "authenticated archive length does not fit this platform",
+        )
+    })
+}
+
+fn charged_candidate_bytes(current: usize, bytes: usize) -> Result<usize, SourceFailure> {
+    let total = current.checked_add(bytes).ok_or_else(|| {
+        SourceFailure::new(
+            "candidate_download_budget_exceeded",
+            "candidate download byte counter overflowed",
+        )
+    })?;
+    if total > MAX_CANDIDATE_DOWNLOAD_BYTES {
+        return Err(SourceFailure::new(
+            "candidate_download_budget_exceeded",
+            format!(
+                "candidate downloads exceeded the {} byte operation budget",
+                MAX_CANDIDATE_DOWNLOAD_BYTES
+            ),
+        ));
+    }
+    Ok(total)
+}
+
+fn retain_verified_materialization_bytes(
+    retained: &mut usize,
+    archive: Vec<u8>,
+    manifest: Vec<u8>,
+) -> Result<(Arc<[u8]>, Arc<[u8]>), PackageManagerError> {
+    let total = retained
+        .checked_add(archive.len())
+        .and_then(|total| total.checked_add(manifest.len()))
+        .filter(|total| *total <= MAX_CANDIDATE_DOWNLOAD_BYTES)
+        .ok_or_else(|| {
+            PackageManagerError::new(
+                "materialized_verified_bytes_budget_exceeded",
+                format!(
+                    "verified registry archive and manifest bytes exceed the {} byte materialization budget",
+                    MAX_CANDIDATE_DOWNLOAD_BYTES
+                ),
+            )
+        })?;
+    *retained = total;
+    Ok((Arc::from(archive), Arc::from(manifest)))
+}
+
+fn locked_selections(
+    lockfile: &LockfileV2,
+    source_identity: &str,
+) -> Result<BTreeMap<PackageKey, LockedSelection>, PackageManagerError> {
+    let mut selections = BTreeMap::new();
+    for package in &lockfile.package {
+        let (Some(registry), Some(namespace)) =
+            (package.registry.as_deref(), package.namespace.as_deref())
+        else {
+            continue;
+        };
+        let version = ReleaseVersion::parse(&package.version).map_err(|error| {
+            PackageManagerError::new(
+                "lockfile_invalid",
+                format!("locked package {} has invalid version: {error}", package.id),
+            )
+        })?;
+        let key = PackageKey::new(
+            registry.to_owned(),
+            source_identity.to_owned(),
+            namespace.to_owned(),
+            package.name.clone(),
+        );
+        if selections
+            .insert(key, LockedSelection { version })
+            .is_some()
+        {
+            return Err(PackageManagerError::new(
+                "lockfile_invalid",
+                "lockfile contains duplicate registry package selections",
+            ));
+        }
+    }
+    Ok(selections)
+}
+
+fn validate_locked_registry(
+    lockfile: &LockfileV2,
+    source: &OnlineResolverSource<'_>,
+) -> Result<(), PackageManagerError> {
+    let record = lockfile
+        .registry
+        .iter()
+        .find(|record| record.name == source.registry.name)
+        .ok_or_else(|| {
+            PackageManagerError::new(
+                "locked_registry_missing",
+                format!(
+                    "axiom.lock has no registry record for {:?}",
+                    source.registry.name
+                ),
+            )
+        })?;
+    let mut current_signers = source.catalog.index_signer_key_ids().to_vec();
+    current_signers.sort();
+    let exact = record.source == source.registry.index
+        && record.registry_identity == source.catalog.registry_identity()
+        && record.source_identity == source.catalog.source_identity()
+        && record.trust_roots_sha256 == sha256_hex(&source.trust_roots_bytes)
+        && record.expectation_sha256 == sha256_hex(&source.expectation_bytes)
+        && record.current_root_version == source.catalog.root_version()
+        && record.current_root_sequence == source.catalog.root_sequence()
+        && record.current_root_transcript_sha256 == source.catalog.root_transcript_sha256()
+        && record.index_sha256 == sha256_hex(source.catalog.exact_index_bytes())
+        && record.index_transcript_sha256 == source.catalog.index_transcript_sha256()
+        && record.index_generation == source.catalog.generation()
+        && record.index_sequence == source.catalog.sequence()
+        && record.index_snapshot_id == source.catalog.snapshot_id()
+        && record.index_signer_key_ids == current_signers;
+    if !exact {
+        return Err(PackageManagerError::new(
+            "locked_registry_mismatch",
+            "authenticated registry metadata does not match the exact axiom.lock v2 pins",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_previous_trust_documents(
+    lockfile: &LockfileV2,
+    configured: &RegistryConfig,
+    trust_roots_bytes: &[u8],
+    expectation_bytes: &[u8],
+) -> Result<(), PackageManagerError> {
+    let locked = lockfile
+        .registry
+        .iter()
+        .find(|registry| registry.name == configured.name)
+        .ok_or_else(|| {
+            PackageManagerError::new(
+                "update_registry_missing",
+                format!(
+                    "previous axiom.lock has no registry state for {:?}",
+                    configured.name
+                ),
+            )
+        })?;
+    if locked.source != configured.index {
+        return Err(PackageManagerError::new(
+            "update_registry_source_changed",
+            "configured registry source differs from the previously accepted lock state",
+        ));
+    }
+    if sha256_hex(trust_roots_bytes) != locked.trust_roots_sha256 {
+        return Err(PackageManagerError::new(
+            "trusted_roots_reset_rejected",
+            "current trust-roots bytes differ from the exact previously accepted lock pin",
+        ));
+    }
+    if sha256_hex(expectation_bytes) != locked.expectation_sha256 {
+        return Err(PackageManagerError::new(
+            "verification_policy_reset_rejected",
+            "current verification-expectation bytes differ from the exact previously accepted lock pin",
+        ));
+    }
+    Ok(())
+}
+
+fn advance_expectation_from_lock(
+    expectation: &mut VerificationExpectation,
+    lockfile: &LockfileV2,
+    configured: &RegistryConfig,
+) -> Result<(), PackageManagerError> {
+    let locked = lockfile
+        .registry
+        .iter()
+        .find(|registry| registry.name == configured.name)
+        .ok_or_else(|| {
+            PackageManagerError::new(
+                "update_registry_missing",
+                format!(
+                    "previous axiom.lock has no registry state for {:?}",
+                    configured.name
+                ),
+            )
+        })?;
+    if locked.source != configured.index {
+        return Err(PackageManagerError::new(
+            "update_registry_source_changed",
+            "configured registry source differs from the previously accepted lock state",
+        ));
+    }
+    let trusted_state = expectation
+        .0
+        .get_mut("trusted_state")
+        .and_then(serde_json::Value::as_object_mut)
+        .ok_or_else(|| {
+            PackageManagerError::new(
+                "expectation_invalid",
+                "verification expectation lacks a trusted_state object",
+            )
+        })?;
+    let advance_number =
+        |state: &mut serde_json::Map<String, serde_json::Value>, field: &str, locked_value: u64| {
+            let current = state.get(field).and_then(serde_json::Value::as_u64);
+            if current.is_none_or(|value| value < locked_value) {
+                state.insert(field.to_owned(), serde_json::Value::from(locked_value));
+            }
+        };
+    advance_number(
+        trusted_state,
+        "highest_root_version",
+        locked.current_root_version,
+    );
+    advance_number(
+        trusted_state,
+        "highest_root_sequence",
+        locked.current_root_sequence,
+    );
+    advance_number(
+        trusted_state,
+        "highest_index_generation",
+        locked.index_generation,
+    );
+    advance_number(
+        trusted_state,
+        "highest_index_sequence",
+        locked.index_sequence,
+    );
+
+    // `trusted_root_anchor` pins the bootstrap root in the trust-roots
+    // transition envelope, not the newest candidate root. Replacing it with
+    // the lock's current candidate makes the same authenticated root chain
+    // fail ROOT_BOOTSTRAP_MISMATCH on every subsequent online or offline use.
+    // The lock advances only the monotonic candidate-root high-water marks.
+
+    let snapshot = serde_json::json!({
+        "generation": locked.index_generation,
+        "sequence": locked.index_sequence,
+        "snapshot_id": locked.index_snapshot_id,
+        "index_transcript_sha256": locked.index_transcript_sha256,
+    });
+    let seen = trusted_state
+        .get_mut("seen_snapshots")
+        .and_then(serde_json::Value::as_array_mut)
+        .ok_or_else(|| {
+            PackageManagerError::new(
+                "expectation_invalid",
+                "verification expectation trusted_state lacks seen_snapshots",
+            )
+        })?;
+    if let Some(rebound) = seen.iter().find(|candidate| {
+        candidate
+            .get("generation")
+            .and_then(serde_json::Value::as_u64)
+            == Some(locked.index_generation)
+            && candidate
+                .get("sequence")
+                .and_then(serde_json::Value::as_u64)
+                == Some(locked.index_sequence)
+            && *candidate != &snapshot
+    }) {
+        return Err(PackageManagerError::new(
+            "update_snapshot_rebound",
+            format!("previous lock conflicts with expectation snapshot {rebound}"),
+        ));
+    }
+    if !seen.contains(&snapshot) {
+        seen.push(snapshot);
+    }
+    Ok(())
+}
+
+fn validate_update_registry_continuity(
+    lockfile: &LockfileV2,
+    source: &OnlineResolverSource<'_>,
+) -> Result<(), PackageManagerError> {
+    let locked = lockfile
+        .registry
+        .iter()
+        .find(|registry| registry.name == source.registry.name)
+        .ok_or_else(|| {
+            PackageManagerError::new(
+                "update_registry_missing",
+                "previous lock has no state for the configured registry",
+            )
+        })?;
+    if locked.registry_identity != source.catalog.registry_identity()
+        || locked.source_identity != source.catalog.source_identity()
+    {
+        return Err(PackageManagerError::new(
+            "update_registry_identity_changed",
+            "authenticated registry identity differs from the previously accepted lock state",
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct FrozenPackageIdentity {
+    version: String,
+    archive_sha256: String,
+    archive_length: u64,
+    manifest_sha256: String,
+    provenance_sha256: String,
+    package_signature_sha256: String,
+    publisher_identity: String,
+    signer_key_ids: Vec<String>,
+    yanked: bool,
+}
+
+fn locked_frozen_identity(
+    package: &LockedPackageV2,
+) -> Result<FrozenPackageIdentity, PackageManagerError> {
+    Ok(FrozenPackageIdentity {
+        version: package.version.clone(),
+        archive_sha256: required_locked_field(package, "archive_sha256", &package.archive_sha256)?
+            .to_owned(),
+        archive_length: package.archive_length.ok_or_else(|| {
+            PackageManagerError::new(
+                "lockfile_invalid",
+                format!("locked package {} lacks archive_length", package.id),
+            )
+        })?,
+        manifest_sha256: required_locked_field(
+            package,
+            "manifest_sha256",
+            &package.manifest_sha256,
+        )?
+        .to_owned(),
+        provenance_sha256: required_locked_field(
+            package,
+            "provenance_sha256",
+            &package.provenance_sha256,
+        )?
+        .to_owned(),
+        package_signature_sha256: required_locked_field(
+            package,
+            "package_signature_sha256",
+            &package.package_signature_sha256,
+        )?
+        .to_owned(),
+        publisher_identity: required_locked_field(
+            package,
+            "publisher_identity",
+            &package.publisher_identity,
+        )?
+        .to_owned(),
+        signer_key_ids: package.signer_key_ids.clone(),
+        yanked: package.yanked_at_resolution.ok_or_else(|| {
+            PackageManagerError::new(
+                "lockfile_invalid",
+                format!("locked package {} lacks yank evidence", package.id),
+            )
+        })?,
+    })
+}
+
+fn downloaded_frozen_identity(
+    selected: &crate::package_resolver::ResolvedPackage,
+    download: &VerifiedDownload,
+) -> FrozenPackageIdentity {
+    FrozenPackageIdentity {
+        version: selected.version.to_string(),
+        archive_sha256: download.release.archive_sha256().to_owned(),
+        archive_length: download.release.archive_length(),
+        manifest_sha256: download.release.manifest_sha256().to_owned(),
+        provenance_sha256: download.release.provenance_statement_sha256().to_owned(),
+        package_signature_sha256: download.release.package_signature_sha256().to_owned(),
+        publisher_identity: download.release.publisher_identity().to_owned(),
+        signer_key_ids: selected.signer_key_ids.clone(),
+        yanked: selected.yanked,
+    }
+}
+
+fn ensure_frozen_identity(
+    package: &PackageKey,
+    locked: FrozenPackageIdentity,
+    observed: FrozenPackageIdentity,
+) -> Result<(), PackageManagerError> {
+    if locked != observed {
+        return Err(PackageManagerError::new(
+            "frozen_package_identity_changed",
+            format!(
+                "targeted update encountered changed artifact or security identity for frozen package {package}"
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_frozen_downloads(
+    previous: Option<&LockfileV2>,
+    frozen: &BTreeMap<PackageKey, LockedSelection>,
+    resolution: &Resolution,
+    source: &OnlineResolverSource<'_>,
+) -> Result<(), PackageManagerError> {
+    if frozen.is_empty() {
+        return Ok(());
+    }
+    let previous = previous.ok_or_else(|| {
+        PackageManagerError::new(
+            "lockfile_v2_required",
+            "frozen package verification requires a previous lockfile",
+        )
+    })?;
+    for key in frozen.keys() {
+        let selected = resolution
+            .packages
+            .iter()
+            .find(|selected| &selected.package == key)
+            .ok_or_else(|| {
+                PackageManagerError::new(
+                    "frozen_package_missing",
+                    format!("resolver omitted frozen package {key}"),
+                )
+            })?;
+        let locked = previous
+            .package
+            .iter()
+            .find(|package| {
+                package.registry.as_deref() == Some(&key.registry)
+                    && package.namespace.as_deref() == Some(&key.namespace)
+                    && package.name == key.name
+            })
+            .ok_or_else(|| {
+                PackageManagerError::new(
+                    "frozen_package_missing",
+                    format!("previous lock omitted frozen package {key}"),
+                )
+            })?;
+        let download = selected_download(source, selected)?;
+        ensure_frozen_identity(
+            key,
+            locked_frozen_identity(locked)?,
+            downloaded_frozen_identity(selected, download),
+        )?;
+    }
+    Ok(())
+}
+
+fn retain_selected_downloads(source: &mut OnlineResolverSource<'_>, resolution: &Resolution) {
+    let selected = resolution
+        .packages
+        .iter()
+        .map(|package| {
+            (
+                package.package.clone(),
+                package.version,
+                package.release_id.clone(),
+            )
+        })
+        .collect::<BTreeSet<_>>();
+    source.downloads.retain(|key, _| selected.contains(key));
+}
+
+fn trace_is_frozen_mismatch(event: &TraceEvent) -> bool {
+    matches!(
+        event,
+        TraceEvent::CandidateRejected {
+            reason: CandidateRejection::FrozenMismatch { .. },
+            ..
+        }
+    )
+}
+
+fn build_path_only_lockfile(local: &LocalGraph) -> Result<LockfileV2, PackageManagerError> {
+    if !local.registry_edges.is_empty() {
+        return Err(PackageManagerError::new(
+            "registry_dependency_unresolved",
+            "path-only lock construction received registry dependencies",
+        ));
+    }
+    let compatibility = current_compatibility()?;
+    let mut package = local
+        .packages
+        .iter()
+        .map(|local| {
+            let section = local.manifest.package.as_ref().ok_or_else(|| {
+                PackageManagerError::new(
+                    "path_package_missing",
+                    format!(
+                        "path package {} has no [package] section",
+                        local.root.display()
+                    ),
+                )
+            })?;
+            Ok(LockedPackageV2 {
+                id: local.id.clone(),
+                name: section.name.clone(),
+                version: section.version.clone(),
+                source: local.source.clone(),
+                registry: None,
+                namespace: None,
+                archive_sha256: None,
+                archive_length: None,
+                manifest_sha256: None,
+                provenance_sha256: None,
+                package_signature_sha256: None,
+                verification_sha256: None,
+                publisher_identity: None,
+                signer_key_ids: Vec::new(),
+                cache_key: None,
+                yanked_at_resolution: None,
+                compatibility: compatibility.clone(),
+            })
+        })
+        .collect::<Result<Vec<_>, PackageManagerError>>()?;
+    package.sort_by(|left, right| left.id.cmp(&right.id));
+    let mut roots = local.roots.clone();
+    roots.sort();
+    roots.dedup();
+    let mut edge = local.path_edges.clone();
+    edge.sort_by(lock_edge_order);
+    let lockfile = LockfileV2 {
+        version: LOCKFILE_V2_VERSION,
+        compatibility,
+        roots,
+        registry: Vec::new(),
+        package,
+        edge,
+    };
+    crate::lockfile::validate_lockfile_v2(&lockfile)
+        .map_err(|error| PackageManagerError::new("lockfile_invalid", error.to_string()))?;
+    Ok(lockfile)
+}
+
+fn build_resolved_lockfile(
+    resolved: &OnlineResolution<'_>,
+) -> Result<LockfileV2, PackageManagerError> {
+    if resolved
+        .resolution
+        .path_dependencies
+        .iter()
+        .any(|dependency| dependency.from.is_some())
+    {
+        return Err(PackageManagerError::new(
+            "registry_path_dependency_unsupported",
+            "authenticated registry packages may not depend on mutable path sources",
+        ));
+    }
+    if resolved.mode == ResolutionMode::Locked {
+        return resolved.previous.clone().ok_or_else(|| {
+            PackageManagerError::new(
+                "lockfile_v2_required",
+                "locked resolution completed without an axiom.lock v2 input",
+            )
+        });
+    }
+
+    let compatibility = current_compatibility()?;
+    let mut index_signer_key_ids = resolved.source.catalog.index_signer_key_ids().to_vec();
+    index_signer_key_ids.sort();
+    index_signer_key_ids.dedup();
+    let registry = vec![LockedRegistryV2 {
+        name: resolved.source.registry.name.clone(),
+        source: resolved.source.registry.index.clone(),
+        registry_identity: resolved.source.catalog.registry_identity().to_owned(),
+        source_identity: resolved.source.catalog.source_identity().to_owned(),
+        trust_roots_sha256: sha256_hex(&resolved.source.trust_roots_bytes),
+        expectation_sha256: sha256_hex(&resolved.source.expectation_bytes),
+        current_root_version: resolved.source.catalog.root_version(),
+        current_root_sequence: resolved.source.catalog.root_sequence(),
+        current_root_transcript_sha256: resolved.source.catalog.root_transcript_sha256().to_owned(),
+        index_sha256: sha256_hex(resolved.source.catalog.exact_index_bytes()),
+        index_transcript_sha256: resolved.source.catalog.index_transcript_sha256().to_owned(),
+        index_generation: resolved.source.catalog.generation(),
+        index_sequence: resolved.source.catalog.sequence(),
+        index_snapshot_id: resolved.source.catalog.snapshot_id().to_owned(),
+        index_signer_key_ids,
+    }];
+
+    let mut package =
+        Vec::with_capacity(resolved.local.packages.len() + resolved.resolution.packages.len());
+    for local in &resolved.local.packages {
+        let section = local.manifest.package.as_ref().ok_or_else(|| {
+            PackageManagerError::new(
+                "path_package_missing",
+                format!(
+                    "path package {} has no [package] section",
+                    local.root.display()
+                ),
+            )
+        })?;
+        package.push(LockedPackageV2 {
+            id: local.id.clone(),
+            name: section.name.clone(),
+            version: section.version.clone(),
+            source: local.source.clone(),
+            registry: None,
+            namespace: None,
+            archive_sha256: None,
+            archive_length: None,
+            manifest_sha256: None,
+            provenance_sha256: None,
+            package_signature_sha256: None,
+            verification_sha256: None,
+            publisher_identity: None,
+            signer_key_ids: Vec::new(),
+            cache_key: None,
+            yanked_at_resolution: None,
+            compatibility: compatibility.clone(),
+        });
+    }
+    for selected in &resolved.resolution.packages {
+        let download = selected_download(&resolved.source, selected)?;
+        let mut signer_key_ids = selected.signer_key_ids.clone();
+        signer_key_ids.sort();
+        signer_key_ids.dedup();
+        let version = selected.version.to_string();
+        let archive_sha256 = download.release.archive_sha256().to_owned();
+        package.push(LockedPackageV2 {
+            id: canonical_registry_package_id(
+                &selected.package.registry,
+                &selected.package.namespace,
+                &selected.package.name,
+                &version,
+            ),
+            name: selected.package.name.clone(),
+            version,
+            source: format!(
+                "registry:{}/{}/{}",
+                selected.package.registry, selected.package.namespace, selected.package.name
+            ),
+            registry: Some(selected.package.registry.clone()),
+            namespace: Some(selected.package.namespace.clone()),
+            archive_sha256: Some(archive_sha256.clone()),
+            archive_length: Some(download.release.archive_length()),
+            manifest_sha256: Some(download.release.manifest_sha256().to_owned()),
+            provenance_sha256: Some(download.release.provenance_statement_sha256().to_owned()),
+            package_signature_sha256: Some(download.release.package_signature_sha256().to_owned()),
+            verification_sha256: Some(sha256_hex(&download.verification_bytes)),
+            publisher_identity: Some(download.release.publisher_identity().to_owned()),
+            signer_key_ids,
+            cache_key: Some(format!("sha256:{archive_sha256}")),
+            yanked_at_resolution: Some(selected.yanked),
+            compatibility: LockedCompatibilityEvidence {
+                contract: selected.compatibility.clone(),
+                compiler: compatibility.compiler.clone(),
+                edition_policy: selected.edition.clone(),
+            },
+        });
+    }
+    package.sort_by(|left, right| left.id.cmp(&right.id));
+
+    let edge = resolved_dependency_edges(resolved)?;
+    let mut roots = resolved.local.roots.clone();
+    roots.sort();
+    roots.dedup();
+    let lockfile = LockfileV2 {
+        version: LOCKFILE_V2_VERSION,
+        compatibility,
+        roots,
+        registry,
+        package,
+        edge,
+    };
+    crate::lockfile::validate_lockfile_v2(&lockfile)
+        .map_err(|error| PackageManagerError::new("lockfile_invalid", error.to_string()))?;
+    Ok(lockfile)
+}
+
+fn same_dependency_edge_set(
+    resolved: &[LockedDependencyEdgeV2],
+    locked: &[LockedDependencyEdgeV2],
+) -> bool {
+    let identity = |edge: &LockedDependencyEdgeV2| {
+        (
+            edge.from.clone(),
+            edge.to.clone(),
+            edge.alias.clone(),
+            edge.requested.clone(),
+            edge.source_kind,
+        )
+    };
+    resolved.len() == locked.len()
+        && resolved.iter().map(identity).collect::<BTreeSet<_>>()
+            == locked.iter().map(identity).collect::<BTreeSet<_>>()
+}
+
+fn resolved_dependency_edges(
+    resolved: &OnlineResolution<'_>,
+) -> Result<Vec<LockedDependencyEdgeV2>, PackageManagerError> {
+    let selected_by_key = resolved
+        .resolution
+        .packages
+        .iter()
+        .map(|selected| (selected.package.clone(), selected))
+        .collect::<BTreeMap<_, _>>();
+    let mut edge = resolved.local.path_edges.clone();
+    for (from, dependency) in &resolved.local.registry_edges {
+        let selected = selected_by_key.get(&dependency.package).ok_or_else(|| {
+            PackageManagerError::new(
+                "resolution_incomplete",
+                format!("resolver omitted direct dependency {}", dependency.package),
+            )
+        })?;
+        edge.push(registry_lock_edge(
+            from.clone(),
+            dependency,
+            selected,
+            resolved,
+        ));
+    }
+    for dependency in &resolved.resolution.edges {
+        let Some(from) = &dependency.from else {
+            continue;
+        };
+        let selected = selected_by_key.get(&dependency.to).ok_or_else(|| {
+            PackageManagerError::new(
+                "resolution_incomplete",
+                format!("resolver omitted transitive dependency {}", dependency.to),
+            )
+        })?;
+        edge.push(registry_lock_edge(
+            registry_package_id(from, &resolved.resolution)?,
+            &RegistryDependency {
+                alias: dependency.alias.clone(),
+                package: dependency.to.clone(),
+                requirement: dependency.requirement.clone(),
+            },
+            selected,
+            resolved,
+        ));
+    }
+    edge.sort_by(lock_edge_order);
+    edge.dedup();
+    Ok(edge)
+}
+
+fn selected_download<'a>(
+    source: &'a OnlineResolverSource<'_>,
+    selected: &crate::package_resolver::ResolvedPackage,
+) -> Result<&'a VerifiedDownload, PackageManagerError> {
+    source
+        .downloads
+        .get(&(
+            selected.package.clone(),
+            selected.version,
+            selected.release_id.clone(),
+        ))
+        .ok_or_else(|| {
+            PackageManagerError::new(
+                "verified_artifact_missing",
+                format!(
+                    "selected package {}@{} has no fully verified artifact set",
+                    selected.package, selected.version
+                ),
+            )
+        })
+}
+
+fn registry_package_id(
+    package: &PackageKey,
+    resolution: &Resolution,
+) -> Result<String, PackageManagerError> {
+    let selected = resolution
+        .packages
+        .iter()
+        .find(|selected| &selected.package == package)
+        .ok_or_else(|| {
+            PackageManagerError::new(
+                "resolution_incomplete",
+                format!("resolver edge source {package} has no selected package"),
+            )
+        })?;
+    Ok(canonical_registry_package_id(
+        &package.registry,
+        &package.namespace,
+        &package.name,
+        &selected.version.to_string(),
+    ))
+}
+
+fn registry_lock_edge(
+    from: String,
+    dependency: &RegistryDependency,
+    selected: &crate::package_resolver::ResolvedPackage,
+    resolved: &OnlineResolution<'_>,
+) -> LockedDependencyEdgeV2 {
+    LockedDependencyEdgeV2 {
+        from,
+        to: canonical_registry_package_id(
+            &selected.package.registry,
+            &selected.package.namespace,
+            &selected.package.name,
+            &selected.version.to_string(),
+        ),
+        alias: dependency.alias.clone(),
+        requested: dependency.requirement.to_string(),
+        source_kind: LockedDependencySourceKind::Registry,
+        reason: selection_reason(selected, resolved),
+    }
+}
+
+fn selection_reason(
+    selected: &crate::package_resolver::ResolvedPackage,
+    resolved: &OnlineResolution<'_>,
+) -> LockedDependencyReason {
+    let retained = resolved
+        .previous
+        .as_ref()
+        .and_then(|lockfile| {
+            lockfile.package.iter().find(|package| {
+                package.registry.as_deref() == Some(&selected.package.registry)
+                    && package.namespace.as_deref() == Some(&selected.package.namespace)
+                    && package.name == selected.package.name
+                    && package.version == selected.version.to_string()
+            })
+        })
+        .is_some();
+    if retained && selected.yanked {
+        LockedDependencyReason::TrustedYankedLockedReplay
+    } else if retained && resolved.frozen.contains_key(&selected.package) {
+        LockedDependencyReason::ExactLockedReplay
+    } else {
+        LockedDependencyReason::HighestCompatible
+    }
+}
+
+fn materialized_graph(
+    lockfile: &LockfileV2,
+    lockfile_sha256: &str,
+    roots: &BTreeMap<String, MaterializedRoot>,
+    root_ids: &[String],
+) -> Result<MaterializedPackageGraph, PackageManagerError> {
+    let registry_by_name = lockfile
+        .registry
+        .iter()
+        .map(|registry| (registry.name.as_str(), registry))
+        .collect::<BTreeMap<_, _>>();
+    let mut packages = Vec::with_capacity(lockfile.package.len());
+    for package in &lockfile.package {
+        let root = roots.get(&package.id).ok_or_else(|| {
+            PackageManagerError::new(
+                "materialization_incomplete",
+                format!(
+                    "locked package {} has no verified materialized root",
+                    package.id
+                ),
+            )
+        })?;
+        let trust = match package.registry.as_deref() {
+            Some(registry_name) => {
+                root.verified_archive.as_ref().ok_or_else(|| {
+                    PackageManagerError::new(
+                        "materialization_incomplete",
+                        format!(
+                            "registry package {} lacks exact reverified archive bytes",
+                            package.id
+                        ),
+                    )
+                })?;
+                root.verified_manifest.as_ref().ok_or_else(|| {
+                    PackageManagerError::new(
+                        "materialization_incomplete",
+                        format!(
+                            "registry package {} lacks exact authenticated manifest bytes",
+                            package.id
+                        ),
+                    )
+                })?;
+                let registry = registry_by_name.get(registry_name).ok_or_else(|| {
+                    PackageManagerError::new(
+                        "lockfile_invalid",
+                        format!(
+                            "package {} references missing registry {registry_name:?}",
+                            package.id
+                        ),
+                    )
+                })?;
+                Some(PackageTrustEvidence {
+                    registry: registry_name.to_owned(),
+                    registry_identity: registry.registry_identity.clone(),
+                    source_identity: registry.source_identity.clone(),
+                    publisher_identity: package.publisher_identity.clone().ok_or_else(|| {
+                        PackageManagerError::new(
+                            "lockfile_invalid",
+                            format!("package {} lacks publisher identity", package.id),
+                        )
+                    })?,
+                    archive_sha256: package.archive_sha256.clone().ok_or_else(|| {
+                        PackageManagerError::new(
+                            "lockfile_invalid",
+                            format!("package {} lacks archive digest", package.id),
+                        )
+                    })?,
+                    manifest_sha256: package.manifest_sha256.clone().ok_or_else(|| {
+                        PackageManagerError::new(
+                            "lockfile_invalid",
+                            format!("package {} lacks manifest digest", package.id),
+                        )
+                    })?,
+                    provenance_sha256: package.provenance_sha256.clone().ok_or_else(|| {
+                        PackageManagerError::new(
+                            "lockfile_invalid",
+                            format!("package {} lacks provenance digest", package.id),
+                        )
+                    })?,
+                    package_signature_sha256: package.package_signature_sha256.clone().ok_or_else(
+                        || {
+                            PackageManagerError::new(
+                                "lockfile_invalid",
+                                format!("package {} lacks package-signature digest", package.id),
+                            )
+                        },
+                    )?,
+                    signer_key_ids: package.signer_key_ids.clone(),
+                    index_sha256: registry.index_sha256.clone(),
+                    index_generation: registry.index_generation,
+                    index_sequence: registry.index_sequence,
+                    index_transcript_sha256: registry.index_transcript_sha256.clone(),
+                    verification_sha256: required_locked_field(
+                        package,
+                        "verification_sha256",
+                        &package.verification_sha256,
+                    )?
+                    .to_owned(),
+                })
+            }
+            None => None,
+        };
+        packages.push(MaterializedPackage {
+            id: package.id.clone(),
+            name: package.name.clone(),
+            version: package.version.clone(),
+            source: package.source.clone(),
+            root: root.path.display().to_string(),
+            verified_archive: root.verified_archive.clone(),
+            verified_manifest: root.verified_manifest.clone(),
+            trust,
+            materialization: MaterializationEvidence {
+                source: root.source.clone(),
+                content_key: root.content_key.clone(),
+                package_trust_verified: package.registry.is_none()
+                    || root.content_key.as_deref() == package.cache_key.as_deref(),
+            },
+        });
+    }
+    packages.sort_by(|left, right| left.id.cmp(&right.id));
+    let mut edges = lockfile
+        .edge
+        .iter()
+        .map(|edge| MaterializedDependencyEdge {
+            from: edge.from.clone(),
+            to: edge.to.clone(),
+            alias: edge.alias.clone(),
+            requested: edge.requested.clone(),
+            source_kind: edge.source_kind.as_str().to_owned(),
+            reason: edge.reason.as_str().to_owned(),
+        })
+        .collect::<Vec<_>>();
+    edges.sort_by(|left, right| {
+        left.from
+            .cmp(&right.from)
+            .then(left.alias.cmp(&right.alias))
+            .then(left.to.cmp(&right.to))
+            .then(left.requested.cmp(&right.requested))
+    });
+    let package_ids = lockfile
+        .package
+        .iter()
+        .map(|package| package.id.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut graph_roots = root_ids.to_vec();
+    graph_roots.sort();
+    graph_roots.dedup();
+    if let Some(missing) = graph_roots
+        .iter()
+        .find(|root| !package_ids.contains(root.as_str()))
+    {
+        return Err(PackageManagerError::new(
+            "materialization_incomplete",
+            format!("graph root {missing:?} is absent from axiom.lock"),
+        ));
+    }
+    Ok(MaterializedPackageGraph {
+        schema_version: MATERIALIZED_PACKAGE_GRAPH_SCHEMA.to_owned(),
+        lockfile_sha256: lockfile_sha256.to_owned(),
+        roots: graph_roots,
+        packages,
+        edges,
+    })
+}
+
+fn operation_report(
+    operation: PackageOperation,
+    project_root: &Path,
+    lockfile_path: &Path,
+    graph: MaterializedPackageGraph,
+    trace: Vec<TraceEvent>,
+    transport_used: bool,
+) -> PackageOperationReport {
+    let registry_count = graph
+        .packages
+        .iter()
+        .filter(|package| package.trust.is_some())
+        .count();
+    let summary = format!(
+        "{} materialized {} packages ({} registry, {} path)",
+        match operation {
+            PackageOperation::Fetch => "fetch",
+            PackageOperation::Update => "update",
+            PackageOperation::Vendor => "vendor",
+        },
+        graph.packages.len(),
+        registry_count,
+        graph.packages.len().saturating_sub(registry_count),
+    );
+    PackageOperationReport {
+        schema_version: PACKAGE_OPERATION_REPORT_SCHEMA.to_owned(),
+        operation,
+        project: project_root.display().to_string(),
+        lockfile: lockfile_path.display().to_string(),
+        packages: graph.packages.clone(),
+        graph,
+        trace,
+        transport_used,
+        summary,
+    }
+}
+
+fn local_materialized_roots(local: &LocalGraph) -> BTreeMap<String, MaterializedRoot> {
+    local
+        .packages
+        .iter()
+        .map(|package| {
+            (
+                package.id.clone(),
+                MaterializedRoot {
+                    path: package.root.clone(),
+                    source: "path".to_owned(),
+                    content_key: None,
+                    verified_archive: None,
+                    verified_manifest: None,
+                },
+            )
+        })
+        .collect()
+}
+
+fn locked_registry_for_package<'a>(
+    lockfile: &'a LockfileV2,
+    package: &LockedPackageV2,
+) -> Result<&'a LockedRegistryV2, PackageManagerError> {
+    let name = package.registry.as_deref().ok_or_else(|| {
+        PackageManagerError::new(
+            "lockfile_invalid",
+            format!("package {} has no registry identity", package.id),
+        )
+    })?;
+    lockfile
+        .registry
+        .iter()
+        .find(|registry| registry.name == name)
+        .ok_or_else(|| {
+            PackageManagerError::new(
+                "lockfile_invalid",
+                format!(
+                    "package {} references missing registry {name:?}",
+                    package.id
+                ),
+            )
+        })
+}
+
+fn verify_cached_against_lock(
+    cached: &CachedPackage,
+    package: &LockedPackageV2,
+    registry: &LockedRegistryV2,
+) -> Result<(), PackageManagerError> {
+    let archive_sha256 = required_locked_field(package, "archive_sha256", &package.archive_sha256)?;
+    let archive_length = package.archive_length.ok_or_else(|| {
+        PackageManagerError::new(
+            "lockfile_invalid",
+            format!("locked package {} lacks archive_length", package.id),
+        )
+    })?;
+    let manifest_sha256 =
+        required_locked_field(package, "manifest_sha256", &package.manifest_sha256)?;
+    let provenance_sha256 =
+        required_locked_field(package, "provenance_sha256", &package.provenance_sha256)?;
+    let package_signature_sha256 = required_locked_field(
+        package,
+        "package_signature_sha256",
+        &package.package_signature_sha256,
+    )?;
+    let verification_sha256 =
+        required_locked_field(package, "verification_sha256", &package.verification_sha256)?;
+    let expected_cache_key = format!("sha256:{archive_sha256}");
+    let exact = cached.archive_sha256 == archive_sha256
+        && cached.integrity.archive_sha256 == archive_sha256
+        && cached.commit.archive_sha256 == archive_sha256
+        && cached.commit.archive_length == archive_length
+        && cached.commit.manifest_sha256 == manifest_sha256
+        && cached.commit.provenance_sha256 == provenance_sha256
+        && cached.commit.signature_sha256 == package_signature_sha256
+        && cached.commit.registry_index_sha256 == registry.index_sha256
+        && cached.commit.verification_sha256 == verification_sha256
+        && package.cache_key.as_deref() == Some(expected_cache_key.as_str());
+    if !exact {
+        return Err(PackageManagerError::new(
+            "locked_package_mismatch",
+            format!(
+                "verified cache material does not match exact axiom.lock pins for {}",
+                package.id
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn required_locked_field<'a>(
+    package: &LockedPackageV2,
+    field: &str,
+    value: &'a Option<String>,
+) -> Result<&'a str, PackageManagerError> {
+    value.as_deref().ok_or_else(|| {
+        PackageManagerError::new(
+            "lockfile_invalid",
+            format!("locked package {} lacks {field}", package.id),
+        )
+    })
+}
+
+fn locked_archive_sha256(package: &LockedPackageV2) -> Result<&str, PackageManagerError> {
+    package.archive_sha256.as_deref().ok_or_else(|| {
+        PackageManagerError::new(
+            "lockfile_invalid",
+            format!("locked package {} lacks archive_sha256", package.id),
+        )
+    })
+}
+
+fn locked_verification_sha256(package: &LockedPackageV2) -> Result<&str, PackageManagerError> {
+    required_locked_field(package, "verification_sha256", &package.verification_sha256)
+}
+
+fn locked_vendor_packages(
+    lockfile: &LockfileV2,
+) -> Result<Vec<VendorPackage<'_>>, PackageManagerError> {
+    lockfile
+        .package
+        .iter()
+        .filter(|package| package.registry.is_some())
+        .map(|package| {
+            let registry = locked_registry_for_package(lockfile, package)?;
+            Ok(VendorPackage {
+                package_id: &package.id,
+                archive_sha256: locked_archive_sha256(package)?,
+                registry_index_sha256: &registry.index_sha256,
+                verification_sha256: locked_verification_sha256(package)?,
+            })
+        })
+        .collect()
+}
+
+fn verify_vendor_against_lock(
+    snapshot: &VendorSnapshot,
+    lockfile: &LockfileV2,
+) -> Result<(), PackageManagerError> {
+    let expected = lockfile
+        .package
+        .iter()
+        .filter(|package| package.registry.is_some())
+        .map(|package| {
+            Ok((
+                package.id.clone(),
+                (
+                    package.cache_key.clone().ok_or_else(|| {
+                        PackageManagerError::new(
+                            "lockfile_invalid",
+                            format!("locked package {} lacks cache_key", package.id),
+                        )
+                    })?,
+                    locked_archive_sha256(package)?.to_owned(),
+                    locked_registry_for_package(lockfile, package)?
+                        .index_sha256
+                        .clone(),
+                    locked_verification_sha256(package)?.to_owned(),
+                ),
+            ))
+        })
+        .collect::<Result<BTreeMap<_, _>, PackageManagerError>>()?;
+    let observed = snapshot
+        .manifest
+        .packages
+        .iter()
+        .map(|package| {
+            (
+                package.package_id.clone(),
+                (
+                    package.content_key.clone(),
+                    package.archive_sha256.clone(),
+                    package.registry_index_sha256.clone(),
+                    package.verification_sha256.clone(),
+                ),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    if observed != expected {
+        return Err(PackageManagerError::new(
+            "vendor_lock_mismatch",
+            "verified vendor snapshot does not exactly match registry packages in axiom.lock",
+        ));
+    }
+    Ok(())
+}
+
+fn offline_trust_context(
+    project_root: &Path,
+    manifest: &Manifest,
+    lockfile: &LockfileV2,
+) -> Result<OfflineTrustContext, PackageManagerError> {
+    let configured = manifest.registry.as_ref().ok_or_else(|| {
+        PackageManagerError::new(
+            "registry_missing",
+            "locked registry graph requires a root [registry] configuration",
+        )
+    })?;
+    if lockfile.registry.len() != 1
+        || lockfile.registry[0].name != configured.name
+        || lockfile.registry[0].source != configured.index
+    {
+        return Err(PackageManagerError::new(
+            "locked_registry_mismatch",
+            "configured registry does not exactly match axiom.lock",
+        ));
+    }
+    let trust_roots = read_bounded_file(
+        &project_root.join(&configured.trust_roots),
+        MAX_TRUST_DOCUMENT_BYTES,
+    )
+    .map_err(|message| PackageManagerError::new("trust_roots_unavailable", message))?;
+    if sha256_hex(&trust_roots) != lockfile.registry[0].trust_roots_sha256 {
+        return Err(PackageManagerError::new(
+            "locked_trust_roots_mismatch",
+            "current trust-roots bytes do not match the exact axiom.lock pin",
+        ));
+    }
+    let trust_roots = parse_trust_roots_json(&trust_roots)
+        .map_err(|error| PackageManagerError::new("trust_roots_invalid", error.to_string()))?;
+    let expectation = read_bounded_file(
+        &project_root.join(&configured.expectation),
+        MAX_TRUST_DOCUMENT_BYTES,
+    )
+    .map_err(|message| PackageManagerError::new("expectation_unavailable", message))?;
+    if sha256_hex(&expectation) != lockfile.registry[0].expectation_sha256 {
+        return Err(PackageManagerError::new(
+            "locked_expectation_mismatch",
+            "current verification-expectation bytes do not match the exact axiom.lock pin",
+        ));
+    }
+    let mut expectation = parse_verification_expectation_json(&expectation)
+        .map_err(|error| PackageManagerError::new("expectation_invalid", error.to_string()))?;
+    advance_expectation_from_lock(&mut expectation, lockfile, configured)?;
+    Ok(OfflineTrustContext {
+        registry: configured.clone(),
+        trust_roots,
+        expectation,
+    })
+}
+
+fn verify_offline_package_trust(
+    cached: &CachedPackage,
+    package: &LockedPackageV2,
+    registry: &LockedRegistryV2,
+    lockfile: &LockfileV2,
+    trust: &OfflineTrustContext,
+) -> Result<(), PackageManagerError> {
+    let artifacts = cached.verified_artifacts().map_err(store_error)?;
+    let catalog = authenticate_registry_catalog(
+        &artifacts.registry_index,
+        &trust.trust_roots,
+        &trust.expectation,
+    )
+    .map_err(|error| {
+        PackageManagerError::new(
+            "offline_registry_catalog_rejected",
+            error.reason_codes.join(", "),
+        )
+    })?;
+    validate_offline_catalog_pins(&catalog, registry)?;
+    let namespace = package.namespace.as_deref().ok_or_else(|| {
+        PackageManagerError::new(
+            "lockfile_invalid",
+            format!("locked package {} lacks namespace", package.id),
+        )
+    })?;
+    let release = catalog
+        .release(namespace, &package.name, &package.version)
+        .ok_or_else(|| {
+            PackageManagerError::new(
+                "offline_release_missing",
+                format!(
+                    "locked package {} is absent from its exact authenticated registry index",
+                    package.id
+                ),
+            )
+        })?;
+    validate_offline_release_pins(release, package, registry, artifacts.archive.len())?;
+    let package_signature =
+        parse_package_signature_json(&artifacts.signature).map_err(|error| {
+            PackageManagerError::new("package_signature_invalid", error.to_string())
+        })?;
+    let registry_index = parse_registry_index_json(&artifacts.registry_index)
+        .map_err(|error| PackageManagerError::new("registry_index_invalid", error.to_string()))?;
+    let expectation =
+        verification_expectation_for_authenticated_release(&trust.expectation, &catalog, release)
+            .map_err(|error| {
+            PackageManagerError::new("release_expectation_invalid", error.reason_codes.join(", "))
+        })?;
+    let verification = verify_package_with_artifacts(
+        &PackageTrustInput {
+            package_signature,
+            trust_roots: trust.trust_roots.clone(),
+            registry_index,
+            verification_expectation: expectation,
+        },
+        PackageArtifacts {
+            archive: Some(&artifacts.archive),
+            manifest: Some(&artifacts.manifest),
+            provenance: Some(&artifacts.provenance),
+        },
+    );
+    if verification.decision != "trusted" {
+        return Err(PackageManagerError::new(
+            "offline_package_trust_rejected",
+            format!(
+                "{} rejected: {}",
+                package.id,
+                verification.reason_codes.join(", ")
+            ),
+        ));
+    }
+    let mut signers = verification
+        .signers
+        .iter()
+        .map(|signer| signer.key_id.clone())
+        .collect::<Vec<_>>();
+    signers.sort();
+    signers.dedup();
+    if signers != package.signer_key_ids {
+        return Err(PackageManagerError::new(
+            "locked_package_mismatch",
+            format!(
+                "fresh Package Trust signer evidence differs from axiom.lock for {}",
+                package.id
+            ),
+        ));
+    }
+    let stored_verification: PackageVerification = serde_json::from_slice(&artifacts.verification)
+        .map_err(|error| {
+            PackageManagerError::new(
+                "stored_verification_invalid",
+                format!("stored Package Trust evidence is invalid: {error}"),
+            )
+        })?;
+    let canonical = serde_json::to_vec(&stored_verification).map_err(|error| {
+        PackageManagerError::new(
+            "stored_verification_invalid",
+            format!("stored Package Trust evidence cannot be rendered: {error}"),
+        )
+    })?;
+    if stored_verification != verification || canonical != artifacts.verification {
+        return Err(PackageManagerError::new(
+            "stored_verification_mismatch",
+            format!(
+                "stored Package Trust verdict differs from a fresh verification for {}",
+                package.id
+            ),
+        ));
+    }
+    verify_offline_manifest_edges(
+        &artifacts.manifest,
+        package,
+        lockfile,
+        &trust.registry,
+        catalog.source_identity(),
+    )
+}
+
+fn validate_offline_catalog_pins(
+    catalog: &AuthenticatedRegistryCatalog,
+    locked: &LockedRegistryV2,
+) -> Result<(), PackageManagerError> {
+    let mut signer_ids = catalog.index_signer_key_ids().to_vec();
+    signer_ids.sort();
+    signer_ids.dedup();
+    let exact = catalog.registry_identity() == locked.registry_identity
+        && catalog.source_identity() == locked.source_identity
+        && catalog.root_version() == locked.current_root_version
+        && catalog.root_sequence() == locked.current_root_sequence
+        && catalog.root_transcript_sha256() == locked.current_root_transcript_sha256
+        && sha256_hex(catalog.exact_index_bytes()) == locked.index_sha256
+        && catalog.index_transcript_sha256() == locked.index_transcript_sha256
+        && catalog.generation() == locked.index_generation
+        && catalog.sequence() == locked.index_sequence
+        && catalog.snapshot_id() == locked.index_snapshot_id
+        && signer_ids == locked.index_signer_key_ids;
+    if !exact {
+        return Err(PackageManagerError::new(
+            "locked_registry_mismatch",
+            "fresh offline catalog authentication differs from exact axiom.lock pins",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_offline_release_pins(
+    release: &AuthenticatedRegistryRelease,
+    package: &LockedPackageV2,
+    registry: &LockedRegistryV2,
+    archive_length: usize,
+) -> Result<(), PackageManagerError> {
+    let exact = release.registry_identity() == registry.registry_identity
+        && release.source_identity() == registry.source_identity
+        && release.namespace() == package.namespace.as_deref().unwrap_or_default()
+        && release.name() == package.name
+        && release.version() == package.version
+        && package.archive_sha256.as_deref() == Some(release.archive_sha256())
+        && package.archive_length == Some(release.archive_length())
+        && archive_length as u64 == release.archive_length()
+        && package.manifest_sha256.as_deref() == Some(release.manifest_sha256())
+        && package.provenance_sha256.as_deref() == Some(release.provenance_statement_sha256())
+        && package.package_signature_sha256.as_deref() == Some(release.package_signature_sha256())
+        && package.publisher_identity.as_deref() == Some(release.publisher_identity())
+        && package.yanked_at_resolution == Some(release.yanked());
+    if !exact {
+        return Err(PackageManagerError::new(
+            "locked_package_mismatch",
+            format!(
+                "authenticated registry release differs from exact axiom.lock pins for {}",
+                package.id
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn verify_offline_manifest_edges(
+    manifest_bytes: &[u8],
+    package: &LockedPackageV2,
+    lockfile: &LockfileV2,
+    registry: &RegistryConfig,
+    source_identity: &str,
+) -> Result<(), PackageManagerError> {
+    let manifest = parse_manifest_exact(manifest_bytes, Path::new("cached/axiom.toml"))
+        .map_err(|error| PackageManagerError::new("package_manifest_invalid", error.to_string()))?;
+    let section = manifest.package.as_ref().ok_or_else(|| {
+        PackageManagerError::new(
+            "package_identity_mismatch",
+            format!(
+                "cached manifest for {} has no [package] section",
+                package.id
+            ),
+        )
+    })?;
+    if section.name != package.name || section.version != package.version {
+        return Err(PackageManagerError::new(
+            "package_identity_mismatch",
+            format!("cached manifest identity differs from {}", package.id),
+        ));
+    }
+    let dependencies = manifest_dependencies(&manifest, registry, source_identity)
+        .map_err(PackageManagerError::from_source)?;
+    let outgoing = lockfile
+        .edge
+        .iter()
+        .filter(|edge| edge.from == package.id)
+        .collect::<Vec<_>>();
+    if outgoing.len() != dependencies.len() {
+        return Err(PackageManagerError::new(
+            "locked_dependency_mismatch",
+            format!(
+                "cached manifest dependency count differs from axiom.lock for {}",
+                package.id
+            ),
+        ));
+    }
+    for dependency in dependencies {
+        let Dependency::Registry(dependency) = dependency else {
+            return Err(PackageManagerError::new(
+                "registry_path_dependency_unsupported",
+                "authenticated registry packages may not depend on mutable path sources",
+            ));
+        };
+        let matched = outgoing.iter().any(|edge| {
+            edge.alias == dependency.alias
+                && edge.requested == dependency.requirement.to_string()
+                && edge.source_kind == LockedDependencySourceKind::Registry
+                && lockfile.package.iter().any(|target| {
+                    target.id == edge.to
+                        && target.registry.as_deref() == Some(&dependency.package.registry)
+                        && target.namespace.as_deref() == Some(&dependency.package.namespace)
+                        && target.name == dependency.package.name
+                })
+        });
+        if !matched {
+            return Err(PackageManagerError::new(
+                "locked_dependency_mismatch",
+                format!(
+                    "cached dependency {:?} differs from axiom.lock for {}",
+                    dependency.alias, package.id
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn store_error(error: StoreError) -> PackageManagerError {
+    PackageManagerError::new(error.code, error.message)
+}
+
+fn lockfile_write_error(error: Diagnostic) -> PackageManagerError {
+    let message = error.to_string();
+    PackageManagerError::new(
+        if message.contains("changed while package resolution was in progress") {
+            "lockfile_concurrent_change"
+        } else {
+            "lockfile_write_failed"
+        },
+        message,
+    )
+}
+
+fn lockfile_has_registry_packages(lockfile: &LockfileV2) -> bool {
+    lockfile
+        .package
+        .iter()
+        .any(|package| package.registry.is_some())
+}
+
+fn verify_locked_local_graph(
+    project_root: &Path,
+    manifest: &Manifest,
+    lockfile: &LockfileV2,
+) -> Result<LocalGraph, PackageManagerError> {
+    let current = current_compatibility()?;
+    if lockfile.compatibility != current {
+        return Err(PackageManagerError::new(
+            "locked_compatibility_mismatch",
+            "axiom.lock compatibility evidence does not match this compiler",
+        ));
+    }
+    if lockfile
+        .package
+        .iter()
+        .any(|package| package.compatibility != current)
+    {
+        return Err(PackageManagerError::new(
+            "locked_compatibility_mismatch",
+            "one or more locked package compatibility records do not match this compiler",
+        ));
+    }
+    let path_only_registry = RegistryConfig {
+        name: "path-only".to_owned(),
+        index: "file:///path-only/index.json".to_owned(),
+        trust_roots: "unused".to_owned(),
+        expectation: "unused".to_owned(),
+        cache: None,
+        vendor: None,
+    };
+    let (registry_config, source_identity) = if lockfile_has_registry_packages(lockfile) {
+        let registry_config = manifest.registry.as_ref().ok_or_else(|| {
+            PackageManagerError::new(
+                "registry_missing",
+                "registry package materialization requires the configured root registry",
+            )
+        })?;
+        let registry_record = lockfile
+            .registry
+            .iter()
+            .find(|registry| registry.name == registry_config.name)
+            .ok_or_else(|| {
+                PackageManagerError::new(
+                    "locked_registry_missing",
+                    format!(
+                        "axiom.lock has no registry record for {:?}",
+                        registry_config.name
+                    ),
+                )
+            })?;
+        if registry_record.source != registry_config.index {
+            return Err(PackageManagerError::new(
+                "locked_registry_mismatch",
+                "configured registry source differs from axiom.lock",
+            ));
+        }
+        (registry_config, registry_record.source_identity.as_str())
+    } else {
+        if !lockfile.registry.is_empty() {
+            return Err(PackageManagerError::new(
+                "lockfile_invalid",
+                "path-only axiom.lock must not retain registry trust records",
+            ));
+        }
+        (&path_only_registry, "path-only")
+    };
+    let local = collect_local_graph(project_root, manifest, registry_config, source_identity)?;
+    if lockfile.roots != local.roots {
+        return Err(PackageManagerError::new(
+            "locked_path_graph_mismatch",
+            "local project/workspace roots differ from axiom.lock",
+        ));
+    }
+    let locked_paths = lockfile
+        .package
+        .iter()
+        .filter(|package| package.registry.is_none())
+        .collect::<Vec<_>>();
+    if locked_paths.len() != local.packages.len() {
+        return Err(PackageManagerError::new(
+            "locked_path_graph_mismatch",
+            "local path package count differs from axiom.lock",
+        ));
+    }
+    for package in &local.packages {
+        let section = package.manifest.package.as_ref().ok_or_else(|| {
+            PackageManagerError::new(
+                "path_package_missing",
+                format!(
+                    "path package {} has no [package] section",
+                    package.root.display()
+                ),
+            )
+        })?;
+        let locked = locked_paths
+            .iter()
+            .find(|locked| locked.id == package.id)
+            .ok_or_else(|| {
+                PackageManagerError::new(
+                    "locked_path_graph_mismatch",
+                    format!(
+                        "local path package {} is absent from axiom.lock",
+                        package.id
+                    ),
+                )
+            })?;
+        if locked.name != section.name
+            || locked.version != section.version
+            || locked.source != package.source
+            || locked.compatibility != current
+        {
+            return Err(PackageManagerError::new(
+                "locked_path_graph_mismatch",
+                format!("local path package {} differs from axiom.lock", package.id),
+            ));
+        }
+    }
+    let locked_path_edges = lockfile
+        .edge
+        .iter()
+        .filter(|edge| edge.source_kind == LockedDependencySourceKind::Path)
+        .cloned()
+        .collect::<Vec<_>>();
+    if locked_path_edges != local.path_edges {
+        return Err(PackageManagerError::new(
+            "locked_path_graph_mismatch",
+            "local path dependency edges differ from axiom.lock",
+        ));
+    }
+    let local_ids = local
+        .packages
+        .iter()
+        .map(|package| package.id.as_str())
+        .collect::<BTreeSet<_>>();
+    let locked_local_registry_edges = lockfile
+        .edge
+        .iter()
+        .filter(|edge| {
+            edge.source_kind == LockedDependencySourceKind::Registry
+                && local_ids.contains(edge.from.as_str())
+        })
+        .collect::<Vec<_>>();
+    if locked_local_registry_edges.len() != local.registry_edges.len() {
+        return Err(PackageManagerError::new(
+            "locked_path_graph_mismatch",
+            "local registry dependency edge set differs from axiom.lock",
+        ));
+    }
+    for (from, dependency) in &local.registry_edges {
+        let matching = locked_local_registry_edges.iter().any(|edge| {
+            edge.from == *from
+                && edge.alias == dependency.alias
+                && edge.requested == dependency.requirement.to_string()
+                && edge.source_kind == LockedDependencySourceKind::Registry
+                && lockfile.package.iter().any(|package| {
+                    package.id == edge.to
+                        && package.registry.as_deref() == Some(&dependency.package.registry)
+                        && package.namespace.as_deref() == Some(&dependency.package.namespace)
+                        && package.name == dependency.package.name
+                })
+        });
+        if !matching {
+            return Err(PackageManagerError::new(
+                "locked_path_graph_mismatch",
+                format!(
+                    "registry dependency {:?} from {from} differs from axiom.lock",
+                    dependency.alias
+                ),
+            ));
+        }
+    }
+    Ok(local)
+}
+
+fn map_resolve_error(error: ResolveError, targeted: bool) -> PackageManagerError {
+    let trace = match &error {
+        ResolveError::Conflict { trace, .. }
+        | ResolveError::BudgetExceeded { trace, .. }
+        | ResolveError::Source { trace, .. } => trace.clone(),
+        _ => Vec::new(),
+    };
+    let broader = match &error {
+        ResolveError::Conflict { trace, .. } | ResolveError::BudgetExceeded { trace, .. } => {
+            targeted && trace.iter().any(trace_is_frozen_mismatch)
+        }
+        _ => false,
+    };
+    let resolver = serde_json::to_value(&error).ok();
+    let mut mapped = if broader {
+        PackageManagerError::new(
+            "broader_update_required",
+            "targeted update conflicts with a frozen package; run an untargeted update",
+        )
+    } else {
+        let code = match error {
+            ResolveError::Conflict { .. } => "resolution_conflict",
+            ResolveError::BudgetExceeded { .. } => "resolution_budget_exceeded",
+            ResolveError::InvalidCatalog { .. } => "registry_catalog_invalid",
+            ResolveError::InvalidRequest(_) => "resolution_request_invalid",
+            ResolveError::Source { .. } => "package_source_failed",
+        };
+        PackageManagerError::new(code, error.to_string())
+    };
+    mapped.trace = trace;
+    mapped.resolver = resolver;
+    mapped
+}
+
+fn manifest_dependencies(
+    manifest: &Manifest,
+    registry: &RegistryConfig,
+    source_identity: &str,
+) -> Result<Vec<Dependency>, SourceFailure> {
+    let mut dependencies = Vec::with_capacity(manifest.dependencies.len());
+    for (alias, spec) in &manifest.dependencies {
+        dependencies.push(manifest_dependency(alias, spec, registry, source_identity)?);
+    }
+    Ok(dependencies)
+}
+
+fn collect_local_graph(
+    project_root: &Path,
+    manifest: &Manifest,
+    registry: &RegistryConfig,
+    source_identity: &str,
+) -> Result<LocalGraph, PackageManagerError> {
+    let project_root = std::fs::canonicalize(project_root).map_err(|error| {
+        PackageManagerError::new(
+            "project_unavailable",
+            format!("failed to canonicalize package root: {error}"),
+        )
+    })?;
+    let mut queue = VecDeque::from([(project_root.clone(), true)]);
+    let mut visited = BTreeSet::new();
+    let mut packages = Vec::new();
+    let mut roots = Vec::new();
+    while let Some((root, is_graph_root)) = queue.pop_front() {
+        if !visited.insert(root.clone()) {
+            continue;
+        }
+        let package_manifest = if root == project_root {
+            manifest.clone()
+        } else {
+            load_manifest(&root).map_err(|error| {
+                PackageManagerError::new("path_manifest_invalid", error.to_string())
+            })?
+        };
+        if let Some(workspace) = &package_manifest.workspace {
+            for member in &workspace.members {
+                let member_root =
+                    canonical_local_root(&project_root, &root, member, "workspace member")?;
+                queue.push_back((member_root, true));
+            }
+        }
+        for (alias, dependency) in &package_manifest.dependencies {
+            if let Some(path) = dependency.path_source() {
+                let dependency_root =
+                    canonical_local_root(&project_root, &root, path, "path dependency")?;
+                queue.push_back((dependency_root, false));
+            } else if package_manifest.package.is_none() {
+                return Err(PackageManagerError::new(
+                    "virtual_root_registry_dependency_unsupported",
+                    format!(
+                        "registry dependency {alias:?} must originate from a package with a stable lockfile identity"
+                    ),
+                ));
+            }
+        }
+        let Some(section) = package_manifest.package.as_ref() else {
+            continue;
+        };
+        let source = local_path_source(&project_root, &root)?;
+        let id = canonical_path_package_id(&source, &section.name, &section.version);
+        if is_graph_root {
+            roots.push(id.clone());
+        }
+        packages.push(LocalPackage {
+            id,
+            source,
+            root,
+            manifest: package_manifest,
+        });
+    }
+    if packages.is_empty() {
+        return Err(PackageManagerError::new(
+            "path_package_missing",
+            "package graph contains no [package] section",
+        ));
+    }
+    let distinct_ids = packages
+        .iter()
+        .map(|package| package.id.as_str())
+        .collect::<BTreeSet<_>>();
+    if distinct_ids.len() != packages.len() {
+        return Err(PackageManagerError::new(
+            "path_graph_ambiguous",
+            "multiple local packages have the same canonical lockfile identity",
+        ));
+    }
+    for package in &packages {
+        if !package.root.starts_with(&project_root) {
+            return Err(PackageManagerError::new(
+                "path_dependency_outside_project",
+                format!(
+                    "local package {} resolves outside {}",
+                    package.root.display(),
+                    project_root.display()
+                ),
+            ));
+        }
+    }
+    packages.sort_by(|left, right| left.id.cmp(&right.id));
+    roots.sort();
+    roots.dedup();
+
+    let ids_by_root = packages
+        .iter()
+        .map(|package| (package.root.clone(), package.id.clone()))
+        .collect::<BTreeMap<_, _>>();
+    let root_ids = roots.iter().cloned().collect::<BTreeSet<_>>();
+    let mut path_edges = Vec::new();
+    let mut registry_edges = Vec::new();
+    let mut resolver_dependencies = Vec::new();
+    for package in &packages {
+        for (alias, spec) in &package.manifest.dependencies {
+            if let Some(path) = spec.path_source() {
+                let target_root =
+                    std::fs::canonicalize(package.root.join(path)).map_err(|error| {
+                        PackageManagerError::new(
+                            "path_dependency_unavailable",
+                            format!(
+                                "failed to canonicalize dependency {alias:?} from {}: {error}",
+                                package.root.display()
+                            ),
+                        )
+                    })?;
+                let to = ids_by_root.get(&target_root).ok_or_else(|| {
+                    PackageManagerError::new(
+                        "path_dependency_unlocked",
+                        format!(
+                            "dependency {alias:?} from {} is absent from the validated path graph",
+                            package.root.display()
+                        ),
+                    )
+                })?;
+                path_edges.push(LockedDependencyEdgeV2 {
+                    from: package.id.clone(),
+                    to: to.clone(),
+                    alias: alias.clone(),
+                    requested: spec.version.clone().unwrap_or_else(|| "*".to_owned()),
+                    source_kind: LockedDependencySourceKind::Path,
+                    reason: if root_ids.contains(&package.id) {
+                        LockedDependencyReason::RootPathConstraint
+                    } else {
+                        LockedDependencyReason::TransitivePathConstraint
+                    },
+                });
+                resolver_dependencies.push(Dependency::Path(PathDependency {
+                    alias: alias.clone(),
+                    path: path.to_owned(),
+                    version: None,
+                }));
+            } else {
+                let dependency = match manifest_dependency(alias, spec, registry, source_identity)
+                    .map_err(PackageManagerError::from_source)?
+                {
+                    Dependency::Registry(dependency) => dependency,
+                    Dependency::Path(_) => unreachable!("path dependency was handled above"),
+                };
+                registry_edges.push((package.id.clone(), dependency.clone()));
+                resolver_dependencies.push(Dependency::Registry(dependency));
+            }
+        }
+    }
+    path_edges.sort_by(lock_edge_order);
+    registry_edges.sort_by(|left, right| {
+        left.0
+            .cmp(&right.0)
+            .then(left.1.alias.cmp(&right.1.alias))
+            .then(left.1.package.cmp(&right.1.package))
+    });
+    resolver_dependencies.sort_by(|left, right| {
+        serde_json::to_string(left)
+            .unwrap_or_default()
+            .cmp(&serde_json::to_string(right).unwrap_or_default())
+    });
+    Ok(LocalGraph {
+        roots,
+        packages,
+        path_edges,
+        registry_edges,
+        resolver_dependencies,
+    })
+}
+
+fn canonical_local_root(
+    project_root: &Path,
+    containing_root: &Path,
+    relative: &str,
+    kind: &str,
+) -> Result<PathBuf, PackageManagerError> {
+    let root = std::fs::canonicalize(containing_root.join(relative)).map_err(|error| {
+        PackageManagerError::new(
+            "path_package_unavailable",
+            format!(
+                "failed to canonicalize {kind} {relative:?} from {}: {error}",
+                containing_root.display()
+            ),
+        )
+    })?;
+    if !root.starts_with(project_root) {
+        return Err(PackageManagerError::new(
+            "path_dependency_outside_project",
+            format!(
+                "{kind} {} resolves outside {}",
+                root.display(),
+                project_root.display()
+            ),
+        ));
+    }
+    Ok(root)
+}
+
+fn local_path_source(
+    project_root: &Path,
+    package_root: &Path,
+) -> Result<String, PackageManagerError> {
+    if package_root == project_root {
+        return Ok("path".to_owned());
+    }
+    let relative = package_root.strip_prefix(project_root).map_err(|_| {
+        PackageManagerError::new(
+            "path_dependency_outside_project",
+            format!(
+                "local package {} resolves outside {}",
+                package_root.display(),
+                project_root.display()
+            ),
+        )
+    })?;
+    let portable = relative
+        .components()
+        .map(|component| component.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/");
+    Ok(format!("path:{portable}"))
+}
+
+fn lock_edge_order(
+    left: &LockedDependencyEdgeV2,
+    right: &LockedDependencyEdgeV2,
+) -> std::cmp::Ordering {
+    left.from
+        .cmp(&right.from)
+        .then(left.alias.cmp(&right.alias))
+        .then(left.to.cmp(&right.to))
+        .then(left.requested.cmp(&right.requested))
+        .then(left.source_kind.cmp(&right.source_kind))
+        .then(left.reason.cmp(&right.reason))
+}
+
+fn manifest_dependency(
+    alias: &str,
+    spec: &DependencySpec,
+    registry: &RegistryConfig,
+    source_identity: &str,
+) -> Result<Dependency, SourceFailure> {
+    if let Some(path) = spec.path_source() {
+        return Ok(Dependency::Path(PathDependency {
+            alias: alias.to_owned(),
+            path: path.to_owned(),
+            version: None,
+        }));
+    }
+    let dependency = spec.registry_source().ok_or_else(|| {
+        SourceFailure::new(
+            "dependency_source_invalid",
+            format!("dependency {alias:?} has no path or registry source"),
+        )
+    })?;
+    if dependency.registry != registry.name {
+        return Err(SourceFailure::new(
+            "registry_alias_mismatch",
+            format!(
+                "dependency {alias:?} selects registry {:?}, but only {:?} is authenticated",
+                dependency.registry, registry.name
+            ),
+        ));
+    }
+    let requirement = spec.version.as_deref().ok_or_else(|| {
+        SourceFailure::new(
+            "dependency_requirement_missing",
+            format!("registry dependency {alias:?} has no version requirement"),
+        )
+    })?;
+    Ok(Dependency::Registry(RegistryDependency {
+        alias: alias.to_owned(),
+        package: PackageKey::new(
+            registry.name.clone(),
+            source_identity.to_owned(),
+            dependency.namespace.clone(),
+            dependency.package.clone(),
+        ),
+        requirement: VersionRequirement::parse(requirement).map_err(|error| {
+            SourceFailure::new(
+                "dependency_requirement_invalid",
+                format!("dependency {alias:?}: {error}"),
+            )
+        })?,
+    }))
+}
+
+fn read_bounded_file(path: &Path, limit: usize) -> Result<Vec<u8>, String> {
+    read_bounded_regular_file(path, limit).map_err(|error| error.to_string())
+}
+
+fn normalize_lexical_path(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                let _ = normalized.pop();
+            }
+            std::path::Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            std::path::Component::RootDir => normalized.push(std::path::MAIN_SEPARATOR.to_string()),
+            std::path::Component::Normal(component) => normalized.push(component),
+        }
+    }
+    normalized
+}
+
+fn vendor_snapshot_is_present(vendor_root: &Path) -> Result<bool, PackageManagerError> {
+    match std::fs::symlink_metadata(vendor_root.join("CURRENT")) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(PackageManagerError::new(
+            "vendor_snapshot_unavailable",
+            format!(
+                "failed to inspect vendor snapshot at {}: {error}",
+                vendor_root.display()
+            ),
+        )),
+    }
+}
+
+fn transport_error(error: RegistryClientError) -> PackageManagerError {
+    PackageManagerError::new("registry_transport_failed", error.to_string())
+}
+
+fn source_transport_error(error: RegistryClientError) -> SourceFailure {
+    SourceFailure::new("registry_transport_failed", error.to_string())
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut encoded = String::with_capacity(64);
+    for byte in digest {
+        use std::fmt::Write;
+        let _ = write!(encoded, "{byte:02x}");
+    }
+    encoded
+}
+
+fn current_compatibility() -> Result<LockedCompatibilityEvidence, PackageManagerError> {
+    let contract: serde_json::Value = serde_json::from_str(include_str!(
+        "../../../compatibility/fixtures/current/contract.json"
+    ))
+    .map_err(|error| {
+        PackageManagerError::new(
+            "compatibility_contract_invalid",
+            format!("embedded Compatibility v1 contract is invalid: {error}"),
+        )
+    })?;
+    let required = |pointer: &str| {
+        contract
+            .pointer(pointer)
+            .and_then(serde_json::Value::as_str)
+            .filter(|value| !value.is_empty())
+            .map(str::to_owned)
+            .ok_or_else(|| {
+                PackageManagerError::new(
+                    "compatibility_contract_invalid",
+                    format!("embedded Compatibility v1 contract lacks {pointer}"),
+                )
+            })
+    };
+    let edition = required("/edition/id")?;
+    let policy = required("/policy_version")?;
+    Ok(LockedCompatibilityEvidence {
+        contract: required("/contract_version")?,
+        compiler: required("/compiler/current")?,
+        edition_policy: format!("{edition}@{policy}"),
+    })
+}
+
+pub fn fetch_packages(project_root: &Path) -> Result<PackageOperationReport, PackageManagerError> {
+    let manager = PackageManager::open(project_root)?;
+    let transport = RegistryClient::default();
+    manager.fetch(FetchOptions::new(&transport))
+}
+
+pub fn update_packages(
+    project_root: &Path,
+    package: Option<&str>,
+) -> Result<PackageOperationReport, PackageManagerError> {
+    let manager = PackageManager::open(project_root)?;
+    let transport = RegistryClient::default();
+    let mut options = UpdateOptions::new(&transport);
+    options.package = package.map(str::to_owned);
+    manager.update(options)
+}
+
+pub fn vendor_packages(
+    project_root: &Path,
+    out: Option<&Path>,
+) -> Result<PackageOperationReport, PackageManagerError> {
+    PackageManager::open(project_root)?.vendor(VendorOptions {
+        out: out.map(Path::to_owned),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture_lockfile() -> LockfileV2 {
+        let mut value: serde_json::Value = serde_json::from_str(include_str!(
+            "../../../package-resolver/fixtures/lockfile-v2.json"
+        ))
+        .expect("parse lockfile fixture");
+        value
+            .as_object_mut()
+            .expect("lockfile object")
+            .entry("roots")
+            .or_insert_with(|| serde_json::json!(["path:.#demo@0.1.0"]));
+        serde_json::from_value(value).expect("deserialize lockfile fixture")
+    }
+
+    fn package_trust_expectation() -> VerificationExpectation {
+        let contract: serde_json::Value = serde_json::from_str(include_str!(
+            "../../../package-trust/contract/package-trust.json"
+        ))
+        .expect("parse Package Trust contract");
+        VerificationExpectation(contract["verification_expectation"].clone())
+    }
+
+    fn write_path_only_project(root: &Path) {
+        std::fs::create_dir_all(root).expect("create project");
+        std::fs::write(
+            root.join("axiom.toml"),
+            "[package]\nname = \"app\"\nversion = \"1.0.0\"\n",
+        )
+        .expect("write manifest");
+    }
+
+    fn package_archive(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut archive = crate::package_archive::ARCHIVE_MAGIC.to_vec();
+        for (path, bytes) in entries {
+            archive.extend_from_slice(format!("--- file {path} {} ---\n", bytes.len()).as_bytes());
+            archive.extend_from_slice(bytes);
+            if !bytes.ends_with(b"\n") {
+                archive.push(b'\n');
+            }
+        }
+        archive
+    }
+
+    fn path_only_v2_lockfile() -> LockfileV2 {
+        let compatibility = current_compatibility().expect("current compatibility");
+        let root = canonical_path_package_id("path", "app", "1.0.0");
+        LockfileV2 {
+            version: LOCKFILE_V2_VERSION,
+            compatibility: compatibility.clone(),
+            roots: vec![root.clone()],
+            registry: Vec::new(),
+            package: vec![LockedPackageV2 {
+                id: root,
+                name: "app".to_owned(),
+                version: "1.0.0".to_owned(),
+                source: "path".to_owned(),
+                registry: None,
+                namespace: None,
+                archive_sha256: None,
+                archive_length: None,
+                manifest_sha256: None,
+                provenance_sha256: None,
+                package_signature_sha256: None,
+                verification_sha256: None,
+                publisher_identity: None,
+                signer_key_ids: Vec::new(),
+                cache_key: None,
+                yanked_at_resolution: None,
+                compatibility,
+            }],
+            edge: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn operation_and_graph_reports_are_deterministically_serializable() {
+        let graph = MaterializedPackageGraph {
+            schema_version: MATERIALIZED_PACKAGE_GRAPH_SCHEMA.to_owned(),
+            lockfile_sha256: "0".repeat(64),
+            roots: vec!["path:.#app@1.0.0".to_owned()],
+            packages: Vec::new(),
+            edges: Vec::new(),
+        };
+        let report = PackageOperationReport {
+            schema_version: PACKAGE_OPERATION_REPORT_SCHEMA.to_owned(),
+            operation: PackageOperation::Fetch,
+            project: "/workspace/app".to_owned(),
+            lockfile: "/workspace/app/axiom.lock".to_owned(),
+            packages: Vec::new(),
+            graph,
+            trace: Vec::new(),
+            transport_used: false,
+            summary: "materialized 0 registry packages".to_owned(),
+        };
+        let first = serde_json::to_string(&report).expect("serialize report");
+        let second = serde_json::to_string(&report).expect("serialize report again");
+        assert_eq!(first, second);
+        assert!(first.contains("\"operation\":\"fetch\""));
+    }
+
+    #[test]
+    fn locked_and_vendor_options_expose_no_transport_handle() {
+        let materialize = MaterializeOptions {
+            prefer_vendor: true,
+        };
+        let vendor = VendorOptions {
+            out: Some(PathBuf::from("vendor")),
+        };
+        assert!(materialize.prefer_vendor);
+        assert_eq!(vendor.out.as_deref(), Some(Path::new("vendor")));
+    }
+
+    #[test]
+    fn authenticated_archive_must_embed_exact_manifest_and_build_entry() {
+        let manifest_bytes = br#"[package]
+name = "demo"
+version = "1.0.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+"#;
+        let manifest = parse_manifest_exact(manifest_bytes, Path::new("authenticated/axiom.toml"))
+            .expect("parse manifest");
+        let archive = package_archive(&[
+            ("axiom.toml", manifest_bytes),
+            ("src/main.ax", b"print \"trusted\"\n"),
+        ]);
+        let digest = sha256_hex(&archive);
+        validate_authenticated_archive_contract(&archive, &digest, manifest_bytes, &manifest)
+            .expect("exact archive contract");
+
+        let mismatch = validate_authenticated_archive_contract(
+            &archive,
+            &digest,
+            b"[package]\nname = \"other\"\nversion = \"1.0.0\"\n",
+            &manifest,
+        )
+        .expect_err("embedded manifest mismatch");
+        assert_eq!(mismatch.code, "archive_manifest_mismatch");
+
+        let missing_entry_archive = package_archive(&[("axiom.toml", manifest_bytes)]);
+        let missing = validate_authenticated_archive_contract(
+            &missing_entry_archive,
+            &sha256_hex(&missing_entry_archive),
+            manifest_bytes,
+            &manifest,
+        )
+        .expect_err("missing build entry");
+        assert_eq!(missing.code, "registry_build_entry_missing");
+    }
+
+    #[test]
+    fn authenticated_registry_archive_rejects_workspace_and_non_ax_entry() {
+        let workspace_bytes = br#"[package]
+name = "demo"
+version = "1.0.0"
+
+[workspace]
+members = []
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+"#;
+        let workspace =
+            parse_manifest_exact(workspace_bytes, Path::new("authenticated/axiom.toml"))
+                .expect("parse workspace manifest");
+        let archive = package_archive(&[
+            ("axiom.toml", workspace_bytes),
+            ("src/main.ax", b"print \"trusted\"\n"),
+        ]);
+        let error = validate_authenticated_archive_contract(
+            &archive,
+            &sha256_hex(&archive),
+            workspace_bytes,
+            &workspace,
+        )
+        .expect_err("registry workspace");
+        assert_eq!(error.code, "registry_workspace_unsupported");
+
+        let non_ax_bytes = br#"[package]
+name = "demo"
+version = "1.0.0"
+
+[build]
+entry = "README.md"
+out_dir = "dist"
+"#;
+        let non_ax = parse_manifest_exact(non_ax_bytes, Path::new("authenticated/axiom.toml"))
+            .expect("parse non-ax entry manifest");
+        let archive =
+            package_archive(&[("README.md", b"not source\n"), ("axiom.toml", non_ax_bytes)]);
+        let error = validate_authenticated_archive_contract(
+            &archive,
+            &sha256_hex(&archive),
+            non_ax_bytes,
+            &non_ax,
+        )
+        .expect_err("non-ax build entry");
+        assert_eq!(error.code, "registry_build_entry_invalid");
+    }
+
+    #[test]
+    fn cache_commit_must_match_every_lock_digest() {
+        let lockfile = fixture_lockfile();
+        let package = lockfile
+            .package
+            .iter()
+            .find(|package| package.registry.is_some())
+            .expect("registry package");
+        let registry = &lockfile.registry[0];
+        let digest = package.archive_sha256.clone().expect("archive digest");
+        let mut cached = CachedPackage {
+            archive_sha256: digest.clone(),
+            blob: PathBuf::from("/cache/blob"),
+            tree: PathBuf::from("/cache/tree"),
+            evidence: PathBuf::from("/cache/evidence"),
+            integrity: crate::package_archive::TreeIntegrityManifest {
+                schema_version: "axiom.package_tree_integrity.v1".to_owned(),
+                extractor_version: "axiom-package-extractor-v1".to_owned(),
+                archive_sha256: digest.clone(),
+                files: Vec::new(),
+            },
+            commit: crate::package_store::CacheCommit {
+                schema_version: "axiom.package_cache_commit.v1".to_owned(),
+                extractor_version: "axiom-package-extractor-v1".to_owned(),
+                archive_sha256: digest,
+                archive_length: package.archive_length.expect("archive length"),
+                tree_manifest_sha256: "7".repeat(64),
+                manifest_sha256: package.manifest_sha256.clone().expect("manifest digest"),
+                provenance_sha256: package
+                    .provenance_sha256
+                    .clone()
+                    .expect("provenance digest"),
+                signature_sha256: package
+                    .package_signature_sha256
+                    .clone()
+                    .expect("signature digest"),
+                registry_index_sha256: registry.index_sha256.clone(),
+                verification_sha256: "6".repeat(64),
+            },
+            artifacts: crate::package_store::RehashedArtifacts {
+                archive: Vec::new(),
+                manifest: Vec::new(),
+                provenance: Vec::new(),
+                signature: Vec::new(),
+                registry_index: Vec::new(),
+                verification: Vec::new(),
+            },
+        };
+        verify_cached_against_lock(&cached, package, registry).expect("exact cache hit");
+        cached.commit.registry_index_sha256 = "0".repeat(64);
+        let error =
+            verify_cached_against_lock(&cached, package, registry).expect_err("reject drift");
+        assert_eq!(error.code, "locked_package_mismatch");
+    }
+
+    #[test]
+    fn vendor_manifest_must_exactly_equal_locked_registry_set() {
+        let lockfile = fixture_lockfile();
+        let package = lockfile
+            .package
+            .iter()
+            .find(|package| package.registry.is_some())
+            .expect("registry package");
+        let snapshot = VendorSnapshot {
+            digest: "1".repeat(64),
+            root: PathBuf::from("/vendor/snapshot"),
+            manifest: crate::package_store::VendorManifest {
+                schema_version: "axiom.vendor_manifest.v1".to_owned(),
+                packages: vec![crate::package_store::VendorManifestPackage {
+                    package_id: package.id.clone(),
+                    content_key: package.cache_key.clone().expect("content key"),
+                    archive_sha256: package.archive_sha256.clone().expect("archive digest"),
+                    registry_index_sha256: lockfile.registry[0].index_sha256.clone(),
+                    verification_sha256: package
+                        .verification_sha256
+                        .clone()
+                        .expect("verification digest"),
+                    evidence_identity: "3".repeat(64),
+                    tree_manifest_sha256: "2".repeat(64),
+                }],
+            },
+            packages: BTreeMap::new(),
+        };
+        verify_vendor_against_lock(&snapshot, &lockfile).expect("exact vendor snapshot");
+        let mut extra = snapshot;
+        extra
+            .manifest
+            .packages
+            .push(extra.manifest.packages.first().expect("package").clone());
+        extra.manifest.packages[1].package_id = "registry:default/axiom/extra@1.0.0".to_owned();
+        let error = verify_vendor_against_lock(&extra, &lockfile).expect_err("reject extra");
+        assert_eq!(error.code, "vendor_lock_mismatch");
+    }
+
+    #[test]
+    fn materialized_graph_exposes_exact_roots_edges_and_trust() {
+        let lockfile = fixture_lockfile();
+        let root = lockfile
+            .package
+            .iter()
+            .find(|package| lockfile.roots.contains(&package.id))
+            .expect("root package");
+        let registry_package = lockfile
+            .package
+            .iter()
+            .find(|package| package.registry.is_some())
+            .expect("registry package");
+        let roots = lockfile
+            .package
+            .iter()
+            .map(|package| {
+                let registry = package.registry.is_some();
+                (
+                    package.id.clone(),
+                    MaterializedRoot {
+                        path: if registry {
+                            PathBuf::from("/cache/tree")
+                        } else if package.id == root.id {
+                            PathBuf::from("/project")
+                        } else {
+                            PathBuf::from("/project/tools/local")
+                        },
+                        source: if registry { "cache" } else { "path" }.to_owned(),
+                        content_key: package.cache_key.clone(),
+                        verified_archive: registry.then(|| Arc::from(Vec::<u8>::new())),
+                        verified_manifest: registry.then(|| Arc::from(Vec::<u8>::new())),
+                    },
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+        let graph = materialized_graph(&lockfile, &"0".repeat(64), &roots, &lockfile.roots)
+            .expect("materialized graph");
+        assert_eq!(graph.roots, lockfile.roots);
+        assert_eq!(graph.packages.len(), lockfile.package.len());
+        assert!(graph.packages[0].trust.is_none());
+        let registry_materialized = graph
+            .packages
+            .iter()
+            .find(|package| package.id == registry_package.id)
+            .expect("materialized registry package");
+        assert!(registry_materialized.trust.is_some());
+        let registry_edge = graph
+            .edges
+            .iter()
+            .find(|edge| edge.to == registry_package.id)
+            .expect("registry dependency edge");
+        assert_eq!(registry_edge.reason, "highest_compatible");
+        assert_eq!(registry_edge.requested, "^1.2.0");
+    }
+
+    #[test]
+    fn local_path_dependencies_preserve_one_project_root_and_exact_edge() {
+        let directory = tempfile::tempdir().expect("temporary project");
+        let dependency = directory.path().join("deps/util");
+        std::fs::create_dir_all(&dependency).expect("create dependency");
+        std::fs::write(
+            directory.path().join("axiom.toml"),
+            r#"
+[package]
+name = "app"
+version = "1.0.0"
+
+[dependencies.util]
+path = "deps/util"
+version = "^0.4.0"
+"#,
+        )
+        .expect("write root manifest");
+        std::fs::write(
+            dependency.join("axiom.toml"),
+            r#"
+[package]
+name = "util"
+version = "0.4.2"
+"#,
+        )
+        .expect("write dependency manifest");
+        let manifest = load_manifest(directory.path()).expect("load manifest");
+        let registry = RegistryConfig {
+            name: "default".to_owned(),
+            index: "file:///registry/index.json".to_owned(),
+            trust_roots: "trust/roots.json".to_owned(),
+            expectation: "trust/expectation.json".to_owned(),
+            cache: None,
+            vendor: None,
+        };
+        let graph = collect_local_graph(
+            directory.path(),
+            &manifest,
+            &registry,
+            "registry:test-source",
+        )
+        .expect("collect local graph");
+        assert_eq!(graph.roots, vec!["path:.#app@1.0.0"]);
+        assert_eq!(
+            graph
+                .packages
+                .iter()
+                .map(|package| package.source.as_str())
+                .collect::<Vec<_>>(),
+            vec!["path", "path:deps/util"]
+        );
+        assert_eq!(graph.path_edges.len(), 1);
+        assert_eq!(graph.path_edges[0].from, "path:.#app@1.0.0");
+        assert_eq!(graph.path_edges[0].to, "path:deps/util#util@0.4.2");
+        assert_eq!(
+            graph.path_edges[0].reason,
+            LockedDependencyReason::RootPathConstraint
+        );
+    }
+
+    #[test]
+    fn update_expectation_advances_from_previous_lock_without_rollback() {
+        let mut lockfile = fixture_lockfile();
+        let registry = &mut lockfile.registry[0];
+        registry.current_root_version = 8;
+        registry.current_root_sequence = 2_000;
+        registry.current_root_transcript_sha256 = "a".repeat(64);
+        registry.index_generation = 43;
+        registry.index_sequence = 2_001;
+        registry.index_snapshot_id = "snapshot-43".to_owned();
+        registry.index_transcript_sha256 = "b".repeat(64);
+        let configured = RegistryConfig {
+            name: registry.name.clone(),
+            index: registry.source.clone(),
+            trust_roots: "roots.json".to_owned(),
+            expectation: "expectation.json".to_owned(),
+            cache: None,
+            vendor: None,
+        };
+        let mut expectation = package_trust_expectation();
+        let bootstrap_anchor = expectation.0["trusted_state"]["trusted_root_anchor"].clone();
+        advance_expectation_from_lock(&mut expectation, &lockfile, &configured)
+            .expect("advance expectation");
+        assert_eq!(
+            expectation.0["trusted_state"]["trusted_root_anchor"], bootstrap_anchor,
+            "lock continuity must not replace the bootstrap trust anchor"
+        );
+        assert_eq!(
+            expectation["trusted_state"]["highest_root_version"],
+            serde_json::json!(8)
+        );
+        assert_eq!(
+            expectation["trusted_state"]["highest_root_sequence"],
+            serde_json::json!(2_000)
+        );
+        assert_eq!(
+            expectation["trusted_state"]["highest_index_generation"],
+            serde_json::json!(43)
+        );
+        assert!(
+            expectation["trusted_state"]["seen_snapshots"]
+                .as_array()
+                .expect("seen snapshots")
+                .iter()
+                .any(|snapshot| snapshot["snapshot_id"] == "snapshot-43")
+        );
+    }
+
+    #[test]
+    fn update_rejects_simultaneous_trust_roots_and_policy_replacement() {
+        let mut lockfile = fixture_lockfile();
+        let registry = &mut lockfile.registry[0];
+        let accepted_roots = b"accepted trust roots";
+        let accepted_policy = b"accepted verification policy";
+        registry.trust_roots_sha256 = sha256_hex(accepted_roots);
+        registry.expectation_sha256 = sha256_hex(accepted_policy);
+        registry.current_root_version += 100;
+        registry.current_root_sequence += 100;
+        registry.index_generation += 100;
+        registry.index_sequence += 100;
+        let configured = RegistryConfig {
+            name: registry.name.clone(),
+            index: registry.source.clone(),
+            trust_roots: "roots.json".to_owned(),
+            expectation: "expectation.json".to_owned(),
+            cache: None,
+            vendor: None,
+        };
+        validate_previous_trust_documents(&lockfile, &configured, accepted_roots, accepted_policy)
+            .expect("exact prior trust documents");
+
+        let error = validate_previous_trust_documents(
+            &lockfile,
+            &configured,
+            b"malicious same-identity higher-counter roots",
+            b"malicious replacement verification policy",
+        )
+        .expect_err("simultaneous trust reset must fail before authentication");
+        assert_eq!(error.code, "trusted_roots_reset_rejected");
+    }
+
+    #[test]
+    fn update_expectation_rejects_same_position_snapshot_overwrite() {
+        let mut lockfile = fixture_lockfile();
+        let registry = &mut lockfile.registry[0];
+        let mut expectation = package_trust_expectation();
+        let seen = expectation.0["trusted_state"]["seen_snapshots"]
+            .as_array_mut()
+            .expect("seen snapshots");
+        let existing = seen.last().expect("existing snapshot").clone();
+        registry.index_generation = existing["generation"].as_u64().expect("generation");
+        registry.index_sequence = existing["sequence"].as_u64().expect("sequence");
+        registry.index_snapshot_id = "rebound-snapshot".to_owned();
+        registry.index_transcript_sha256 = "0".repeat(64);
+        let configured = RegistryConfig {
+            name: registry.name.clone(),
+            index: registry.source.clone(),
+            trust_roots: "roots.json".to_owned(),
+            expectation: "expectation.json".to_owned(),
+            cache: None,
+            vendor: None,
+        };
+        let error = advance_expectation_from_lock(&mut expectation, &lockfile, &configured)
+            .expect_err("reject rebound");
+        assert_eq!(error.code, "update_snapshot_rebound");
+    }
+
+    #[test]
+    fn targeted_freeze_rejects_same_version_artifact_overwrite() {
+        let lockfile = fixture_lockfile();
+        let package = lockfile
+            .package
+            .iter()
+            .find(|package| package.registry.is_some())
+            .expect("registry package");
+        let locked = locked_frozen_identity(package).expect("locked identity");
+        let mut overwritten = locked.clone();
+        overwritten.archive_sha256 = "0".repeat(64);
+        let key = PackageKey::new(
+            package.registry.clone().expect("registry"),
+            lockfile.registry[0].source_identity.clone(),
+            package.namespace.clone().expect("namespace"),
+            package.name.clone(),
+        );
+        let error =
+            ensure_frozen_identity(&key, locked, overwritten).expect_err("reject overwrite");
+        assert_eq!(error.code, "frozen_package_identity_changed");
+    }
+
+    #[test]
+    fn path_only_v2_materializes_without_registry_or_store() {
+        let directory = tempfile::tempdir().expect("temporary project");
+        write_path_only_project(directory.path());
+        write_lockfile_v2_atomic(directory.path(), &path_only_v2_lockfile())
+            .expect("write path-only v2 lock");
+        let manager = PackageManager::open(directory.path()).expect("open manager");
+        let graph = manager
+            .materialize_locked(MaterializeOptions::default())
+            .expect("materialize path-only graph");
+        assert_eq!(graph.roots, vec!["path:.#app@1.0.0"]);
+        assert_eq!(graph.packages.len(), 1);
+        assert_eq!(graph.packages[0].materialization.source, "path");
+        assert!(
+            !directory.path().join(DEFAULT_PACKAGE_CACHE_DIR).exists(),
+            "path-only materialization must not open the package store"
+        );
+    }
+
+    #[test]
+    fn update_rewrites_removed_last_registry_dependency_without_transport() {
+        let directory = tempfile::tempdir().expect("temporary project");
+        write_path_only_project(directory.path());
+        let mut stale = path_only_v2_lockfile();
+        let fixture = fixture_lockfile();
+        stale.registry = fixture.registry;
+        let mut registry_package = fixture
+            .package
+            .into_iter()
+            .find(|package| package.registry.is_some())
+            .expect("registry package fixture");
+        registry_package.compatibility = stale.compatibility.clone();
+        let registry_id = registry_package.id.clone();
+        stale.package.push(registry_package);
+        stale.package.sort_by(|left, right| left.id.cmp(&right.id));
+        stale.edge.push(LockedDependencyEdgeV2 {
+            from: stale.roots[0].clone(),
+            to: registry_id,
+            alias: "obsolete".to_owned(),
+            requested: "^1.0.0".to_owned(),
+            source_kind: LockedDependencySourceKind::Registry,
+            reason: LockedDependencyReason::HighestCompatible,
+        });
+        stale.edge.sort_by(lock_edge_order);
+        write_lockfile_v2_atomic(directory.path(), &stale).expect("write stale registry lock");
+
+        let manager = PackageManager::open(directory.path()).expect("open path-only project");
+        let transport = RegistryClient::default();
+        let report = manager
+            .update(UpdateOptions::new(&transport))
+            .expect("transport-free path-only update");
+        assert!(!report.transport_used);
+        assert_eq!(report.graph.lockfile_sha256.len(), 64);
+        let ParsedLockfile::V2(rewritten) =
+            load_lockfile(directory.path()).expect("reload path-only v2")
+        else {
+            panic!("update must write v2");
+        };
+        assert!(rewritten.registry.is_empty());
+        assert_eq!(rewritten.package.len(), 1);
+        assert!(rewritten.package[0].registry.is_none());
+        assert!(rewritten.edge.is_empty());
+    }
+
+    #[test]
+    fn path_only_fetch_rejects_dependency_cycle() {
+        let directory = tempfile::tempdir().expect("temporary project");
+        let dependency = directory.path().join("deps/b");
+        std::fs::create_dir_all(&dependency).expect("create dependency");
+        std::fs::write(
+            directory.path().join("axiom.toml"),
+            "[package]\nname = \"a\"\nversion = \"1.0.0\"\n\n\
+             [dependencies.b]\npath = \"deps/b\"\n",
+        )
+        .expect("write root manifest");
+        std::fs::write(
+            dependency.join("axiom.toml"),
+            "[package]\nname = \"b\"\nversion = \"1.0.0\"\n\n\
+             [dependencies.a]\npath = \"../..\"\n",
+        )
+        .expect("write dependency manifest");
+        let manager = PackageManager::open(directory.path()).expect("open manager");
+        let transport = RegistryClient::default();
+        let error = manager
+            .fetch(FetchOptions::new(&transport))
+            .expect_err("path cycle must fail");
+        assert_eq!(error.code, "lockfile_invalid");
+    }
+
+    #[test]
+    fn path_only_cas_rejects_concurrent_lock_replacement() {
+        let directory = tempfile::tempdir().expect("temporary project");
+        write_path_only_project(directory.path());
+        let original = path_only_v2_lockfile();
+        write_lockfile_v2_atomic(directory.path(), &original).expect("write original lock");
+        let manager = PackageManager::open(directory.path()).expect("open manager");
+        let previous = manager
+            .optional_v2_lockfile()
+            .expect("capture exact previous lock");
+        let lock_path = lockfile_path(directory.path());
+        let mut replaced = std::fs::read(&lock_path).expect("read lock");
+        replaced.push(b'\n');
+        std::fs::write(&lock_path, &replaced).expect("replace lock bytes");
+
+        let error = manager
+            .finish_path_only_operation(
+                PackageOperation::Update,
+                None,
+                previous.expected_sha256.as_deref(),
+            )
+            .expect_err("CAS must reject concurrent replacement");
+        assert_eq!(error.code, "lockfile_concurrent_change");
+        assert_eq!(
+            std::fs::read(&lock_path).expect("read retained replacement"),
+            replaced
+        );
+    }
+
+    #[test]
+    fn vendor_override_cannot_collide_with_effective_cache_root() {
+        let directory = tempfile::tempdir().expect("temporary project");
+        write_path_only_project(directory.path());
+        let mut manager = PackageManager::open(directory.path()).expect("open manager");
+        manager.manifest.registry = Some(RegistryConfig {
+            name: "fixture".to_owned(),
+            index: "file:///registry/index.json".to_owned(),
+            trust_roots: "trust/roots.json".to_owned(),
+            expectation: "trust/expectation.json".to_owned(),
+            cache: None,
+            vendor: None,
+        });
+        let error = manager
+            .vendor_root(Some(Path::new(DEFAULT_PACKAGE_CACHE_DIR)))
+            .expect_err("vendor override must not alias cache");
+        assert_eq!(error.code, "package_storage_path_collision");
+    }
+
+    #[test]
+    fn locked_local_graph_rejects_extra_stale_registry_edge() {
+        let directory = tempfile::tempdir().expect("temporary project");
+        let local_tools = directory.path().join("tools/local");
+        std::fs::create_dir_all(&local_tools).expect("create local tools");
+        std::fs::write(
+            directory.path().join("axiom.toml"),
+            r#"
+[package]
+name = "resolver-demo"
+version = "0.1.0"
+
+[registry]
+name = "fixture"
+index = "file:///registry/index.json"
+trust_roots = "trust/roots.json"
+expectation = "trust/expectation.json"
+
+[dependencies.core]
+registry = "fixture"
+namespace = "axiom"
+package = "core"
+version = "^1.2.0"
+
+[dependencies.local-tools]
+path = "tools/local"
+"#,
+        )
+        .expect("write root manifest");
+        std::fs::write(
+            local_tools.join("axiom.toml"),
+            "[package]\nname = \"local-tools\"\nversion = \"0.4.0\"\n",
+        )
+        .expect("write local manifest");
+        let manifest = load_manifest(directory.path()).expect("load manifest");
+        let mut lockfile = fixture_lockfile();
+        let compatibility = current_compatibility().expect("current compatibility");
+        lockfile.compatibility = compatibility.clone();
+        for package in &mut lockfile.package {
+            package.compatibility = compatibility.clone();
+        }
+        verify_locked_local_graph(directory.path(), &manifest, &lockfile)
+            .expect("baseline exact local graph");
+        let original = lockfile
+            .edge
+            .iter()
+            .find(|edge| edge.source_kind == LockedDependencySourceKind::Registry)
+            .expect("registry edge")
+            .clone();
+        let mut stale = original;
+        stale.alias = "obsolete-core".to_owned();
+        lockfile.edge.push(stale);
+        lockfile.edge.sort_by(lock_edge_order);
+        let error = verify_locked_local_graph(directory.path(), &manifest, &lockfile)
+            .expect_err("extra stale registry edge must fail before materialization");
+        assert_eq!(error.code, "locked_path_graph_mismatch");
+    }
+
+    #[test]
+    fn v1_migration_rejects_stale_path_graph_and_accepts_exact_graph() {
+        let directory = tempfile::tempdir().expect("temporary project");
+        write_path_only_project(directory.path());
+        let lock_path = lockfile_path(directory.path());
+        std::fs::write(
+            &lock_path,
+            "version = 1\n\n[[package]]\nname = \"app\"\nversion = \"0.9.0\"\nsource = \"path\"\n",
+        )
+        .expect("write stale v1 lock");
+        let manager = PackageManager::open(directory.path()).expect("open manager");
+        let error = manager
+            .optional_v2_lockfile()
+            .expect_err("stale v1 must fail closed");
+        assert_eq!(error.code, "stale_v1_lockfile");
+        std::fs::write(
+            &lock_path,
+            "version = 1\n\n[[package]]\nname = \"app\"\nversion = \"1.0.0\"\nsource = \"path\"\n",
+        )
+        .expect("write exact v1 lock");
+        assert!(
+            manager
+                .optional_v2_lockfile()
+                .expect("exact v1 migration boundary")
+                .lockfile
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn resolver_failures_preserve_structured_trace_and_payload() {
+        let trace = vec![TraceEvent::PathPreserved {
+            from: None,
+            alias: "local".to_owned(),
+            path: "deps/local".to_owned(),
+        }];
+        let error = map_resolve_error(
+            ResolveError::BudgetExceeded {
+                budget: "candidate_attempts",
+                limit: 1,
+                trace: trace.clone(),
+            },
+            false,
+        );
+        assert_eq!(error.code, "resolution_budget_exceeded");
+        assert_eq!(error.trace, trace);
+        assert_eq!(
+            error.resolver.as_ref().expect("resolver payload")["kind"],
+            "budget_exceeded"
+        );
+    }
+
+    #[test]
+    fn authenticated_archive_and_cumulative_download_budgets_are_bounded() {
+        assert_eq!(
+            validate_authenticated_archive_length(MAX_PACKAGE_ARCHIVE_BODY_BYTES as u64)
+                .expect("maximum archive"),
+            MAX_PACKAGE_ARCHIVE_BODY_BYTES
+        );
+        assert_eq!(
+            validate_authenticated_archive_length(MAX_PACKAGE_ARCHIVE_BODY_BYTES as u64 + 1)
+                .expect_err("oversized archive")
+                .code,
+            "archive_length_out_of_bounds"
+        );
+        assert_eq!(
+            charged_candidate_bytes(MAX_CANDIDATE_DOWNLOAD_BYTES - 1, 1)
+                .expect("exact operation budget"),
+            MAX_CANDIDATE_DOWNLOAD_BYTES
+        );
+        assert_eq!(
+            charged_candidate_bytes(MAX_CANDIDATE_DOWNLOAD_BYTES, 1)
+                .expect_err("operation budget exceeded")
+                .code,
+            "candidate_download_budget_exceeded"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bounded_trust_file_reader_rejects_symlinks_at_open() {
+        use std::os::unix::fs::symlink;
+
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let target = directory.path().join("expectation.json");
+        let link = directory.path().join("linked-expectation.json");
+        std::fs::write(&target, b"{}").expect("write target");
+        symlink(&target, &link).expect("create symlink");
+
+        let error = read_bounded_file(&link, 16).expect_err("symlink must be rejected");
+        assert!(
+            error.contains("store_file_unavailable"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bounded_trust_file_reader_rejects_fifo_without_blocking() {
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt;
+        use std::time::{Duration, Instant};
+
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let fifo = directory.path().join("expectation.fifo");
+        let fifo_c = CString::new(fifo.as_os_str().as_bytes()).expect("fifo path");
+        let result = unsafe { libc::mkfifo(fifo_c.as_ptr(), 0o600) };
+        assert_eq!(
+            result,
+            0,
+            "create FIFO: {}",
+            std::io::Error::last_os_error()
+        );
+
+        let started = Instant::now();
+        let error = read_bounded_file(&fifo, 16).expect_err("FIFO must be rejected");
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "FIFO validation blocked instead of failing closed"
+        );
+        assert!(
+            error.contains("store_file_invalid"),
+            "unexpected error: {error}"
+        );
+    }
+}

--- a/stage1/crates/axiomc/src/package_resolver.rs
+++ b/stage1/crates/axiomc/src/package_resolver.rs
@@ -1,0 +1,1590 @@
+//! Deterministic, bounded, single-version package resolution.
+//!
+//! The source boundary deliberately separates authenticated catalog metadata
+//! from verified release manifests. Resolver graph expansion can only observe
+//! dependencies returned by `verify_candidate`.
+
+use crate::package_version::{ReleaseVersion, VersionRequirement};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct PackageKey {
+    pub registry: String,
+    pub source: String,
+    pub namespace: String,
+    pub name: String,
+}
+
+impl PackageKey {
+    pub fn new(
+        registry: impl Into<String>,
+        source: impl Into<String>,
+        namespace: impl Into<String>,
+        name: impl Into<String>,
+    ) -> Self {
+        Self {
+            registry: registry.into(),
+            source: source.into(),
+            namespace: namespace.into(),
+            name: name.into(),
+        }
+    }
+}
+
+impl fmt::Display for PackageKey {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "{}@{}::{}/{}",
+            self.registry, self.source, self.namespace, self.name
+        )
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum Dependency {
+    Registry(RegistryDependency),
+    Path(PathDependency),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RegistryDependency {
+    pub alias: String,
+    pub package: PackageKey,
+    pub requirement: VersionRequirement,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct PathDependency {
+    pub alias: String,
+    pub path: String,
+    pub version: Option<ReleaseVersion>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CatalogCandidate {
+    pub version: ReleaseVersion,
+    pub yanked: bool,
+    /// Stable authenticated release identity, normally a target path or digest.
+    pub release_id: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthenticatedCatalog {
+    package: PackageKey,
+    candidates: Vec<CatalogCandidate>,
+    authentication_id: String,
+}
+
+impl AuthenticatedCatalog {
+    pub fn new(
+        package: PackageKey,
+        candidates: Vec<CatalogCandidate>,
+        authentication_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            package,
+            candidates,
+            authentication_id: authentication_id.into(),
+        }
+    }
+
+    pub fn package(&self) -> &PackageKey {
+        &self.package
+    }
+
+    pub fn candidates(&self) -> &[CatalogCandidate] {
+        &self.candidates
+    }
+
+    pub fn authentication_id(&self) -> &str {
+        &self.authentication_id
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VerifiedCandidate {
+    pub package: PackageKey,
+    pub version: ReleaseVersion,
+    pub release_id: String,
+    pub dependencies: Vec<Dependency>,
+    pub manifest_digest: String,
+    pub signer_key_ids: Vec<String>,
+    pub edition: String,
+    pub compatibility: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SourceFailure {
+    pub code: String,
+    pub message: String,
+}
+
+impl SourceFailure {
+    pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            code: code.into(),
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for SourceFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for SourceFailure {}
+
+pub trait ResolverSource {
+    /// Authenticate the registry index/catalog before exposing release rows.
+    fn authenticate_catalog(
+        &mut self,
+        package: &PackageKey,
+    ) -> Result<AuthenticatedCatalog, SourceFailure>;
+
+    /// Fetch and fully Package-Trust-verify exact candidate artifacts, then
+    /// return the dependency manifest obtained from those verified bytes.
+    fn verify_candidate(
+        &mut self,
+        catalog: &AuthenticatedCatalog,
+        candidate: &CatalogCandidate,
+    ) -> Result<VerifiedCandidate, SourceFailure>;
+
+    /// Release retained bytes for a candidate rejected after verification.
+    /// Sources that retain verified artifacts can override this to keep
+    /// backtracking within the live materialization budget.
+    fn discard_candidate(&mut self, _candidate: &CatalogCandidate) {}
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LockedSelection {
+    pub version: ReleaseVersion,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolverLimits {
+    pub max_packages: usize,
+    pub max_catalog_candidates: usize,
+    pub max_candidate_attempts: usize,
+    pub max_backtracks: usize,
+    pub max_trace_events: usize,
+}
+
+impl Default for ResolverLimits {
+    fn default() -> Self {
+        Self {
+            max_packages: 256,
+            max_catalog_candidates: 16_384,
+            max_candidate_attempts: 16_384,
+            max_backtracks: 8_192,
+            max_trace_events: 65_536,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResolutionMode {
+    Fresh,
+    Locked,
+    Update,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolveRequest {
+    pub dependencies: Vec<Dependency>,
+    pub locked: BTreeMap<PackageKey, LockedSelection>,
+    /// Exact selections that a targeted update must retain. These constrain
+    /// selection without adding synthetic graph edges.
+    pub frozen: BTreeMap<PackageKey, LockedSelection>,
+    pub mode: ResolutionMode,
+    pub limits: ResolverLimits,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Resolution {
+    pub schema_version: String,
+    pub packages: Vec<ResolvedPackage>,
+    pub edges: Vec<ResolvedEdge>,
+    pub path_dependencies: Vec<PreservedPathDependency>,
+    pub trace: Vec<TraceEvent>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolvedPackage {
+    pub package: PackageKey,
+    pub version: ReleaseVersion,
+    pub release_id: String,
+    pub manifest_digest: String,
+    pub signer_key_ids: Vec<String>,
+    pub edition: String,
+    pub compatibility: String,
+    pub yanked: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct ResolvedEdge {
+    pub from: Option<PackageKey>,
+    pub alias: String,
+    pub to: PackageKey,
+    pub requirement: VersionRequirement,
+    pub selected: ReleaseVersion,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct PreservedPathDependency {
+    pub from: Option<PackageKey>,
+    pub alias: String,
+    pub path: String,
+    pub version: Option<ReleaseVersion>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum TraceEvent {
+    PathPreserved {
+        from: Option<PackageKey>,
+        alias: String,
+        path: String,
+    },
+    ConstraintAdded {
+        from: Option<PackageKey>,
+        package: PackageKey,
+        requirement: VersionRequirement,
+    },
+    CatalogAuthenticated {
+        package: PackageKey,
+        authentication_id: String,
+        candidate_count: usize,
+    },
+    CandidateConsidered {
+        package: PackageKey,
+        version: ReleaseVersion,
+        release_id: String,
+    },
+    CandidateRejected {
+        package: PackageKey,
+        version: ReleaseVersion,
+        reason: CandidateRejection,
+    },
+    CandidateVerified {
+        package: PackageKey,
+        version: ReleaseVersion,
+        manifest_digest: String,
+    },
+    Selected {
+        package: PackageKey,
+        version: ReleaseVersion,
+    },
+    Backtracked {
+        package: PackageKey,
+        version: ReleaseVersion,
+    },
+    Conflict {
+        package: PackageKey,
+        requirements: Vec<VersionRequirement>,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "reason", rename_all = "snake_case")]
+pub enum CandidateRejection {
+    ConstraintMismatch,
+    FrozenMismatch { required: ReleaseVersion },
+    Yanked,
+    VerificationFailed { code: String },
+    IdentityMismatch,
+    Cycle { through: PackageKey },
+    DownstreamConflict,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ResolveError {
+    InvalidRequest(String),
+    InvalidCatalog {
+        package: Box<PackageKey>,
+        message: String,
+    },
+    Source {
+        package: Box<PackageKey>,
+        failure: Box<SourceFailure>,
+        trace: Vec<TraceEvent>,
+    },
+    Conflict {
+        package: Box<PackageKey>,
+        requirements: Vec<VersionRequirement>,
+        trace: Vec<TraceEvent>,
+    },
+    BudgetExceeded {
+        budget: &'static str,
+        limit: usize,
+        trace: Vec<TraceEvent>,
+    },
+}
+
+impl fmt::Display for ResolveError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidRequest(message) => formatter.write_str(message),
+            Self::InvalidCatalog { package, message } => {
+                write!(
+                    formatter,
+                    "invalid authenticated catalog for {package}: {message}"
+                )
+            }
+            Self::Source {
+                package, failure, ..
+            } => {
+                write!(formatter, "package source failed for {package}: {failure}")
+            }
+            Self::Conflict {
+                package,
+                requirements,
+                ..
+            } => write!(
+                formatter,
+                "no single version of {package} satisfies {}",
+                requirements
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+            Self::BudgetExceeded { budget, limit, .. } => {
+                write!(formatter, "resolver {budget} budget exceeded ({limit})")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ResolveError {}
+
+#[derive(Clone, Debug)]
+struct Constraint {
+    from: Option<PackageKey>,
+    alias: String,
+    requirement: VersionRequirement,
+}
+
+#[derive(Clone, Debug)]
+struct Selection {
+    candidate: CatalogCandidate,
+    verified: VerifiedCandidate,
+}
+
+#[derive(Clone, Debug, Default)]
+struct SolverState {
+    constraints: BTreeMap<PackageKey, Vec<Constraint>>,
+    selected: BTreeMap<PackageKey, Selection>,
+    paths: BTreeSet<PreservedPathDependency>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct CandidateCacheKey {
+    package: PackageKey,
+    version: ReleaseVersion,
+    release_id: String,
+}
+
+struct Solver<'a, S: ResolverSource> {
+    source: &'a mut S,
+    request: ResolveRequest,
+    catalogs: BTreeMap<PackageKey, AuthenticatedCatalog>,
+    verified: BTreeMap<CandidateCacheKey, Result<VerifiedCandidate, SourceFailure>>,
+    trace: Vec<TraceEvent>,
+    catalog_candidate_count: usize,
+    candidate_attempts: usize,
+    backtracks: usize,
+    last_conflict: Option<(PackageKey, Vec<VersionRequirement>)>,
+}
+
+pub fn resolve_packages<S: ResolverSource>(
+    source: &mut S,
+    request: ResolveRequest,
+) -> Result<Resolution, ResolveError> {
+    validate_limits(request.limits)?;
+    let mut solver = Solver {
+        source,
+        request,
+        catalogs: BTreeMap::new(),
+        verified: BTreeMap::new(),
+        trace: Vec::new(),
+        catalog_candidate_count: 0,
+        candidate_attempts: 0,
+        backtracks: 0,
+        last_conflict: None,
+    };
+    let mut state = SolverState::default();
+    let mut dependencies = solver.request.dependencies.clone();
+    dependencies.sort_by(dependency_order);
+    for dependency in dependencies {
+        solver.add_dependency(&mut state, None, dependency)?;
+    }
+    let first = state.constraints.keys().next().cloned();
+    match solver.solve(state)? {
+        Some(state) => Ok(solver.finish(state)),
+        None => {
+            let (package, requirements) = solver.last_conflict.clone().unwrap_or_else(|| {
+                (
+                    first.unwrap_or_else(|| PackageKey::new("", "", "", "<root>")),
+                    Vec::new(),
+                )
+            });
+            solver.push_trace(TraceEvent::Conflict {
+                package: package.clone(),
+                requirements: requirements.clone(),
+            })?;
+            Err(ResolveError::Conflict {
+                package: Box::new(package),
+                requirements,
+                trace: solver.trace,
+            })
+        }
+    }
+}
+
+fn validate_limits(limits: ResolverLimits) -> Result<(), ResolveError> {
+    if limits.max_packages == 0
+        || limits.max_catalog_candidates == 0
+        || limits.max_candidate_attempts == 0
+        || limits.max_backtracks == 0
+        || limits.max_trace_events == 0
+    {
+        return Err(ResolveError::InvalidRequest(
+            "resolver budgets must all be positive".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn dependency_order(left: &Dependency, right: &Dependency) -> std::cmp::Ordering {
+    dependency_key(left).cmp(&dependency_key(right))
+}
+
+fn dependency_key(dependency: &Dependency) -> (u8, String, String) {
+    match dependency {
+        Dependency::Registry(dependency) => {
+            (0, dependency.package.to_string(), dependency.alias.clone())
+        }
+        Dependency::Path(dependency) => (1, dependency.path.clone(), dependency.alias.clone()),
+    }
+}
+
+impl<S: ResolverSource> Solver<'_, S> {
+    fn push_trace(&mut self, event: TraceEvent) -> Result<(), ResolveError> {
+        if self.trace.len() >= self.request.limits.max_trace_events {
+            return Err(self.budget_error("trace events", self.request.limits.max_trace_events));
+        }
+        self.trace.push(event);
+        Ok(())
+    }
+
+    fn budget_error(&self, budget: &'static str, limit: usize) -> ResolveError {
+        ResolveError::BudgetExceeded {
+            budget,
+            limit,
+            trace: self.trace.clone(),
+        }
+    }
+
+    fn add_dependency(
+        &mut self,
+        state: &mut SolverState,
+        from: Option<PackageKey>,
+        dependency: Dependency,
+    ) -> Result<(), ResolveError> {
+        match dependency {
+            Dependency::Path(dependency) => {
+                if dependency.alias.is_empty()
+                    || dependency.path.is_empty()
+                    || dependency.path.contains('\0')
+                {
+                    return Err(ResolveError::InvalidRequest(
+                        "path dependency alias and path must be non-empty and NUL-free".to_owned(),
+                    ));
+                }
+                state.paths.insert(PreservedPathDependency {
+                    from: from.clone(),
+                    alias: dependency.alias.clone(),
+                    path: dependency.path.clone(),
+                    version: dependency.version,
+                });
+                self.push_trace(TraceEvent::PathPreserved {
+                    from,
+                    alias: dependency.alias,
+                    path: dependency.path,
+                })
+            }
+            Dependency::Registry(dependency) => {
+                if dependency.alias.is_empty()
+                    || dependency.package.registry.is_empty()
+                    || dependency.package.source.is_empty()
+                    || dependency.package.namespace.is_empty()
+                    || dependency.package.name.is_empty()
+                {
+                    return Err(ResolveError::InvalidRequest(
+                        "registry dependency coordinates and alias must be non-empty".to_owned(),
+                    ));
+                }
+                if !state.constraints.contains_key(&dependency.package)
+                    && state.constraints.len() >= self.request.limits.max_packages
+                {
+                    return Err(self.budget_error("packages", self.request.limits.max_packages));
+                }
+                state
+                    .constraints
+                    .entry(dependency.package.clone())
+                    .or_default()
+                    .push(Constraint {
+                        from: from.clone(),
+                        alias: dependency.alias,
+                        requirement: dependency.requirement,
+                    });
+                self.push_trace(TraceEvent::ConstraintAdded {
+                    from,
+                    package: dependency.package,
+                    requirement: dependency.requirement,
+                })
+            }
+        }
+    }
+
+    fn solve(&mut self, state: SolverState) -> Result<Option<SolverState>, ResolveError> {
+        let selected_conflict = state.selected.iter().find_map(|(package, selection)| {
+            state.constraints.get(package).and_then(|constraints| {
+                constraints
+                    .iter()
+                    .any(|constraint| !constraint.requirement.matches(selection.candidate.version))
+                    .then(|| package.clone())
+            })
+        });
+        if let Some(package) = selected_conflict {
+            let requirements = self.requirements_for(&package, Some(&state));
+            self.last_conflict = Some((package.clone(), requirements.clone()));
+            self.push_trace(TraceEvent::Conflict {
+                package,
+                requirements,
+            })?;
+            return Ok(None);
+        }
+        let Some(package) = state
+            .constraints
+            .keys()
+            .find(|package| !state.selected.contains_key(*package))
+            .cloned()
+        else {
+            return Ok(Some(state));
+        };
+        let requirements = self.requirements_for(&package, Some(&state));
+        let catalog = self.catalog(&package)?;
+        let mut candidates = catalog.candidates.clone();
+        candidates.sort_by(|left, right| {
+            right
+                .version
+                .cmp(&left.version)
+                .then(left.release_id.cmp(&right.release_id))
+        });
+        if self.request.mode == ResolutionMode::Locked
+            && let Some(locked) = self.request.locked.get(&package)
+        {
+            candidates.sort_by_key(|candidate| candidate.version != locked.version);
+        }
+        let mut attempted = false;
+        for candidate in candidates {
+            self.bump_candidate_attempts()?;
+            self.push_trace(TraceEvent::CandidateConsidered {
+                package: package.clone(),
+                version: candidate.version,
+                release_id: candidate.release_id.clone(),
+            })?;
+            if let Some(frozen) = self.request.frozen.get(&package)
+                && candidate.version != frozen.version
+            {
+                self.push_trace(TraceEvent::CandidateRejected {
+                    package: package.clone(),
+                    version: candidate.version,
+                    reason: CandidateRejection::FrozenMismatch {
+                        required: frozen.version,
+                    },
+                })?;
+                continue;
+            }
+            if !requirements
+                .iter()
+                .all(|requirement| requirement.matches(candidate.version))
+            {
+                self.push_trace(TraceEvent::CandidateRejected {
+                    package: package.clone(),
+                    version: candidate.version,
+                    reason: CandidateRejection::ConstraintMismatch,
+                })?;
+                continue;
+            }
+            let exact_locked_yank_replay = match self.request.mode {
+                ResolutionMode::Fresh => false,
+                ResolutionMode::Locked => {
+                    self.request
+                        .locked
+                        .get(&package)
+                        .is_some_and(|locked| locked.version == candidate.version)
+                        || self
+                            .request
+                            .frozen
+                            .get(&package)
+                            .is_some_and(|locked| locked.version == candidate.version)
+                }
+                ResolutionMode::Update => self
+                    .request
+                    .frozen
+                    .get(&package)
+                    .is_some_and(|locked| locked.version == candidate.version),
+            };
+            if candidate.yanked && !exact_locked_yank_replay {
+                self.push_trace(TraceEvent::CandidateRejected {
+                    package: package.clone(),
+                    version: candidate.version,
+                    reason: CandidateRejection::Yanked,
+                })?;
+                continue;
+            }
+            attempted = true;
+            let verified = match self.verified_candidate(&catalog, &candidate)? {
+                Ok(verified) => verified,
+                Err(failure) => {
+                    self.push_trace(TraceEvent::CandidateRejected {
+                        package: package.clone(),
+                        version: candidate.version,
+                        reason: CandidateRejection::VerificationFailed {
+                            code: failure.code.clone(),
+                        },
+                    })?;
+                    return Err(ResolveError::Source {
+                        package: Box::new(package),
+                        failure: Box::new(failure),
+                        trace: self.trace.clone(),
+                    });
+                }
+            };
+            if verified.package != package
+                || verified.version != candidate.version
+                || verified.release_id != candidate.release_id
+            {
+                self.push_trace(TraceEvent::CandidateRejected {
+                    package: package.clone(),
+                    version: candidate.version,
+                    reason: CandidateRejection::IdentityMismatch,
+                })?;
+                self.source.discard_candidate(&candidate);
+                continue;
+            }
+            self.push_trace(TraceEvent::CandidateVerified {
+                package: package.clone(),
+                version: candidate.version,
+                manifest_digest: verified.manifest_digest.clone(),
+            })?;
+
+            let mut next = state.clone();
+            next.selected.insert(
+                package.clone(),
+                Selection {
+                    candidate: candidate.clone(),
+                    verified: verified.clone(),
+                },
+            );
+            let mut dependencies = verified.dependencies.clone();
+            dependencies.sort_by(dependency_order);
+            let mut cycle = None;
+            for dependency in dependencies {
+                if let Dependency::Registry(registry) = &dependency
+                    && dependency_path_exists(&next, &registry.package, &package)
+                {
+                    cycle = Some(registry.package.clone());
+                    break;
+                }
+                self.add_dependency(&mut next, Some(package.clone()), dependency)?;
+            }
+            if let Some(through) = cycle {
+                self.push_trace(TraceEvent::CandidateRejected {
+                    package: package.clone(),
+                    version: candidate.version,
+                    reason: CandidateRejection::Cycle { through },
+                })?;
+                self.source.discard_candidate(&candidate);
+                self.backtrack(&package, candidate.version)?;
+                continue;
+            }
+            if let Some(solution) = self.solve(next)? {
+                self.push_trace(TraceEvent::Selected {
+                    package,
+                    version: candidate.version,
+                })?;
+                return Ok(Some(solution));
+            }
+            self.push_trace(TraceEvent::CandidateRejected {
+                package: package.clone(),
+                version: candidate.version,
+                reason: CandidateRejection::DownstreamConflict,
+            })?;
+            self.source.discard_candidate(&candidate);
+            self.backtrack(&package, candidate.version)?;
+        }
+        if attempted || !catalog.candidates.is_empty() {
+            self.last_conflict = Some((package.clone(), requirements.clone()));
+            self.push_trace(TraceEvent::Conflict {
+                package,
+                requirements,
+            })?;
+        }
+        Ok(None)
+    }
+
+    fn backtrack(
+        &mut self,
+        package: &PackageKey,
+        version: ReleaseVersion,
+    ) -> Result<(), ResolveError> {
+        if self.backtracks >= self.request.limits.max_backtracks {
+            return Err(self.budget_error("backtracks", self.request.limits.max_backtracks));
+        }
+        self.backtracks += 1;
+        self.push_trace(TraceEvent::Backtracked {
+            package: package.clone(),
+            version,
+        })
+    }
+
+    fn bump_candidate_attempts(&mut self) -> Result<(), ResolveError> {
+        if self.candidate_attempts >= self.request.limits.max_candidate_attempts {
+            return Err(self.budget_error(
+                "candidate attempts",
+                self.request.limits.max_candidate_attempts,
+            ));
+        }
+        self.candidate_attempts += 1;
+        Ok(())
+    }
+
+    fn catalog(&mut self, package: &PackageKey) -> Result<AuthenticatedCatalog, ResolveError> {
+        if let Some(catalog) = self.catalogs.get(package) {
+            return Ok(catalog.clone());
+        }
+        let catalog = self
+            .source
+            .authenticate_catalog(package)
+            .map_err(|failure| ResolveError::Source {
+                package: Box::new(package.clone()),
+                failure: Box::new(failure),
+                trace: self.trace.clone(),
+            })?;
+        if catalog.package != *package {
+            return Err(ResolveError::InvalidCatalog {
+                package: Box::new(package.clone()),
+                message: format!("catalog is bound to {}, not {package}", catalog.package),
+            });
+        }
+        if catalog.authentication_id.is_empty() {
+            return Err(ResolveError::InvalidCatalog {
+                package: Box::new(package.clone()),
+                message: "catalog authentication identity must be non-empty".to_owned(),
+            });
+        }
+        let mut versions = BTreeSet::new();
+        for candidate in &catalog.candidates {
+            if candidate.release_id.is_empty() || !versions.insert(candidate.version) {
+                return Err(ResolveError::InvalidCatalog {
+                    package: Box::new(package.clone()),
+                    message: "release identities must be non-empty and versions unique".to_owned(),
+                });
+            }
+        }
+        self.catalog_candidate_count = self
+            .catalog_candidate_count
+            .checked_add(catalog.candidates.len())
+            .ok_or_else(|| {
+                self.budget_error(
+                    "catalog candidates",
+                    self.request.limits.max_catalog_candidates,
+                )
+            })?;
+        if self.catalog_candidate_count > self.request.limits.max_catalog_candidates {
+            return Err(self.budget_error(
+                "catalog candidates",
+                self.request.limits.max_catalog_candidates,
+            ));
+        }
+        self.push_trace(TraceEvent::CatalogAuthenticated {
+            package: package.clone(),
+            authentication_id: catalog.authentication_id.clone(),
+            candidate_count: catalog.candidates.len(),
+        })?;
+        self.catalogs.insert(package.clone(), catalog.clone());
+        Ok(catalog)
+    }
+
+    fn verified_candidate(
+        &mut self,
+        catalog: &AuthenticatedCatalog,
+        candidate: &CatalogCandidate,
+    ) -> Result<Result<VerifiedCandidate, SourceFailure>, ResolveError> {
+        let key = CandidateCacheKey {
+            package: catalog.package.clone(),
+            version: candidate.version,
+            release_id: candidate.release_id.clone(),
+        };
+        if let Some(cached) = self.verified.get(&key) {
+            return Ok(cached.clone());
+        }
+        let result = self.source.verify_candidate(catalog, candidate);
+        self.verified.insert(key, result.clone());
+        Ok(result)
+    }
+
+    fn requirements_for(
+        &self,
+        package: &PackageKey,
+        state: Option<&SolverState>,
+    ) -> Vec<VersionRequirement> {
+        let constraints = state.and_then(|state| state.constraints.get(package));
+        let mut requirements = constraints
+            .into_iter()
+            .flatten()
+            .map(|constraint| constraint.requirement)
+            .collect::<Vec<_>>();
+        requirements.sort_by_key(ToString::to_string);
+        requirements.dedup();
+        requirements
+    }
+
+    fn finish(self, state: SolverState) -> Resolution {
+        let packages = state
+            .selected
+            .iter()
+            .map(|(package, selection)| {
+                let mut signer_key_ids = selection.verified.signer_key_ids.clone();
+                signer_key_ids.sort();
+                signer_key_ids.dedup();
+                ResolvedPackage {
+                    package: package.clone(),
+                    version: selection.candidate.version,
+                    release_id: selection.candidate.release_id.clone(),
+                    manifest_digest: selection.verified.manifest_digest.clone(),
+                    signer_key_ids,
+                    edition: selection.verified.edition.clone(),
+                    compatibility: selection.verified.compatibility.clone(),
+                    yanked: selection.candidate.yanked,
+                }
+            })
+            .collect();
+        let mut edges = state
+            .constraints
+            .iter()
+            .flat_map(|(package, constraints)| {
+                let selected = state.selected[package].candidate.version;
+                constraints.iter().map(move |constraint| ResolvedEdge {
+                    from: constraint.from.clone(),
+                    alias: constraint.alias.clone(),
+                    to: package.clone(),
+                    requirement: constraint.requirement,
+                    selected,
+                })
+            })
+            .collect::<Vec<_>>();
+        edges.sort();
+        Resolution {
+            schema_version: "axiom.package_resolution.v1".to_owned(),
+            packages,
+            edges,
+            path_dependencies: state.paths.into_iter().collect(),
+            trace: self.trace,
+        }
+    }
+}
+
+fn dependency_path_exists(state: &SolverState, start: &PackageKey, goal: &PackageKey) -> bool {
+    if start == goal {
+        return true;
+    }
+    let mut pending = vec![start.clone()];
+    let mut visited = BTreeSet::new();
+    while let Some(package) = pending.pop() {
+        if !visited.insert(package.clone()) {
+            continue;
+        }
+        for (target, constraints) in &state.constraints {
+            if constraints
+                .iter()
+                .any(|constraint| constraint.from.as_ref() == Some(&package))
+            {
+                if target == goal {
+                    return true;
+                }
+                pending.push(target.clone());
+            }
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Default)]
+    struct MockSource {
+        catalogs: BTreeMap<PackageKey, AuthenticatedCatalog>,
+        verified: BTreeMap<(PackageKey, ReleaseVersion), Result<VerifiedCandidate, SourceFailure>>,
+        calls: Vec<String>,
+    }
+
+    impl ResolverSource for MockSource {
+        fn authenticate_catalog(
+            &mut self,
+            package: &PackageKey,
+        ) -> Result<AuthenticatedCatalog, SourceFailure> {
+            self.calls.push(format!("auth:{package}"));
+            self.catalogs
+                .get(package)
+                .cloned()
+                .ok_or_else(|| SourceFailure::new("missing_catalog", package.to_string()))
+        }
+
+        fn verify_candidate(
+            &mut self,
+            catalog: &AuthenticatedCatalog,
+            candidate: &CatalogCandidate,
+        ) -> Result<VerifiedCandidate, SourceFailure> {
+            self.calls
+                .push(format!("verify:{}@{}", catalog.package, candidate.version));
+            self.verified
+                .get(&(catalog.package.clone(), candidate.version))
+                .cloned()
+                .unwrap_or_else(|| {
+                    Err(SourceFailure::new(
+                        "missing_release",
+                        candidate.release_id.clone(),
+                    ))
+                })
+        }
+    }
+
+    fn key(name: &str) -> PackageKey {
+        PackageKey::new("default", "file:///registry/index.json", "axiom", name)
+    }
+
+    fn requirement(value: &str) -> VersionRequirement {
+        VersionRequirement::parse(value).expect("requirement fixture")
+    }
+
+    fn version(value: &str) -> ReleaseVersion {
+        ReleaseVersion::parse(value).expect("version fixture")
+    }
+
+    fn registry(alias: &str, name: &str, required: &str) -> Dependency {
+        Dependency::Registry(RegistryDependency {
+            alias: alias.to_owned(),
+            package: key(name),
+            requirement: requirement(required),
+        })
+    }
+
+    fn add_package(
+        source: &mut MockSource,
+        name: &str,
+        releases: &[(&str, bool, Vec<Dependency>)],
+    ) {
+        let package = key(name);
+        let candidates = releases
+            .iter()
+            .map(|(release, yanked, _)| CatalogCandidate {
+                version: version(release),
+                yanked: *yanked,
+                release_id: format!("{name}-{release}"),
+            })
+            .collect::<Vec<_>>();
+        source.catalogs.insert(
+            package.clone(),
+            AuthenticatedCatalog::new(package.clone(), candidates, format!("auth-{name}")),
+        );
+        for (release, _, dependencies) in releases {
+            let release = version(release);
+            source.verified.insert(
+                (package.clone(), release),
+                Ok(VerifiedCandidate {
+                    package: package.clone(),
+                    version: release,
+                    release_id: format!("{name}-{release}"),
+                    dependencies: dependencies.clone(),
+                    manifest_digest: format!("digest-{name}-{release}"),
+                    signer_key_ids: vec!["signer".to_owned()],
+                    edition: "2026".to_owned(),
+                    compatibility: "axiom-v1".to_owned(),
+                }),
+            );
+        }
+    }
+
+    fn request(dependencies: Vec<Dependency>) -> ResolveRequest {
+        ResolveRequest {
+            dependencies,
+            locked: BTreeMap::new(),
+            frozen: BTreeMap::new(),
+            mode: ResolutionMode::Fresh,
+            limits: ResolverLimits::default(),
+        }
+    }
+
+    #[test]
+    fn exact_and_caret_choose_highest_compatible_release() {
+        let mut source = MockSource::default();
+        add_package(
+            &mut source,
+            "a",
+            &[
+                ("1.0.0", false, vec![]),
+                ("1.5.0", false, vec![]),
+                ("2.0.0", false, vec![]),
+            ],
+        );
+        let exact = resolve_packages(&mut source, request(vec![registry("a", "a", "1.0.0")]))
+            .expect("exact resolution");
+        assert_eq!(exact.packages[0].version, version("1.0.0"));
+
+        let caret = resolve_packages(&mut source, request(vec![registry("a", "a", "^1.0.0")]))
+            .expect("caret resolution");
+        assert_eq!(caret.packages[0].version, version("1.5.0"));
+    }
+
+    #[test]
+    fn diamond_resolution_uses_one_version_and_backtracks_deterministically() {
+        let mut source = MockSource::default();
+        add_package(
+            &mut source,
+            "a",
+            &[
+                ("1.9.0", false, vec![registry("c", "c", "^1.0.0")]),
+                ("1.0.0", false, vec![registry("c", "c", "^1.0.0")]),
+            ],
+        );
+        add_package(
+            &mut source,
+            "b",
+            &[("1.0.0", false, vec![registry("c", "c", "^1.0.0")])],
+        );
+        add_package(
+            &mut source,
+            "c",
+            &[
+                ("2.1.0", false, vec![]),
+                ("1.9.0", false, vec![]),
+                ("1.2.0", false, vec![]),
+            ],
+        );
+        let resolution = resolve_packages(
+            &mut source,
+            request(vec![
+                registry("a", "a", "^1.0.0"),
+                registry("b", "b", "1.0.0"),
+            ]),
+        )
+        .expect("diamond resolves");
+        assert_eq!(
+            resolution
+                .packages
+                .iter()
+                .find(|package| package.package == key("c"))
+                .expect("c selected")
+                .version,
+            version("1.9.0")
+        );
+        assert_eq!(
+            resolution
+                .packages
+                .iter()
+                .find(|package| package.package == key("a"))
+                .expect("a selected")
+                .version,
+            version("1.9.0")
+        );
+    }
+
+    #[test]
+    fn eligible_newest_candidate_verification_failure_is_fatal() {
+        let mut source = MockSource::default();
+        add_package(
+            &mut source,
+            "a",
+            &[("1.2.0", false, vec![]), ("1.1.0", false, vec![])],
+        );
+        source.verified.insert(
+            (key("a"), version("1.2.0")),
+            Err(SourceFailure::new(
+                "archive_manifest_mismatch",
+                "newest eligible release embeds a different manifest",
+            )),
+        );
+        let error = resolve_packages(&mut source, request(vec![registry("a", "a", "^1.0.0")]))
+            .expect_err("tampered newest candidate must fail closed");
+        match error {
+            ResolveError::Source {
+                package,
+                failure,
+                trace,
+            } => {
+                assert_eq!(*package, key("a"));
+                assert_eq!(failure.code, "archive_manifest_mismatch");
+                assert!(trace.iter().any(|event| matches!(
+                    event,
+                    TraceEvent::CandidateRejected {
+                        package,
+                        version: rejected,
+                        reason: CandidateRejection::VerificationFailed { code },
+                    } if package == &key("a")
+                        && *rejected == version("1.2.0")
+                        && code == "archive_manifest_mismatch"
+                )));
+            }
+            other => panic!("unexpected error {other:?}"),
+        }
+        assert!(
+            !source
+                .calls
+                .iter()
+                .any(|call| call.starts_with("verify:") && call.ends_with("@1.1.0")),
+            "resolver must not downgrade after a trust failure"
+        );
+    }
+
+    #[test]
+    fn downstream_conflict_backtracks_from_highest_candidate() {
+        let mut source = MockSource::default();
+        add_package(
+            &mut source,
+            "a",
+            &[
+                ("1.9.0", false, vec![registry("c", "c", "^2.0.0")]),
+                ("1.0.0", false, vec![registry("c", "c", "^1.0.0")]),
+            ],
+        );
+        add_package(
+            &mut source,
+            "b",
+            &[("1.0.0", false, vec![registry("c", "c", "^1.0.0")])],
+        );
+        add_package(
+            &mut source,
+            "c",
+            &[("2.0.0", false, vec![]), ("1.0.0", false, vec![])],
+        );
+        let resolution = resolve_packages(
+            &mut source,
+            request(vec![
+                registry("a", "a", "^1.0.0"),
+                registry("b", "b", "1.0.0"),
+            ]),
+        )
+        .expect("backtracking resolution");
+        assert!(resolution.trace.iter().any(|event| matches!(
+            event,
+            TraceEvent::Backtracked { package, .. } if package == &key("a")
+        )));
+    }
+
+    #[test]
+    fn conflicts_and_cycles_fail_with_stable_trace() {
+        let mut source = MockSource::default();
+        add_package(
+            &mut source,
+            "a",
+            &[("1.0.0", false, vec![registry("b", "b", "1.0.0")])],
+        );
+        add_package(
+            &mut source,
+            "b",
+            &[("1.0.0", false, vec![registry("a", "a", "1.0.0")])],
+        );
+        let cycle = resolve_packages(&mut source, request(vec![registry("a", "a", "1.0.0")]))
+            .expect_err("cycle fails");
+        let trace = match cycle {
+            ResolveError::Conflict { trace, .. } => trace,
+            other => panic!("unexpected error {other:?}"),
+        };
+        assert!(trace.iter().any(|event| matches!(
+            event,
+            TraceEvent::CandidateRejected {
+                reason: CandidateRejection::Cycle { .. },
+                ..
+            }
+        )));
+
+        let mut source = MockSource::default();
+        add_package(&mut source, "a", &[("1.0.0", false, vec![])]);
+        let conflict = resolve_packages(
+            &mut source,
+            request(vec![
+                registry("a1", "a", "1.0.0"),
+                registry("a2", "a", "2.0.0"),
+            ]),
+        )
+        .expect_err("incompatible root constraints fail");
+        match conflict {
+            ResolveError::Conflict { requirements, .. } => {
+                assert_eq!(requirements, [requirement("1.0.0"), requirement("2.0.0")]);
+            }
+            other => panic!("unexpected error {other:?}"),
+        }
+    }
+
+    #[test]
+    fn independent_roots_do_not_form_a_cycle_from_selection_order() {
+        let mut source = MockSource::default();
+        add_package(&mut source, "a", &[("1.0.0", false, vec![])]);
+        add_package(
+            &mut source,
+            "b",
+            &[("1.0.0", false, vec![registry("a", "a", "1.0.0")])],
+        );
+        let resolution = resolve_packages(
+            &mut source,
+            request(vec![
+                registry("a", "a", "1.0.0"),
+                registry("b", "b", "1.0.0"),
+            ]),
+        )
+        .expect("independent root plus inbound dependency resolves");
+        assert_eq!(resolution.packages.len(), 2);
+    }
+
+    #[test]
+    fn fresh_yanks_are_excluded_but_verified_locked_yanks_are_permitted() {
+        let mut source = MockSource::default();
+        add_package(
+            &mut source,
+            "a",
+            &[("2.0.0", true, vec![]), ("1.0.0", false, vec![])],
+        );
+        let fresh = resolve_packages(&mut source, request(vec![registry("a", "a", "^1.0.0")]))
+            .expect("fresh resolution");
+        assert_eq!(fresh.packages[0].version, version("1.0.0"));
+
+        let mut locked_request = request(vec![registry("a", "a", "^2.0.0")]);
+        locked_request.locked.insert(
+            key("a"),
+            LockedSelection {
+                version: version("2.0.0"),
+            },
+        );
+        locked_request.mode = ResolutionMode::Locked;
+        let locked = resolve_packages(&mut source, locked_request).expect("trusted locked yank");
+        assert_eq!(locked.packages[0].version, version("2.0.0"));
+        assert!(locked.packages[0].yanked);
+
+        let mut source = MockSource::default();
+        add_package(
+            &mut source,
+            "a",
+            &[("1.9.0", false, vec![]), ("1.5.0", true, vec![])],
+        );
+        let mut update = request(vec![registry("a", "a", "^1.0.0")]);
+        update.mode = ResolutionMode::Update;
+        update.locked.insert(
+            key("a"),
+            LockedSelection {
+                version: version("1.5.0"),
+            },
+        );
+        let updated = resolve_packages(&mut source, update).expect("update moves off yank");
+        assert_eq!(updated.packages[0].version, version("1.9.0"));
+    }
+
+    #[test]
+    fn path_dependencies_are_preserved_without_source_access() {
+        let mut source = MockSource::default();
+        let resolution = resolve_packages(
+            &mut source,
+            request(vec![Dependency::Path(PathDependency {
+                alias: "local".to_owned(),
+                path: "../local".to_owned(),
+                version: Some(version("1.0.0")),
+            })]),
+        )
+        .expect("path-only resolution");
+        assert!(resolution.packages.is_empty());
+        assert_eq!(resolution.path_dependencies[0].path, "../local");
+        assert!(source.calls.is_empty());
+    }
+
+    #[test]
+    fn catalog_authentication_precedes_candidate_verification_and_dependency_expansion() {
+        let mut source = MockSource::default();
+        add_package(
+            &mut source,
+            "a",
+            &[("1.0.0", false, vec![registry("b", "b", "1.0.0")])],
+        );
+        add_package(&mut source, "b", &[("1.0.0", false, vec![])]);
+        resolve_packages(&mut source, request(vec![registry("a", "a", "1.0.0")]))
+            .expect("trusted graph");
+        assert_eq!(
+            source.calls,
+            [
+                "auth:default@file:///registry/index.json::axiom/a",
+                "verify:default@file:///registry/index.json::axiom/a@1.0.0",
+                "auth:default@file:///registry/index.json::axiom/b",
+                "verify:default@file:///registry/index.json::axiom/b@1.0.0",
+            ]
+        );
+    }
+
+    #[test]
+    fn mismatched_exact_release_identity_cannot_expand_dependencies() {
+        let mut source = MockSource::default();
+        add_package(
+            &mut source,
+            "a",
+            &[("1.0.0", false, vec![registry("b", "b", "1.0.0")])],
+        );
+        source
+            .verified
+            .get_mut(&(key("a"), version("1.0.0")))
+            .expect("release")
+            .as_mut()
+            .expect("verified fixture")
+            .release_id = "different-release".to_owned();
+        let error = resolve_packages(&mut source, request(vec![registry("a", "a", "1.0.0")]))
+            .expect_err("release identity mismatch fails");
+        let trace = match error {
+            ResolveError::Conflict { trace, .. } => trace,
+            other => panic!("unexpected error {other:?}"),
+        };
+        assert!(trace.iter().any(|event| matches!(
+            event,
+            TraceEvent::CandidateRejected {
+                reason: CandidateRejection::IdentityMismatch,
+                ..
+            }
+        )));
+        assert!(
+            !source.calls.iter().any(|call| call.contains("axiom/b")),
+            "dependencies from mismatched release identity must stay invisible"
+        );
+    }
+
+    #[test]
+    fn input_order_is_canonical_and_budgets_fail_closed() {
+        let build = |dependencies: Vec<Dependency>| {
+            let mut source = MockSource::default();
+            add_package(&mut source, "a", &[("1.0.0", false, vec![])]);
+            add_package(&mut source, "b", &[("1.0.0", false, vec![])]);
+            resolve_packages(&mut source, request(dependencies)).expect("ordered resolution")
+        };
+        let left = build(vec![
+            registry("b", "b", "1.0.0"),
+            registry("a", "a", "1.0.0"),
+        ]);
+        let right = build(vec![
+            registry("a", "a", "1.0.0"),
+            registry("b", "b", "1.0.0"),
+        ]);
+        assert_eq!(left.packages, right.packages);
+        assert_eq!(left.edges, right.edges);
+        assert_eq!(left.trace, right.trace);
+
+        let mut source = MockSource::default();
+        add_package(
+            &mut source,
+            "a",
+            &[("2.0.0", false, vec![]), ("1.0.0", false, vec![])],
+        );
+        let mut limited = request(vec![registry("a", "a", "^1.0.0")]);
+        limited.limits.max_catalog_candidates = 1;
+        assert!(matches!(
+            resolve_packages(&mut source, limited),
+            Err(ResolveError::BudgetExceeded {
+                budget: "catalog candidates",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn duplicate_catalog_versions_are_rejected_even_with_distinct_release_ids() {
+        let mut source = MockSource::default();
+        let package = key("a");
+        source.catalogs.insert(
+            package.clone(),
+            AuthenticatedCatalog::new(
+                package,
+                vec![
+                    CatalogCandidate {
+                        version: version("1.0.0"),
+                        yanked: false,
+                        release_id: "first-target".to_owned(),
+                    },
+                    CatalogCandidate {
+                        version: version("1.0.0"),
+                        yanked: false,
+                        release_id: "second-target".to_owned(),
+                    },
+                ],
+                "authenticated",
+            ),
+        );
+        assert!(matches!(
+            resolve_packages(&mut source, request(vec![registry("a", "a", "1.0.0")])),
+            Err(ResolveError::InvalidCatalog { .. })
+        ));
+        assert!(
+            !source.calls.iter().any(|call| call.starts_with("verify:")),
+            "ambiguous catalog must fail before candidate verification"
+        );
+    }
+
+    #[test]
+    fn targeted_update_freezes_non_target_without_synthetic_edges() {
+        let mut source = MockSource::default();
+        add_package(
+            &mut source,
+            "a",
+            &[("1.9.0", false, vec![]), ("1.0.0", false, vec![])],
+        );
+        add_package(
+            &mut source,
+            "b",
+            &[("1.9.0", false, vec![]), ("1.0.0", false, vec![])],
+        );
+        let mut update = request(vec![
+            registry("a", "a", "^1.0.0"),
+            registry("b", "b", "^1.0.0"),
+        ]);
+        update.mode = ResolutionMode::Update;
+        update.locked.insert(
+            key("a"),
+            LockedSelection {
+                version: version("1.0.0"),
+            },
+        );
+        let frozen = LockedSelection {
+            version: version("1.0.0"),
+        };
+        update.locked.insert(key("b"), frozen.clone());
+        update.frozen.insert(key("b"), frozen);
+
+        let resolution = resolve_packages(&mut source, update).expect("targeted update");
+        assert_eq!(
+            resolution
+                .packages
+                .iter()
+                .find(|package| package.package == key("a"))
+                .expect("a")
+                .version,
+            version("1.9.0")
+        );
+        assert_eq!(
+            resolution
+                .packages
+                .iter()
+                .find(|package| package.package == key("b"))
+                .expect("b")
+                .version,
+            version("1.0.0")
+        );
+        assert_eq!(resolution.edges.len(), 2);
+    }
+
+    #[test]
+    fn targeted_update_preserves_broader_update_required_trace_evidence() {
+        let mut source = MockSource::default();
+        add_package(
+            &mut source,
+            "a",
+            &[
+                ("1.9.0", false, vec![registry("b", "b", "^1.5.0")]),
+                ("1.0.0", false, vec![registry("b", "b", "^1.0.0")]),
+            ],
+        );
+        add_package(
+            &mut source,
+            "b",
+            &[("1.5.0", false, vec![]), ("1.0.0", false, vec![])],
+        );
+        let mut update = request(vec![
+            registry("a", "a", "^1.0.0"),
+            registry("b", "b", "^1.0.0"),
+        ]);
+        update.mode = ResolutionMode::Update;
+        update.frozen.insert(
+            key("b"),
+            LockedSelection {
+                version: version("1.0.0"),
+            },
+        );
+
+        let resolution =
+            resolve_packages(&mut source, update).expect("old target remains resolvable");
+        assert_eq!(
+            resolution
+                .packages
+                .iter()
+                .find(|package| package.package == key("a"))
+                .expect("target")
+                .version,
+            version("1.0.0")
+        );
+        assert!(resolution.trace.iter().any(|event| matches!(
+            event,
+            TraceEvent::CandidateRejected {
+                package,
+                reason: CandidateRejection::FrozenMismatch { required },
+                ..
+            } if package == &key("b") && *required == version("1.0.0")
+        )));
+    }
+
+    #[test]
+    fn resolution_and_trace_have_stable_tagged_serialization() {
+        let package = key("a");
+        let value = serde_json::to_value(Resolution {
+            schema_version: "axiom.package_resolution.v1".to_owned(),
+            packages: vec![],
+            edges: vec![],
+            path_dependencies: vec![],
+            trace: vec![TraceEvent::CandidateRejected {
+                package: package.clone(),
+                version: version("1.2.3"),
+                reason: CandidateRejection::FrozenMismatch {
+                    required: version("1.0.0"),
+                },
+            }],
+        })
+        .expect("serialize resolution");
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "schema_version": "axiom.package_resolution.v1",
+                "packages": [],
+                "edges": [],
+                "path_dependencies": [],
+                "trace": [{
+                    "event": "candidate_rejected",
+                    "package": {
+                        "registry": "default",
+                        "source": "file:///registry/index.json",
+                        "namespace": "axiom",
+                        "name": "a"
+                    },
+                    "version": {"major": 1, "minor": 2, "patch": 3},
+                    "reason": {
+                        "reason": "frozen_mismatch",
+                        "required": {"major": 1, "minor": 0, "patch": 0}
+                    }
+                }]
+            })
+        );
+    }
+}

--- a/stage1/crates/axiomc/src/package_store.rs
+++ b/stage1/crates/axiomc/src/package_store.rs
@@ -1,0 +1,2398 @@
+//! Content-addressed package cache and deterministic vendor snapshots.
+//!
+//! This module proves byte and tree integrity. Callers must still rerun Package
+//! Trust over [`CachedPackage::verified_artifacts`] before treating the package
+//! as authenticated; a rehashed cache record is deliberately not a trust verdict.
+
+use crate::package_archive::{
+    ArchiveError, ArchiveLimits, EXTRACTOR_VERSION, TreeIntegrityManifest, expected_tree_integrity,
+    extract_archive, integrity_manifest_bytes, integrity_manifest_sha256, parse_archive,
+    sha256_hex, verify_tree, verify_tree_with_limits,
+};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Component, Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const CACHE_COMMIT_SCHEMA: &str = "axiom.package_cache_commit.v1";
+const VENDOR_MANIFEST_SCHEMA: &str = "axiom.vendor_manifest.v1";
+const TRANSACTION_MARKER_SCHEMA: &str = "axiom.store_transaction.v1";
+const TRANSACTION_MARKER_NAME: &str = ".axiom-transaction";
+const MAX_EVIDENCE_BYTES: usize = 16 * 1024 * 1024;
+const MAX_VENDOR_PACKAGES: usize = 4_096;
+const MAX_VENDOR_BYTES: u64 = 512 * 1024 * 1024;
+const MAX_TRANSACTION_SCAN_ENTRIES: usize = 1_024;
+const STALE_TRANSACTION_AGE_NANOS: u128 = 24 * 60 * 60 * 1_000_000_000;
+const EVIDENCE_NAMES: [&str; 6] = [
+    "integrity.json",
+    "manifest",
+    "provenance",
+    "registry-index",
+    "signature",
+    "verification",
+];
+static TRANSACTION_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StoreError {
+    pub code: &'static str,
+    pub message: String,
+}
+
+impl StoreError {
+    fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for StoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for StoreError {}
+
+impl From<ArchiveError> for StoreError {
+    fn from(error: ArchiveError) -> Self {
+        Self {
+            code: error.code,
+            message: error.message,
+        }
+    }
+}
+
+/// Secure bounded reader shared by package-store and manager trust inputs.
+///
+/// On Unix, nonblocking no-follow open happens before descriptor metadata
+/// validation so a FIFO substitution cannot stall the caller.
+pub fn read_bounded_regular_file(path: &Path, limit: usize) -> Result<Vec<u8>, StoreError> {
+    read_regular_file(path, limit)
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct VerifiedArtifacts<'a> {
+    pub archive_sha256: &'a str,
+    pub archive: &'a [u8],
+    pub manifest: &'a [u8],
+    pub provenance: &'a [u8],
+    pub signature: &'a [u8],
+    pub registry_index: &'a [u8],
+    pub verification: &'a [u8],
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CacheCommit {
+    pub schema_version: String,
+    pub extractor_version: String,
+    pub archive_sha256: String,
+    pub archive_length: u64,
+    pub tree_manifest_sha256: String,
+    pub manifest_sha256: String,
+    pub provenance_sha256: String,
+    pub signature_sha256: String,
+    pub registry_index_sha256: String,
+    pub verification_sha256: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RehashedArtifacts {
+    pub archive: Vec<u8>,
+    pub manifest: Vec<u8>,
+    pub provenance: Vec<u8>,
+    pub signature: Vec<u8>,
+    pub registry_index: Vec<u8>,
+    pub verification: Vec<u8>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CachedPackage {
+    pub archive_sha256: String,
+    pub blob: PathBuf,
+    pub tree: PathBuf,
+    pub evidence: PathBuf,
+    pub integrity: TreeIntegrityManifest,
+    pub commit: CacheCommit,
+    pub artifacts: RehashedArtifacts,
+}
+
+impl CachedPackage {
+    /// Exact bytes rehashed by offline cache verification. These are inputs to,
+    /// not a replacement for, a fresh Package Trust verification.
+    pub fn verified_artifacts(&self) -> Result<VerifiedArtifacts<'_>, StoreError> {
+        verify_tree(&self.tree, &self.integrity)?;
+        verify_evidence_directory(&self.evidence)?;
+        let current = read_artifacts(&self.blob, &self.evidence, ArchiveLimits::default())?;
+        if current != self.artifacts {
+            return Err(StoreError::new(
+                "cache_artifact_mismatch",
+                "cached artifacts changed after package verification",
+            ));
+        }
+        Ok(VerifiedArtifacts {
+            archive_sha256: &self.archive_sha256,
+            archive: &self.artifacts.archive,
+            manifest: &self.artifacts.manifest,
+            provenance: &self.artifacts.provenance,
+            signature: &self.artifacts.signature,
+            registry_index: &self.artifacts.registry_index,
+            verification: &self.artifacts.verification,
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VendorPackage<'a> {
+    pub package_id: &'a str,
+    pub archive_sha256: &'a str,
+    pub registry_index_sha256: &'a str,
+    pub verification_sha256: &'a str,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct VendorManifestPackage {
+    pub package_id: String,
+    pub content_key: String,
+    pub archive_sha256: String,
+    pub registry_index_sha256: String,
+    pub verification_sha256: String,
+    pub evidence_identity: String,
+    pub tree_manifest_sha256: String,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct VendorManifest {
+    pub schema_version: String,
+    pub packages: Vec<VendorManifestPackage>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VendorSnapshot {
+    pub digest: String,
+    pub root: PathBuf,
+    pub manifest: VendorManifest,
+    pub packages: BTreeMap<String, VendorPackagePaths>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VendorPackagePaths {
+    pub archive_sha256: String,
+    pub registry_index_sha256: String,
+    pub verification_sha256: String,
+    pub evidence_identity: String,
+    pub blob: PathBuf,
+    pub tree: PathBuf,
+    pub evidence: PathBuf,
+    pub commit: PathBuf,
+}
+
+impl VendorSnapshot {
+    /// Return an exact, reverified tree root for one expected locked package.
+    pub fn package_tree(&self, package_id: &str) -> Option<PathBuf> {
+        self.packages
+            .get(package_id)
+            .map(|package| package.tree.clone())
+    }
+
+    /// Load and rehash one exact package so callers retain at most one package's
+    /// archive and evidence buffers while traversing a vendor snapshot.
+    pub fn package(&self, package_id: &str) -> Result<Option<CachedPackage>, StoreError> {
+        let Some(package) = self.packages.get(package_id) else {
+            return Ok(None);
+        };
+        let cached = load_package_from_paths(
+            &package.archive_sha256,
+            &package.blob,
+            &package.tree,
+            &package.evidence,
+            &package.commit,
+            &package.registry_index_sha256,
+            &package.evidence_identity,
+            ArchiveLimits::default(),
+        )?;
+        if cached.commit.verification_sha256 != package.verification_sha256 {
+            return Err(StoreError::new(
+                "vendor_evidence_selector_mismatch",
+                "vendor package path does not match its exact verification digest",
+            ));
+        }
+        Ok(Some(cached))
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct VendorLimits {
+    max_packages: usize,
+    max_bytes: u64,
+}
+
+impl Default for VendorLimits {
+    fn default() -> Self {
+        Self {
+            max_packages: MAX_VENDOR_PACKAGES,
+            max_bytes: MAX_VENDOR_BYTES,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PackageStore {
+    root: PathBuf,
+    limits: ArchiveLimits,
+    vendor_limits: VendorLimits,
+}
+
+impl PackageStore {
+    /// Open a project-relative cache root without following configured path
+    /// components beneath the trusted anchor.
+    pub fn open_anchored(anchor: &Path, configured: &Path) -> Result<Self, StoreError> {
+        let root = secure_anchored_root(anchor, configured, true)?;
+        Self::with_limits(&root, ArchiveLimits::default())
+    }
+
+    /// Create and validate a configured root beneath a trusted anchor.
+    pub fn prepare_anchored_root(anchor: &Path, configured: &Path) -> Result<PathBuf, StoreError> {
+        secure_anchored_root(anchor, configured, true)
+    }
+
+    /// Validate an existing configured root beneath a trusted anchor.
+    pub fn require_anchored_root(anchor: &Path, configured: &Path) -> Result<PathBuf, StoreError> {
+        secure_anchored_root(anchor, configured, false)
+    }
+
+    pub fn open(root: &Path) -> Result<Self, StoreError> {
+        Self::with_limits(root, ArchiveLimits::default())
+    }
+
+    pub fn with_limits(root: &Path, limits: ArchiveLimits) -> Result<Self, StoreError> {
+        ensure_directory_tree(root)?;
+        for relative in [
+            "blobs/sha256",
+            "trees/axiom-package-extractor-v1/sha256",
+            "evidence/sha256",
+            "commits/sha256",
+            ".transactions",
+        ] {
+            ensure_directory_tree(&root.join(relative))?;
+        }
+        Ok(Self {
+            root: root.to_path_buf(),
+            limits,
+            vendor_limits: VendorLimits::default(),
+        })
+    }
+
+    pub fn admit(&self, artifacts: VerifiedArtifacts<'_>) -> Result<CachedPackage, StoreError> {
+        let parsed = parse_archive(artifacts.archive, artifacts.archive_sha256, self.limits)?;
+        let registry_index_sha256 = sha256_hex(artifacts.registry_index);
+        let verification_sha256 = sha256_hex(artifacts.verification);
+        let evidence_identity = evidence_identity(&registry_index_sha256, &verification_sha256);
+        let transaction = unique_transaction(&self.root.join(".transactions"), "admit")?;
+        let result = (|| {
+            let blob = transaction.join("blob");
+            write_new_file(&blob, artifacts.archive)?;
+            let tree = transaction.join("tree");
+            let integrity = extract_archive(&parsed, &tree)?;
+            let evidence = transaction.join("evidence");
+            create_synced_directory(&evidence)?;
+            write_new_file(
+                &evidence.join("integrity.json"),
+                &integrity_manifest_bytes(&integrity)?,
+            )?;
+            write_new_file(&evidence.join("manifest"), artifacts.manifest)?;
+            write_new_file(&evidence.join("provenance"), artifacts.provenance)?;
+            write_new_file(&evidence.join("signature"), artifacts.signature)?;
+            write_new_file(&evidence.join("registry-index"), artifacts.registry_index)?;
+            write_new_file(&evidence.join("verification"), artifacts.verification)?;
+            sync_directory(&evidence)?;
+
+            let commit = build_commit(&integrity, artifacts);
+            let commit_bytes = canonical_json_bytes(&commit)?;
+            write_new_file(&transaction.join("commit.json"), &commit_bytes)?;
+            let digest = artifacts.archive_sha256;
+            let final_blob = self.blob_path(digest);
+            let final_tree = self.tree_path(digest);
+            ensure_directory_tree(&self.evidence_archive_path(digest))?;
+            ensure_directory_tree(&self.commit_archive_path(digest))?;
+            ensure_directory_tree(&self.commit_index_path(digest, &registry_index_sha256))?;
+            let final_evidence = self.evidence_path(digest, &evidence_identity);
+            let final_commit = self.commit_path(digest, &registry_index_sha256, &evidence_identity);
+            publish_file(&blob, &final_blob, artifacts.archive)?;
+            publish_directory(&tree, &final_tree)?;
+            verify_tree_with_limits(&final_tree, &integrity, self.limits)?;
+            publish_directory(&evidence, &final_evidence)?;
+            verify_evidence_directory(&final_evidence)?;
+            // The commit is the admission marker and is deliberately published last.
+            publish_file(
+                &transaction.join("commit.json"),
+                &final_commit,
+                &commit_bytes,
+            )?;
+            self.load_verified_identity(digest, &registry_index_sha256, &evidence_identity)
+        })();
+        finish_transaction(result, &transaction)
+    }
+
+    pub fn load_verified(&self, archive_sha256: &str) -> Result<CachedPackage, StoreError> {
+        validate_digest(archive_sha256)?;
+        let versions = self.evidence_versions(archive_sha256)?;
+        if versions.len() != 1 {
+            return Err(StoreError::new(
+                if versions.is_empty() {
+                    "cache_evidence_unavailable"
+                } else {
+                    "cache_evidence_ambiguous"
+                },
+                format!(
+                    "archive {archive_sha256} has {} committed evidence versions; select an exact registry index",
+                    versions.len()
+                ),
+            ));
+        }
+        self.load_verified_identity(archive_sha256, &versions[0].0, &versions[0].1)
+    }
+
+    pub fn load_verified_for_index(
+        &self,
+        archive_sha256: &str,
+        registry_index_sha256: &str,
+    ) -> Result<CachedPackage, StoreError> {
+        validate_digest(archive_sha256)?;
+        validate_digest(registry_index_sha256)?;
+        let identities = self.evidence_versions_for_index(archive_sha256, registry_index_sha256)?;
+        if identities.len() != 1 {
+            return Err(StoreError::new(
+                if identities.is_empty() {
+                    "cache_evidence_unavailable"
+                } else {
+                    "cache_evidence_ambiguous"
+                },
+                format!(
+                    "archive {archive_sha256} has {} evidence versions for registry index {registry_index_sha256}",
+                    identities.len()
+                ),
+            ));
+        }
+        self.load_verified_identity(archive_sha256, registry_index_sha256, &identities[0])
+    }
+
+    pub fn load_verified_exact(
+        &self,
+        archive_sha256: &str,
+        registry_index_sha256: &str,
+        verification_sha256: &str,
+    ) -> Result<CachedPackage, StoreError> {
+        validate_digest(archive_sha256)?;
+        validate_digest(registry_index_sha256)?;
+        validate_digest(verification_sha256)?;
+        self.load_verified_identity(
+            archive_sha256,
+            registry_index_sha256,
+            &evidence_identity(registry_index_sha256, verification_sha256),
+        )
+    }
+
+    fn load_verified_identity(
+        &self,
+        archive_sha256: &str,
+        registry_index_sha256: &str,
+        identity: &str,
+    ) -> Result<CachedPackage, StoreError> {
+        validate_digest(identity)?;
+        load_package_from_paths(
+            archive_sha256,
+            &self.blob_path(archive_sha256),
+            &self.tree_path(archive_sha256),
+            &self.evidence_path(archive_sha256, identity),
+            &self.commit_path(archive_sha256, registry_index_sha256, identity),
+            registry_index_sha256,
+            identity,
+            self.limits,
+        )
+    }
+
+    pub fn vendor_snapshot(
+        &self,
+        vendor_root: &Path,
+        packages: &[VendorPackage<'_>],
+    ) -> Result<VendorSnapshot, StoreError> {
+        let expected = canonical_expected_packages(packages, self.vendor_limits)?;
+        ensure_directory_tree(vendor_root)?;
+        ensure_directory_tree(&vendor_root.join("snapshots/sha256"))?;
+        ensure_directory_tree(&vendor_root.join(".transactions"))?;
+        let transaction = unique_transaction(&vendor_root.join(".transactions"), "vendor")?;
+        let result = (|| {
+            let snapshot = transaction.join("snapshot");
+            create_synced_directory(&snapshot)?;
+            let package_root = snapshot.join("packages/sha256");
+            ensure_directory_tree(&package_root)?;
+
+            let mut records = Vec::with_capacity(expected.len());
+            let mut budget = VendorBudget::new(self.vendor_limits, expected.len())?;
+            let mut copied_digests = BTreeSet::new();
+            let mut copied_evidence = BTreeSet::new();
+            for (package_id, archive_sha256, registry_index_sha256, verification_sha256) in
+                &expected
+            {
+                let package = self.load_verified_exact(
+                    archive_sha256,
+                    registry_index_sha256,
+                    verification_sha256,
+                )?;
+                let identity = evidence_identity(registry_index_sha256, verification_sha256);
+                let new_archive = copied_digests.insert(archive_sha256.clone());
+                let new_evidence =
+                    copied_evidence.insert((archive_sha256.clone(), identity.clone()));
+                budget.account_package(&package, new_archive, new_evidence)?;
+                records.push(VendorManifestPackage {
+                    package_id: package_id.clone(),
+                    content_key: format!("sha256:{archive_sha256}"),
+                    archive_sha256: archive_sha256.clone(),
+                    registry_index_sha256: registry_index_sha256.clone(),
+                    verification_sha256: verification_sha256.clone(),
+                    evidence_identity: identity.clone(),
+                    tree_manifest_sha256: package.commit.tree_manifest_sha256.clone(),
+                });
+
+                let artifacts = package.verified_artifacts()?;
+                let destination = package_root.join(&package.archive_sha256);
+                if new_archive {
+                    create_synced_directory(&destination)?;
+                    write_new_file(&destination.join("archive"), artifacts.archive)?;
+                    let parsed =
+                        parse_archive(artifacts.archive, &package.archive_sha256, self.limits)?;
+                    extract_archive(&parsed, &destination.join("tree"))?;
+                    create_synced_directory(&destination.join("evidence"))?;
+                    create_synced_directory(&destination.join("commits"))?;
+                }
+                if new_evidence {
+                    let evidence = destination.join("evidence").join(&identity);
+                    create_synced_directory(&evidence)?;
+                    write_new_file(
+                        &evidence.join("integrity.json"),
+                        &integrity_manifest_bytes(&package.integrity)?,
+                    )?;
+                    write_new_file(&evidence.join("manifest"), artifacts.manifest)?;
+                    write_new_file(&evidence.join("provenance"), artifacts.provenance)?;
+                    write_new_file(&evidence.join("signature"), artifacts.signature)?;
+                    write_new_file(&evidence.join("registry-index"), artifacts.registry_index)?;
+                    write_new_file(&evidence.join("verification"), artifacts.verification)?;
+                    write_new_file(
+                        &destination.join("commits").join(format!("{identity}.json")),
+                        &canonical_json_bytes(&package.commit)?,
+                    )?;
+                    sync_directory(&evidence)?;
+                    sync_directory(&destination.join("evidence"))?;
+                    sync_directory(&destination.join("commits"))?;
+                }
+                sync_directory(&destination)?;
+            }
+            sync_directory(&package_root)?;
+            sync_directory(&snapshot.join("packages"))?;
+
+            let manifest = VendorManifest {
+                schema_version: VENDOR_MANIFEST_SCHEMA.to_owned(),
+                packages: records,
+            };
+            let manifest_bytes = canonical_json_bytes(&manifest)?;
+            budget.account_bytes(manifest_bytes.len() as u64)?;
+            write_new_file(&snapshot.join("vendor-manifest.json"), &manifest_bytes)?;
+            sync_directory(&snapshot)?;
+            let digest = sha256_hex(&manifest_bytes);
+            let final_snapshot = vendor_root.join("snapshots/sha256").join(&digest);
+            publish_directory(&snapshot, &final_snapshot)?;
+            let verified =
+                verify_vendor_snapshot_at(&final_snapshot, &digest, &expected, self.vendor_limits)?;
+            atomic_replace_file(
+                &vendor_root.join("CURRENT"),
+                format!("{digest}\n").as_bytes(),
+            )?;
+            Ok(verified)
+        })();
+        finish_transaction(result, &transaction)
+    }
+
+    /// Rehash the current snapshot and require the caller's exact locked
+    /// registry package IDs and archive digests.
+    pub fn verify_vendor_snapshot(
+        vendor_root: &Path,
+        expected_packages: &[VendorPackage<'_>],
+    ) -> Result<VendorSnapshot, StoreError> {
+        let limits = VendorLimits::default();
+        let expected = canonical_expected_packages(expected_packages, limits)?;
+        let current = read_regular_file(&vendor_root.join("CURRENT"), 65)?;
+        let current = std::str::from_utf8(&current)
+            .map_err(|_| StoreError::new("vendor_current_invalid", "CURRENT is not UTF-8"))?;
+        let digest = current.strip_suffix('\n').ok_or_else(|| {
+            StoreError::new(
+                "vendor_current_invalid",
+                "CURRENT must end in one canonical newline",
+            )
+        })?;
+        validate_digest(digest)?;
+        let root = vendor_root.join("snapshots/sha256").join(digest);
+        verify_vendor_snapshot_at(&root, digest, &expected, limits)
+    }
+
+    pub fn verify_vendor_snapshot_exact(
+        vendor_root: &Path,
+        expected_packages: &[VendorPackage<'_>],
+    ) -> Result<VendorSnapshot, StoreError> {
+        Self::verify_vendor_snapshot(vendor_root, expected_packages)
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    fn blob_path(&self, digest: &str) -> PathBuf {
+        self.root.join("blobs/sha256").join(digest)
+    }
+
+    fn tree_path(&self, digest: &str) -> PathBuf {
+        self.root
+            .join("trees")
+            .join(EXTRACTOR_VERSION)
+            .join("sha256")
+            .join(digest)
+    }
+
+    fn evidence_archive_path(&self, digest: &str) -> PathBuf {
+        self.root.join("evidence/sha256").join(digest)
+    }
+
+    fn evidence_path(&self, digest: &str, identity: &str) -> PathBuf {
+        self.evidence_archive_path(digest).join(identity)
+    }
+
+    fn commit_archive_path(&self, digest: &str) -> PathBuf {
+        self.root.join("commits/sha256").join(digest)
+    }
+
+    fn commit_index_path(&self, digest: &str, registry_index_sha256: &str) -> PathBuf {
+        self.commit_archive_path(digest).join(registry_index_sha256)
+    }
+
+    fn commit_path(&self, digest: &str, registry_index_sha256: &str, identity: &str) -> PathBuf {
+        self.commit_index_path(digest, registry_index_sha256)
+            .join(format!("{identity}.json"))
+    }
+
+    fn evidence_versions(&self, digest: &str) -> Result<Vec<(String, String)>, StoreError> {
+        let directory = self.commit_archive_path(digest);
+        match fs::symlink_metadata(&directory) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(error) => {
+                return Err(StoreError::new(
+                    "cache_evidence_unavailable",
+                    format!("failed to stat {}: {error}", directory.display()),
+                ));
+            }
+            Ok(_) => require_safe_directory(&directory)?,
+        }
+        let mut versions = Vec::new();
+        for entry in fs::read_dir(&directory).map_err(|error| {
+            StoreError::new(
+                "cache_evidence_unavailable",
+                format!("failed to read {}: {error}", directory.display()),
+            )
+        })? {
+            let entry = entry.map_err(|error| {
+                StoreError::new("cache_evidence_unavailable", error.to_string())
+            })?;
+            let index = entry.file_name().into_string().map_err(|_| {
+                StoreError::new(
+                    "cache_evidence_invalid",
+                    "commit index directory is not UTF-8",
+                )
+            })?;
+            validate_digest(&index)?;
+            for identity in self.evidence_versions_for_index(digest, &index)? {
+                versions.push((index.clone(), identity));
+                if versions.len() > 1 {
+                    return Ok(versions);
+                }
+            }
+        }
+        versions.sort();
+        versions.dedup();
+        Ok(versions)
+    }
+
+    fn evidence_versions_for_index(
+        &self,
+        digest: &str,
+        registry_index_sha256: &str,
+    ) -> Result<Vec<String>, StoreError> {
+        let directory = self.commit_index_path(digest, registry_index_sha256);
+        match fs::symlink_metadata(&directory) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(error) => {
+                return Err(StoreError::new(
+                    "cache_evidence_unavailable",
+                    format!("failed to stat {}: {error}", directory.display()),
+                ));
+            }
+            Ok(_) => require_safe_directory(&directory)?,
+        }
+        let mut identities = Vec::new();
+        for entry in fs::read_dir(&directory).map_err(|error| {
+            StoreError::new(
+                "cache_evidence_unavailable",
+                format!("failed to read {}: {error}", directory.display()),
+            )
+        })? {
+            let entry = entry.map_err(|error| {
+                StoreError::new("cache_evidence_unavailable", error.to_string())
+            })?;
+            let name = entry.file_name().into_string().map_err(|_| {
+                StoreError::new(
+                    "cache_evidence_invalid",
+                    "commit version filename is not UTF-8",
+                )
+            })?;
+            let identity = name.strip_suffix(".json").ok_or_else(|| {
+                StoreError::new(
+                    "cache_evidence_invalid",
+                    format!("unexpected commit entry {name:?}"),
+                )
+            })?;
+            validate_digest(identity)?;
+            let metadata = fs::symlink_metadata(entry.path()).map_err(|error| {
+                StoreError::new("cache_evidence_unavailable", error.to_string())
+            })?;
+            if metadata.file_type().is_symlink() || !metadata.is_file() {
+                return Err(StoreError::new(
+                    "cache_evidence_invalid",
+                    format!("commit version {name:?} is not a regular file"),
+                ));
+            }
+            identities.push(identity.to_owned());
+            if identities.len() > 1 {
+                return Ok(identities);
+            }
+        }
+        identities.sort();
+        identities.dedup();
+        Ok(identities)
+    }
+}
+
+type ExpectedVendorPackage = (String, String, String, String);
+
+struct VendorBudget {
+    limits: VendorLimits,
+    bytes: u64,
+}
+
+impl VendorBudget {
+    fn new(limits: VendorLimits, packages: usize) -> Result<Self, StoreError> {
+        if packages > limits.max_packages {
+            return Err(StoreError::new(
+                "vendor_package_count_exceeded",
+                format!(
+                    "vendor snapshot requests {packages} packages; limit is {}",
+                    limits.max_packages
+                ),
+            ));
+        }
+        Ok(Self { limits, bytes: 0 })
+    }
+
+    fn account_bytes(&mut self, bytes: u64) -> Result<(), StoreError> {
+        self.bytes = self.bytes.checked_add(bytes).ok_or_else(|| {
+            StoreError::new(
+                "vendor_total_bytes_exceeded",
+                "vendor snapshot byte count overflowed",
+            )
+        })?;
+        if self.bytes > self.limits.max_bytes {
+            return Err(StoreError::new(
+                "vendor_total_bytes_exceeded",
+                format!(
+                    "vendor snapshot requires {} bytes; limit is {}",
+                    self.bytes, self.limits.max_bytes
+                ),
+            ));
+        }
+        Ok(())
+    }
+
+    fn account_package(
+        &mut self,
+        package: &CachedPackage,
+        new_archive: bool,
+        new_evidence: bool,
+    ) -> Result<(), StoreError> {
+        if new_archive {
+            let tree_bytes = package
+                .integrity
+                .files
+                .iter()
+                .try_fold(0u64, |total, file| {
+                    total.checked_add(file.length).ok_or_else(|| {
+                        StoreError::new(
+                            "vendor_total_bytes_exceeded",
+                            "vendor tree byte count overflowed",
+                        )
+                    })
+                })?;
+            self.account_bytes(package.commit.archive_length)?;
+            self.account_bytes(tree_bytes)?;
+        }
+        if new_evidence {
+            let integrity_bytes = integrity_manifest_bytes(&package.integrity)?.len() as u64;
+            let commit_bytes = canonical_json_bytes(&package.commit)?.len() as u64;
+            let evidence_bytes = [
+                package.artifacts.manifest.len(),
+                package.artifacts.provenance.len(),
+                package.artifacts.signature.len(),
+                package.artifacts.registry_index.len(),
+                package.artifacts.verification.len(),
+            ]
+            .into_iter()
+            .try_fold(0u64, |total, length| {
+                total.checked_add(length as u64).ok_or_else(|| {
+                    StoreError::new(
+                        "vendor_total_bytes_exceeded",
+                        "vendor evidence byte count overflowed",
+                    )
+                })
+            })?;
+            self.account_bytes(integrity_bytes)?;
+            self.account_bytes(commit_bytes)?;
+            self.account_bytes(evidence_bytes)?;
+        }
+        Ok(())
+    }
+}
+
+fn verify_vendor_snapshot_at(
+    root: &Path,
+    digest: &str,
+    expected: &[ExpectedVendorPackage],
+    limits: VendorLimits,
+) -> Result<VendorSnapshot, StoreError> {
+    validate_digest(digest)?;
+    require_safe_directory(root)?;
+    let manifest_bytes = read_regular_file(&root.join("vendor-manifest.json"), MAX_EVIDENCE_BYTES)?;
+    if sha256_hex(&manifest_bytes) != digest {
+        return Err(StoreError::new(
+            "vendor_manifest_digest_mismatch",
+            "snapshot path does not name the exact vendor manifest bytes",
+        ));
+    }
+    let manifest: VendorManifest = parse_json_exact(&manifest_bytes, "vendor_manifest_invalid")?;
+    if canonical_json_bytes(&manifest)? != manifest_bytes {
+        return Err(StoreError::new(
+            "vendor_manifest_noncanonical",
+            "vendor manifest is not the canonical byte representation",
+        ));
+    }
+    let mut budget = VendorBudget::new(limits, manifest.packages.len())?;
+    budget.account_bytes(manifest_bytes.len() as u64)?;
+    validate_vendor_manifest(&manifest, expected)?;
+    verify_vendor_layout(root, &manifest)?;
+
+    let mut seen_archives = BTreeSet::new();
+    let mut seen_evidence = BTreeSet::new();
+    let mut packages = BTreeMap::new();
+    for record in &manifest.packages {
+        let paths = vendor_package_paths(root, record);
+        let package = load_package_from_paths(
+            &record.archive_sha256,
+            &paths.blob,
+            &paths.tree,
+            &paths.evidence,
+            &paths.commit,
+            &record.registry_index_sha256,
+            &record.evidence_identity,
+            ArchiveLimits::default(),
+        )?;
+        if package.commit.tree_manifest_sha256 != record.tree_manifest_sha256 {
+            return Err(StoreError::new(
+                "vendor_tree_manifest_mismatch",
+                format!(
+                    "vendor record for {:?} does not bind its exact tree",
+                    record.package_id
+                ),
+            ));
+        }
+        if package.commit.registry_index_sha256 != record.registry_index_sha256
+            || package.commit.verification_sha256 != record.verification_sha256
+        {
+            return Err(StoreError::new(
+                "vendor_evidence_selector_mismatch",
+                format!(
+                    "vendor record for {:?} does not bind its exact evidence selector",
+                    record.package_id
+                ),
+            ));
+        }
+        let new_archive = seen_archives.insert(record.archive_sha256.clone());
+        let new_evidence = seen_evidence.insert((
+            record.archive_sha256.clone(),
+            record.evidence_identity.clone(),
+        ));
+        budget.account_package(&package, new_archive, new_evidence)?;
+        packages.insert(record.package_id.clone(), paths);
+    }
+    Ok(VendorSnapshot {
+        digest: digest.to_owned(),
+        root: root.to_path_buf(),
+        manifest,
+        packages,
+    })
+}
+
+fn vendor_package_paths(root: &Path, record: &VendorManifestPackage) -> VendorPackagePaths {
+    let package_root = root.join("packages/sha256").join(&record.archive_sha256);
+    VendorPackagePaths {
+        archive_sha256: record.archive_sha256.clone(),
+        registry_index_sha256: record.registry_index_sha256.clone(),
+        verification_sha256: record.verification_sha256.clone(),
+        evidence_identity: record.evidence_identity.clone(),
+        blob: package_root.join("archive"),
+        tree: package_root.join("tree"),
+        evidence: package_root
+            .join("evidence")
+            .join(&record.evidence_identity),
+        commit: package_root
+            .join("commits")
+            .join(format!("{}.json", record.evidence_identity)),
+    }
+}
+
+fn build_commit(
+    integrity: &TreeIntegrityManifest,
+    artifacts: VerifiedArtifacts<'_>,
+) -> CacheCommit {
+    CacheCommit {
+        schema_version: CACHE_COMMIT_SCHEMA.to_owned(),
+        extractor_version: EXTRACTOR_VERSION.to_owned(),
+        archive_sha256: artifacts.archive_sha256.to_owned(),
+        archive_length: artifacts.archive.len() as u64,
+        tree_manifest_sha256: integrity_manifest_sha256(integrity)
+            .expect("validated integrity manifest must serialize"),
+        manifest_sha256: sha256_hex(artifacts.manifest),
+        provenance_sha256: sha256_hex(artifacts.provenance),
+        signature_sha256: sha256_hex(artifacts.signature),
+        registry_index_sha256: sha256_hex(artifacts.registry_index),
+        verification_sha256: sha256_hex(artifacts.verification),
+    }
+}
+
+fn load_package_from_paths(
+    archive_sha256: &str,
+    blob_path: &Path,
+    tree_path: &Path,
+    evidence_path: &Path,
+    commit_path: &Path,
+    expected_registry_index_sha256: &str,
+    expected_evidence_identity: &str,
+    limits: ArchiveLimits,
+) -> Result<CachedPackage, StoreError> {
+    validate_digest(archive_sha256)?;
+    verify_evidence_directory(evidence_path)?;
+    let artifacts = read_artifacts(blob_path, evidence_path, limits)?;
+    let archive = &artifacts.archive;
+    let parsed_archive = parse_archive(archive, archive_sha256, limits)?;
+    let signed_integrity = expected_tree_integrity(&parsed_archive)?;
+    let integrity_bytes =
+        read_regular_file(&evidence_path.join("integrity.json"), MAX_EVIDENCE_BYTES)?;
+    let integrity: TreeIntegrityManifest =
+        parse_json_exact(&integrity_bytes, "integrity_manifest_invalid")?;
+    if integrity_manifest_bytes(&integrity)? != integrity_bytes {
+        return Err(StoreError::new(
+            "integrity_manifest_noncanonical",
+            "integrity.json is not the canonical byte representation",
+        ));
+    }
+    if integrity != signed_integrity {
+        return Err(StoreError::new(
+            "archive_tree_binding_mismatch",
+            "tree integrity manifest is not derived from the exact signed archive bytes",
+        ));
+    }
+    verify_tree(tree_path, &signed_integrity)?;
+
+    let commit_bytes = read_regular_file(commit_path, MAX_EVIDENCE_BYTES)?;
+    let commit: CacheCommit = parse_json_exact(&commit_bytes, "cache_commit_invalid")?;
+    if canonical_json_bytes(&commit)? != commit_bytes {
+        return Err(StoreError::new(
+            "cache_commit_noncanonical",
+            "cache commit is not the canonical byte representation",
+        ));
+    }
+    let expected = CacheCommit {
+        schema_version: CACHE_COMMIT_SCHEMA.to_owned(),
+        extractor_version: EXTRACTOR_VERSION.to_owned(),
+        archive_sha256: archive_sha256.to_owned(),
+        archive_length: artifacts.archive.len() as u64,
+        tree_manifest_sha256: integrity_manifest_sha256(&signed_integrity)?,
+        manifest_sha256: sha256_hex(&artifacts.manifest),
+        provenance_sha256: sha256_hex(&artifacts.provenance),
+        signature_sha256: sha256_hex(&artifacts.signature),
+        registry_index_sha256: sha256_hex(&artifacts.registry_index),
+        verification_sha256: sha256_hex(&artifacts.verification),
+    };
+    if commit != expected {
+        return Err(StoreError::new(
+            "cache_commit_mismatch",
+            "cache commit does not bind the exact blob, tree, and evidence bytes",
+        ));
+    }
+    if commit.registry_index_sha256 != expected_registry_index_sha256 {
+        return Err(StoreError::new(
+            "cache_registry_index_mismatch",
+            "cache commit is stored under a different registry index",
+        ));
+    }
+    if evidence_identity(&commit.registry_index_sha256, &commit.verification_sha256)
+        != expected_evidence_identity
+    {
+        return Err(StoreError::new(
+            "cache_evidence_identity_mismatch",
+            "cache evidence path does not bind its exact index and verification bytes",
+        ));
+    }
+    Ok(CachedPackage {
+        archive_sha256: archive_sha256.to_owned(),
+        blob: blob_path.to_path_buf(),
+        tree: tree_path.to_path_buf(),
+        evidence: evidence_path.to_path_buf(),
+        integrity: signed_integrity,
+        commit,
+        artifacts,
+    })
+}
+
+fn read_artifacts(
+    blob_path: &Path,
+    evidence_path: &Path,
+    limits: ArchiveLimits,
+) -> Result<RehashedArtifacts, StoreError> {
+    Ok(RehashedArtifacts {
+        archive: read_regular_file(blob_path, limits.max_archive_bytes)?,
+        manifest: read_regular_file(&evidence_path.join("manifest"), MAX_EVIDENCE_BYTES)?,
+        provenance: read_regular_file(&evidence_path.join("provenance"), MAX_EVIDENCE_BYTES)?,
+        signature: read_regular_file(&evidence_path.join("signature"), MAX_EVIDENCE_BYTES)?,
+        registry_index: read_regular_file(
+            &evidence_path.join("registry-index"),
+            MAX_EVIDENCE_BYTES,
+        )?,
+        verification: read_regular_file(&evidence_path.join("verification"), MAX_EVIDENCE_BYTES)?,
+    })
+}
+
+fn validate_vendor_manifest(
+    manifest: &VendorManifest,
+    expected: &[ExpectedVendorPackage],
+) -> Result<(), StoreError> {
+    if manifest.schema_version != VENDOR_MANIFEST_SCHEMA {
+        return Err(StoreError::new(
+            "vendor_manifest_version_invalid",
+            "unsupported vendor manifest schema",
+        ));
+    }
+    let mut actual = Vec::with_capacity(manifest.packages.len());
+    let mut previous: Option<&str> = None;
+    for package in &manifest.packages {
+        if package.package_id.is_empty()
+            || previous.is_some_and(|value| value >= package.package_id.as_str())
+        {
+            return Err(StoreError::new(
+                "vendor_manifest_order_invalid",
+                "vendor package IDs must be nonempty and strictly sorted",
+            ));
+        }
+        validate_digest(&package.archive_sha256)?;
+        validate_digest(&package.registry_index_sha256)?;
+        validate_digest(&package.verification_sha256)?;
+        validate_digest(&package.evidence_identity)?;
+        validate_digest(&package.tree_manifest_sha256)?;
+        if package.content_key != format!("sha256:{}", package.archive_sha256) {
+            return Err(StoreError::new(
+                "vendor_content_key_invalid",
+                "vendor content key does not match archive digest",
+            ));
+        }
+        if package.evidence_identity
+            != evidence_identity(&package.registry_index_sha256, &package.verification_sha256)
+        {
+            return Err(StoreError::new(
+                "vendor_evidence_identity_invalid",
+                "vendor evidence identity does not match its exact index and verification digests",
+            ));
+        }
+        actual.push((
+            package.package_id.clone(),
+            package.archive_sha256.clone(),
+            package.registry_index_sha256.clone(),
+            package.verification_sha256.clone(),
+        ));
+        previous = Some(&package.package_id);
+    }
+    if actual != expected {
+        return Err(StoreError::new(
+            "vendor_lock_mismatch",
+            "vendor snapshot does not exactly match expected locked registry packages",
+        ));
+    }
+    Ok(())
+}
+
+fn canonical_expected_packages(
+    packages: &[VendorPackage<'_>],
+    limits: VendorLimits,
+) -> Result<Vec<ExpectedVendorPackage>, StoreError> {
+    if packages.len() > limits.max_packages {
+        return Err(StoreError::new(
+            "vendor_package_count_exceeded",
+            format!(
+                "vendor snapshot requests {} packages; limit is {}",
+                packages.len(),
+                limits.max_packages
+            ),
+        ));
+    }
+    let mut expected = Vec::with_capacity(packages.len());
+    let mut ids = BTreeSet::new();
+    for package in packages {
+        if package.package_id.is_empty() || !ids.insert(package.package_id) {
+            return Err(StoreError::new(
+                "vendor_package_invalid",
+                "vendor package IDs must be nonempty and unique",
+            ));
+        }
+        validate_digest(package.archive_sha256)?;
+        validate_digest(package.registry_index_sha256)?;
+        validate_digest(package.verification_sha256)?;
+        expected.push((
+            package.package_id.to_owned(),
+            package.archive_sha256.to_owned(),
+            package.registry_index_sha256.to_owned(),
+            package.verification_sha256.to_owned(),
+        ));
+    }
+    expected.sort();
+    Ok(expected)
+}
+
+fn verify_vendor_layout(root: &Path, manifest: &VendorManifest) -> Result<(), StoreError> {
+    verify_directory_names(root, &["packages", "vendor-manifest.json"])?;
+    let packages = root.join("packages");
+    verify_directory_names(&packages, &["sha256"])?;
+    let mut evidence_by_digest = BTreeMap::<&str, BTreeSet<&str>>::new();
+    for package in &manifest.packages {
+        evidence_by_digest
+            .entry(&package.archive_sha256)
+            .or_default()
+            .insert(&package.evidence_identity);
+    }
+    let digest_names = evidence_by_digest.keys().copied().collect::<Vec<_>>();
+    verify_directory_names(&packages.join("sha256"), &digest_names)?;
+    for (digest, identities) in evidence_by_digest {
+        let package_root = packages.join("sha256").join(digest);
+        verify_directory_names(&package_root, &["archive", "commits", "evidence", "tree"])?;
+        let identity_names = identities.iter().copied().collect::<Vec<_>>();
+        verify_directory_names(&package_root.join("evidence"), &identity_names)?;
+        let commit_names = identities
+            .iter()
+            .map(|identity| format!("{identity}.json"))
+            .collect::<Vec<_>>();
+        let commit_name_refs = commit_names.iter().map(String::as_str).collect::<Vec<_>>();
+        verify_directory_names(&package_root.join("commits"), &commit_name_refs)?;
+    }
+    Ok(())
+}
+
+fn verify_directory_names(path: &Path, expected: &[&str]) -> Result<(), StoreError> {
+    require_safe_directory(path)?;
+    let mut remaining = expected.iter().copied().collect::<BTreeSet<_>>();
+    if remaining.len() != expected.len() {
+        return Err(StoreError::new(
+            "store_expected_entry_set_invalid",
+            format!("expected entry names for {} are not unique", path.display()),
+        ));
+    }
+    let entries = fs::read_dir(path).map_err(|error| {
+        StoreError::new(
+            "store_directory_unavailable",
+            format!("failed to read {}: {error}", path.display()),
+        )
+    })?;
+    for entry in entries {
+        let name = entry
+            .map_err(|error| StoreError::new("store_directory_unavailable", error.to_string()))?
+            .file_name()
+            .into_string()
+            .map_err(|_| {
+                StoreError::new(
+                    "store_entry_invalid",
+                    format!("{} contains a non-UTF-8 entry", path.display()),
+                )
+            })?;
+        if !remaining.remove(name.as_str()) {
+            return Err(StoreError::new(
+                "store_entry_set_mismatch",
+                format!("{} has missing or unexpected entries", path.display()),
+            ));
+        }
+    }
+    if !remaining.is_empty() {
+        return Err(StoreError::new(
+            "store_entry_set_mismatch",
+            format!("{} has missing or unexpected entries", path.display()),
+        ));
+    }
+    Ok(())
+}
+
+fn canonical_json_bytes<T: Serialize>(value: &T) -> Result<Vec<u8>, StoreError> {
+    let mut bytes = serde_json::to_vec(value).map_err(|error| {
+        StoreError::new(
+            "canonical_json_failed",
+            format!("failed to serialize store record: {error}"),
+        )
+    })?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+fn parse_json_exact<T: DeserializeOwned>(
+    bytes: &[u8],
+    code: &'static str,
+) -> Result<T, StoreError> {
+    serde_json::from_slice(bytes)
+        .map_err(|error| StoreError::new(code, format!("invalid JSON record: {error}")))
+}
+
+fn validate_digest(digest: &str) -> Result<(), StoreError> {
+    if digest.len() != 64
+        || !digest
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(StoreError::new(
+            "content_digest_invalid",
+            "content digest must be 64 lowercase hexadecimal characters",
+        ));
+    }
+    Ok(())
+}
+
+fn evidence_identity(registry_index_sha256: &str, verification_sha256: &str) -> String {
+    sha256_hex(
+        format!(
+            "axiom-package-evidence-v1\nregistry-index-sha256={registry_index_sha256}\nverification-sha256={verification_sha256}\n"
+        )
+        .as_bytes(),
+    )
+}
+
+fn verify_evidence_directory(path: &Path) -> Result<(), StoreError> {
+    require_safe_directory(path)?;
+    let mut remaining = EVIDENCE_NAMES.into_iter().collect::<BTreeSet<_>>();
+    let entries = fs::read_dir(path).map_err(|error| {
+        StoreError::new(
+            "evidence_unavailable",
+            format!("failed to read {}: {error}", path.display()),
+        )
+    })?;
+    for entry in entries {
+        let name = entry
+            .map_err(|error| StoreError::new("evidence_unavailable", error.to_string()))?
+            .file_name()
+            .into_string()
+            .map_err(|_| {
+                StoreError::new("evidence_entry_invalid", "evidence filename is not UTF-8")
+            })?;
+        if !remaining.remove(name.as_str()) {
+            return Err(StoreError::new(
+                "evidence_set_mismatch",
+                "evidence directory has missing or unexpected entries",
+            ));
+        }
+    }
+    if !remaining.is_empty() {
+        return Err(StoreError::new(
+            "evidence_set_mismatch",
+            "evidence directory has missing or unexpected entries",
+        ));
+    }
+    for name in EVIDENCE_NAMES {
+        let metadata = fs::symlink_metadata(path.join(name)).map_err(|error| {
+            StoreError::new(
+                "evidence_unavailable",
+                format!("failed to stat evidence {name}: {error}"),
+            )
+        })?;
+        if metadata.file_type().is_symlink() || !metadata.is_file() {
+            return Err(StoreError::new(
+                "evidence_entry_invalid",
+                format!("evidence {name} must be a regular non-symlink file"),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn secure_anchored_root(
+    anchor: &Path,
+    configured: &Path,
+    create: bool,
+) -> Result<PathBuf, StoreError> {
+    let relative = if configured.is_absolute() {
+        configured.strip_prefix(anchor).map_err(|_| {
+            StoreError::new(
+                "store_root_escape",
+                format!(
+                    "{} is not beneath trusted anchor {}",
+                    configured.display(),
+                    anchor.display()
+                ),
+            )
+        })?
+    } else {
+        configured
+    };
+    let mut names = Vec::new();
+    for component in relative.components() {
+        match component {
+            Component::Normal(name) => names.push(name.to_owned()),
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(StoreError::new(
+                    "store_root_escape",
+                    format!(
+                        "configured root {:?} escapes trusted anchor {}",
+                        configured,
+                        anchor.display()
+                    ),
+                ));
+            }
+        }
+    }
+    if names.is_empty() {
+        return Err(StoreError::new(
+            "store_root_invalid",
+            "configured root must name a directory beneath the trusted anchor",
+        ));
+    }
+
+    #[cfg(unix)]
+    {
+        secure_anchored_root_unix(anchor, &names, create)
+    }
+    #[cfg(not(unix))]
+    {
+        secure_anchored_root_portable(anchor, &names, create)
+    }
+}
+
+#[cfg(unix)]
+fn secure_anchored_root_unix(
+    anchor: &Path,
+    names: &[std::ffi::OsString],
+    create: bool,
+) -> Result<PathBuf, StoreError> {
+    use std::ffi::CString;
+    use std::os::fd::{AsRawFd, FromRawFd};
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let mut options = OpenOptions::new();
+    options
+        .read(true)
+        .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK);
+    let mut directory = options.open(anchor).map_err(|error| {
+        StoreError::new(
+            "store_root_invalid",
+            format!(
+                "failed to securely open anchor {}: {error}",
+                anchor.display()
+            ),
+        )
+    })?;
+    if !directory
+        .metadata()
+        .map_err(|error| StoreError::new("store_root_invalid", error.to_string()))?
+        .is_dir()
+    {
+        return Err(StoreError::new(
+            "store_root_invalid",
+            format!("trusted anchor {} is not a directory", anchor.display()),
+        ));
+    }
+
+    let mut path = anchor.to_path_buf();
+    for component in names {
+        let name = CString::new(component.as_os_str().as_bytes()).map_err(|_| {
+            StoreError::new(
+                "store_root_invalid",
+                "configured root component contains a NUL byte",
+            )
+        })?;
+        let open_component = |parent: &File| -> std::io::Result<File> {
+            let descriptor = unsafe {
+                libc::openat(
+                    parent.as_raw_fd(),
+                    name.as_ptr(),
+                    libc::O_RDONLY
+                        | libc::O_DIRECTORY
+                        | libc::O_NOFOLLOW
+                        | libc::O_CLOEXEC
+                        | libc::O_NONBLOCK,
+                    0,
+                )
+            };
+            if descriptor < 0 {
+                Err(std::io::Error::last_os_error())
+            } else {
+                Ok(unsafe { File::from_raw_fd(descriptor) })
+            }
+        };
+        let child = match open_component(&directory) {
+            Ok(child) => child,
+            Err(error) if create && error.kind() == std::io::ErrorKind::NotFound => {
+                let created = unsafe { libc::mkdirat(directory.as_raw_fd(), name.as_ptr(), 0o700) };
+                if created != 0 {
+                    let create_error = std::io::Error::last_os_error();
+                    if create_error.kind() != std::io::ErrorKind::AlreadyExists {
+                        return Err(StoreError::new(
+                            "store_directory_create_failed",
+                            format!(
+                                "failed to securely create {:?} beneath {}: {create_error}",
+                                name,
+                                path.display()
+                            ),
+                        ));
+                    }
+                }
+                let child = open_component(&directory).map_err(|error| {
+                    StoreError::new(
+                        "store_root_invalid",
+                        format!(
+                            "failed to securely open {:?} beneath {}: {error}",
+                            name,
+                            path.display()
+                        ),
+                    )
+                })?;
+                child.sync_all().map_err(|error| {
+                    StoreError::new(
+                        "store_sync_failed",
+                        format!(
+                            "failed to sync new directory below {}: {error}",
+                            path.display()
+                        ),
+                    )
+                })?;
+                directory.sync_all().map_err(|error| {
+                    StoreError::new(
+                        "store_sync_failed",
+                        format!("failed to sync {}: {error}", path.display()),
+                    )
+                })?;
+                child
+            }
+            Err(error) => {
+                return Err(StoreError::new(
+                    if error.kind() == std::io::ErrorKind::NotFound {
+                        "store_directory_unavailable"
+                    } else {
+                        "store_root_invalid"
+                    },
+                    format!(
+                        "failed to securely open {:?} beneath {}: {error}",
+                        name,
+                        path.display()
+                    ),
+                ));
+            }
+        };
+        path.push(component);
+        directory = child;
+    }
+    Ok(path)
+}
+
+#[cfg(not(unix))]
+fn secure_anchored_root_portable(
+    anchor: &Path,
+    names: &[std::ffi::OsString],
+    create: bool,
+) -> Result<PathBuf, StoreError> {
+    let mut current = anchor.to_path_buf();
+    require_safe_directory(&current)?;
+    for name in names {
+        current.push(name);
+        match fs::symlink_metadata(&current) {
+            Ok(metadata) => {
+                if unsafe_directory_metadata(&metadata) {
+                    return Err(StoreError::new(
+                        "store_root_invalid",
+                        format!(
+                            "{} is a symlink, reparse point, or non-directory",
+                            current.display()
+                        ),
+                    ));
+                }
+            }
+            Err(error) if create && error.kind() == std::io::ErrorKind::NotFound => {
+                create_synced_directory(&current)?;
+            }
+            Err(error) => {
+                return Err(StoreError::new(
+                    "store_directory_unavailable",
+                    format!("failed to inspect {}: {error}", current.display()),
+                ));
+            }
+        }
+    }
+    Ok(current)
+}
+
+fn unsafe_directory_metadata(metadata: &fs::Metadata) -> bool {
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+        metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 || !metadata.is_dir()
+    }
+    #[cfg(not(windows))]
+    {
+        metadata.file_type().is_symlink() || !metadata.is_dir()
+    }
+}
+
+fn create_synced_directory(path: &Path) -> Result<(), StoreError> {
+    fs::create_dir(path).map_err(|error| {
+        StoreError::new(
+            "store_directory_create_failed",
+            format!("failed to create {}: {error}", path.display()),
+        )
+    })?;
+    sync_directory(path)?;
+    sync_parent_directory(path)
+}
+
+fn ensure_directory_tree(path: &Path) -> Result<(), StoreError> {
+    if let Ok(metadata) = fs::symlink_metadata(path) {
+        if unsafe_directory_metadata(&metadata) {
+            return Err(StoreError::new(
+                "store_directory_invalid",
+                format!("{} is not a safe directory", path.display()),
+            ));
+        }
+        return Ok(());
+    }
+    let parent = path.parent().ok_or_else(|| {
+        StoreError::new(
+            "store_directory_invalid",
+            format!("{} has no parent", path.display()),
+        )
+    })?;
+    if parent != path {
+        ensure_directory_tree(parent)?;
+    }
+    match fs::create_dir(path) {
+        Ok(()) => {
+            sync_directory(path)?;
+            sync_parent_directory(path)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            require_safe_directory(path)
+        }
+        Err(error) => Err(StoreError::new(
+            "store_directory_create_failed",
+            format!("failed to create {}: {error}", path.display()),
+        )),
+    }
+}
+
+fn require_safe_directory(path: &Path) -> Result<(), StoreError> {
+    let metadata = fs::symlink_metadata(path).map_err(|error| {
+        StoreError::new(
+            "store_directory_unavailable",
+            format!("failed to stat {}: {error}", path.display()),
+        )
+    })?;
+    if unsafe_directory_metadata(&metadata) {
+        return Err(StoreError::new(
+            "store_directory_invalid",
+            format!("{} must be a non-symlink directory", path.display()),
+        ));
+    }
+    Ok(())
+}
+
+fn unique_transaction(parent: &Path, prefix: &str) -> Result<PathBuf, StoreError> {
+    require_safe_directory(parent)?;
+    let now = unix_epoch_nanos()?;
+    reap_stale_transactions(parent, now)?;
+    for _ in 0..128 {
+        let sequence = TRANSACTION_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let epoch_nanos = unix_epoch_nanos()?;
+        let pid = std::process::id();
+        let path = parent.join(format!(".{prefix}-{pid}-{epoch_nanos}-{sequence}",));
+        match fs::create_dir(&path) {
+            Ok(()) => {
+                let marker = transaction_marker_bytes(pid, epoch_nanos, sequence);
+                if let Err(error) = write_new_file(&path.join(TRANSACTION_MARKER_NAME), &marker) {
+                    return Err(cleanup_created_transaction(error, &path));
+                }
+                if let Err(error) = sync_directory(&path) {
+                    return Err(cleanup_created_transaction(error, &path));
+                }
+                if let Err(error) = sync_parent_directory(&path) {
+                    return Err(cleanup_created_transaction(error, &path));
+                }
+                return Ok(path);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(StoreError::new(
+                    "store_transaction_create_failed",
+                    format!("failed to create {}: {error}", path.display()),
+                ));
+            }
+        }
+    }
+    Err(StoreError::new(
+        "store_transaction_exhausted",
+        "could not allocate a unique store transaction",
+    ))
+}
+
+fn cleanup_created_transaction(error: StoreError, path: &Path) -> StoreError {
+    match fs::remove_dir_all(path) {
+        Ok(()) => error,
+        Err(cleanup) => StoreError::new(
+            "store_transaction_cleanup_failed",
+            format!(
+                "{error}; additionally failed to clean {}: {cleanup}",
+                path.display()
+            ),
+        ),
+    }
+}
+
+fn unix_epoch_nanos() -> Result<u128, StoreError> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .map_err(|_| {
+            StoreError::new(
+                "store_clock_invalid",
+                "system clock precedes the Unix epoch",
+            )
+        })
+}
+
+fn transaction_marker_bytes(pid: u32, epoch_nanos: u128, sequence: u64) -> Vec<u8> {
+    format!(
+        "{TRANSACTION_MARKER_SCHEMA}\npid={pid}\ncreated_unix_nanos={epoch_nanos}\nsequence={sequence}\n"
+    )
+    .into_bytes()
+}
+
+fn parse_transaction_name(name: &str) -> Option<(u32, u128, u64)> {
+    let name = name.strip_prefix('.')?;
+    let (prefix_and_pid, sequence) = name.rsplit_once('-')?;
+    let (prefix_and_pid, epoch_nanos) = prefix_and_pid.rsplit_once('-')?;
+    let (prefix, pid) = prefix_and_pid.rsplit_once('-')?;
+    if !matches!(prefix, "admit" | "vendor" | "replace") {
+        return None;
+    }
+    Some((
+        pid.parse().ok()?,
+        epoch_nanos.parse().ok()?,
+        sequence.parse().ok()?,
+    ))
+}
+
+fn reap_stale_transactions(parent: &Path, now: u128) -> Result<(), StoreError> {
+    let entries = fs::read_dir(parent).map_err(|error| {
+        StoreError::new(
+            "store_transaction_cleanup_failed",
+            format!(
+                "failed to inspect transactions in {}: {error}",
+                parent.display()
+            ),
+        )
+    })?;
+    let mut bounded_entries = Vec::with_capacity(MAX_TRANSACTION_SCAN_ENTRIES);
+    for entry in entries {
+        if bounded_entries.len() == MAX_TRANSACTION_SCAN_ENTRIES {
+            return Err(StoreError::new(
+                "store_transaction_scan_exceeded",
+                format!(
+                    "{} contains more than {} transaction entries",
+                    parent.display(),
+                    MAX_TRANSACTION_SCAN_ENTRIES
+                ),
+            ));
+        }
+        bounded_entries.push(entry.map_err(|error| {
+            StoreError::new("store_transaction_cleanup_failed", error.to_string())
+        })?);
+    }
+    for entry in bounded_entries {
+        let Ok(name) = entry.file_name().into_string() else {
+            continue;
+        };
+        let Some((pid, epoch_nanos, sequence)) = parse_transaction_name(&name) else {
+            continue;
+        };
+        if now.saturating_sub(epoch_nanos) < STALE_TRANSACTION_AGE_NANOS || process_is_alive(pid) {
+            continue;
+        }
+        let path = entry.path();
+        let Ok(metadata) = fs::symlink_metadata(&path) else {
+            continue;
+        };
+        if metadata.file_type().is_symlink() || !metadata.is_dir() {
+            continue;
+        }
+        let expected = transaction_marker_bytes(pid, epoch_nanos, sequence);
+        let Ok(marker) = read_regular_file(&path.join(TRANSACTION_MARKER_NAME), 256) else {
+            continue;
+        };
+        if marker != expected {
+            continue;
+        }
+        match fs::remove_dir_all(&path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(StoreError::new(
+                    "store_transaction_cleanup_failed",
+                    format!("failed to remove stale {}: {error}", path.display()),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn process_is_alive(pid: u32) -> bool {
+    let Ok(pid) = i32::try_from(pid) else {
+        return true;
+    };
+    let result = unsafe { libc::kill(pid, 0) };
+    result == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+#[cfg(not(unix))]
+fn process_is_alive(_pid: u32) -> bool {
+    false
+}
+
+fn finish_transaction<T>(
+    result: Result<T, StoreError>,
+    transaction: &Path,
+) -> Result<T, StoreError> {
+    match fs::remove_dir_all(transaction) {
+        Ok(()) => result,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => result,
+        Err(cleanup) => match result {
+            Ok(_) => Err(StoreError::new(
+                "store_transaction_cleanup_failed",
+                format!("failed to clean {}: {cleanup}", transaction.display()),
+            )),
+            Err(mut primary) => {
+                primary.message.push_str(&format!(
+                    "; additionally failed to clean {}: {cleanup}",
+                    transaction.display()
+                ));
+                Err(primary)
+            }
+        },
+    }
+}
+
+fn write_new_file(path: &Path, bytes: &[u8]) -> Result<(), StoreError> {
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+        options.mode(0o600);
+    }
+    let mut file = options.open(path).map_err(|error| {
+        StoreError::new(
+            "store_write_failed",
+            format!("failed to create {}: {error}", path.display()),
+        )
+    })?;
+    file.write_all(bytes).map_err(|error| {
+        StoreError::new(
+            "store_write_failed",
+            format!("failed to write {}: {error}", path.display()),
+        )
+    })?;
+    file.sync_all().map_err(|error| {
+        StoreError::new(
+            "store_sync_failed",
+            format!("failed to sync {}: {error}", path.display()),
+        )
+    })
+}
+
+fn read_regular_file(path: &Path, limit: usize) -> Result<Vec<u8>, StoreError> {
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+        let metadata = fs::symlink_metadata(path).map_err(|error| {
+            StoreError::new(
+                "store_file_unavailable",
+                format!("failed to inspect {}: {error}", path.display()),
+            )
+        })?;
+        if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+            return Err(StoreError::new(
+                "store_file_invalid",
+                format!("{} is a reparse point", path.display()),
+            ));
+        }
+    }
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK);
+    }
+    let mut file = options.open(path).map_err(|error| {
+        StoreError::new(
+            "store_file_unavailable",
+            format!("failed to open {}: {error}", path.display()),
+        )
+    })?;
+    let metadata = file.metadata().map_err(|error| {
+        StoreError::new(
+            "store_file_unavailable",
+            format!("failed to stat {}: {error}", path.display()),
+        )
+    })?;
+    if !metadata.is_file() || metadata.len() > limit as u64 {
+        return Err(StoreError::new(
+            "store_file_invalid",
+            format!("{} is not a bounded regular file", path.display()),
+        ));
+    }
+    let mut bytes = Vec::new();
+    Read::by_ref(&mut file)
+        .take((limit as u64).saturating_add(1))
+        .read_to_end(&mut bytes)
+        .map_err(|error| {
+            StoreError::new(
+                "store_read_failed",
+                format!("failed to read {}: {error}", path.display()),
+            )
+        })?;
+    if bytes.len() > limit || bytes.len() as u64 != metadata.len() {
+        return Err(StoreError::new(
+            "store_file_raced",
+            format!("{} changed while being read", path.display()),
+        ));
+    }
+    Ok(bytes)
+}
+
+fn publish_file(source: &Path, destination: &Path, expected: &[u8]) -> Result<(), StoreError> {
+    match fs::hard_link(source, destination) {
+        Ok(()) => {
+            sync_directory(destination.parent().unwrap_or(Path::new(".")))?;
+            Ok(())
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            if read_regular_file(destination, expected.len())? == expected {
+                Ok(())
+            } else {
+                Err(StoreError::new(
+                    "content_address_collision",
+                    format!("existing {} has different bytes", destination.display()),
+                ))
+            }
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Err(StoreError::new(
+            "publish_source_unavailable",
+            format!("failed to publish {}: {error}", source.display()),
+        )),
+        Err(error) => Err(StoreError::new(
+            "store_publish_failed",
+            format!(
+                "failed to publish {} to {}: {error}",
+                source.display(),
+                destination.display()
+            ),
+        )),
+    }
+}
+
+fn publish_directory(source: &Path, destination: &Path) -> Result<(), StoreError> {
+    match fs::rename(source, destination) {
+        Ok(()) => {
+            sync_directory(destination.parent().unwrap_or(Path::new(".")))?;
+            Ok(())
+        }
+        Err(_error) if destination.exists() => {
+            require_safe_directory(destination)?;
+            Ok(())
+        }
+        Err(error) => Err(StoreError::new(
+            "store_publish_failed",
+            format!(
+                "failed to publish {} to {}: {error}",
+                source.display(),
+                destination.display()
+            ),
+        )),
+    }
+}
+
+fn atomic_replace_file(path: &Path, bytes: &[u8]) -> Result<(), StoreError> {
+    let parent = path.parent().ok_or_else(|| {
+        StoreError::new(
+            "store_write_failed",
+            format!("{} has no parent", path.display()),
+        )
+    })?;
+    let transaction = unique_transaction(parent, "replace")?;
+    let temporary = transaction.join("value");
+    let result = (|| {
+        write_new_file(&temporary, bytes)?;
+        fs::rename(&temporary, path).map_err(|error| {
+            StoreError::new(
+                "store_publish_failed",
+                format!("failed to replace {}: {error}", path.display()),
+            )
+        })?;
+        sync_directory(parent)
+    })();
+    finish_transaction(result, &transaction)
+}
+
+fn sync_directory(path: &Path) -> Result<(), StoreError> {
+    File::open(path)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|error| {
+            StoreError::new(
+                "store_sync_failed",
+                format!("failed to sync {}: {error}", path.display()),
+            )
+        })
+}
+
+fn sync_parent_directory(path: &Path) -> Result<(), StoreError> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    sync_directory(parent)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::package_archive::ARCHIVE_MAGIC;
+
+    fn archive(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut bytes = ARCHIVE_MAGIC.to_vec();
+        for (path, content) in entries {
+            bytes.extend_from_slice(format!("--- file {path} {} ---\n", content.len()).as_bytes());
+            bytes.extend_from_slice(content);
+            if !content.ends_with(b"\n") {
+                bytes.push(b'\n');
+            }
+        }
+        bytes
+    }
+
+    fn fixture<'a>(archive: &'a [u8], digest: &'a str) -> VerifiedArtifacts<'a> {
+        fixture_version(archive, digest, b"registry-index", b"verification")
+    }
+
+    fn fixture_version<'a>(
+        archive: &'a [u8],
+        digest: &'a str,
+        registry_index: &'a [u8],
+        verification: &'a [u8],
+    ) -> VerifiedArtifacts<'a> {
+        VerifiedArtifacts {
+            archive_sha256: digest,
+            archive,
+            manifest: b"manifest",
+            provenance: b"provenance",
+            signature: b"signature",
+            registry_index,
+            verification,
+        }
+    }
+
+    #[test]
+    fn admission_is_idempotent_and_offline_load_returns_exact_bytes() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = PackageStore::open(&temp.path().join("cache")).unwrap();
+        let bytes = archive(&[("axiom.toml", b"[package]\n"), ("src/main.ax", b"main")]);
+        let digest = sha256_hex(&bytes);
+        let first = store.admit(fixture(&bytes, &digest)).unwrap();
+        let second = store.admit(fixture(&bytes, &digest)).unwrap();
+        assert_eq!(first.commit, second.commit);
+        let artifacts = second.verified_artifacts().unwrap();
+        assert_eq!(artifacts.archive, bytes);
+        assert_eq!(artifacts.manifest, b"manifest");
+        assert_eq!(fs::read(second.tree.join("src/main.ax")).unwrap(), b"main");
+    }
+
+    #[test]
+    fn same_archive_preserves_two_exact_registry_index_evidence_versions() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = PackageStore::open(&temp.path().join("cache")).unwrap();
+        let bytes = archive(&[("a", b"x")]);
+        let digest = sha256_hex(&bytes);
+        let old_index = b"registry-index-generation-1";
+        let new_index = b"registry-index-generation-2-yanked";
+        store
+            .admit(fixture_version(
+                &bytes,
+                &digest,
+                old_index,
+                b"verification-generation-1",
+            ))
+            .unwrap();
+        store
+            .admit(fixture_version(
+                &bytes,
+                &digest,
+                new_index,
+                b"verification-generation-2",
+            ))
+            .unwrap();
+
+        assert_eq!(
+            store.load_verified(&digest).unwrap_err().code,
+            "cache_evidence_ambiguous"
+        );
+        let old = store
+            .load_verified_for_index(&digest, &sha256_hex(old_index))
+            .unwrap();
+        let new = store
+            .load_verified_for_index(&digest, &sha256_hex(new_index))
+            .unwrap();
+        assert_eq!(old.verified_artifacts().unwrap().registry_index, old_index);
+        assert_eq!(new.verified_artifacts().unwrap().registry_index, new_index);
+        assert_eq!(old.blob, new.blob);
+        assert_eq!(old.tree, new.tree);
+        assert_ne!(old.evidence, new.evidence);
+
+        fs::write(
+            old.evidence.join("verification"),
+            b"corrupt unrelated evidence",
+        )
+        .unwrap();
+        let exact_new = store
+            .load_verified_for_index(&digest, &sha256_hex(new_index))
+            .unwrap();
+        assert_eq!(
+            exact_new.verified_artifacts().unwrap().registry_index,
+            new_index
+        );
+    }
+
+    #[test]
+    fn offline_load_rejects_blob_tree_evidence_and_commit_tampering() {
+        for target in ["blob", "tree", "evidence", "commit"] {
+            let temp = tempfile::tempdir().unwrap();
+            let store = PackageStore::open(&temp.path().join("cache")).unwrap();
+            let bytes = archive(&[("a", b"x")]);
+            let digest = sha256_hex(&bytes);
+            let cached = store.admit(fixture(&bytes, &digest)).unwrap();
+            match target {
+                "blob" => fs::write(&cached.blob, b"bad").unwrap(),
+                "tree" => fs::write(cached.tree.join("a"), b"bad").unwrap(),
+                "evidence" => fs::write(cached.evidence.join("manifest"), b"bad").unwrap(),
+                "commit" => fs::write(
+                    store.commit_path(
+                        &digest,
+                        &sha256_hex(b"registry-index"),
+                        cached
+                            .evidence
+                            .file_name()
+                            .and_then(|name| name.to_str())
+                            .unwrap(),
+                    ),
+                    b"{\"schema_version\":\"forged\"}\n",
+                )
+                .unwrap(),
+                _ => unreachable!(),
+            }
+            assert!(store.load_verified(&digest).is_err(), "{target}");
+        }
+    }
+
+    #[test]
+    fn offline_load_rejects_coherently_recomputed_tree_integrity_and_commit() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = PackageStore::open(&temp.path().join("cache")).unwrap();
+        let bytes = archive(&[("a", b"x")]);
+        let digest = sha256_hex(&bytes);
+        let cached = store.admit(fixture(&bytes, &digest)).unwrap();
+        fs::write(cached.tree.join("a"), b"y").unwrap();
+
+        let mut forged_integrity = cached.integrity.clone();
+        forged_integrity.files[0].sha256 = sha256_hex(b"y");
+        fs::write(
+            cached.evidence.join("integrity.json"),
+            integrity_manifest_bytes(&forged_integrity).unwrap(),
+        )
+        .unwrap();
+        let mut forged_commit = cached.commit.clone();
+        forged_commit.tree_manifest_sha256 = integrity_manifest_sha256(&forged_integrity).unwrap();
+        let identity = cached
+            .evidence
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap();
+        fs::write(
+            store.commit_path(&digest, &forged_commit.registry_index_sha256, identity),
+            canonical_json_bytes(&forged_commit).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            store
+                .load_verified_for_index(&digest, &forged_commit.registry_index_sha256,)
+                .unwrap_err()
+                .code,
+            "archive_tree_binding_mismatch"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn offline_load_rejects_symlink_substitution() {
+        use std::os::unix::fs::symlink;
+        let temp = tempfile::tempdir().unwrap();
+        let store = PackageStore::open(&temp.path().join("cache")).unwrap();
+        let bytes = archive(&[("a", b"x")]);
+        let digest = sha256_hex(&bytes);
+        let cached = store.admit(fixture(&bytes, &digest)).unwrap();
+        fs::remove_file(cached.tree.join("a")).unwrap();
+        symlink("/dev/null", cached.tree.join("a")).unwrap();
+        assert!(store.load_verified(&digest).is_err());
+    }
+
+    #[test]
+    fn vendor_snapshot_binds_expected_lock_and_exposes_verified_tree() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = PackageStore::open(&temp.path().join("cache")).unwrap();
+        let bytes = archive(&[("a", b"x")]);
+        let digest = sha256_hex(&bytes);
+        store.admit(fixture(&bytes, &digest)).unwrap();
+        let index_digest = sha256_hex(b"registry-index");
+        let verification_digest = sha256_hex(b"verification");
+        let expected = [VendorPackage {
+            package_id: "registry:demo/core@1.0.0",
+            archive_sha256: &digest,
+            registry_index_sha256: &index_digest,
+            verification_sha256: &verification_digest,
+        }];
+        let vendor = temp.path().join("vendor");
+        let snapshot = store.vendor_snapshot(&vendor, &expected).unwrap();
+        assert_eq!(
+            fs::read(
+                snapshot
+                    .package_tree(expected[0].package_id)
+                    .unwrap()
+                    .join("a")
+            )
+            .unwrap(),
+            b"x"
+        );
+        assert!(PackageStore::verify_vendor_snapshot(&vendor, &expected).is_ok());
+        let wrong = [VendorPackage {
+            package_id: "registry:demo/other@1.0.0",
+            archive_sha256: &digest,
+            registry_index_sha256: &index_digest,
+            verification_sha256: &verification_digest,
+        }];
+        assert_eq!(
+            PackageStore::verify_vendor_snapshot(&vendor, &wrong)
+                .unwrap_err()
+                .code,
+            "vendor_lock_mismatch"
+        );
+    }
+
+    #[test]
+    fn vendor_supports_shared_archive_with_exact_distinct_evidence_identities() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = PackageStore::open(&temp.path().join("cache")).unwrap();
+        let bytes = archive(&[("a", b"x")]);
+        let digest = sha256_hex(&bytes);
+        let index = b"registry-index";
+        let verification_one = b"verification-1";
+        let verification_two = b"verification-2";
+        store
+            .admit(fixture_version(&bytes, &digest, index, verification_one))
+            .unwrap();
+        store
+            .admit(fixture_version(&bytes, &digest, index, verification_two))
+            .unwrap();
+        let index_digest = sha256_hex(index);
+        let verification_one_digest = sha256_hex(verification_one);
+        let verification_two_digest = sha256_hex(verification_two);
+        let packages = [
+            VendorPackage {
+                package_id: "registry:demo/one@1.0.0",
+                archive_sha256: &digest,
+                registry_index_sha256: &index_digest,
+                verification_sha256: &verification_one_digest,
+            },
+            VendorPackage {
+                package_id: "registry:demo/two@1.0.0",
+                archive_sha256: &digest,
+                registry_index_sha256: &index_digest,
+                verification_sha256: &verification_two_digest,
+            },
+        ];
+        let vendor = temp.path().join("vendor");
+        let snapshot = store.vendor_snapshot(&vendor, &packages).unwrap();
+        let one = snapshot.package(packages[0].package_id).unwrap().unwrap();
+        let two = snapshot.package(packages[1].package_id).unwrap().unwrap();
+        assert_eq!(
+            one.verified_artifacts().unwrap().verification,
+            verification_one
+        );
+        assert_eq!(
+            two.verified_artifacts().unwrap().verification,
+            verification_two
+        );
+        assert_eq!(one.tree, two.tree);
+        assert_ne!(one.evidence, two.evidence);
+        assert_eq!(
+            snapshot
+                .root
+                .join("packages/sha256")
+                .read_dir()
+                .unwrap()
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn vendor_enforces_aggregate_package_and_byte_budgets_before_publication() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut store = PackageStore::open(&temp.path().join("cache")).unwrap();
+        let bytes = archive(&[("a", b"x")]);
+        let digest = sha256_hex(&bytes);
+        store.admit(fixture(&bytes, &digest)).unwrap();
+        let index_digest = sha256_hex(b"registry-index");
+        let verification_digest = sha256_hex(b"verification");
+        let expected = [VendorPackage {
+            package_id: "registry:demo/core@1.0.0",
+            archive_sha256: &digest,
+            registry_index_sha256: &index_digest,
+            verification_sha256: &verification_digest,
+        }];
+        let vendor = temp.path().join("vendor");
+
+        store.vendor_limits = VendorLimits {
+            max_packages: 0,
+            max_bytes: MAX_VENDOR_BYTES,
+        };
+        assert_eq!(
+            store.vendor_snapshot(&vendor, &expected).unwrap_err().code,
+            "vendor_package_count_exceeded"
+        );
+
+        store.vendor_limits = VendorLimits {
+            max_packages: 1,
+            max_bytes: 1,
+        };
+        assert_eq!(
+            store.vendor_snapshot(&vendor, &expected).unwrap_err().code,
+            "vendor_total_bytes_exceeded"
+        );
+        assert!(!vendor.join("CURRENT").exists());
+    }
+
+    #[test]
+    fn corrupt_existing_same_digest_snapshot_never_replaces_current() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = PackageStore::open(&temp.path().join("cache")).unwrap();
+        let first_bytes = archive(&[("a", b"first")]);
+        let second_bytes = archive(&[("a", b"second")]);
+        let first_digest = sha256_hex(&first_bytes);
+        let second_digest = sha256_hex(&second_bytes);
+        store.admit(fixture(&first_bytes, &first_digest)).unwrap();
+        store.admit(fixture(&second_bytes, &second_digest)).unwrap();
+        let index_digest = sha256_hex(b"registry-index");
+        let verification_digest = sha256_hex(b"verification");
+        let first = [VendorPackage {
+            package_id: "registry:demo/first@1.0.0",
+            archive_sha256: &first_digest,
+            registry_index_sha256: &index_digest,
+            verification_sha256: &verification_digest,
+        }];
+        let second = [VendorPackage {
+            package_id: "registry:demo/second@1.0.0",
+            archive_sha256: &second_digest,
+            registry_index_sha256: &index_digest,
+            verification_sha256: &verification_digest,
+        }];
+        let vendor = temp.path().join("vendor");
+        let first_snapshot = store.vendor_snapshot(&vendor, &first).unwrap();
+        let second_snapshot = store.vendor_snapshot(&vendor, &second).unwrap();
+        let current_before = fs::read(vendor.join("CURRENT")).unwrap();
+        assert_eq!(
+            current_before,
+            format!("{}\n", second_snapshot.digest).as_bytes()
+        );
+        fs::write(
+            first_snapshot
+                .root
+                .join("packages/sha256")
+                .join(&first_digest)
+                .join("tree/a"),
+            b"corrupt",
+        )
+        .unwrap();
+
+        assert!(store.vendor_snapshot(&vendor, &first).is_err());
+        assert_eq!(fs::read(vendor.join("CURRENT")).unwrap(), current_before);
+    }
+
+    #[test]
+    fn stale_owned_transactions_are_reaped_but_unowned_entries_are_preserved() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = PackageStore::open(&temp.path().join("cache")).unwrap();
+        let transactions = store.root().join(".transactions");
+        let stale_pid = 2_000_000_000u32;
+        let stale = transactions.join(format!(".vendor-{stale_pid}-0-7"));
+        fs::create_dir(&stale).unwrap();
+        write_new_file(
+            &stale.join(TRANSACTION_MARKER_NAME),
+            &transaction_marker_bytes(stale_pid, 0, 7),
+        )
+        .unwrap();
+        write_new_file(&stale.join("partial"), b"partial").unwrap();
+        let unowned = transactions.join(".vendor-1999999999-0-8");
+        fs::create_dir(&unowned).unwrap();
+
+        let active = unique_transaction(&transactions, "admit").unwrap();
+        assert!(!stale.exists());
+        assert!(unowned.exists());
+        finish_transaction(Ok(()), &active).unwrap();
+    }
+
+    #[test]
+    fn stale_transaction_scan_has_a_deterministic_cardinality_bound() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = PackageStore::open(&temp.path().join("cache")).unwrap();
+        let transactions = store.root().join(".transactions");
+        for index in 0..=MAX_TRANSACTION_SCAN_ENTRIES {
+            fs::write(transactions.join(format!("unowned-{index:04}")), b"x").unwrap();
+        }
+        let error =
+            reap_stale_transactions(&transactions, unix_epoch_nanos().unwrap()).unwrap_err();
+        assert_eq!(error.code, "store_transaction_scan_exceeded");
+        assert_eq!(
+            error.message,
+            format!(
+                "{} contains more than {} transaction entries",
+                transactions.display(),
+                MAX_TRANSACTION_SCAN_ENTRIES
+            )
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn anchored_root_rejects_symlink_ancestor_escape() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let anchor = temp.path().join("project");
+        let outside = temp.path().join("outside");
+        fs::create_dir(&anchor).unwrap();
+        fs::create_dir(&outside).unwrap();
+        symlink(&outside, anchor.join("cache-link")).unwrap();
+
+        let error =
+            PackageStore::open_anchored(&anchor, Path::new("cache-link/packages")).unwrap_err();
+        assert_eq!(error.code, "store_root_invalid");
+        assert!(!outside.join("packages").exists());
+        assert_eq!(
+            PackageStore::prepare_anchored_root(&anchor, Path::new("../escape"))
+                .unwrap_err()
+                .code,
+            "store_root_escape"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bounded_reader_rejects_fifo_without_blocking() {
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let fifo = temp.path().join("evidence-fifo");
+        let fifo_name = CString::new(fifo.as_os_str().as_bytes()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(fifo_name.as_ptr(), 0o600) }, 0);
+        assert_eq!(
+            read_bounded_regular_file(&fifo, 16).unwrap_err().code,
+            "store_file_invalid"
+        );
+    }
+
+    #[test]
+    fn vendor_verification_rejects_tampered_tree_and_manifest_pointer() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = PackageStore::open(&temp.path().join("cache")).unwrap();
+        let bytes = archive(&[("a", b"x")]);
+        let digest = sha256_hex(&bytes);
+        store.admit(fixture(&bytes, &digest)).unwrap();
+        let index_digest = sha256_hex(b"registry-index");
+        let verification_digest = sha256_hex(b"verification");
+        let expected = [VendorPackage {
+            package_id: "registry:demo/core@1.0.0",
+            archive_sha256: &digest,
+            registry_index_sha256: &index_digest,
+            verification_sha256: &verification_digest,
+        }];
+        let vendor = temp.path().join("vendor");
+        let snapshot = store.vendor_snapshot(&vendor, &expected).unwrap();
+        fs::write(
+            snapshot
+                .root
+                .join("packages/sha256")
+                .join(&digest)
+                .join("tree/a"),
+            b"bad",
+        )
+        .unwrap();
+        assert!(PackageStore::verify_vendor_snapshot(&vendor, &expected).is_err());
+        fs::write(vendor.join("CURRENT"), format!("{}\n", "0".repeat(64))).unwrap();
+        assert!(PackageStore::verify_vendor_snapshot(&vendor, &expected).is_err());
+    }
+}

--- a/stage1/crates/axiomc/src/package_trust.rs
+++ b/stage1/crates/axiomc/src/package_trust.rs
@@ -270,6 +270,235 @@ pub struct RegistryIndexTrustPreflight {
     pub package_eligible_key_ids: Vec<String>,
 }
 
+/// One release exposed by an authenticated registry catalog.
+///
+/// Every field was covered by the catalog's authenticated index transcript.
+/// The original JSON representation remains private so consumers cannot
+/// accidentally treat an arbitrary, untrusted release object as authenticated.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AuthenticatedRegistryArtifactPaths {
+    pub archive: String,
+    pub manifest: String,
+    pub provenance: String,
+    pub package_signature: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AuthenticatedRegistryRelease {
+    registry_identity: String,
+    source_identity: String,
+    namespace: String,
+    name: String,
+    version: String,
+    target_path: String,
+    publisher_identity: String,
+    archive_length: u64,
+    archive_sha256: String,
+    manifest_sha256: String,
+    provenance_statement_sha256: String,
+    provenance_predicate_type: String,
+    provenance_subject_name: String,
+    provenance_subject_sha256: String,
+    package_signature_sha256: String,
+    yanked: bool,
+    yank_reason: Option<String>,
+    artifact_paths: AuthenticatedRegistryArtifactPaths,
+    authenticated_value: Value,
+}
+
+impl AuthenticatedRegistryRelease {
+    pub fn registry_identity(&self) -> &str {
+        &self.registry_identity
+    }
+
+    pub fn source_identity(&self) -> &str {
+        &self.source_identity
+    }
+
+    pub fn namespace(&self) -> &str {
+        &self.namespace
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn version(&self) -> &str {
+        &self.version
+    }
+
+    pub fn target_path(&self) -> &str {
+        &self.target_path
+    }
+
+    pub fn publisher_identity(&self) -> &str {
+        &self.publisher_identity
+    }
+
+    pub fn archive_length(&self) -> u64 {
+        self.archive_length
+    }
+
+    pub fn archive_sha256(&self) -> &str {
+        &self.archive_sha256
+    }
+
+    pub fn manifest_sha256(&self) -> &str {
+        &self.manifest_sha256
+    }
+
+    pub fn provenance_statement_sha256(&self) -> &str {
+        &self.provenance_statement_sha256
+    }
+
+    pub fn provenance_predicate_type(&self) -> &str {
+        &self.provenance_predicate_type
+    }
+
+    pub fn provenance_subject_name(&self) -> &str {
+        &self.provenance_subject_name
+    }
+
+    pub fn provenance_subject_sha256(&self) -> &str {
+        &self.provenance_subject_sha256
+    }
+
+    pub fn package_signature_sha256(&self) -> &str {
+        &self.package_signature_sha256
+    }
+
+    pub fn yanked(&self) -> bool {
+        self.yanked
+    }
+
+    pub fn yank_reason(&self) -> Option<&str> {
+        self.yank_reason.as_deref()
+    }
+
+    /// Return normalized relative paths for every artifact needed by full
+    /// Package Trust verification.
+    pub fn artifact_paths(&self) -> &AuthenticatedRegistryArtifactPaths {
+        &self.artifact_paths
+    }
+}
+
+/// Strictly parsed releases from an authenticated Registry Index v2 snapshot.
+///
+/// The catalog retains the exact delivered index bytes as well as the
+/// authenticated root and index transcript pins. Resolver code must consume
+/// releases through this type rather than reparsing the index JSON.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AuthenticatedRegistryCatalog {
+    registry_identity: String,
+    source_identity: String,
+    trusted_root_version: u64,
+    trusted_root_sequence: u64,
+    trusted_root_transcript_sha256: String,
+    root_version: u64,
+    root_sequence: u64,
+    root_transcript_sha256: String,
+    generation: u64,
+    sequence: u64,
+    snapshot_id: String,
+    index_transcript_sha256: String,
+    index_signer_key_ids: Vec<String>,
+    releases: Vec<AuthenticatedRegistryRelease>,
+    exact_index_bytes: Vec<u8>,
+}
+
+impl AuthenticatedRegistryCatalog {
+    pub fn registry_identity(&self) -> &str {
+        &self.registry_identity
+    }
+
+    pub fn source_identity(&self) -> &str {
+        &self.source_identity
+    }
+
+    pub fn trusted_root_version(&self) -> u64 {
+        self.trusted_root_version
+    }
+
+    pub fn trusted_root_sequence(&self) -> u64 {
+        self.trusted_root_sequence
+    }
+
+    pub fn trusted_root_transcript_sha256(&self) -> &str {
+        &self.trusted_root_transcript_sha256
+    }
+
+    pub fn root_version(&self) -> u64 {
+        self.root_version
+    }
+
+    pub fn root_sequence(&self) -> u64 {
+        self.root_sequence
+    }
+
+    pub fn root_transcript_sha256(&self) -> &str {
+        &self.root_transcript_sha256
+    }
+
+    pub fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    pub fn sequence(&self) -> u64 {
+        self.sequence
+    }
+
+    pub fn snapshot_id(&self) -> &str {
+        &self.snapshot_id
+    }
+
+    pub fn index_transcript_sha256(&self) -> &str {
+        &self.index_transcript_sha256
+    }
+
+    pub fn index_signer_key_ids(&self) -> &[String] {
+        &self.index_signer_key_ids
+    }
+
+    pub fn releases(&self) -> &[AuthenticatedRegistryRelease] {
+        &self.releases
+    }
+
+    /// Return the exact strict JSON bytes whose signed body was authenticated.
+    pub fn exact_index_bytes(&self) -> &[u8] {
+        &self.exact_index_bytes
+    }
+
+    /// Find one exact package coordinate in the authenticated catalog.
+    pub fn release(
+        &self,
+        namespace: &str,
+        name: &str,
+        version: &str,
+    ) -> Option<&AuthenticatedRegistryRelease> {
+        self.releases.iter().find(|release| {
+            release.namespace == namespace && release.name == name && release.version == version
+        })
+    }
+}
+
+/// Stable fail-closed reasons returned by index-only catalog authentication.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RegistryCatalogAuthenticationError {
+    pub reason_codes: Vec<String>,
+}
+
+impl fmt::Display for RegistryCatalogAuthenticationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "Package Trust registry catalog rejected: {}",
+            self.reason_codes.join(", ")
+        )
+    }
+}
+
+impl std::error::Error for RegistryCatalogAuthenticationError {}
+
 /// Stable fail-closed reasons returned by registry-index trust preflight.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TrustRootPreflightError {
@@ -2354,6 +2583,478 @@ pub fn preflight_registry_index_trust(
     })
 }
 
+fn catalog_error(failures: &BTreeSet<String>) -> RegistryCatalogAuthenticationError {
+    RegistryCatalogAuthenticationError {
+        reason_codes: ordered_reason_codes(failures),
+    }
+}
+
+fn registry_artifact_paths(target_path: &str) -> Option<AuthenticatedRegistryArtifactPaths> {
+    if !safe_target_path(&Value::String(target_path.to_owned())) {
+        return None;
+    }
+    let release_dir = target_path.strip_suffix("/package.axp")?;
+    if release_dir.is_empty() {
+        return None;
+    }
+    Some(AuthenticatedRegistryArtifactPaths {
+        archive: target_path.to_owned(),
+        manifest: format!("{release_dir}/axiom.toml"),
+        provenance: format!("{release_dir}/provenance.json"),
+        package_signature: format!("{release_dir}/package.axp.sig"),
+    })
+}
+
+fn authenticated_registry_release(value: &Value) -> Option<AuthenticatedRegistryRelease> {
+    let provenance = field(value, "provenance");
+    let statement = field(provenance, "statement");
+    let subject = field(provenance, "selected_subject");
+    let target_path = text(field(value, "target_path"))?.to_owned();
+    Some(AuthenticatedRegistryRelease {
+        registry_identity: text(field(value, "registry_identity"))?.to_owned(),
+        source_identity: text(field(value, "source_identity"))?.to_owned(),
+        namespace: text(field(value, "namespace"))?.to_owned(),
+        name: text(field(value, "name"))?.to_owned(),
+        version: text(field(value, "version"))?.to_owned(),
+        target_path: target_path.clone(),
+        publisher_identity: text(field(value, "publisher_identity"))?.to_owned(),
+        archive_length: number(field(field(value, "archive"), "length"))?,
+        archive_sha256: text(field(field(field(value, "archive"), "digest"), "value"))?.to_owned(),
+        manifest_sha256: text(field(field(value, "manifest"), "value"))?.to_owned(),
+        provenance_statement_sha256: text(field(field(statement, "digest"), "value"))?.to_owned(),
+        provenance_predicate_type: text(field(field(statement, "value"), "predicateType"))?
+            .to_owned(),
+        provenance_subject_name: text(field(subject, "name"))?.to_owned(),
+        provenance_subject_sha256: text(field(field(subject, "digest"), "sha256"))?.to_owned(),
+        package_signature_sha256: text(field(value, "package_signature_sha256"))?.to_owned(),
+        yanked: field(value, "yanked").as_bool()?,
+        yank_reason: optional_string(field(value, "yank_reason")),
+        artifact_paths: registry_artifact_paths(&target_path)?,
+        authenticated_value: value.clone(),
+    })
+}
+
+/// Authenticate strict Registry Index v2 bytes without admitting package
+/// artifacts.
+///
+/// This is the resolver's index-only trust boundary. It authenticates the root
+/// transition and index role, verifies the exact signed transcript, enforces
+/// time and monotonic trusted-state rules, rejects snapshot rebinding and
+/// duplicate release identities, and only then projects releases into typed
+/// values.
+pub fn authenticate_registry_catalog(
+    index_bytes: &[u8],
+    roots: &TrustRootsEnvelope,
+    expectation: &VerificationExpectation,
+) -> Result<AuthenticatedRegistryCatalog, RegistryCatalogAuthenticationError> {
+    let index = parse_registry_index_json(index_bytes).map_err(|_| {
+        let mut failures = BTreeSet::new();
+        add(&mut failures, "INDEX_DIGEST_MISMATCH");
+        catalog_error(&failures)
+    })?;
+    let mut failures = BTreeSet::new();
+    if !validate_document_work_budget(roots, DocumentKind::Roots)
+        || validate_schema_value(
+            roots,
+            include_bytes!("../../../schemas/axiom-trust-roots-v1.schema.json"),
+            &TRUST_ROOTS_SCHEMA,
+            "trust roots",
+        )
+        .is_err()
+    {
+        add(&mut failures, "ROOT_DIGEST_MISMATCH");
+    }
+    if !validate_document_work_budget(expectation, DocumentKind::Expectation)
+        || validate_schema_value(
+            expectation,
+            include_bytes!(
+                "../../../schemas/axiom-package-verification-expectation-v1.schema.json"
+            ),
+            &VERIFICATION_EXPECTATION_SCHEMA,
+            "verification expectation",
+        )
+        .is_err()
+    {
+        add(&mut failures, "OFFLINE_INPUT_MISSING");
+    }
+    if !failures.is_empty() {
+        return Err(catalog_error(&failures));
+    }
+
+    let RootValidation {
+        verification_time,
+        candidate_keys,
+        candidate_roles,
+        candidate_version,
+        candidate_sequence,
+        ..
+    } = validate_trust_root_transition(roots, expectation, &mut failures);
+    let candidate_root = field(roots, "candidate_root");
+    let candidate_signed = field(candidate_root, "signed");
+    let candidate_raw = metadata_transcript(ROOT_DOMAIN, candidate_signed).unwrap_or_default();
+    let trusted_root = field(roots, "trusted_root");
+    let trusted_signed = field(trusted_root, "signed");
+    let trusted_raw = metadata_transcript(ROOT_DOMAIN, trusted_signed).unwrap_or_default();
+
+    let signed = field(&index, "signed");
+    let index_raw = match metadata_transcript(INDEX_DOMAIN, signed) {
+        Ok(transcript) => transcript,
+        Err(_) => {
+            add(&mut failures, "INDEX_DIGEST_MISMATCH");
+            Vec::new()
+        }
+    };
+    let index_transcript_sha256 = sha256(&index_raw);
+    if !transcript_matches(&index, &index_raw) {
+        add(&mut failures, "INDEX_DIGEST_MISMATCH");
+    }
+    if timestamp(field(signed, "issued_at")).is_none_or(|issued| issued > verification_time)
+        || timestamp(field(signed, "expires_at")).is_none_or(|expiry| expiry <= verification_time)
+    {
+        add(&mut failures, "METADATA_EXPIRED");
+    }
+
+    let generation = number(field(signed, "generation")).unwrap_or(0);
+    let sequence = number(field(signed, "sequence")).unwrap_or(0);
+    let request = field(expectation, "request");
+    if field(signed, "registry_identity") != field(request, "registry_identity")
+        || field(signed, "source_identity") != field(request, "source_identity")
+    {
+        add(&mut failures, "SOURCE_MISMATCH");
+    }
+
+    let required_signers = field(expectation, "required_signers");
+    let expected_role_id = text(field(required_signers, "index_role_id"));
+    let signed_role_id = text(field(signed, "signature_role"));
+    if signed_role_id != expected_role_id {
+        add(&mut failures, "INDEX_THRESHOLD_NOT_MET");
+    }
+    let role = signed_role_id
+        .filter(|role_id| Some(*role_id) == expected_role_id)
+        .and_then(|role_id| candidate_roles.get(role_id));
+    let (valid_signers, valid_signer_count) = signature_evidence(
+        field(&index, "signatures"),
+        SignatureEvidence {
+            role,
+            keys: &candidate_keys,
+            message: &index_raw,
+            sequence,
+            verification_time,
+            context: "INDEX",
+            required_key_ids: None,
+            expected_publisher: None,
+            publisher_grant_authorized: true,
+        },
+        &mut failures,
+    );
+    let expected_threshold = number(field(required_signers, "index_threshold"));
+    if role.and_then(|role| number(field(role, "threshold"))) != expected_threshold {
+        add(&mut failures, "INDEX_THRESHOLD_NOT_MET");
+    }
+    let index_authenticated = transcript_matches(&index, &index_raw)
+        && role.is_some()
+        && role.and_then(|role| number(field(role, "threshold"))) == expected_threshold
+        && expected_threshold.is_some_and(|threshold| valid_signer_count >= threshold as usize);
+
+    let trusted_state = field(expectation, "trusted_state");
+    if index_authenticated {
+        let highest_generation =
+            number(field(trusted_state, "highest_index_generation")).unwrap_or(generation);
+        let highest_sequence =
+            number(field(trusted_state, "highest_index_sequence")).unwrap_or(sequence);
+        if generation < highest_generation || sequence < highest_sequence {
+            add(&mut failures, "ROLLBACK_DETECTED");
+            add(&mut failures, "METADATA_REPLAYED");
+        }
+        let seen_snapshots = field(trusted_state, "seen_snapshots")
+            .as_array()
+            .cloned()
+            .unwrap_or_default();
+        let snapshot = field(signed, "consistent_snapshot");
+        let snapshot_state = serde_json::json!({
+            "generation": generation,
+            "sequence": sequence,
+            "snapshot_id": field(snapshot, "snapshot_id"),
+            "index_transcript_sha256": index_transcript_sha256,
+        });
+        let exact_repeat = seen_snapshots.contains(&snapshot_state);
+        let rebound = seen_snapshots.iter().any(|seen| {
+            object(seen).is_some()
+                && seen != &snapshot_state
+                && ((number(field(seen, "generation")) == Some(generation)
+                    && number(field(seen, "sequence")) == Some(sequence))
+                    || field(seen, "snapshot_id") == field(&snapshot_state, "snapshot_id")
+                    || field(seen, "index_transcript_sha256")
+                        == field(&snapshot_state, "index_transcript_sha256"))
+        });
+        let highest_position_seen = seen_snapshots.iter().any(|seen| {
+            number(field(seen, "generation")) == Some(highest_generation)
+                && number(field(seen, "sequence")) == Some(highest_sequence)
+        });
+        let highest_snapshot_sha256 = seen_snapshots.iter().find_map(|seen| {
+            (number(field(seen, "generation")) == Some(highest_generation)
+                && number(field(seen, "sequence")) == Some(highest_sequence))
+            .then(|| text(field(seen, "index_transcript_sha256")))
+            .flatten()
+        });
+        if !highest_position_seen {
+            add(&mut failures, "OFFLINE_INPUT_MISSING");
+        }
+        if (generation > highest_generation || sequence > highest_sequence)
+            && text(field(snapshot, "previous_snapshot_sha256")) != highest_snapshot_sha256
+        {
+            add(&mut failures, "METADATA_REPLAYED");
+        }
+        if rebound
+            || (generation == highest_generation
+                && sequence == highest_sequence
+                && highest_position_seen
+                && !exact_repeat)
+        {
+            add(&mut failures, "METADATA_REPLAYED");
+        }
+    }
+
+    let releases = field(signed, "releases")
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    let mut full_releases = HashSet::new();
+    let mut coordinates = HashSet::new();
+    let mut target_paths = HashSet::new();
+    for release in &releases {
+        let full = (
+            optional_string(field(release, "registry_identity")),
+            optional_string(field(release, "source_identity")),
+            optional_string(field(release, "namespace")),
+            optional_string(field(release, "name")),
+            optional_string(field(release, "version")),
+            optional_string(field(release, "target_path")),
+        );
+        let coordinate = (
+            full.0.clone(),
+            full.1.clone(),
+            full.2.clone(),
+            full.3.clone(),
+            full.4.clone(),
+        );
+        if !full_releases.insert(full.clone()) {
+            add(&mut failures, "DUPLICATE_RELEASE");
+        }
+        if !coordinates.insert(coordinate) {
+            add(&mut failures, "DUPLICATE_PACKAGE_COORDINATE");
+        }
+        if !target_paths.insert(full.5.clone()) {
+            add(&mut failures, "DUPLICATE_TARGET_PATH");
+        }
+        if field(release, "registry_identity") != field(signed, "registry_identity")
+            || field(release, "source_identity") != field(signed, "source_identity")
+        {
+            add(&mut failures, "SOURCE_MISMATCH");
+        }
+        if text(field(release, "target_path"))
+            .and_then(registry_artifact_paths)
+            .is_none()
+        {
+            add(&mut failures, "TARGET_PATH_INVALID");
+        }
+    }
+    let typed_releases = releases
+        .iter()
+        .filter_map(authenticated_registry_release)
+        .collect::<Vec<_>>();
+    if typed_releases.len() != releases.len() {
+        add(&mut failures, "INDEX_DIGEST_MISMATCH");
+    }
+    if !failures.is_empty() {
+        return Err(catalog_error(&failures));
+    }
+
+    let mut index_signer_key_ids = valid_signers.into_iter().collect::<Vec<_>>();
+    index_signer_key_ids.sort();
+    Ok(AuthenticatedRegistryCatalog {
+        registry_identity: text(field(signed, "registry_identity"))
+            .unwrap_or_default()
+            .to_owned(),
+        source_identity: text(field(signed, "source_identity"))
+            .unwrap_or_default()
+            .to_owned(),
+        trusted_root_version: number(field(trusted_signed, "root_version")).unwrap_or(0),
+        trusted_root_sequence: number(field(trusted_signed, "sequence")).unwrap_or(0),
+        trusted_root_transcript_sha256: sha256(&trusted_raw),
+        root_version: candidate_version.unwrap_or(0),
+        root_sequence: candidate_sequence.unwrap_or(0),
+        root_transcript_sha256: sha256(&candidate_raw),
+        generation,
+        sequence,
+        snapshot_id: text(field(field(signed, "consistent_snapshot"), "snapshot_id"))
+            .unwrap_or_default()
+            .to_owned(),
+        index_transcript_sha256,
+        index_signer_key_ids,
+        releases: typed_releases,
+        exact_index_bytes: index_bytes.to_vec(),
+    })
+}
+
+/// Build the exact release-scoped verification expectation for one
+/// authenticated catalog entry.
+///
+/// The returned value preserves policy fields from `template` while replacing
+/// every release request and current root/index/offline pin with authenticated
+/// catalog evidence. It is suitable for [`verify_package_with_artifacts`].
+pub fn verification_expectation_for_authenticated_release(
+    template: &VerificationExpectation,
+    catalog: &AuthenticatedRegistryCatalog,
+    release: &AuthenticatedRegistryRelease,
+) -> Result<VerificationExpectation, RegistryCatalogAuthenticationError> {
+    let mut failures = BTreeSet::new();
+    if !catalog
+        .releases
+        .iter()
+        .any(|candidate| candidate == release)
+    {
+        add(&mut failures, "OFFLINE_INPUT_MISSING");
+        return Err(catalog_error(&failures));
+    }
+
+    let mut value = template.0.clone();
+    value["request"] = serde_json::json!({
+        "registry_identity": field(&release.authenticated_value, "registry_identity"),
+        "source_identity": field(&release.authenticated_value, "source_identity"),
+        "namespace": field(&release.authenticated_value, "namespace"),
+        "name": field(&release.authenticated_value, "name"),
+        "version": field(&release.authenticated_value, "version"),
+        "target_path": field(&release.authenticated_value, "target_path"),
+        "publisher_identity": field(&release.authenticated_value, "publisher_identity"),
+        "archive": field(&release.authenticated_value, "archive"),
+        "manifest": field(&release.authenticated_value, "manifest"),
+        "provenance": field(&release.authenticated_value, "provenance"),
+    });
+    value["trusted_state"]["trusted_root_anchor"] = serde_json::json!({
+        "root_version": catalog.trusted_root_version,
+        "root_sequence": catalog.trusted_root_sequence,
+        "root_transcript_sha256": catalog.trusted_root_transcript_sha256,
+    });
+    value["trusted_state"]["highest_root_version"] = Value::from(catalog.root_version);
+    value["trusted_state"]["highest_root_sequence"] = Value::from(catalog.root_sequence);
+    value["trusted_state"]["highest_index_generation"] = Value::from(catalog.generation);
+    value["trusted_state"]["highest_index_sequence"] = Value::from(catalog.sequence);
+    let snapshot_state = serde_json::json!({
+        "generation": catalog.generation,
+        "sequence": catalog.sequence,
+        "snapshot_id": catalog.snapshot_id,
+        "index_transcript_sha256": catalog.index_transcript_sha256,
+    });
+    let seen_snapshots = value["trusted_state"]["seen_snapshots"]
+        .as_array_mut()
+        .ok_or_else(|| {
+            add(&mut failures, "OFFLINE_INPUT_MISSING");
+            catalog_error(&failures)
+        })?;
+    if !seen_snapshots.contains(&snapshot_state) {
+        if seen_snapshots.len() >= MAX_SEEN_SNAPSHOTS {
+            add(&mut failures, "OFFLINE_INPUT_MISSING");
+            return Err(catalog_error(&failures));
+        }
+        seen_snapshots.push(snapshot_state);
+    }
+    value["offline_lock"] = serde_json::json!({
+        "mode": "offline_locked",
+        "network_fallback": false,
+        "root_version": catalog.root_version,
+        "root_sequence": catalog.root_sequence,
+        "root_transcript_sha256": catalog.root_transcript_sha256,
+        "index_generation": catalog.generation,
+        "index_sequence": catalog.sequence,
+        "index_transcript_sha256": catalog.index_transcript_sha256,
+        "release": {
+            "registry_identity": field(&release.authenticated_value, "registry_identity"),
+            "source_identity": field(&release.authenticated_value, "source_identity"),
+            "namespace": field(&release.authenticated_value, "namespace"),
+            "name": field(&release.authenticated_value, "name"),
+            "version": field(&release.authenticated_value, "version"),
+            "target_path": field(&release.authenticated_value, "target_path"),
+            "publisher_identity": field(&release.authenticated_value, "publisher_identity"),
+            "archive": field(&release.authenticated_value, "archive"),
+            "manifest": field(&release.authenticated_value, "manifest"),
+            "provenance_statement_sha256": field(field(field(&release.authenticated_value, "provenance"), "statement"), "digest").get("value").unwrap_or(&Value::Null),
+            "provenance_predicate_type": field(field(field(field(&release.authenticated_value, "provenance"), "statement"), "value"), "predicateType"),
+            "provenance_subject": field(field(&release.authenticated_value, "provenance"), "selected_subject"),
+            "package_signature_sha256": field(&release.authenticated_value, "package_signature_sha256"),
+        },
+    });
+    let expectation = VerificationExpectation(value);
+    if !validate_document_work_budget(&expectation, DocumentKind::Expectation)
+        || validate_schema_value(
+            &expectation,
+            include_bytes!(
+                "../../../schemas/axiom-package-verification-expectation-v1.schema.json"
+            ),
+            &VERIFICATION_EXPECTATION_SCHEMA,
+            "verification expectation",
+        )
+        .is_err()
+    {
+        add(&mut failures, "OFFLINE_INPUT_MISSING");
+        return Err(catalog_error(&failures));
+    }
+    Ok(expectation)
+}
+
+/// Construct release-scoped expectation fields for a package publication that
+/// has not yet been admitted to a signed index.
+///
+/// This crate-private entry point exists only for the registry publication
+/// preflight. Resolver and install consumers must use
+/// [`verification_expectation_for_authenticated_release`] instead.
+pub(crate) fn verification_expectation_for_unindexed_release(
+    template: &VerificationExpectation,
+    release: &Value,
+) -> Result<VerificationExpectation, PackageTrustError> {
+    let mut value = template.0.clone();
+    value["request"] = serde_json::json!({
+        "registry_identity": field(release, "registry_identity"),
+        "source_identity": field(release, "source_identity"),
+        "namespace": field(release, "namespace"),
+        "name": field(release, "name"),
+        "version": field(release, "version"),
+        "target_path": field(release, "target_path"),
+        "publisher_identity": field(release, "publisher_identity"),
+        "archive": field(release, "archive"),
+        "manifest": field(release, "manifest"),
+        "provenance": field(release, "provenance"),
+    });
+    value["offline_lock"]["release"] = serde_json::json!({
+        "registry_identity": field(release, "registry_identity"),
+        "source_identity": field(release, "source_identity"),
+        "namespace": field(release, "namespace"),
+        "name": field(release, "name"),
+        "version": field(release, "version"),
+        "target_path": field(release, "target_path"),
+        "publisher_identity": field(release, "publisher_identity"),
+        "archive": field(release, "archive"),
+        "manifest": field(release, "manifest"),
+        "provenance_statement_sha256": field(field(field(release, "provenance"), "statement"), "digest").get("value").unwrap_or(&Value::Null),
+        "provenance_predicate_type": field(field(field(field(release, "provenance"), "statement"), "value"), "predicateType"),
+        "provenance_subject": field(field(release, "provenance"), "selected_subject"),
+        "package_signature_sha256": field(release, "package_signature_sha256"),
+    });
+    let expectation = VerificationExpectation(value);
+    if !validate_document_work_budget(&expectation, DocumentKind::Expectation) {
+        return Err(PackageTrustError::new(
+            "release verification expectation exceeds the Package Trust work budget",
+        ));
+    }
+    validate_schema_value(
+        &expectation,
+        include_bytes!("../../../schemas/axiom-package-verification-expectation-v1.schema.json"),
+        &VERIFICATION_EXPECTATION_SCHEMA,
+        "verification expectation",
+    )?;
+    Ok(expectation)
+}
+
 /// Validate canonical in-toto/SLSA semantics before invoking a package signer.
 ///
 /// The envelope may still be unsigned; this checks the selected subject,
@@ -3576,6 +4277,244 @@ mod tests {
             )
             .is_err()
         );
+    }
+
+    fn catalog_bytes(index: &RegistryIndexEnvelope) -> Vec<u8> {
+        serde_json::to_vec(index).expect("serialize registry index")
+    }
+
+    fn catalog_reasons(
+        index: &RegistryIndexEnvelope,
+        roots: &TrustRootsEnvelope,
+        expectation: &VerificationExpectation,
+    ) -> Vec<String> {
+        authenticate_registry_catalog(&catalog_bytes(index), roots, expectation)
+            .expect_err("catalog mutation must fail closed")
+            .reason_codes
+    }
+
+    fn flip_first_hex(value: &mut Value) {
+        let encoded = value.as_str().expect("fixture value is hex");
+        let replacement = if encoded.starts_with('0') { "1" } else { "0" };
+        *value = Value::String(format!("{replacement}{}", &encoded[1..]));
+    }
+
+    #[test]
+    fn authenticated_catalog_retains_exact_bytes_and_typed_release_artifacts() {
+        let bundle = bundle();
+        let bytes = catalog_bytes(&bundle.registry_index);
+        let catalog = authenticate_registry_catalog(
+            &bytes,
+            &bundle.trust_roots,
+            &bundle.verification_expectation,
+        )
+        .expect("published catalog authenticates");
+
+        assert_eq!(catalog.exact_index_bytes(), bytes);
+        assert_eq!(catalog.registry_identity, "axiom-registry-production");
+        assert_eq!(catalog.source_identity, "registry:axiom-production");
+        assert_eq!(catalog.root_version, 4);
+        assert_eq!(catalog.root_sequence, 1040);
+        assert_eq!(catalog.generation, 42);
+        assert_eq!(catalog.sequence, 1042);
+        assert_eq!(catalog.index_signer_key_ids.len(), 2);
+        let release = catalog
+            .release("axiom", "core", "1.2.3")
+            .expect("typed release is addressable by exact coordinate");
+        assert_eq!(release.archive_length, 4096);
+        assert_eq!(
+            release.archive_sha256,
+            "fe8d20ff71a399777064fc096654d204b5e46894bdca6dba4fb0eb9bdf4a6fd5"
+        );
+        assert!(!release.yanked);
+        assert_eq!(
+            release.artifact_paths(),
+            &AuthenticatedRegistryArtifactPaths {
+                archive: "axiom/core/1.2.3/package.axp".to_owned(),
+                manifest: "axiom/core/1.2.3/axiom.toml".to_owned(),
+                provenance: "axiom/core/1.2.3/provenance.json".to_owned(),
+                package_signature: "axiom/core/1.2.3/package.axp.sig".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn catalog_rejects_bad_index_and_root_transition_signatures() {
+        let bundle = bundle();
+        let mut index = bundle.registry_index.clone();
+        flip_first_hex(&mut index.0["signatures"][0]["value"]);
+        let reasons = catalog_reasons(
+            &index,
+            &bundle.trust_roots,
+            &bundle.verification_expectation,
+        );
+        assert!(reasons.contains(&"INDEX_SIGNATURE_INVALID".to_owned()));
+        assert!(reasons.contains(&"INDEX_THRESHOLD_NOT_MET".to_owned()));
+
+        let mut roots = bundle.trust_roots.clone();
+        flip_first_hex(&mut roots.0["transition"]["candidate_signatures_by_old_root"][0]["value"]);
+        let reasons = catalog_reasons(
+            &bundle.registry_index,
+            &roots,
+            &bundle.verification_expectation,
+        );
+        assert!(reasons.contains(&"ROOT_SIGNATURE_INVALID".to_owned()));
+        assert!(reasons.contains(&"ROOT_THRESHOLD_NOT_MET".to_owned()));
+    }
+
+    #[test]
+    fn catalog_rejects_expiry_rollback_replay_and_wrong_identity() {
+        let bundle = bundle();
+
+        let mut expired = bundle.verification_expectation.clone();
+        expired.0["verification_time"] = Value::String("2028-01-01T00:00:00Z".to_owned());
+        assert!(
+            catalog_reasons(&bundle.registry_index, &bundle.trust_roots, &expired)
+                .contains(&"METADATA_EXPIRED".to_owned())
+        );
+
+        let mut rollback = bundle.verification_expectation.clone();
+        rollback.0["trusted_state"]["highest_index_generation"] = Value::from(43_u64);
+        rollback.0["trusted_state"]["highest_index_sequence"] = Value::from(1043_u64);
+        assert!(
+            catalog_reasons(&bundle.registry_index, &bundle.trust_roots, &rollback)
+                .contains(&"ROLLBACK_DETECTED".to_owned())
+        );
+
+        let mut replay = bundle.verification_expectation.clone();
+        replay.0["trusted_state"]["seen_snapshots"][1]["index_transcript_sha256"] =
+            Value::String("0".repeat(64));
+        assert!(
+            catalog_reasons(&bundle.registry_index, &bundle.trust_roots, &replay)
+                .contains(&"METADATA_REPLAYED".to_owned())
+        );
+
+        let mut wrong_identity = bundle.verification_expectation.clone();
+        wrong_identity.0["request"]["registry_identity"] =
+            Value::String("shadow-registry".to_owned());
+        assert!(
+            catalog_reasons(&bundle.registry_index, &bundle.trust_roots, &wrong_identity)
+                .contains(&"SOURCE_MISMATCH".to_owned())
+        );
+
+        for (vector_id, expected_reason) in [
+            ("stale-snapshot-replay", "ROLLBACK_DETECTED"),
+            ("snapshot-id-rebound", "METADATA_REPLAYED"),
+        ] {
+            let replacement = bundle
+                .negative_vectors
+                .iter()
+                .find(|vector| text(field(vector, "id")) == Some(vector_id))
+                .and_then(|vector| field(vector, "mutations").as_array())
+                .and_then(|mutations| mutations.first())
+                .map(|mutation| field(mutation, "value").clone())
+                .expect("resigned replay index vector");
+            let reasons = catalog_reasons(
+                &RegistryIndexEnvelope(replacement),
+                &bundle.trust_roots,
+                &bundle.verification_expectation,
+            );
+            assert!(
+                reasons.contains(&expected_reason.to_owned()),
+                "{vector_id}: {reasons:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn catalog_rejects_resigned_duplicate_coordinates_and_targets() {
+        let bundle = bundle();
+        for (vector_id, expected_reason) in [
+            ("duplicate-target-path-resigned", "DUPLICATE_TARGET_PATH"),
+            (
+                "duplicate-package-coordinate-resigned",
+                "DUPLICATE_PACKAGE_COORDINATE",
+            ),
+        ] {
+            let replacement = bundle
+                .negative_vectors
+                .iter()
+                .find(|vector| text(field(vector, "id")) == Some(vector_id))
+                .and_then(|vector| field(vector, "mutations").as_array())
+                .and_then(|mutations| mutations.first())
+                .map(|mutation| field(mutation, "value").clone())
+                .expect("resigned duplicate index vector");
+            let index = RegistryIndexEnvelope(replacement);
+            let reasons = catalog_reasons(
+                &index,
+                &bundle.trust_roots,
+                &bundle.verification_expectation,
+            );
+            assert!(
+                reasons.contains(&expected_reason.to_owned()),
+                "{vector_id}: {reasons:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn authenticated_release_expectation_installs_exact_catalog_pins() {
+        let bundle = bundle();
+        let bytes = catalog_bytes(&bundle.registry_index);
+        let catalog = authenticate_registry_catalog(
+            &bytes,
+            &bundle.trust_roots,
+            &bundle.verification_expectation,
+        )
+        .expect("catalog authenticates");
+        let release = catalog
+            .release("axiom", "core", "1.2.3")
+            .expect("selected release");
+        let expectation = verification_expectation_for_authenticated_release(
+            &bundle.verification_expectation,
+            &catalog,
+            release,
+        )
+        .expect("release expectation");
+
+        assert_eq!(
+            number(field(
+                field(&expectation, "trusted_state"),
+                "highest_root_version"
+            )),
+            Some(catalog.root_version)
+        );
+        assert_eq!(
+            text(field(
+                field(&expectation, "offline_lock"),
+                "root_transcript_sha256"
+            )),
+            Some(catalog.root_transcript_sha256.as_str())
+        );
+        assert_eq!(
+            text(field(
+                field(&expectation, "offline_lock"),
+                "index_transcript_sha256"
+            )),
+            Some(catalog.index_transcript_sha256.as_str())
+        );
+        assert_eq!(
+            text(field(field(&expectation, "request"), "target_path")),
+            Some(release.target_path.as_str())
+        );
+        assert_eq!(
+            text(field(
+                field(field(&expectation, "offline_lock"), "release"),
+                "package_signature_sha256"
+            )),
+            Some(release.package_signature_sha256.as_str())
+        );
+        parse_verification_expectation_json(
+            &serde_json::to_vec(&expectation).expect("serialize exact expectation"),
+        )
+        .expect("builder output remains strict and schema-valid");
+        let verdict = verify_package(&PackageTrustInput {
+            package_signature: bundle.package_signature,
+            trust_roots: bundle.trust_roots,
+            registry_index: bundle.registry_index,
+            verification_expectation: expectation,
+        });
+        assert_eq!(verdict.decision, "trusted", "{verdict:#?}");
     }
 
     #[test]

--- a/stage1/crates/axiomc/src/package_version.rs
+++ b/stage1/crates/axiomc/src/package_version.rs
@@ -1,0 +1,223 @@
+//! Strict release-only semantic versions used by the package resolver.
+
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ReleaseVersion {
+    pub major: u64,
+    pub minor: u64,
+    pub patch: u64,
+}
+
+impl ReleaseVersion {
+    pub const fn new(major: u64, minor: u64, patch: u64) -> Self {
+        Self {
+            major,
+            minor,
+            patch,
+        }
+    }
+
+    pub fn parse(value: &str) -> Result<Self, VersionParseError> {
+        value.parse()
+    }
+}
+
+impl fmt::Display for ReleaseVersion {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+impl FromStr for ReleaseVersion {
+    type Err = VersionParseError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if value.is_empty() || !value.is_ascii() {
+            return Err(VersionParseError::InvalidRelease(value.to_owned()));
+        }
+        let mut parts = value.split('.');
+        let major = parse_component(parts.next(), value)?;
+        let minor = parse_component(parts.next(), value)?;
+        let patch = parse_component(parts.next(), value)?;
+        if parts.next().is_some() {
+            return Err(VersionParseError::InvalidRelease(value.to_owned()));
+        }
+        Ok(Self::new(major, minor, patch))
+    }
+}
+
+fn parse_component(component: Option<&str>, original: &str) -> Result<u64, VersionParseError> {
+    let component =
+        component.ok_or_else(|| VersionParseError::InvalidRelease(original.to_owned()))?;
+    if component.is_empty()
+        || !component.bytes().all(|byte| byte.is_ascii_digit())
+        || (component.len() > 1 && component.starts_with('0'))
+    {
+        return Err(VersionParseError::InvalidRelease(original.to_owned()));
+    }
+    component
+        .parse()
+        .map_err(|_| VersionParseError::ComponentOverflow(original.to_owned()))
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "version", rename_all = "snake_case")]
+pub enum VersionRequirement {
+    Exact(ReleaseVersion),
+    Caret(ReleaseVersion),
+}
+
+impl VersionRequirement {
+    pub fn parse(value: &str) -> Result<Self, VersionParseError> {
+        value.parse()
+    }
+
+    pub const fn minimum(self) -> ReleaseVersion {
+        match self {
+            Self::Exact(version) | Self::Caret(version) => version,
+        }
+    }
+
+    pub fn matches(self, candidate: ReleaseVersion) -> bool {
+        let minimum = self.minimum();
+        if candidate < minimum {
+            return false;
+        }
+        match self {
+            Self::Exact(version) => candidate == version,
+            Self::Caret(version) if version.major > 0 => candidate.major == version.major,
+            Self::Caret(version) if version.minor > 0 => {
+                candidate.major == 0 && candidate.minor == version.minor
+            }
+            Self::Caret(version) => {
+                candidate.major == 0 && candidate.minor == 0 && candidate.patch == version.patch
+            }
+        }
+    }
+}
+
+impl fmt::Display for VersionRequirement {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Exact(version) => version.fmt(formatter),
+            Self::Caret(version) => write!(formatter, "^{version}"),
+        }
+    }
+}
+
+impl FromStr for VersionRequirement {
+    type Err = VersionParseError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if let Some(version) = value.strip_prefix('^') {
+            if version.starts_with('^') {
+                return Err(VersionParseError::InvalidRequirement(value.to_owned()));
+            }
+            return ReleaseVersion::parse(version)
+                .map(Self::Caret)
+                .map_err(|_| VersionParseError::InvalidRequirement(value.to_owned()));
+        }
+        ReleaseVersion::parse(value)
+            .map(Self::Exact)
+            .map_err(|_| VersionParseError::InvalidRequirement(value.to_owned()))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum VersionParseError {
+    InvalidRelease(String),
+    ComponentOverflow(String),
+    InvalidRequirement(String),
+}
+
+impl fmt::Display for VersionParseError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidRelease(value) => {
+                write!(formatter, "{value:?} is not a strict release SemVer")
+            }
+            Self::ComponentOverflow(value) => {
+                write!(
+                    formatter,
+                    "{value:?} contains an overflowing SemVer component"
+                )
+            }
+            Self::InvalidRequirement(value) => {
+                write!(formatter, "{value:?} is not an exact or caret requirement")
+            }
+        }
+    }
+}
+
+impl std::error::Error for VersionParseError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn version(value: &str) -> ReleaseVersion {
+        ReleaseVersion::parse(value).expect("version fixture")
+    }
+
+    #[test]
+    fn strict_release_versions_reject_noncanonical_or_extended_semver() {
+        assert_eq!(version("0.0.0"), ReleaseVersion::new(0, 0, 0));
+        assert_eq!(version("12.34.56").to_string(), "12.34.56");
+        for invalid in [
+            "",
+            "1",
+            "1.2",
+            "1.2.3.4",
+            "01.2.3",
+            "1.02.3",
+            "1.2.03",
+            "1.2.3-alpha",
+            "1.2.3+build",
+            " 1.2.3",
+            "1.2.3 ",
+            "１.2.3",
+        ] {
+            assert!(
+                ReleaseVersion::parse(invalid).is_err(),
+                "{invalid:?} must fail"
+            );
+        }
+    }
+
+    #[test]
+    fn exact_and_caret_requirements_follow_release_semver_boundaries() {
+        let exact = VersionRequirement::parse("1.2.3").expect("exact");
+        assert!(exact.matches(version("1.2.3")));
+        assert!(!exact.matches(version("1.2.4")));
+
+        let stable = VersionRequirement::parse("^1.2.3").expect("stable caret");
+        assert!(stable.matches(version("1.2.3")));
+        assert!(stable.matches(version("1.99.99")));
+        assert!(!stable.matches(version("1.2.2")));
+        assert!(!stable.matches(version("2.0.0")));
+
+        let zero_minor = VersionRequirement::parse("^0.2.3").expect("zero-minor caret");
+        assert!(zero_minor.matches(version("0.2.99")));
+        assert!(!zero_minor.matches(version("0.3.0")));
+        assert!(!zero_minor.matches(version("0.2.2")));
+
+        let zero_patch = VersionRequirement::parse("^0.0.3").expect("zero-patch caret");
+        assert!(zero_patch.matches(version("0.0.3")));
+        assert!(!zero_patch.matches(version("0.0.4")));
+    }
+
+    #[test]
+    fn requirements_reject_wildcards_ranges_and_overflow() {
+        for invalid in ["*", "~1.2.3", ">=1.2.3", "^^1.2.3", "^", "^01.2.3"] {
+            assert!(VersionRequirement::parse(invalid).is_err(), "{invalid}");
+        }
+        assert!(
+            ReleaseVersion::parse("18446744073709551616.0.0").is_err(),
+            "u64 overflow must fail"
+        );
+    }
+}

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -5750,6 +5750,18 @@ fn parse_module_with_cache(
     macro_recursion_limit: usize,
     parse_cache: &mut ModuleParseCache,
 ) -> Result<(syntax::Program, Arc<str>), Diagnostic> {
+    if let Some(source) = parse_cache.overlay_source(module_path) {
+        let source = Arc::<str>::from(source.to_owned());
+        let program = syntax::parse_program_with_options(
+            source.as_ref(),
+            module_path,
+            &syntax::ParseOptions {
+                macro_recursion_limit,
+                ..syntax::ParseOptions::default()
+            },
+        )?;
+        return Ok((program, source));
+    }
     let cache_key = if graph
         .has_verified_source(package_root, module_path)
         .is_some()

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -5,17 +5,24 @@ use crate::codegen::{
 use crate::cranelift_backend::compile_cranelift_hello_spike;
 use crate::diagnostics::Diagnostic;
 use crate::hir;
-use crate::json_contract;
-use crate::lockfile::validate_lockfile;
+use crate::lockfile::{ParsedLockfile, load_lockfile, validate_lockfile};
 use crate::manifest::{
     BuildSection, CapabilityConfig, CapabilityDescriptor, CapabilityKind, Manifest, PackageSection,
     ProcessCommandPolicy, RuntimeConfig, TestKind, binary_path_for_target, capability_descriptors,
     entry_path, generated_rust_path, load_manifest, manifest_path, out_dir_path,
+    parse_manifest_exact,
 };
 use crate::mir;
+use crate::package_archive::{ArchiveLimits, parse_archive};
+use crate::package_manager::{
+    MATERIALIZED_PACKAGE_GRAPH_SCHEMA, MaterializationEvidence, MaterializeOptions,
+    MaterializedDependencyEdge, MaterializedPackage, MaterializedPackageGraph, PackageManager,
+    PackageManagerError, PackageTrustEvidence,
+};
 use crate::stdlib;
 use crate::syntax;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::env;
 #[cfg(unix)]
@@ -38,18 +45,22 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread;
 use std::time::{Duration, Instant};
 
+const PACKAGE_GRAPH_RUNTIME_SCHEMA_VERSION: &str = "axiom.compiler.package_graph.runtime.v1";
+const PACKAGE_GRAPH_RUNTIME_CONTRACT: &str = "compiler.package_graph.runtime";
+
 mod expected_build_failure;
 mod lsp_analysis;
 mod module_parse_cache;
 use expected_build_failure::{expected_build_error_path, run_build_fail_case};
 pub use lsp_analysis::{LspResolvedModule, analyze_package_for_lsp};
-use module_parse_cache::{ModuleParseCache, module_parse_cache_key, parse_module_with_cache};
+use module_parse_cache::ModuleParseCache;
 mod test_case_result;
 pub use test_case_result::{ExpectedDiagnostic, TestCaseResult};
 
 const BUILD_CACHE_VERSION: u32 = 2;
 const BUILD_CACHE_COMPILER: &str = concat!("axiomc-stage1-", env!("CARGO_PKG_VERSION"));
 const MAX_TEST_EXPECTED_STREAM_BYTES: u64 = 1024 * 1024;
+const MAX_RESOLUTION_LOCKFILE_BYTES: u64 = 4 * 1024 * 1024;
 
 #[derive(Debug, Clone, Copy)]
 pub struct RunLimits {
@@ -355,16 +366,25 @@ pub struct TestOutput {
 #[derive(Debug, Clone, Serialize)]
 pub struct PackageGraphOutput {
     pub schema_version: &'static str,
+    pub contract: &'static str,
     pub manifest: String,
     pub packages: Vec<PackageGraphPackage>,
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct PackageGraphPackage {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
     pub root: String,
     pub manifest: String,
     pub name: Option<String>,
     pub version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trust: Option<PackageTrustEvidence>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub materialization: Option<MaterializationEvidence>,
     pub workspace_only: bool,
     pub entrypoint: Option<String>,
     pub capabilities: Vec<CapabilityDescriptor>,
@@ -378,6 +398,14 @@ pub struct PackageGraphDependency {
     pub name: String,
     pub path: String,
     pub package: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub package_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_kind: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requested: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -391,6 +419,10 @@ pub struct PackageGraphLockfile {
     pub path: String,
     pub status: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
 }
 
@@ -401,10 +433,18 @@ pub struct CapabilitySbomOutput {
 }
 #[derive(Debug, Clone, Serialize)]
 pub struct CapabilitySbomPackage {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
     pub root: String,
     pub manifest: String,
     pub name: Option<String>,
     pub version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trust: Option<PackageTrustEvidence>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub materialization: Option<MaterializationEvidence>,
     pub workspace_only: bool,
     pub entrypoint: Option<String>,
     pub package_graph: CapabilitySbomPackageGraph,
@@ -495,12 +535,19 @@ pub fn check_project_with_options(
 ) -> Result<CheckOutput, Diagnostic> {
     let project_root = canonicalize_existing_path(&normalize_path(project_root), "project root")?;
     let graph = load_package_graph(&project_root)?;
-    validate_workspace_root_lockfile(&graph, &project_root)?;
+    check_project_with_graph(&project_root, &graph, options)
+}
+
+fn check_project_with_graph(
+    project_root: &Path,
+    graph: &PackageGraph,
+    options: &CheckOptions,
+) -> Result<CheckOutput, Diagnostic> {
+    validate_workspace_root_lockfile(graph, project_root)?;
     let mut packages = Vec::new();
-    for package_root in workspace_package_roots(&graph, &project_root, options.package.as_deref())?
-    {
+    for package_root in workspace_package_roots(graph, project_root, options.package.as_deref())? {
         let analyzed =
-            analyze_package_with_macro_limit(&graph, &package_root, options.macro_recursion_limit)?;
+            analyze_package_with_macro_limit(graph, &package_root, options.macro_recursion_limit)?;
         let exports = if options.include_exports {
             public_api_exports(&analyzed.modules, &package_root)
         } else {
@@ -658,8 +705,8 @@ fn build_project_with_graph(
     let cache_misses = packages.len().saturating_sub(cache_hits);
     Ok(BuildOutput {
         backend: options.backend,
-        locked: options.locked,
-        offline: options.offline,
+        locked: options.locked || graph.resolution_lockfile.is_some(),
+        offline: options.offline || graph.resolution_lockfile.is_some(),
         manifest: root.manifest,
         entry: root.entry,
         binary: root.binary,
@@ -890,10 +937,10 @@ fn configure_bounded_command(command: &mut Command, limits: RunLimits) {
             if libc::setsid() < 0 {
                 return Err(io::Error::last_os_error());
             }
-            set_bounded_rlimit(limits.max_cpu_seconds, |rlimit| unsafe {
+            set_bounded_rlimit(limits.max_cpu_seconds, |rlimit| {
                 libc::setrlimit(libc::RLIMIT_CPU, rlimit)
             })?;
-            set_bounded_rlimit(limits.max_file_bytes, |rlimit| unsafe {
+            set_bounded_rlimit(limits.max_file_bytes, |rlimit| {
                 libc::setrlimit(libc::RLIMIT_FSIZE, rlimit)
             })?;
             Ok(())
@@ -948,8 +995,16 @@ fn prepare_run_project(
 ) -> Result<(PathBuf, BuildOutput, PathBuf), Diagnostic> {
     let project_root = canonicalize_existing_path(&normalize_path(project_root), "project root")?;
     let graph = load_package_graph(&project_root)?;
-    if options.package.is_none() && graph.context(&project_root)?.manifest.is_workspace_only() {
-        let packages = workspace_package_names(&graph, &project_root)?;
+    prepare_run_project_with_graph(&project_root, &graph, options)
+}
+
+fn prepare_run_project_with_graph(
+    project_root: &Path,
+    graph: &PackageGraph,
+    options: &RunOptions,
+) -> Result<(PathBuf, BuildOutput, PathBuf), Diagnostic> {
+    if options.package.is_none() && graph.context(project_root)?.manifest.is_workspace_only() {
+        let packages = workspace_package_names(graph, project_root)?;
         return Err(Diagnostic::new(
             "run",
             format!(
@@ -960,8 +1015,8 @@ fn prepare_run_project(
         .with_path(manifest_path(&project_root).display().to_string()));
     }
     let built = build_project_with_graph(
-        &project_root,
-        &graph,
+        project_root,
+        graph,
         &BuildOptions {
             backend: options.backend,
             target: None,
@@ -981,7 +1036,7 @@ fn prepare_run_project(
         )
     })?;
     let build_output_dir = build_output_dir.to_path_buf();
-    Ok((project_root, built, build_output_dir))
+    Ok((project_root.to_path_buf(), built, build_output_dir))
 }
 
 pub fn run_project_tests(project_root: &Path) -> Result<TestOutput, Diagnostic> {
@@ -1001,7 +1056,7 @@ pub fn list_project_tests_with_options(
     for package_root in workspace_package_roots(&graph, &project_root, options.package.as_deref())?
     {
         let manifest = &graph.context(&package_root)?.manifest;
-        validate_lockfile(&package_root, manifest)?;
+        validate_package_lockfile(&graph, &package_root, manifest)?;
         let package_root_text = package_root.display().to_string();
         let expected_error = expected_error_path(&package_root);
         let expected_build_error = expected_build_error_path(&package_root);
@@ -1060,16 +1115,23 @@ pub fn run_project_tests_with_options(
 ) -> Result<TestOutput, Diagnostic> {
     let project_root = canonicalize_existing_path(&normalize_path(project_root), "project root")?;
     let graph = load_package_graph(&project_root)?;
-    validate_workspace_root_lockfile(&graph, &project_root)?;
+    run_project_tests_with_graph(&project_root, &graph, options)
+}
+
+fn run_project_tests_with_graph(
+    project_root: &Path,
+    graph: &PackageGraph,
+    options: &TestOptions,
+) -> Result<TestOutput, Diagnostic> {
+    validate_workspace_root_lockfile(graph, project_root)?;
     let manifest_path_text = manifest_path(&project_root).display().to_string();
     let mut packages = Vec::new();
     let mut cases = Vec::new();
     let mut parse_cache = ModuleParseCache::default();
     let started = Instant::now();
-    for package_root in workspace_package_roots(&graph, &project_root, options.package.as_deref())?
-    {
+    for package_root in workspace_package_roots(graph, project_root, options.package.as_deref())? {
         let manifest = &graph.context(&package_root)?.manifest;
-        validate_lockfile(&package_root, manifest)?;
+        validate_package_lockfile(graph, &package_root, manifest)?;
         let package_root_text = package_root.display().to_string();
         let expected_error = expected_error_path(&package_root);
         let expected_build_error = expected_build_error_path(&package_root);
@@ -1084,11 +1146,11 @@ pub fn run_project_tests_with_options(
             ) {
                 packages.push(package_root_text.clone());
                 cases.push(if expected_build_error.exists() {
-                    run_build_fail_case(&package_root, &graph, manifest, &test.name, test.kind)
+                    run_build_fail_case(&package_root, graph, manifest, &test.name, test.kind)
                 } else {
                     run_compile_fail_case(
                         &package_root,
-                        &graph,
+                        graph,
                         manifest,
                         &test.name,
                         test.kind,
@@ -1113,7 +1175,7 @@ pub fn run_project_tests_with_options(
         for test in &tests {
             cases.push(run_test_case(
                 &package_root,
-                &graph,
+                graph,
                 manifest,
                 test,
                 options.backend,
@@ -1622,6 +1684,13 @@ pub fn project_capabilities(project_root: &Path) -> Result<Vec<CapabilityDescrip
 pub fn capability_sbom(project_root: &Path) -> Result<CapabilitySbomOutput, Diagnostic> {
     let project_root = canonicalize_existing_path(&normalize_path(project_root), "project root")?;
     let graph = load_package_graph(&project_root)?;
+    capability_sbom_with_graph(&project_root, &graph)
+}
+
+fn capability_sbom_with_graph(
+    project_root: &Path,
+    graph: &PackageGraph,
+) -> Result<CapabilitySbomOutput, Diagnostic> {
     let graph_output = package_graph_metadata_with_graph(&project_root, &graph)?;
     let mut packages = Vec::new();
     for graph_package in graph_output.packages {
@@ -1662,10 +1731,14 @@ pub fn capability_sbom(project_root: &Path) -> Result<CapabilitySbomOutput, Diag
             })
             .collect();
         packages.push(CapabilitySbomPackage {
+            id: graph_package.id,
             root: graph_package.root,
             manifest: graph_package.manifest,
             name: graph_package.name,
             version: graph_package.version,
+            source: graph_package.source,
+            trust: graph_package.trust,
+            materialization: graph_package.materialization,
             workspace_only: graph_package.workspace_only,
             entrypoint: graph_package.entrypoint,
             package_graph: CapabilitySbomPackageGraph {
@@ -1701,7 +1774,37 @@ fn package_graph_metadata_with_graph(
         .filter(|root| **root != stdlib::stdlib_root())
         .cloned()
         .collect::<Vec<_>>();
-    roots.sort();
+    roots.sort_by(|left, right| {
+        let left_root_rank = usize::from(left != project_root);
+        let right_root_rank = usize::from(right != project_root);
+        left_root_rank
+            .cmp(&right_root_rank)
+            .then_with(|| {
+                graph
+                    .materialized_package(left)
+                    .map(|package| package.source.as_str())
+                    .cmp(
+                        &graph
+                            .materialized_package(right)
+                            .map(|package| package.source.as_str()),
+                    )
+            })
+            .then_with(|| {
+                graph
+                    .context(left)
+                    .ok()
+                    .and_then(|context| context.manifest.package.as_ref())
+                    .map(|package| package.name.as_str())
+                    .cmp(
+                        &graph
+                            .context(right)
+                            .ok()
+                            .and_then(|context| context.manifest.package.as_ref())
+                            .map(|package| package.name.as_str()),
+                    )
+            })
+            .then(left.cmp(right))
+    });
     let mut packages = Vec::new();
     for root in roots {
         let package = graph.context(&root)?;
@@ -1720,11 +1823,13 @@ fn package_graph_metadata_with_graph(
             .package
             .as_ref()
             .map(|_| entry_path(&root, &package.manifest).display().to_string());
+        let materialized_package = graph.materialized_package(&root);
         let dependencies = package
             .dependencies
             .iter()
             .map(|(name, dependency_root)| {
                 let dependency = graph.context(dependency_root)?;
+                let edge = graph.materialized_edge(&root, name, dependency_root);
                 Ok(PackageGraphDependency {
                     name: name.clone(),
                     path: dependency_root.display().to_string(),
@@ -1733,6 +1838,10 @@ fn package_graph_metadata_with_graph(
                         .package
                         .as_ref()
                         .map(|package| package.name.clone()),
+                    package_id: graph.package_id(dependency_root).map(str::to_owned),
+                    source_kind: edge.map(|edge| edge.source_kind.clone()),
+                    requested: edge.map(|edge| edge.requested.clone()),
+                    reason: edge.map(|edge| edge.reason.clone()),
                 })
             })
             .collect::<Result<Vec<_>, Diagnostic>>()?;
@@ -1751,23 +1860,32 @@ fn package_graph_metadata_with_graph(
                 })
             })
             .collect::<Result<Vec<_>, Diagnostic>>()?;
-        let lockfile = match validate_lockfile(&root, &package.manifest) {
+        let graph_lockfile_path = graph.lockfile_path_for(&root);
+        let lockfile = match validate_package_lockfile(graph, &root, &package.manifest) {
             Ok(()) => PackageGraphLockfile {
-                path: crate::manifest::lockfile_path(&root).display().to_string(),
+                path: graph_lockfile_path.display().to_string(),
                 status: String::from("current"),
+                version: graph.lockfile_version_for(&root),
+                hash: graph.lockfile_hash_for(&root).ok(),
                 message: None,
             },
             Err(error) => PackageGraphLockfile {
-                path: crate::manifest::lockfile_path(&root).display().to_string(),
+                path: graph_lockfile_path.display().to_string(),
                 status: String::from("stale"),
+                version: graph.lockfile_version_for(&root),
+                hash: graph.lockfile_hash_for(&root).ok(),
                 message: Some(error.message),
             },
         };
         packages.push(PackageGraphPackage {
+            id: graph.package_id(&root).map(str::to_owned),
             root: root.display().to_string(),
             manifest: manifest_path(&root).display().to_string(),
             name,
             version,
+            source: materialized_package.map(|package| package.source.clone()),
+            trust: materialized_package.and_then(|package| package.trust.clone()),
+            materialization: materialized_package.map(|package| package.materialization.clone()),
             workspace_only: package.manifest.is_workspace_only(),
             entrypoint,
             capabilities: capability_descriptors(&package.manifest.capabilities),
@@ -1777,7 +1895,8 @@ fn package_graph_metadata_with_graph(
         });
     }
     Ok(PackageGraphOutput {
-        schema_version: json_contract::JSON_SCHEMA_VERSION,
+        schema_version: PACKAGE_GRAPH_RUNTIME_SCHEMA_VERSION,
+        contract: PACKAGE_GRAPH_RUNTIME_CONTRACT,
         manifest: manifest_path(&project_root).display().to_string(),
         packages,
     })
@@ -1790,11 +1909,22 @@ struct PackageContext {
     source_root: PathBuf,
     dependencies: BTreeMap<String, PathBuf>,
     workspace_members: Vec<PathBuf>,
+    verified_sources: Option<VerifiedPackageSources>,
+}
+
+#[derive(Debug, Clone)]
+struct VerifiedPackageSources {
+    archive_sha256: String,
+    sources: BTreeMap<PathBuf, Arc<str>>,
 }
 
 #[derive(Debug, Clone, Default)]
 struct PackageGraph {
     packages: HashMap<PathBuf, PackageContext>,
+    package_ids: HashMap<PathBuf, String>,
+    materialized: Option<MaterializedPackageGraph>,
+    resolution_lockfile: Option<PathBuf>,
+    resolution_lockfile_hash: Option<String>,
 }
 
 impl PackageGraph {
@@ -1809,6 +1939,79 @@ impl PackageGraph {
             )
         })
     }
+
+    fn package_id(&self, package_root: &Path) -> Option<&str> {
+        self.package_ids.get(package_root).map(String::as_str)
+    }
+
+    fn materialized_package(&self, package_root: &Path) -> Option<&MaterializedPackage> {
+        let id = self.package_id(package_root)?;
+        self.materialized
+            .as_ref()?
+            .packages
+            .iter()
+            .find(|package| package.id == id)
+    }
+
+    fn materialized_edge(
+        &self,
+        package_root: &Path,
+        alias: &str,
+        dependency_root: &Path,
+    ) -> Option<&MaterializedDependencyEdge> {
+        let from = self.package_id(package_root)?;
+        let to = self.package_id(dependency_root)?;
+        self.materialized
+            .as_ref()?
+            .edges
+            .iter()
+            .find(|edge| edge.from == from && edge.to == to && edge.alias == alias)
+    }
+
+    fn lockfile_path_for(&self, package_root: &Path) -> PathBuf {
+        self.resolution_lockfile
+            .clone()
+            .unwrap_or_else(|| crate::manifest::lockfile_path(package_root))
+    }
+
+    fn lockfile_version_for(&self, package_root: &Path) -> Option<u32> {
+        if self.resolution_lockfile.is_some() {
+            return Some(2);
+        }
+        load_lockfile(package_root)
+            .ok()
+            .map(|lockfile| lockfile.version())
+    }
+
+    fn lockfile_hash_for(&self, package_root: &Path) -> Result<String, Diagnostic> {
+        self.resolution_lockfile_hash
+            .clone()
+            .map(Ok)
+            .unwrap_or_else(|| hash_file(&crate::manifest::lockfile_path(package_root)))
+    }
+
+    fn package_root(&self, package_root: &Path) -> Result<PathBuf, Diagnostic> {
+        let normalized = normalize_path(package_root);
+        if self.packages.contains_key(&normalized) {
+            return Ok(normalized);
+        }
+        canonicalize_existing_path(&normalized, "package root")
+    }
+
+    fn verified_source(&self, package_root: &Path, module_path: &Path) -> Option<Arc<str>> {
+        self.packages
+            .get(package_root)?
+            .verified_sources
+            .as_ref()?
+            .sources
+            .get(&normalize_path(module_path))
+            .cloned()
+    }
+
+    fn has_verified_source(&self, package_root: &Path, module_path: &Path) -> Option<bool> {
+        let sources = self.packages.get(package_root)?.verified_sources.as_ref()?;
+        Some(sources.sources.contains_key(&normalize_path(module_path)))
+    }
 }
 
 struct AnalyzedProject {
@@ -1822,6 +2025,7 @@ struct AnalyzedProject {
 #[derive(Debug, Clone)]
 struct LoadedModule {
     path: PathBuf,
+    source: Arc<str>,
     program: syntax::Program,
     resolved_imports: Vec<ResolvedImport>,
     is_entry: bool,
@@ -1906,14 +2110,14 @@ fn analyze_package_for_capability_sbom(
     graph: &PackageGraph,
     package_root: &Path,
 ) -> Result<AnalyzedProject, Diagnostic> {
-    let package_root = normalize_path(package_root);
-    let package_root = canonicalize_existing_path(&package_root, "package root")?;
+    let package_root = graph.package_root(package_root)?;
     let mut manifest = buildable_package_manifest(graph, &package_root)?;
-    validate_lockfile(&package_root, &manifest)?;
+    validate_package_lockfile(graph, &package_root, &manifest)?;
     let entry = entry_path(&package_root, &manifest);
-    let entry = canonicalize_package_path(
-        &entry,
+    let entry = validate_compiler_source_path(
+        graph,
         &package_root,
+        &entry,
         "manifest",
         "build.entry resolves outside the package",
     )?;
@@ -1949,14 +2153,14 @@ fn analyze_package_with_macro_limit(
     package_root: &Path,
     macro_recursion_limit: usize,
 ) -> Result<AnalyzedProject, Diagnostic> {
-    let package_root = normalize_path(package_root);
-    let package_root = canonicalize_existing_path(&package_root, "package root")?;
+    let package_root = graph.package_root(package_root)?;
     let manifest = buildable_package_manifest(graph, &package_root)?;
-    validate_lockfile(&package_root, &manifest)?;
+    validate_package_lockfile(graph, &package_root, &manifest)?;
     let entry = entry_path(&package_root, &manifest);
-    let entry = canonicalize_package_path(
-        &entry,
+    let entry = validate_compiler_source_path(
+        graph,
         &package_root,
+        &entry,
         "manifest",
         "build.entry resolves outside the package",
     )?;
@@ -2017,9 +2221,10 @@ fn analyze_entry_with_parse_cache(
     // Axiom source and echoed back through diagnostics. We only gate access
     // here and keep using `entry` for loading, so module paths and diagnostics
     // are unchanged for legitimate (non-symlinked) entries.
-    canonicalize_package_path(
-        &entry,
+    validate_compiler_source_path(
+        graph,
         package_root,
+        &entry,
         "manifest",
         "build.entry resolves outside the package",
     )?;
@@ -2173,17 +2378,614 @@ fn validate_workspace_root_lockfile(
 ) -> Result<(), Diagnostic> {
     let manifest = &graph.context(project_root)?.manifest;
     if manifest.is_workspace_only() {
-        validate_lockfile(project_root, manifest)?;
+        validate_package_lockfile(graph, project_root, manifest)?;
     }
     Ok(())
 }
 
+fn validate_package_lockfile(
+    graph: &PackageGraph,
+    package_root: &Path,
+    manifest: &Manifest,
+) -> Result<(), Diagnostic> {
+    if let Some(lockfile) = graph.resolution_lockfile.as_deref() {
+        // Registry graphs reach this point only after PackageManager has
+        // validated lockfile v2, the local path graph, exact trust pins, and
+        // every cache or vendor tree. Registry package roots intentionally do
+        // not carry independent lockfiles: the root v2 lock is the identity
+        // and integrity source for the complete graph.
+        let expected = graph
+            .resolution_lockfile_hash
+            .as_deref()
+            .expect("materialized graph has a lockfile identity");
+        let actual = sha256_lockfile(lockfile)?;
+        if actual != expected {
+            return Err(Diagnostic::new(
+                "lockfile",
+                "root axiom.lock changed after the registry package graph was materialized",
+            )
+            .with_code("lockfile_changed")
+            .with_path(lockfile.display().to_string()));
+        }
+        return Ok(());
+    }
+    validate_lockfile(package_root, manifest)
+}
+
 fn load_package_graph(project_root: &Path) -> Result<PackageGraph, Diagnostic> {
-    let mut graph = PackageGraph::default();
-    let mut visiting = Vec::new();
-    load_package_graph_recursive(project_root, &mut graph, &mut visiting, &BTreeSet::new())?;
+    let project_root = canonicalize_existing_path(&normalize_path(project_root), "project root")?;
+    let manifest = load_manifest(&project_root)?;
+    let has_direct_registry_dependency = manifest
+        .dependencies
+        .values()
+        .any(crate::manifest::DependencySpec::is_registry);
+    let has_v2_lockfile = matches!(load_lockfile(&project_root), Ok(ParsedLockfile::V2(_)));
+    let mut graph = if has_direct_registry_dependency || has_v2_lockfile {
+        load_materialized_package_graph(&project_root)?
+    } else {
+        let mut graph = PackageGraph::default();
+        let mut visiting = Vec::new();
+        load_package_graph_recursive(&project_root, &mut graph, &mut visiting, &BTreeSet::new())?;
+        graph
+    };
     register_stdlib_package(&mut graph);
     Ok(graph)
+}
+
+fn load_materialized_package_graph(project_root: &Path) -> Result<PackageGraph, Diagnostic> {
+    let manager = PackageManager::open(project_root).map_err(package_manager_diagnostic)?;
+    let materialized = manager
+        .materialize_locked(MaterializeOptions::default())
+        .map_err(package_manager_diagnostic)?;
+    package_graph_from_materialized(project_root, materialized)
+}
+
+fn package_graph_from_materialized(
+    project_root: &Path,
+    mut materialized: MaterializedPackageGraph,
+) -> Result<PackageGraph, Diagnostic> {
+    let resolution_lockfile = crate::manifest::lockfile_path(project_root);
+    let current_lockfile_hash = sha256_lockfile(&resolution_lockfile)?;
+    if current_lockfile_hash != materialized.lockfile_sha256 {
+        return Err(Diagnostic::new(
+            "lockfile",
+            "root axiom.lock changed while the registry package graph was being materialized",
+        )
+        .with_code("lockfile_changed")
+        .with_path(resolution_lockfile.display().to_string()));
+    }
+    let resolution_lockfile_hash = materialized.lockfile_sha256.clone();
+    if materialized.schema_version != MATERIALIZED_PACKAGE_GRAPH_SCHEMA {
+        return Err(package_graph_diagnostic(
+            &resolution_lockfile,
+            format!(
+                "unsupported materialized package graph schema {:?}",
+                materialized.schema_version
+            ),
+        ));
+    }
+    if materialized.roots.is_empty() {
+        return Err(package_graph_diagnostic(
+            &resolution_lockfile,
+            "materialized package graph has no roots",
+        ));
+    }
+    let package_id_set = materialized
+        .packages
+        .iter()
+        .map(|package| package.id.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut reachable = materialized
+        .roots
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    loop {
+        let before = reachable.len();
+        for edge in &materialized.edges {
+            if reachable.contains(edge.from.as_str()) {
+                reachable.insert(edge.to.as_str());
+            }
+        }
+        if reachable.len() == before {
+            break;
+        }
+    }
+    if reachable != package_id_set {
+        return Err(package_graph_diagnostic(
+            &resolution_lockfile,
+            "materialized package graph is disconnected or names an unknown root",
+        ));
+    }
+    let mut roots_by_id = BTreeMap::<String, PathBuf>::new();
+    let mut package_ids = HashMap::<PathBuf, String>::new();
+    let mut contexts = HashMap::<PathBuf, PackageContext>::new();
+
+    for package in &mut materialized.packages {
+        // Raw authenticated artifacts are compiler-conversion inputs, not
+        // graph/report state. Taking them here keeps Arc-backed manager
+        // handoff shallow and ensures the retained materialized graph cannot
+        // pin complete package archives after the bounded source map exists.
+        let verified_archive = package.verified_archive.take();
+        let verified_manifest = package.verified_manifest.take();
+        let is_registry = package.source.starts_with("registry:");
+        let root = if is_registry {
+            normalize_path(Path::new(&package.root))
+        } else {
+            canonicalize_existing_path(
+                &normalize_path(Path::new(&package.root)),
+                "materialized package root",
+            )?
+        };
+        if roots_by_id
+            .insert(package.id.clone(), root.clone())
+            .is_some()
+        {
+            return Err(package_graph_diagnostic(
+                &resolution_lockfile,
+                format!(
+                    "materialized package id {:?} appears more than once",
+                    package.id
+                ),
+            ));
+        }
+        if let Some(existing) = package_ids.insert(root.clone(), package.id.clone()) {
+            return Err(package_graph_diagnostic(
+                &resolution_lockfile,
+                format!(
+                    "materialized package root {} is shared by {:?} and {:?}",
+                    root.display(),
+                    existing,
+                    package.id
+                ),
+            ));
+        }
+        if package.trust.is_some() != is_registry
+            || (package.trust.is_some()
+                && (!package.materialization.package_trust_verified
+                    || package.materialization.content_key.is_none()))
+        {
+            return Err(package_graph_diagnostic(
+                &resolution_lockfile,
+                format!(
+                    "materialized registry package {} lacks exact Package Trust evidence",
+                    package.id
+                ),
+            ));
+        }
+        let (manifest, source_root, workspace_members, verified_sources) = if is_registry {
+            let (manifest, source_root, verified_sources) = authenticated_registry_package(
+                package,
+                verified_archive.as_deref(),
+                verified_manifest.as_deref(),
+                &root,
+                &resolution_lockfile,
+            )?;
+            (manifest, source_root, Vec::new(), Some(verified_sources))
+        } else {
+            let manifest = load_manifest(&root)?;
+            let source_root = package_source_root(&root, &manifest)?;
+            let workspace_members = resolve_workspace_members(&root, &manifest)?;
+            (manifest, source_root, workspace_members, None)
+        };
+        let section = manifest.package.as_ref().ok_or_else(|| {
+            package_graph_diagnostic(
+                &resolution_lockfile,
+                format!(
+                    "materialized package {} has no [package] identity in {}",
+                    package.id,
+                    manifest_path(&root).display()
+                ),
+            )
+        })?;
+        if section.name != package.name || section.version != package.version {
+            return Err(package_graph_diagnostic(
+                &resolution_lockfile,
+                format!(
+                    "materialized package {} identity differs from its authenticated manifest",
+                    package.id
+                ),
+            ));
+        }
+        contexts.insert(
+            root.clone(),
+            PackageContext {
+                root,
+                manifest,
+                source_root,
+                dependencies: BTreeMap::new(),
+                workspace_members,
+                verified_sources,
+            },
+        );
+    }
+
+    // Virtual workspace roots do not have a package identity and therefore do
+    // not appear in lockfile v2's package array. Preserve the existing
+    // workspace selection surface while still requiring all buildable members
+    // to be represented by the authenticated graph.
+    if !contexts.contains_key(project_root) {
+        let manifest = load_manifest(project_root)?;
+        if !manifest.is_workspace_only() {
+            return Err(package_graph_diagnostic(
+                &resolution_lockfile,
+                "the root package is absent from the materialized lockfile graph",
+            ));
+        }
+        if !manifest.dependencies.is_empty() {
+            return Err(package_graph_diagnostic(
+                &resolution_lockfile,
+                "workspace-only roots with dependencies cannot be represented by lockfile v2",
+            ));
+        }
+        let workspace_members = resolve_workspace_members(project_root, &manifest)?;
+        contexts.insert(
+            project_root.to_path_buf(),
+            PackageContext {
+                root: project_root.to_path_buf(),
+                source_root: package_source_root(project_root, &manifest)?,
+                manifest,
+                dependencies: BTreeMap::new(),
+                workspace_members,
+                verified_sources: None,
+            },
+        );
+    }
+
+    let declared_roots = materialized
+        .roots
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    if let Some(root_id) = package_ids.get(project_root) {
+        if !declared_roots.contains(root_id.as_str()) {
+            return Err(package_graph_diagnostic(
+                &resolution_lockfile,
+                "the root package is not a materialized graph root",
+            ));
+        }
+    } else {
+        let virtual_root = contexts
+            .get(project_root)
+            .expect("virtual root context was inserted");
+        for member in &virtual_root.workspace_members {
+            let member_id = package_ids.get(member).ok_or_else(|| {
+                package_graph_diagnostic(
+                    &resolution_lockfile,
+                    format!(
+                        "workspace member {} has no materialized package identity",
+                        member.display()
+                    ),
+                )
+            })?;
+            if !declared_roots.contains(member_id.as_str()) {
+                return Err(package_graph_diagnostic(
+                    &resolution_lockfile,
+                    format!(
+                        "workspace member {} is not a materialized graph root",
+                        member.display()
+                    ),
+                ));
+            }
+        }
+    }
+
+    for context in contexts.values() {
+        for member in &context.workspace_members {
+            if !contexts.contains_key(member) {
+                return Err(package_graph_diagnostic(
+                    &resolution_lockfile,
+                    format!(
+                        "workspace member {} is absent from the materialized lockfile graph",
+                        member.display()
+                    ),
+                ));
+            }
+        }
+    }
+
+    let mut dependencies_by_root =
+        HashMap::<PathBuf, BTreeMap<String, PathBuf>>::with_capacity(contexts.len());
+    for edge in &materialized.edges {
+        let from_root = roots_by_id.get(&edge.from).ok_or_else(|| {
+            package_graph_diagnostic(
+                &resolution_lockfile,
+                format!(
+                    "dependency edge references unknown source package {}",
+                    edge.from
+                ),
+            )
+        })?;
+        let to_root = roots_by_id.get(&edge.to).ok_or_else(|| {
+            package_graph_diagnostic(
+                &resolution_lockfile,
+                format!(
+                    "dependency edge references unknown target package {}",
+                    edge.to
+                ),
+            )
+        })?;
+        let from = contexts.get(from_root).ok_or_else(|| {
+            package_graph_diagnostic(
+                &resolution_lockfile,
+                format!(
+                    "dependency edge source {} has no compiler package context",
+                    edge.from
+                ),
+            )
+        })?;
+        let spec = from.manifest.dependencies.get(&edge.alias).ok_or_else(|| {
+            package_graph_diagnostic(
+                &resolution_lockfile,
+                format!(
+                    "locked edge {:?} from {} is absent from its authenticated manifest",
+                    edge.alias, edge.from
+                ),
+            )
+        })?;
+        let source_matches = match edge.source_kind.as_str() {
+            "path" => spec.is_path(),
+            "registry" => spec.is_registry(),
+            _ => false,
+        };
+        if !source_matches {
+            return Err(package_graph_diagnostic(
+                &resolution_lockfile,
+                format!(
+                    "locked edge {:?} from {} has source kind {:?} inconsistent with its manifest",
+                    edge.alias, edge.from, edge.source_kind
+                ),
+            ));
+        }
+        let requested = spec.version.as_deref().unwrap_or("*");
+        if requested != edge.requested {
+            return Err(package_graph_diagnostic(
+                &resolution_lockfile,
+                format!(
+                    "locked edge {:?} from {} requests {:?}, but its manifest requests {:?}",
+                    edge.alias, edge.from, edge.requested, requested
+                ),
+            ));
+        }
+        let dependencies = dependencies_by_root.entry(from_root.clone()).or_default();
+        if dependencies
+            .insert(edge.alias.clone(), to_root.clone())
+            .is_some()
+        {
+            return Err(package_graph_diagnostic(
+                &resolution_lockfile,
+                format!(
+                    "materialized package {} has duplicate dependency alias {:?}",
+                    edge.from, edge.alias
+                ),
+            ));
+        }
+    }
+
+    for (root, dependencies) in dependencies_by_root {
+        contexts
+            .get_mut(&root)
+            .expect("materialized edge source was validated")
+            .dependencies = dependencies;
+    }
+
+    for root_id in &materialized.roots {
+        if !roots_by_id.contains_key(root_id) {
+            return Err(package_graph_diagnostic(
+                &resolution_lockfile,
+                format!("materialized graph root {root_id:?} has no package root"),
+            ));
+        }
+    }
+
+    let graph = PackageGraph {
+        packages: contexts,
+        package_ids,
+        materialized: Some(materialized),
+        resolution_lockfile: Some(resolution_lockfile),
+        resolution_lockfile_hash: Some(resolution_lockfile_hash),
+    };
+    for (root, context) in &graph.packages {
+        for (alias, spec) in &context.manifest.dependencies {
+            let Some(target) = context.dependencies.get(alias) else {
+                return Err(package_graph_diagnostic(
+                    graph
+                        .resolution_lockfile
+                        .as_deref()
+                        .expect("materialized graph has a resolution lockfile"),
+                    format!(
+                        "manifest dependency {alias:?} from {} is absent from axiom.lock v2",
+                        root.display()
+                    ),
+                ));
+            };
+            validate_dependency_version(&manifest_path(root), alias, spec, &graph, target)?;
+        }
+    }
+    Ok(graph)
+}
+
+fn authenticated_registry_package(
+    package: &MaterializedPackage,
+    verified_archive: Option<&[u8]>,
+    verified_manifest: Option<&[u8]>,
+    root: &Path,
+    resolution_lockfile: &Path,
+) -> Result<(Manifest, PathBuf, VerifiedPackageSources), Diagnostic> {
+    let trust = package.trust.as_ref().ok_or_else(|| {
+        package_graph_diagnostic(
+            resolution_lockfile,
+            format!(
+                "materialized registry package {} has no Package Trust evidence",
+                package.id
+            ),
+        )
+    })?;
+    let archive_bytes = verified_archive.ok_or_else(|| {
+        package_graph_diagnostic(
+            resolution_lockfile,
+            format!(
+                "materialized registry package {} has no authenticated archive bytes",
+                package.id
+            ),
+        )
+    })?;
+    let authenticated_manifest = verified_manifest.ok_or_else(|| {
+        package_graph_diagnostic(
+            resolution_lockfile,
+            format!(
+                "materialized registry package {} has no authenticated manifest bytes",
+                package.id
+            ),
+        )
+    })?;
+    if sha256_bytes(authenticated_manifest) != trust.manifest_sha256 {
+        return Err(package_graph_diagnostic(
+            resolution_lockfile,
+            format!(
+                "materialized registry package {} manifest bytes do not match Package Trust",
+                package.id
+            ),
+        ));
+    }
+    let archive = parse_archive(
+        archive_bytes,
+        &trust.archive_sha256,
+        ArchiveLimits::default(),
+    )
+    .map_err(|error| {
+        package_graph_diagnostic(
+            resolution_lockfile,
+            format!(
+                "materialized registry package {} archive is invalid: {}",
+                package.id, error
+            ),
+        )
+    })?;
+    let archive_manifest = archive
+        .entries
+        .iter()
+        .find(|entry| entry.path == crate::manifest::MANIFEST_FILENAME)
+        .ok_or_else(|| {
+            package_graph_diagnostic(
+                resolution_lockfile,
+                format!(
+                    "materialized registry package {} archive has no axiom.toml",
+                    package.id
+                ),
+            )
+        })?;
+    if archive_manifest.bytes != authenticated_manifest {
+        return Err(package_graph_diagnostic(
+            resolution_lockfile,
+            format!(
+                "materialized registry package {} archive manifest differs from its separately authenticated manifest",
+                package.id
+            ),
+        ));
+    }
+    let manifest = parse_manifest_exact(authenticated_manifest, &manifest_path(root))?;
+    if manifest.workspace.is_some() {
+        return Err(package_graph_diagnostic(
+            resolution_lockfile,
+            format!(
+                "materialized registry package {} may not define workspace members",
+                package.id
+            ),
+        ));
+    }
+
+    let mut sources = BTreeMap::new();
+    for entry in &archive.entries {
+        if Path::new(&entry.path)
+            .extension()
+            .and_then(|value| value.to_str())
+            != Some("ax")
+        {
+            continue;
+        }
+        let logical_path = normalize_path(root.join(&entry.path));
+        if !logical_path.starts_with(root) {
+            return Err(package_graph_diagnostic(
+                resolution_lockfile,
+                format!(
+                    "materialized registry package {} source path {:?} escapes its package root",
+                    package.id, entry.path
+                ),
+            ));
+        }
+        let source = std::str::from_utf8(&entry.bytes).map_err(|error| {
+            package_graph_diagnostic(
+                resolution_lockfile,
+                format!(
+                    "materialized registry package {} source {:?} is not UTF-8: {error}",
+                    package.id, entry.path
+                ),
+            )
+        })?;
+        sources.insert(logical_path, Arc::<str>::from(source));
+    }
+
+    let entry = normalize_path(entry_path(root, &manifest));
+    if !entry.starts_with(root) || !sources.contains_key(&entry) {
+        return Err(package_graph_diagnostic(
+            resolution_lockfile,
+            format!(
+                "materialized registry package {} build.entry is absent from its authenticated archive",
+                package.id
+            ),
+        ));
+    }
+    let source_root = entry
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| root.to_path_buf());
+    Ok((
+        manifest,
+        source_root,
+        VerifiedPackageSources {
+            archive_sha256: archive.archive_sha256,
+            sources,
+        },
+    ))
+}
+
+fn package_manager_diagnostic(error: PackageManagerError) -> Diagnostic {
+    Diagnostic::new("package", error.message)
+        .with_code(error.code)
+        .with_package_resolution(error.trace, error.resolver)
+}
+
+fn package_graph_diagnostic(lockfile: &Path, message: impl Into<String>) -> Diagnostic {
+    Diagnostic::new("package", message)
+        .with_code("package_graph_invalid")
+        .with_path(lockfile.display().to_string())
+}
+
+fn package_source_root(project_root: &Path, manifest: &Manifest) -> Result<PathBuf, Diagnostic> {
+    let source_root = if manifest.package.is_some() {
+        entry_path(project_root, manifest)
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| project_root.to_path_buf())
+    } else {
+        let src_root = project_root.join("src");
+        if src_root.exists() {
+            src_root
+        } else {
+            project_root.to_path_buf()
+        }
+    };
+    if source_root.exists() {
+        canonicalize_package_path(
+            &source_root,
+            project_root,
+            "manifest",
+            "build.entry source root resolves outside the package",
+        )
+    } else {
+        Ok(source_root)
+    }
 }
 
 /// Registers the synthetic `<stdlib>` package in the graph. The synthetic
@@ -2205,6 +3007,7 @@ fn register_stdlib_package(graph: &mut PackageGraph) {
             version: stdlib::STDLIB_PACKAGE_VERSION.to_string(),
         }),
         publish: None,
+        registry: None,
         dependencies: BTreeMap::new(),
         workspace: None,
         build: BuildSection {
@@ -2245,6 +3048,7 @@ fn register_stdlib_package(graph: &mut PackageGraph) {
             source_root: root,
             dependencies: BTreeMap::new(),
             workspace_members: Vec::new(),
+            verified_sources: None,
         },
     );
 }
@@ -2271,33 +3075,21 @@ fn load_package_graph_recursive(
     let workspace_members = resolve_workspace_members(&project_root, &manifest)?;
     let mut dependency_allowed_members = allowed_workspace_members.clone();
     dependency_allowed_members.extend(workspace_members.iter().cloned());
-    let source_root = if manifest.package.is_some() {
-        entry_path(&project_root, &manifest)
-            .parent()
-            .map(Path::to_path_buf)
-            .unwrap_or_else(|| project_root.clone())
-    } else {
-        let src_root = project_root.join("src");
-        if src_root.exists() {
-            src_root
-        } else {
-            project_root.clone()
-        }
-    };
-    let source_root = if source_root.exists() {
-        canonicalize_package_path(
-            &source_root,
-            &project_root,
-            "manifest",
-            "build.entry source root resolves outside the package",
-        )?
-    } else {
-        source_root
-    };
+    let source_root = package_source_root(&project_root, &manifest)?;
     visiting.push(project_root.clone());
     let mut dependencies = BTreeMap::new();
     for (name, spec) in &manifest.dependencies {
-        let dependency_root = normalize_path(project_root.join(&spec.path));
+        let Some(path) = spec.path_source() else {
+            return Err(Diagnostic::new(
+                "package",
+                format!(
+                    "registry dependency {name:?} requires an exact axiom.lock v2 graph and authenticated cache or vendor material"
+                ),
+            )
+            .with_code("lockfile_v2_required")
+            .with_path(manifest_path(&project_root).display().to_string()));
+        };
+        let dependency_root = normalize_path(project_root.join(path));
         if !dependency_root.exists() {
             return Err(Diagnostic::new(
                 "manifest",
@@ -2341,6 +3133,7 @@ fn load_package_graph_recursive(
             source_root,
             dependencies,
             workspace_members,
+            verified_sources: None,
         },
     );
     Ok(())
@@ -2590,7 +3383,7 @@ fn build_artifacts(
             options.backend,
         )?;
         return Ok(BuildArtifactReport {
-            metadata: build_metadata(package_root, &cache),
+            metadata: build_metadata(graph, package_root, &cache),
             cache_status: BuildCacheStatus::Hit,
             cache_key: build_cache_metadata(&cache),
             compile_ms: 0,
@@ -2681,7 +3474,7 @@ fn build_artifacts(
         options.backend,
     )?;
     Ok(BuildArtifactReport {
-        metadata: build_metadata(package_root, &cache),
+        metadata: build_metadata(graph, package_root, &cache),
         cache_status: BuildCacheStatus::Miss,
         cache_key: build_cache_metadata(&cache),
         compile_ms,
@@ -3291,13 +4084,15 @@ fn build_cache_metadata(cache: &BuildCacheFile) -> BuildCacheMetadata {
     }
 }
 
-fn build_metadata(package_root: &Path, cache: &BuildCacheFile) -> BuildMetadata {
+fn build_metadata(
+    graph: &PackageGraph,
+    package_root: &Path,
+    cache: &BuildCacheFile,
+) -> BuildMetadata {
     BuildMetadata {
         target: cache.target.clone(),
         debug: cache.debug,
-        lockfile: crate::manifest::lockfile_path(package_root)
-            .display()
-            .to_string(),
+        lockfile: graph.lockfile_path_for(package_root).display().to_string(),
         lockfile_hash: cache.lockfile_hash.clone(),
         source_hash: source_hash_for_cache(cache),
     }
@@ -3616,12 +4411,12 @@ fn debug_source_files(
         .modules
         .iter()
         .map(|module| {
-            let source = module_source(&module.path)?;
+            let source = &module.source;
             let path = module.path.display().to_string();
             Ok(DebugSourceFile {
                 mapping_count: mapping_counts.get(&path).copied().unwrap_or(0),
                 path,
-                source_hash: hash_text(&source),
+                source_hash: hash_text(source),
                 line_count: source.lines().count(),
             })
         })
@@ -3639,12 +4434,12 @@ fn direct_native_debug_source_files(
         .modules
         .iter()
         .map(|module| {
-            let source = module_source(&module.path)?;
+            let source = &module.source;
             let path = module.path.display().to_string();
             Ok(DebugSourceFile {
                 mapping_count: span_counts.get(&path).copied().unwrap_or(0),
                 path,
-                source_hash: hash_text(&source),
+                source_hash: hash_text(source),
                 line_count: source.lines().count(),
             })
         })
@@ -3860,7 +4655,7 @@ fn build_cache_file(
         target,
         debug,
         manifest_hash: hash_file(&manifest_path(package_root))?,
-        lockfile_hash: hash_file(&crate::manifest::lockfile_path(package_root))?,
+        lockfile_hash: graph.lockfile_hash_for(package_root)?,
         backend_input_hash: backend_input_hash.to_string(),
         lowering,
         binary_hash: None,
@@ -3875,7 +4670,7 @@ fn cached_modules(
     modules
         .iter()
         .map(|module| {
-            let source = module_source(&module.path)?;
+            let source = &module.source;
             let mut imports = module
                 .program
                 .imports
@@ -3888,17 +4683,34 @@ fn cached_modules(
             imports.sort();
             Ok(CachedModule {
                 path: module.path.display().to_string(),
-                source_hash: hash_text(&source),
+                source_hash: hash_text(source),
                 imports,
             })
         })
         .collect()
 }
 
-fn module_source(module_path: &Path) -> Result<String, Diagnostic> {
+fn compiler_module_source(
+    graph: &PackageGraph,
+    package_root: &Path,
+    module_path: &Path,
+) -> Result<Arc<str>, Diagnostic> {
+    if let Some(source) = graph.verified_source(package_root, module_path) {
+        return Ok(source);
+    }
+    if graph.has_verified_source(package_root, module_path) == Some(false) {
+        return Err(Diagnostic::new(
+            "source",
+            format!(
+                "authenticated package source {} is absent",
+                module_path.display()
+            ),
+        )
+        .with_path(module_path.display().to_string()));
+    }
     if stdlib::is_stdlib_path(module_path) {
         return stdlib::stdlib_source_for(module_path)
-            .map(str::to_string)
+            .map(Arc::<str>::from)
             .ok_or_else(|| {
                 Diagnostic::new(
                     "source",
@@ -3910,13 +4722,15 @@ fn module_source(module_path: &Path) -> Result<String, Diagnostic> {
                 .with_path(module_path.display().to_string())
             });
     }
-    fs::read_to_string(module_path).map_err(|err| {
-        Diagnostic::new(
-            "source",
-            format!("failed to read {}: {err}", module_path.display()),
-        )
-        .with_path(module_path.display().to_string())
-    })
+    fs::read_to_string(module_path)
+        .map(Arc::<str>::from)
+        .map_err(|err| {
+            Diagnostic::new(
+                "source",
+                format!("failed to read {}: {err}", module_path.display()),
+            )
+            .with_path(module_path.display().to_string())
+        })
 }
 
 fn hash_file(path: &Path) -> Result<String, Diagnostic> {
@@ -3933,6 +4747,84 @@ fn hash_file_bytes(path: &Path) -> Result<String, Diagnostic> {
             .with_path(path.display().to_string())
     })?;
     Ok(hash_bytes(&content))
+}
+
+fn sha256_lockfile(path: &Path) -> Result<String, Diagnostic> {
+    let metadata = fs::symlink_metadata(path).map_err(|err| {
+        Diagnostic::new(
+            "lockfile",
+            format!("failed to inspect {}: {err}", path.display()),
+        )
+        .with_path(path.display().to_string())
+    })?;
+    if !metadata.file_type().is_file() || metadata.file_type().is_symlink() {
+        return Err(Diagnostic::new(
+            "lockfile",
+            "axiom.lock must be a regular file, not a symlink",
+        )
+        .with_path(path.display().to_string()));
+    }
+    if metadata.len() > MAX_RESOLUTION_LOCKFILE_BYTES {
+        return Err(Diagnostic::new(
+            "lockfile",
+            format!(
+                "axiom.lock is {} bytes; limit is {}",
+                metadata.len(),
+                MAX_RESOLUTION_LOCKFILE_BYTES
+            ),
+        )
+        .with_path(path.display().to_string()));
+    }
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    options.custom_flags(libc::O_NOFOLLOW);
+    let file = options.open(path).map_err(|err| {
+        Diagnostic::new(
+            "lockfile",
+            format!("failed to open {}: {err}", path.display()),
+        )
+        .with_path(path.display().to_string())
+    })?;
+    let opened = file.metadata().map_err(|err| {
+        Diagnostic::new(
+            "lockfile",
+            format!("failed to inspect opened {}: {err}", path.display()),
+        )
+        .with_path(path.display().to_string())
+    })?;
+    if !opened_expected_stream_matches(&metadata, &opened) || !opened.file_type().is_file() {
+        return Err(
+            Diagnostic::new("lockfile", "axiom.lock changed while being opened")
+                .with_code("lockfile_changed")
+                .with_path(path.display().to_string()),
+        );
+    }
+    let mut content = Vec::new();
+    file.take(MAX_RESOLUTION_LOCKFILE_BYTES + 1)
+        .read_to_end(&mut content)
+        .map_err(|err| {
+            Diagnostic::new(
+                "lockfile",
+                format!("failed to read {}: {err}", path.display()),
+            )
+            .with_path(path.display().to_string())
+        })?;
+    if content.len() as u64 > MAX_RESOLUTION_LOCKFILE_BYTES {
+        return Err(Diagnostic::new(
+            "lockfile",
+            format!(
+                "axiom.lock exceeds the {} byte limit",
+                MAX_RESOLUTION_LOCKFILE_BYTES
+            ),
+        )
+        .with_path(path.display().to_string()));
+    }
+    Ok(sha256_bytes(&content))
+}
+
+fn sha256_bytes(value: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(value))
 }
 
 fn hash_text(value: &str) -> String {
@@ -4789,7 +5681,13 @@ fn load_module_recursive(
         return Ok(());
     }
 
-    let program = parse_module_with_cache(&module_path, macro_recursion_limit, parse_cache)?;
+    let (program, source) = parse_module_with_cache(
+        graph,
+        package_root,
+        &module_path,
+        macro_recursion_limit,
+        parse_cache,
+    )?;
     if !is_entry && !program.stmts.is_empty() {
         let stmt = &program.stmts[0];
         return Err(Diagnostic::new(
@@ -4834,6 +5732,7 @@ fn load_module_recursive(
     .clone();
     ordered.push(LoadedModule {
         path: module_path,
+        source,
         program,
         resolved_imports,
         is_entry,
@@ -4844,6 +5743,51 @@ fn load_module_recursive(
     Ok(())
 }
 
+fn parse_module_with_cache(
+    graph: &PackageGraph,
+    package_root: &Path,
+    module_path: &Path,
+    macro_recursion_limit: usize,
+    parse_cache: &mut ModuleParseCache,
+) -> Result<(syntax::Program, Arc<str>), Diagnostic> {
+    let cache_key = if graph
+        .has_verified_source(package_root, module_path)
+        .is_some()
+    {
+        (normalize_path(module_path), macro_recursion_limit)
+    } else {
+        module_parse_cache_key(module_path, macro_recursion_limit)?
+    };
+    let source = compiler_module_source(graph, package_root, module_path)?;
+    if let Some(program) = parse_cache.programs.get(&cache_key) {
+        return Ok((program.clone(), source));
+    }
+    let program = syntax::parse_program_with_options(
+        source.as_ref(),
+        module_path,
+        &syntax::ParseOptions {
+            macro_recursion_limit,
+            ..syntax::ParseOptions::default()
+        },
+    )?;
+    parse_cache.programs.insert(cache_key, program.clone());
+    Ok((program, source))
+}
+
+// The parse result depends on the macro recursion limit, so the limit is part
+// of the key: a cache hit must never return a program parsed under a
+// different limit than the caller requested.
+fn module_parse_cache_key(
+    module_path: &Path,
+    macro_recursion_limit: usize,
+) -> Result<(PathBuf, usize), Diagnostic> {
+    let path = if stdlib::is_stdlib_path(module_path) {
+        normalize_path(module_path)
+    } else {
+        canonicalize_existing_path(module_path, "module path")?
+    };
+    Ok((path, macro_recursion_limit))
+}
 fn package_section<'a>(
     manifest: &'a Manifest,
     message: &'static str,
@@ -9525,6 +10469,20 @@ fn resolve_import_path(
                 .with_path(module_path.display().to_string())
                 .with_span(import.line, import.column));
             }
+            if let Some(verified) = &dependency.verified_sources {
+                if !verified.sources.contains_key(&candidate) {
+                    return Err(Diagnostic::new(
+                        "import",
+                        format!(
+                            "missing authenticated import {}",
+                            import_diagnostic_path(&dependency.root, &candidate)
+                        ),
+                    )
+                    .with_path(module_path.display().to_string())
+                    .with_span(import.line, import.column));
+                }
+                return Ok((dependency.root.clone(), candidate));
+            }
             if !candidate.exists() {
                 return Err(Diagnostic::new(
                     "import",
@@ -9556,6 +10514,20 @@ fn resolve_import_path(
                 .with_path(module_path.display().to_string())
                 .with_span(import.line, import.column),
         );
+    }
+    if let Some(verified) = &package.verified_sources {
+        if !verified.sources.contains_key(&candidate) {
+            return Err(Diagnostic::new(
+                "import",
+                format!(
+                    "missing authenticated import {}",
+                    import_diagnostic_path(&package.root, &candidate)
+                ),
+            )
+            .with_path(module_path.display().to_string())
+            .with_span(import.line, import.column));
+        }
+        return Ok((package.root.clone(), candidate));
     }
     if !candidate.exists() {
         return Err(Diagnostic::new(
@@ -9594,6 +10566,37 @@ fn canonicalize_existing_path(path: &Path, label: &str) -> Result<PathBuf, Diagn
         )
         .with_path(path.display().to_string())
     })
+}
+
+fn validate_compiler_source_path(
+    graph: &PackageGraph,
+    package_root: &Path,
+    path: &Path,
+    kind: &'static str,
+    outside_message: &'static str,
+) -> Result<PathBuf, Diagnostic> {
+    let package = graph.context(package_root)?;
+    if let Some(verified) = &package.verified_sources {
+        let path = normalize_path(path);
+        if !path.starts_with(package_root) {
+            return Err(
+                Diagnostic::new(kind, outside_message).with_path(path.display().to_string())
+            );
+        }
+        if !verified.sources.contains_key(&path) {
+            return Err(Diagnostic::new(
+                kind,
+                format!(
+                    "authenticated compiler source {} is absent from package archive {}",
+                    path.display(),
+                    verified.archive_sha256
+                ),
+            )
+            .with_path(path.display().to_string()));
+        }
+        return Ok(path);
+    }
+    canonicalize_package_path(path, package_root, kind, outside_message)
 }
 
 fn canonicalize_package_path(
@@ -9804,6 +10807,7 @@ mod tests {
         Manifest {
             package: None,
             publish: None,
+            registry: None,
             dependencies: BTreeMap::new(),
             workspace: None,
             build: BuildSection {
@@ -9823,6 +10827,7 @@ mod tests {
                 version: "0.1.0".to_string(),
             }),
             publish: None,
+            registry: None,
             dependencies: BTreeMap::new(),
             workspace: None,
             build: BuildSection {
@@ -9877,6 +10882,433 @@ out_dir = "dist"
             direct.packages[0].lockfile.status,
             public.packages[0].lockfile.status
         );
+    }
+
+    fn write_test_package(root: &Path, name: &str, version: &str) {
+        fs::create_dir_all(root.join("src")).expect("create package source");
+        fs::write(
+            root.join("axiom.toml"),
+            format!(
+                "[package]\nname = {name:?}\nversion = {version:?}\n\n[build]\nentry = \"src/lib.ax\"\nout_dir = \"dist\"\n"
+            ),
+        )
+        .expect("write package manifest");
+        fs::write(
+            root.join("src/lib.ax"),
+            "pub fn value(): int {\nreturn 1\n}\n",
+        )
+        .expect("write package source");
+    }
+
+    fn materialized_path_package(id: &str, root: &Path, name: &str) -> MaterializedPackage {
+        MaterializedPackage {
+            id: id.to_owned(),
+            name: name.to_owned(),
+            version: "0.1.0".to_owned(),
+            source: "path".to_owned(),
+            root: root.display().to_string(),
+            verified_archive: None,
+            verified_manifest: None,
+            trust: None,
+            materialization: MaterializationEvidence {
+                source: "path".to_owned(),
+                content_key: None,
+                package_trust_verified: true,
+            },
+        }
+    }
+
+    fn materialized_registry_package(id: &str, root: &Path, trusted: bool) -> MaterializedPackage {
+        let manifest = fs::read(root.join("axiom.toml")).expect("read registry test manifest");
+        let source = fs::read(root.join("src/lib.ax")).expect("read registry test source");
+        let nested = fs::read(root.join("src/nested.ax")).ok();
+        let mut archive = crate::package_archive::ARCHIVE_MAGIC.to_vec();
+        let mut entries = vec![
+            ("axiom.toml", manifest.as_slice()),
+            ("src/lib.ax", source.as_slice()),
+        ];
+        if let Some(nested) = nested.as_deref() {
+            entries.push(("src/nested.ax", nested));
+        }
+        for (path, bytes) in entries {
+            archive.extend_from_slice(format!("--- file {path} {} ---\n", bytes.len()).as_bytes());
+            archive.extend_from_slice(bytes);
+            if !bytes.ends_with(b"\n") {
+                archive.push(b'\n');
+            }
+        }
+        let archive_sha256 = sha256_bytes(&archive);
+        let manifest_sha256 = sha256_bytes(&manifest);
+        MaterializedPackage {
+            id: id.to_owned(),
+            name: "dep".to_owned(),
+            version: "1.2.3".to_owned(),
+            source: "registry:default/acme/dep".to_owned(),
+            root: root.display().to_string(),
+            verified_archive: trusted.then_some(archive.into()),
+            verified_manifest: trusted.then_some(manifest.into()),
+            trust: trusted.then(|| PackageTrustEvidence {
+                registry: "default".to_owned(),
+                registry_identity: "registry.test".to_owned(),
+                source_identity: "registry-source.test".to_owned(),
+                publisher_identity: "publisher.test".to_owned(),
+                archive_sha256: archive_sha256.clone(),
+                manifest_sha256,
+                provenance_sha256: "c".repeat(64),
+                package_signature_sha256: "d".repeat(64),
+                signer_key_ids: vec![format!("sha256:{}", "e".repeat(64))],
+                index_sha256: "0".repeat(64),
+                index_generation: 1,
+                index_sequence: 2,
+                index_transcript_sha256: "f".repeat(64),
+                verification_sha256: "1".repeat(64),
+            }),
+            materialization: MaterializationEvidence {
+                source: "cache".to_owned(),
+                content_key: Some(format!("sha256:{archive_sha256}")),
+                package_trust_verified: trusted,
+            },
+        }
+    }
+
+    #[test]
+    fn materialized_registry_graph_maps_exact_identity_trust_and_decision_evidence() {
+        let dir = tempdir().expect("tempdir");
+        let root = dir.path().join("app");
+        let dep = dir.path().join("cache/dep");
+        fs::create_dir_all(root.join("src")).expect("create root source");
+        fs::write(
+            root.join("axiom.toml"),
+            r#"[package]
+name = "app"
+version = "0.1.0"
+
+[registry]
+name = "default"
+index = "file:///registry/index.json"
+trust_roots = "registry/trust-roots.json"
+expectation = "registry/expectation.json"
+
+[dependencies.dep]
+registry = "default"
+namespace = "acme"
+package = "dep"
+version = "^1.2.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+"#,
+        )
+        .expect("write root manifest");
+        fs::write(
+            root.join("src/main.ax"),
+            "import \"dep/lib.ax\"\nprint \"registry run\"\n",
+        )
+        .expect("write root source");
+        fs::write(
+            root.join("src/main_test.ax"),
+            "import \"dep/lib.ax\"\nprint \"registry test\"\n",
+        )
+        .expect("write root test");
+        fs::write(root.join("src/main_test.stdout"), "registry test\n")
+            .expect("write root test golden");
+        write_test_package(&dep, "dep", "1.2.3");
+        fs::write(
+            dep.join("src/lib.ax"),
+            "import \"nested.ax\"\npub fn value(): int {\nreturn nested()\n}\n",
+        )
+        .expect("write registry package entry");
+        fs::write(
+            dep.join("src/nested.ax"),
+            "pub fn nested(): int {\nreturn 7\n}\n",
+        )
+        .expect("write nested registry source");
+        fs::write(root.join("axiom.lock"), "version = 2\n").expect("write lock identity");
+        let root = root.canonicalize().expect("canonical root");
+        let dep = dep.canonicalize().expect("canonical dependency");
+        let root_id = "path:.#app@0.1.0";
+        let dep_id = "registry:default/acme/dep@1.2.3";
+        let materialized = MaterializedPackageGraph {
+            schema_version: "axiom.materialized_package_graph.v1".to_owned(),
+            lockfile_sha256: sha256_lockfile(&root.join("axiom.lock")).expect("lockfile digest"),
+            roots: vec![root_id.to_owned()],
+            packages: vec![
+                materialized_path_package(root_id, &root, "app"),
+                materialized_registry_package(dep_id, &dep, true),
+            ],
+            edges: vec![MaterializedDependencyEdge {
+                from: root_id.to_owned(),
+                to: dep_id.to_owned(),
+                alias: "dep".to_owned(),
+                requested: "^1.2.0".to_owned(),
+                source_kind: "registry".to_owned(),
+                reason: "highest_compatible".to_owned(),
+            }],
+        };
+
+        let mut split_brain = materialized.clone();
+        let split_manifest = br#"[package]
+name = "dep"
+version = "1.2.3"
+
+[build]
+entry = "src/other.ax"
+out_dir = "dist"
+"#
+        .to_vec();
+        let split_package = split_brain
+            .packages
+            .iter_mut()
+            .find(|package| package.id == dep_id)
+            .expect("registry package");
+        split_package.verified_manifest = Some(split_manifest.clone().into());
+        split_package
+            .trust
+            .as_mut()
+            .expect("registry trust")
+            .manifest_sha256 = sha256_bytes(&split_manifest);
+        let split_error = package_graph_from_materialized(&root, split_brain)
+            .expect_err("split-brain archive and authenticated manifest must fail");
+        assert!(
+            split_error.message.contains("archive manifest differs"),
+            "unexpected split-brain diagnostic: {split_error:?}"
+        );
+
+        fs::write(root.join("axiom.lock"), "version = 2\n# replaced\n")
+            .expect("replace lock before graph conversion");
+        let replacement_error = package_graph_from_materialized(&root, materialized.clone())
+            .expect_err("lock replacement during graph conversion must fail");
+        assert_eq!(replacement_error.code.as_deref(), Some("lockfile_changed"));
+        fs::write(root.join("axiom.lock"), "version = 2\n").expect("restore lock identity");
+
+        let graph =
+            package_graph_from_materialized(&root, materialized).expect("materialized graph");
+        assert!(
+            graph
+                .materialized
+                .as_ref()
+                .expect("retained materialized graph")
+                .packages
+                .iter()
+                .all(|package| package.verified_archive.is_none()
+                    && package.verified_manifest.is_none()),
+            "compiler graph must release raw authenticated artifacts after source extraction"
+        );
+        fs::write(dep.join("axiom.toml"), "not authenticated")
+            .expect("mutate materialized manifest");
+        fs::write(dep.join("src/lib.ax"), "not authenticated").expect("mutate materialized source");
+        let entry = root.join("src/main.ax");
+        let modules_after_mutation =
+            load_modules(&graph, &root, &entry, syntax::DEFAULT_MACRO_RECURSION_LIMIT)
+                .expect("load authenticated sources after cache mutation");
+        assert!(modules_after_mutation.iter().any(|module| {
+            module.path == dep.join("src/nested.ax") && module.source.contains("return 7")
+        }));
+        fs::remove_dir_all(&dep).expect("remove materialized cache tree");
+        let modules_after_deletion =
+            load_modules(&graph, &root, &entry, syntax::DEFAULT_MACRO_RECURSION_LIMIT)
+                .expect("load authenticated sources after cache deletion");
+        assert!(modules_after_deletion.iter().any(|module| {
+            module.path == dep.join("src/lib.ax") && module.source.contains("return nested()")
+        }));
+        let output = package_graph_metadata_with_graph(&root, &graph).expect("graph metadata");
+        assert_eq!(
+            output.schema_version,
+            "axiom.compiler.package_graph.runtime.v1"
+        );
+        assert_eq!(output.contract, "compiler.package_graph.runtime");
+        let app = output
+            .packages
+            .iter()
+            .find(|package| package.name.as_deref() == Some("app"))
+            .expect("root package");
+        let dependency = app.dependencies.first().expect("registry dependency");
+        assert_eq!(app.id.as_deref(), Some(root_id));
+        assert_eq!(app.lockfile.version, Some(2));
+        assert!(app.lockfile.hash.is_some());
+        assert_eq!(dependency.package_id.as_deref(), Some(dep_id));
+        assert_eq!(dependency.source_kind.as_deref(), Some("registry"));
+        assert_eq!(dependency.requested.as_deref(), Some("^1.2.0"));
+        assert_eq!(dependency.reason.as_deref(), Some("highest_compatible"));
+        let dep = output
+            .packages
+            .iter()
+            .find(|package| package.id.as_deref() == Some(dep_id))
+            .expect("registry package");
+        assert_eq!(dep.source.as_deref(), Some("registry:default/acme/dep"));
+        assert!(dep.trust.is_some());
+        assert!(
+            dep.materialization
+                .as_ref()
+                .is_some_and(|evidence| evidence.package_trust_verified)
+        );
+
+        let schema_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .join("compiler-contracts/schemas/axiom.compiler.package_graph.runtime.v1.schema.json");
+        let schema: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(schema_path).expect("read runtime package graph schema"),
+        )
+        .expect("parse runtime package graph schema");
+        let serialized = serde_json::to_value(&output).expect("serialize runtime package graph");
+        let validator =
+            jsonschema::validator_for(&schema).expect("compile runtime package graph schema");
+        let errors = validator
+            .iter_errors(&serialized)
+            .map(|error| error.to_string())
+            .collect::<Vec<_>>();
+        assert!(
+            errors.is_empty(),
+            "runtime package graph must satisfy its published schema: {errors:?}"
+        );
+
+        let checked = check_project_with_graph(&root, &graph, &CheckOptions::default())
+            .expect("check materialized registry graph");
+        assert_eq!(checked.packages.len(), 1);
+        assert_eq!(checked.packages[0].package_root, root.display().to_string());
+
+        let sbom =
+            capability_sbom_with_graph(&root, &graph).expect("SBOM materialized registry graph");
+        let sbom_dep = sbom
+            .packages
+            .iter()
+            .find(|package| package.id.as_deref() == Some(dep_id))
+            .expect("registry package SBOM row");
+        assert_eq!(
+            sbom_dep.source.as_deref(),
+            Some("registry:default/acme/dep")
+        );
+        let expected_signer = format!("sha256:{}", "e".repeat(64));
+        assert_eq!(
+            sbom_dep
+                .trust
+                .as_ref()
+                .map(|trust| trust.signer_key_ids.as_slice()),
+            Some([expected_signer].as_slice())
+        );
+        let expected_content_key = dep
+            .trust
+            .as_ref()
+            .map(|trust| format!("sha256:{}", trust.archive_sha256))
+            .expect("registry trust");
+        assert_eq!(
+            sbom_dep
+                .materialization
+                .as_ref()
+                .and_then(|evidence| evidence.content_key.as_deref()),
+            Some(expected_content_key.as_str())
+        );
+
+        #[cfg(not(windows))]
+        if which::which("cc").is_ok() {
+            let (_, built, _) =
+                prepare_run_project_with_graph(&root, &graph, &RunOptions::default())
+                    .expect("prepare run from materialized registry graph");
+            assert_eq!(built.packages.len(), 1);
+            assert_eq!(built.packages[0].package_root, root.display().to_string());
+
+            let tests = run_project_tests_with_graph(&root, &graph, &TestOptions::default())
+                .expect("test materialized registry graph");
+            assert_eq!(tests.passed, 1);
+            assert_eq!(tests.failed, 0);
+            assert_eq!(tests.cases[0].stdout, "registry test\n");
+        }
+
+        fs::write(root.join("axiom.lock"), "version = 2\n# altered\n")
+            .expect("alter lock identity");
+        let error = validate_package_lockfile(
+            &graph,
+            &root,
+            &graph.context(&root).expect("root context").manifest,
+        )
+        .expect_err("post-materialization lock mutation must fail");
+        assert_eq!(error.code.as_deref(), Some("lockfile_changed"));
+    }
+
+    #[test]
+    fn materialized_graph_preserves_virtual_workspace_and_multiple_roots() {
+        let dir = tempdir().expect("tempdir");
+        let root = dir.path().join("workspace");
+        let alpha = root.join("alpha");
+        let beta = root.join("beta");
+        fs::create_dir_all(&root).expect("create workspace");
+        fs::write(
+            root.join("axiom.toml"),
+            "[workspace]\nmembers = [\"alpha\", \"beta\"]\n",
+        )
+        .expect("write workspace manifest");
+        write_test_package(&alpha, "alpha", "0.1.0");
+        write_test_package(&beta, "beta", "0.1.0");
+        fs::write(root.join("axiom.lock"), "version = 2\n").expect("write lock identity");
+        let root = root.canonicalize().expect("canonical workspace");
+        let alpha = alpha.canonicalize().expect("canonical alpha");
+        let beta = beta.canonicalize().expect("canonical beta");
+        let alpha_id = "path:alpha#alpha@0.1.0";
+        let beta_id = "path:beta#beta@0.1.0";
+        let graph = package_graph_from_materialized(
+            &root,
+            MaterializedPackageGraph {
+                schema_version: "axiom.materialized_package_graph.v1".to_owned(),
+                lockfile_sha256: sha256_lockfile(&root.join("axiom.lock"))
+                    .expect("lockfile digest"),
+                roots: vec![beta_id.to_owned(), alpha_id.to_owned()],
+                packages: vec![
+                    materialized_path_package(alpha_id, &alpha, "alpha"),
+                    materialized_path_package(beta_id, &beta, "beta"),
+                ],
+                edges: Vec::new(),
+            },
+        )
+        .expect("workspace graph");
+
+        let packages = workspace_package_roots(&graph, &root, None).expect("workspace packages");
+        assert_eq!(packages, vec![alpha, beta]);
+        assert_eq!(
+            graph
+                .context(&root)
+                .expect("virtual root")
+                .workspace_members,
+            packages
+        );
+    }
+
+    #[test]
+    fn materialized_graph_and_manager_failures_keep_stable_diagnostic_codes() {
+        let dir = tempdir().expect("tempdir");
+        let root = dir.path().join("app");
+        let dep = dir.path().join("cache/dep");
+        write_test_package(&root, "app", "0.1.0");
+        write_test_package(&dep, "dep", "1.2.3");
+        fs::write(root.join("axiom.lock"), "version = 2\n").expect("write lock identity");
+        let root = root.canonicalize().expect("canonical root");
+        let dep = dep.canonicalize().expect("canonical dependency");
+        let error = package_graph_from_materialized(
+            &root,
+            MaterializedPackageGraph {
+                schema_version: "axiom.materialized_package_graph.v1".to_owned(),
+                lockfile_sha256: sha256_lockfile(&root.join("axiom.lock"))
+                    .expect("lockfile digest"),
+                roots: vec!["path:.#app@0.1.0".to_owned()],
+                packages: vec![
+                    materialized_path_package("path:.#app@0.1.0", &root, "app"),
+                    materialized_registry_package("registry:default/acme/dep@1.2.3", &dep, false),
+                ],
+                edges: Vec::new(),
+            },
+        )
+        .expect_err("untrusted registry root must fail");
+        assert_eq!(error.code.as_deref(), Some("package_graph_invalid"));
+
+        let mapped = package_manager_diagnostic(PackageManagerError {
+            code: "cache_tampered".to_owned(),
+            message: "cached tree differs from its integrity manifest".to_owned(),
+            trace: Vec::new(),
+            resolver: None,
+        });
+        assert_eq!(mapped.kind, "package");
+        assert_eq!(mapped.code.as_deref(), Some("cache_tampered"));
+        assert!(mapped.message.contains("integrity manifest"));
     }
 
     #[test]
@@ -11088,6 +12520,7 @@ return async_serve_route(1, "/", "ok", 1)
                 source_root,
                 dependencies: BTreeMap::new(),
                 workspace_members: Vec::new(),
+                verified_sources: None,
             },
         );
 
@@ -11137,6 +12570,7 @@ return async_serve_route(1, "/", "ok", 1)
                 source_root,
                 dependencies: BTreeMap::new(),
                 workspace_members: Vec::new(),
+                verified_sources: None,
             },
         );
         let mut parse_cache = ModuleParseCache::default();
@@ -11202,6 +12636,7 @@ return async_serve_route(1, "/", "ok", 1)
                 source_root,
                 dependencies: BTreeMap::new(),
                 workspace_members: Vec::new(),
+                verified_sources: None,
             },
         );
 
@@ -11796,6 +13231,7 @@ out_dir = "dist"
                     .unwrap_or_else(|err| panic!("canonical source root: {err}")),
                 dependencies: BTreeMap::new(),
                 workspace_members: Vec::new(),
+                verified_sources: None,
             },
         );
         let mut parse_cache = ModuleParseCache::default();
@@ -11842,6 +13278,7 @@ out_dir = "dist"
                 source_root: source_root.clone(),
                 dependencies: BTreeMap::new(),
                 workspace_members: Vec::new(),
+                verified_sources: None,
             },
         );
 
@@ -11947,6 +13384,7 @@ out_dir = "dist"
                     .unwrap_or_else(|err| panic!("canonical source root: {err}")),
                 dependencies: BTreeMap::new(),
                 workspace_members: Vec::new(),
+                verified_sources: None,
             },
         );
 

--- a/stage1/crates/axiomc/src/project/module_parse_cache.rs
+++ b/stage1/crates/axiomc/src/project/module_parse_cache.rs
@@ -13,13 +13,24 @@ pub(super) struct ModuleParseCache {
 
 impl ModuleParseCache {
     pub(super) fn with_overlays(overlays: &BTreeMap<PathBuf, String>) -> Self {
+        let mut normalized = BTreeMap::new();
+        for (path, source) in overlays {
+            let path = normalize_path(path);
+            normalized.insert(path.clone(), source.clone());
+            if let Ok(canonical) = fs::canonicalize(&path) {
+                normalized.insert(canonical, source.clone());
+            }
+        }
         Self {
             programs: HashMap::new(),
-            overlays: overlays
-                .iter()
-                .map(|(path, source)| (normalize_path(path), source.clone()))
-                .collect(),
+            overlays: normalized,
         }
+    }
+
+    pub(super) fn overlay_source(&self, module_path: &Path) -> Option<&str> {
+        self.overlays
+            .get(&normalize_path(module_path))
+            .map(String::as_str)
     }
 }
 

--- a/stage1/crates/axiomc/src/registry.rs
+++ b/stage1/crates/axiomc/src/registry.rs
@@ -1,14 +1,19 @@
 use crate::diagnostics::Diagnostic;
 use crate::lockfile::validate_lockfile;
-use crate::manifest::{LOCK_FILENAME, MANIFEST_FILENAME, load_manifest, manifest_path};
+use crate::manifest::{
+    DEFAULT_PACKAGE_CACHE_DIR, DEFAULT_PACKAGE_VENDOR_DIR, LOCK_FILENAME, MANIFEST_FILENAME,
+    load_manifest, manifest_path,
+};
 use crate::package_trust::{
     Ed25519Signer, INDEX_DOMAIN, MAX_SIGNATURES, PACKAGE_FIELDS, PackageArtifacts,
     PackageSignatureEnvelope, PackageTrustInput, RegistryIndexEnvelope,
-    RegistryIndexTrustPreflight, TrustRootsEnvelope, VerificationExpectation, canonical_json,
-    metadata_transcript, package_index_floor_is_satisfied, package_transcript,
-    parse_package_signature_json, parse_registry_index_json, preflight_package_release_trust,
-    preflight_registry_index_trust, sign_package_transcript, validate_package_provenance_semantics,
-    verify_package_with_artifacts,
+    RegistryIndexTrustPreflight, TrustRootsEnvelope, VerificationExpectation,
+    authenticate_registry_catalog, canonical_json, metadata_transcript,
+    package_index_floor_is_satisfied, package_transcript, parse_package_signature_json,
+    parse_registry_index_json, preflight_package_release_trust, preflight_registry_index_trust,
+    sign_package_transcript, validate_package_provenance_semantics,
+    verification_expectation_for_authenticated_release,
+    verification_expectation_for_unindexed_release, verify_package_with_artifacts,
 };
 use serde::Serialize;
 use serde_json::{Value, json};
@@ -1040,8 +1045,29 @@ fn publish_release_transaction(
  */
 
 fn render_package_archive(project_root: &Path) -> Result<RenderedPackage, Diagnostic> {
+    let manifest = load_manifest(project_root)?;
+    let mut excluded_roots = BTreeSet::from([
+        normalized_project_relative_root(project_root, DEFAULT_PACKAGE_CACHE_DIR)?,
+        normalized_project_relative_root(project_root, DEFAULT_PACKAGE_VENDOR_DIR)?,
+    ]);
+    if let Some(registry) = manifest.registry.as_ref() {
+        excluded_roots.insert(normalized_project_relative_root(
+            project_root,
+            registry.cache_root(),
+        )?);
+        excluded_roots.insert(normalized_project_relative_root(
+            project_root,
+            registry.vendor_root(),
+        )?);
+    }
+    if excluded_roots.contains(project_root) {
+        return Err(publish_error(
+            Some(&manifest_path(project_root)),
+            "registry cache and vendor roots must not name the project root",
+        ));
+    }
     let mut files = Vec::new();
-    collect_publishable_files(project_root, project_root, &mut files)?;
+    collect_publishable_files(project_root, project_root, &excluded_roots, &mut files)?;
     files.sort();
     let mut archive = Vec::new();
     let mut captured = BTreeMap::new();
@@ -1090,6 +1116,7 @@ fn render_package_archive(project_root: &Path) -> Result<RenderedPackage, Diagno
 fn collect_publishable_files(
     project_root: &Path,
     dir: &Path,
+    excluded_roots: &BTreeSet<PathBuf>,
     files: &mut Vec<PathBuf>,
 ) -> Result<(), Diagnostic> {
     for entry in fs::read_dir(dir)
@@ -1107,13 +1134,16 @@ fn collect_publishable_files(
             ));
         }
         if metadata.is_dir() {
+            if excluded_roots.contains(&path) {
+                continue;
+            }
             if matches!(
                 entry.file_name().to_string_lossy().as_ref(),
                 ".git" | "target" | "dist"
             ) {
                 continue;
             }
-            collect_publishable_files(project_root, &path, files)?;
+            collect_publishable_files(project_root, &path, excluded_roots, files)?;
         } else if metadata.is_file() && should_publish_file(&path) {
             let canonical = fs::canonicalize(&path).map_err(|error| {
                 publish_error(Some(&path), format!("failed to resolve path: {error}"))
@@ -1128,6 +1158,26 @@ fn collect_publishable_files(
         }
     }
     Ok(())
+}
+
+fn normalized_project_relative_root(
+    project_root: &Path,
+    relative: &str,
+) -> Result<PathBuf, Diagnostic> {
+    let mut output = project_root.to_path_buf();
+    for component in Path::new(relative).components() {
+        match component {
+            Component::Normal(component) => output.push(component),
+            Component::CurDir => {}
+            Component::Prefix(_) | Component::RootDir | Component::ParentDir => {
+                return Err(publish_error(
+                    Some(&manifest_path(project_root)),
+                    "registry cache and vendor roots must be project-relative without parent traversal",
+                ));
+            }
+        }
+    }
+    Ok(output)
 }
 
 fn should_publish_file(path: &Path) -> bool {
@@ -1484,12 +1534,25 @@ fn verify_registry_index_and_capture(
             "retained index bytes do not match parsed index envelope",
         ));
     }
+    let catalog =
+        authenticate_registry_catalog(&index.bytes, trust_roots, expectation).map_err(|error| {
+            registry_error(
+                None,
+                format!("Package Trust rejected registry catalog: {error}"),
+            )
+        })?;
     validate_registry_index(&index.envelope, None)?;
     let releases = index.envelope["signed"]["releases"]
         .as_array()
         .ok_or_else(|| registry_error(None, "registry index releases are invalid"))?;
     let mut captured = Vec::with_capacity(releases.len());
-    for release in releases {
+    for (release_index, release) in releases.iter().enumerate() {
+        let authenticated_release = catalog.releases().get(release_index).ok_or_else(|| {
+            registry_error(
+                None,
+                "authenticated registry catalog release projection is incomplete",
+            )
+        })?;
         let target = required_value_text(release, "target_path", None)?;
         let archive = read_registry_relative(packages_root, &target, MAX_ARCHIVE_BYTES)?;
         let release_dir = Path::new(&target)
@@ -1514,7 +1577,12 @@ fn verify_registry_index_and_capture(
                     format!("invalid package signature envelope: {error}"),
                 )
             })?;
-        let exact_expectation = expectation_for_release(expectation, release)?;
+        let exact_expectation = verification_expectation_for_authenticated_release(
+            expectation,
+            &catalog,
+            authenticated_release,
+        )
+        .map_err(|error| registry_error(None, error.to_string()))?;
         let verification = verify_package_with_artifacts(
             &PackageTrustInput {
                 package_signature,
@@ -1839,7 +1907,9 @@ where
             "package signature omits an expectation-required key",
         ));
     }
-    let exact_expectation = expectation_for_release(options.verification_expectation, release)?;
+    let exact_expectation =
+        verification_expectation_for_unindexed_release(options.verification_expectation, release)
+            .map_err(|error| registry_error(None, error.to_string()))?;
     preflight_package_release_trust(
         signature,
         options.trust_roots,
@@ -1871,42 +1941,6 @@ fn decode_lower_hex(value: &str) -> Result<Vec<u8>, Diagnostic> {
                 .map_err(|_| registry_error(None, "invalid lowercase hexadecimal value"))
         })
         .collect()
-}
-
-fn expectation_for_release(
-    template: &VerificationExpectation,
-    release: &Value,
-) -> Result<VerificationExpectation, Diagnostic> {
-    let mut value = template.0.clone();
-    let request = json!({
-        "registry_identity": release["registry_identity"],
-        "source_identity": release["source_identity"],
-        "namespace": release["namespace"],
-        "name": release["name"],
-        "version": release["version"],
-        "target_path": release["target_path"],
-        "publisher_identity": release["publisher_identity"],
-        "archive": release["archive"],
-        "manifest": release["manifest"],
-        "provenance": release["provenance"]
-    });
-    value["request"] = request;
-    value["offline_lock"]["release"] = json!({
-        "registry_identity": release["registry_identity"],
-        "source_identity": release["source_identity"],
-        "namespace": release["namespace"],
-        "name": release["name"],
-        "version": release["version"],
-        "target_path": release["target_path"],
-        "publisher_identity": release["publisher_identity"],
-        "archive": release["archive"],
-        "manifest": release["manifest"],
-        "provenance_statement_sha256": release["provenance"]["statement"]["digest"]["value"],
-        "provenance_predicate_type": release["provenance"]["statement"]["value"]["predicateType"],
-        "provenance_subject": release["provenance"]["selected_subject"],
-        "package_signature_sha256": release["package_signature_sha256"]
-    });
-    Ok(VerificationExpectation(value))
 }
 
 #[cfg(test)]
@@ -2812,6 +2846,8 @@ mod tests {
         let mut expectation = VerificationExpectation(contract["verification_expectation"].clone());
         expectation.0["contract_status"] = json!("implemented");
         expectation.0["verification_time"] = json!("2026-07-29T12:00:00Z");
+        expectation.0["request"]["registry_identity"] = json!("registry:test");
+        expectation.0["request"]["source_identity"] = json!("registry:test-source");
         expectation.0["required_signers"]["index_role_id"] = json!("registry-index");
         expectation.0["required_signers"]["index_threshold"] = json!(2);
         expectation.0["required_signers"]["package_role_id"] = json!("targets:axiom");
@@ -3172,6 +3208,55 @@ mod tests {
         ] {
             assert!(normalize_archive_path(Path::new(path)).is_err(), "{path}");
         }
+    }
+
+    #[test]
+    fn package_archive_excludes_default_and_configured_materialization_roots() {
+        let dir = tempdir().unwrap();
+        let project = write_project(dir.path());
+        fs::write(
+            project.join(MANIFEST_FILENAME),
+            r#"[package]
+name = "core"
+version = "1.2.3"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[registry]
+name = "local"
+index = "http://127.0.0.1:8787/index.v2.json"
+trust_roots = "trust-roots.json"
+expectation = "expectation.json"
+cache = "cache-packages"
+vendor = "vendor-packages"
+"#,
+        )
+        .unwrap();
+        for excluded in [
+            ".axiom/cache/default/src",
+            "vendor/default/src",
+            "cache-packages/custom/src",
+            "vendor-packages/custom/src",
+        ] {
+            let root = project.join(excluded);
+            fs::create_dir_all(&root).unwrap();
+            fs::write(root.join("must-not-publish.ax"), "print \"secret\"\n").unwrap();
+        }
+
+        let rendered = render_package_archive(&fs::canonicalize(&project).unwrap()).unwrap();
+
+        assert!(rendered.files.contains_key(MANIFEST_FILENAME));
+        assert!(rendered.files.contains_key(LOCK_FILENAME));
+        assert!(rendered.files.contains_key("src/main.ax"));
+        assert_eq!(rendered.files.len(), 3);
+        assert!(
+            rendered
+                .files
+                .keys()
+                .all(|path| !path.contains("must-not-publish"))
+        );
     }
 
     #[cfg(unix)]

--- a/stage1/crates/axiomc/src/registry_client.rs
+++ b/stage1/crates/axiomc/src/registry_client.rs
@@ -1,0 +1,992 @@
+//! Bounded registry transport for local files and loopback HTTP fixtures.
+
+use std::fmt;
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Write};
+use std::net::{IpAddr, SocketAddr, TcpStream};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+pub const DEFAULT_MAX_REGISTRY_BODY_BYTES: usize = 8 * 1024 * 1024;
+pub const MAX_PACKAGE_ARCHIVE_BODY_BYTES: usize = 64 * 1024 * 1024;
+pub const DEFAULT_MAX_HTTP_HEADER_BYTES: usize = 64 * 1024;
+pub const MAX_REGISTRY_URL_BYTES: usize = 4_096;
+
+#[derive(Clone, Debug)]
+pub struct RegistryClient {
+    max_body_bytes: usize,
+    max_header_bytes: usize,
+    timeout: Duration,
+}
+
+impl Default for RegistryClient {
+    fn default() -> Self {
+        Self::new(DEFAULT_MAX_REGISTRY_BODY_BYTES)
+    }
+}
+
+impl RegistryClient {
+    pub fn new(max_body_bytes: usize) -> Self {
+        Self {
+            max_body_bytes,
+            max_header_bytes: DEFAULT_MAX_HTTP_HEADER_BYTES,
+            timeout: Duration::from_secs(5),
+        }
+    }
+
+    pub fn with_limits(max_body_bytes: usize, max_header_bytes: usize, timeout: Duration) -> Self {
+        Self {
+            max_body_bytes,
+            max_header_bytes,
+            timeout,
+        }
+    }
+
+    pub const fn max_body_bytes(&self) -> usize {
+        self.max_body_bytes
+    }
+
+    /// Fetch a registry index, trust document, manifest, or other bounded
+    /// metadata body. The client's configured document limit applies.
+    pub fn fetch(&self, url: &str) -> Result<Vec<u8>, RegistryClientError> {
+        self.fetch_bounded(url, self.max_body_bytes)
+    }
+
+    /// Fetch a package archive using the package-format contract's independent
+    /// 64 MiB ceiling. Callers must opt into this larger allowance explicitly;
+    /// metadata fetches continue to use [`Self::fetch`] and its smaller limit.
+    pub fn fetch_package_archive(&self, url: &str) -> Result<Vec<u8>, RegistryClientError> {
+        self.fetch_bounded(url, MAX_PACKAGE_ARCHIVE_BODY_BYTES)
+    }
+
+    fn fetch_bounded(
+        &self,
+        url: &str,
+        max_body_bytes: usize,
+    ) -> Result<Vec<u8>, RegistryClientError> {
+        if url.len() > MAX_REGISTRY_URL_BYTES || !url.is_ascii() {
+            return Err(RegistryClientError::InvalidUrl(
+                "registry URL is non-ASCII or exceeds 4096 bytes".to_owned(),
+            ));
+        }
+        if url.starts_with("https://") {
+            return Err(RegistryClientError::UnsupportedScheme("https".to_owned()));
+        }
+        if let Some(path) = url.strip_prefix("file://") {
+            return self.fetch_file(parse_file_path(path)?, max_body_bytes);
+        }
+        if let Some(endpoint) = url.strip_prefix("http://") {
+            return self.fetch_http(parse_http_endpoint(endpoint)?, max_body_bytes);
+        }
+        let scheme = url.split_once(':').map_or("", |(scheme, _)| scheme);
+        Err(RegistryClientError::UnsupportedScheme(scheme.to_owned()))
+    }
+
+    fn fetch_file(
+        &self,
+        path: PathBuf,
+        max_body_bytes: usize,
+    ) -> Result<Vec<u8>, RegistryClientError> {
+        let file = open_registry_file(&path)?;
+        let metadata = file
+            .metadata()
+            .map_err(|error| io_error("inspect opened registry file", error))?;
+        if !metadata.is_file() {
+            return Err(RegistryClientError::InvalidFile(
+                "file registry endpoint must be a regular non-symlink file".to_owned(),
+            ));
+        }
+        if metadata.len() > max_body_bytes as u64 {
+            return Err(RegistryClientError::ResponseTooLarge {
+                limit: max_body_bytes,
+                declared: Some(metadata.len()),
+            });
+        }
+        read_bounded(file, max_body_bytes)
+    }
+
+    fn fetch_http(
+        &self,
+        endpoint: HttpEndpoint,
+        max_body_bytes: usize,
+    ) -> Result<Vec<u8>, RegistryClientError> {
+        let started_at = Instant::now();
+        let deadline =
+            started_at
+                .checked_add(self.timeout)
+                .ok_or_else(|| RegistryClientError::Io {
+                    context: "configure loopback registry deadline".to_owned(),
+                    message: "registry timeout exceeds the platform clock range".to_owned(),
+                })?;
+        let connect_timeout = remaining_http_time(deadline, "connect to loopback registry")?;
+        let mut stream = TcpStream::connect_timeout(&endpoint.address, connect_timeout)
+            .map_err(|error| io_error("connect to loopback registry", error))?;
+        let request = format!(
+            "GET {} HTTP/1.1\r\nHost: {}\r\nAccept: application/json, application/octet-stream\r\nAccept-Encoding: identity\r\nConnection: close\r\n\r\n",
+            endpoint.target, endpoint.host_header
+        );
+        write_all_before_deadline(
+            &mut stream,
+            request.as_bytes(),
+            deadline,
+            "write registry request",
+        )?;
+        self.read_http_response(stream, max_body_bytes, deadline)
+    }
+
+    fn read_http_response(
+        &self,
+        mut stream: TcpStream,
+        max_body_bytes: usize,
+        deadline: Instant,
+    ) -> Result<Vec<u8>, RegistryClientError> {
+        let mut received = Vec::new();
+        let header_end = loop {
+            if let Some(offset) = find_bytes(&received, b"\r\n\r\n") {
+                break offset + 4;
+            }
+            if received.len() >= self.max_header_bytes {
+                return Err(RegistryClientError::HeadersTooLarge {
+                    limit: self.max_header_bytes,
+                });
+            }
+            let remaining = self.max_header_bytes - received.len();
+            let mut buffer = [0_u8; 8 * 1024];
+            let capacity = buffer.len();
+            let read = read_before_deadline(
+                &mut stream,
+                &mut buffer[..remaining.min(capacity)],
+                deadline,
+                "read registry response headers",
+            )?;
+            if read == 0 {
+                return Err(RegistryClientError::TruncatedResponse {
+                    expected: None,
+                    received: received.len(),
+                });
+            }
+            received.extend_from_slice(&buffer[..read]);
+        };
+        let headers = std::str::from_utf8(&received[..header_end])
+            .map_err(|_| RegistryClientError::MalformedResponse("headers are not UTF-8".into()))?;
+        let parsed = parse_response_headers(headers)?;
+        if (300..400).contains(&parsed.status) {
+            return Err(RegistryClientError::Redirect(parsed.status));
+        }
+        if parsed.status != 200 {
+            return Err(RegistryClientError::HttpStatus(parsed.status));
+        }
+        if parsed.transfer_encoding {
+            return Err(RegistryClientError::UnsupportedTransferEncoding);
+        }
+        let content_length = parsed
+            .content_length
+            .ok_or(RegistryClientError::AmbiguousLength)?;
+        if content_length > max_body_bytes as u64 {
+            return Err(RegistryClientError::ResponseTooLarge {
+                limit: max_body_bytes,
+                declared: Some(content_length),
+            });
+        }
+        let expected =
+            usize::try_from(content_length).map_err(|_| RegistryClientError::ResponseTooLarge {
+                limit: max_body_bytes,
+                declared: Some(content_length),
+            })?;
+        let mut body = received[header_end..].to_vec();
+        if body.len() > expected {
+            return Err(RegistryClientError::AmbiguousLength);
+        }
+        while body.len() < expected {
+            let mut buffer = [0_u8; 8 * 1024];
+            let remaining = expected - body.len();
+            let capacity = buffer.len();
+            let read = read_before_deadline(
+                &mut stream,
+                &mut buffer[..remaining.min(capacity)],
+                deadline,
+                "read registry response body",
+            )?;
+            if read == 0 {
+                return Err(RegistryClientError::TruncatedResponse {
+                    expected: Some(expected),
+                    received: body.len(),
+                });
+            }
+            body.extend_from_slice(&buffer[..read]);
+        }
+        // Content-Length is the HTTP message framing boundary. Once exactly
+        // that many bytes have arrived the response is complete; waiting for
+        // EOF would let a keep-alive or delayed-close peer consume a fresh
+        // per-read timeout after an otherwise successful bounded fetch.
+        Ok(body)
+    }
+}
+
+fn remaining_http_time(deadline: Instant, context: &str) -> Result<Duration, RegistryClientError> {
+    deadline
+        .checked_duration_since(Instant::now())
+        .filter(|remaining| !remaining.is_zero())
+        .ok_or_else(|| RegistryClientError::Io {
+            context: context.to_owned(),
+            message: "registry HTTP fetch deadline elapsed".to_owned(),
+        })
+}
+
+fn read_before_deadline(
+    stream: &mut TcpStream,
+    buffer: &mut [u8],
+    deadline: Instant,
+    context: &str,
+) -> Result<usize, RegistryClientError> {
+    let remaining = remaining_http_time(deadline, context)?;
+    stream
+        .set_read_timeout(Some(remaining))
+        .map_err(|error| io_error("configure registry read deadline", error))?;
+    stream
+        .read(buffer)
+        .map_err(|error| io_error(context, error))
+}
+
+fn write_all_before_deadline(
+    stream: &mut TcpStream,
+    mut bytes: &[u8],
+    deadline: Instant,
+    context: &str,
+) -> Result<(), RegistryClientError> {
+    while !bytes.is_empty() {
+        let remaining = remaining_http_time(deadline, context)?;
+        stream
+            .set_write_timeout(Some(remaining))
+            .map_err(|error| io_error("configure registry write deadline", error))?;
+        let written = stream
+            .write(bytes)
+            .map_err(|error| io_error(context, error))?;
+        if written == 0 {
+            return Err(io_error(
+                context,
+                std::io::Error::new(
+                    std::io::ErrorKind::WriteZero,
+                    "failed to write complete registry request",
+                ),
+            ));
+        }
+        bytes = &bytes[written..];
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn open_registry_file(path: &Path) -> Result<File, RegistryClientError> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let file = OpenOptions::new()
+        .read(true)
+        // O_NOFOLLOW closes the stat-then-open race for the final path
+        // component. O_NONBLOCK prevents a swapped FIFO from blocking before
+        // descriptor metadata rejects it, and O_CLOEXEC avoids descriptor
+        // inheritance into compiler subprocesses.
+        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_CLOEXEC)
+        .open(path)
+        .map_err(|error| {
+            if error.raw_os_error() == Some(libc::ELOOP) {
+                RegistryClientError::InvalidFile(
+                    "file registry endpoint must not be a symlink".to_owned(),
+                )
+            } else {
+                io_error("open registry file without following symlinks", error)
+            }
+        })?;
+    validate_opened_registry_file(file)
+}
+
+#[cfg(windows)]
+fn open_registry_file(path: &Path) -> Result<File, RegistryClientError> {
+    use std::os::windows::fs::OpenOptionsExt;
+
+    // FILE_FLAG_OPEN_REPARSE_POINT opens the final reparse point itself rather
+    // than following it. Descriptor metadata below then rejects symlinks,
+    // directories, devices, and other non-regular endpoints.
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    let file = OpenOptions::new()
+        .read(true)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)
+        .map_err(|error| io_error("open registry file without following reparse points", error))?;
+    validate_opened_registry_file(file)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn open_registry_file(_path: &Path) -> Result<File, RegistryClientError> {
+    // std does not expose a portable no-follow open. Refuse file transport on
+    // an unsupported target instead of reintroducing a check-then-open race.
+    Err(RegistryClientError::InvalidFile(
+        "file registry endpoints require descriptor-level no-follow support on this platform"
+            .to_owned(),
+    ))
+}
+
+fn validate_opened_registry_file(file: File) -> Result<File, RegistryClientError> {
+    let metadata = file
+        .metadata()
+        .map_err(|error| io_error("inspect opened registry file", error))?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(RegistryClientError::InvalidFile(
+            "file registry endpoint must be a regular non-symlink file".to_owned(),
+        ));
+    }
+    Ok(file)
+}
+
+/// Resolve an authenticated catalog's relative artifact path against the
+/// directory containing its index URL.
+///
+/// Artifact paths are deliberately narrower than general URLs. They must be
+/// normalized ASCII relative paths and cannot contain escaping, query,
+/// fragment, backslash, control, empty, or traversal components.
+pub fn resolve_registry_artifact_url(
+    index_url: &str,
+    relative_path: &str,
+) -> Result<String, RegistryClientError> {
+    validate_relative_artifact_path(relative_path)?;
+    if index_url.len() > MAX_REGISTRY_URL_BYTES || !index_url.is_ascii() {
+        return Err(RegistryClientError::InvalidUrl(
+            "registry URL is non-ASCII or exceeds 4096 bytes".to_owned(),
+        ));
+    }
+    let resolved = if let Some(value) = index_url.strip_prefix("file://") {
+        let index_path = parse_file_path(value)?;
+        validate_normalized_index_path(value)?;
+        let directory = index_path.parent().ok_or_else(|| {
+            RegistryClientError::InvalidUrl(
+                "file registry index URL has no containing directory".to_owned(),
+            )
+        })?;
+        format!("file://{}", directory.join(relative_path).display())
+    } else if let Some(value) = index_url.strip_prefix("http://") {
+        let endpoint = parse_http_endpoint(value)?;
+        validate_normalized_index_path(&endpoint.target)?;
+        let directory_end = endpoint.target.rfind('/').ok_or_else(|| {
+            RegistryClientError::InvalidUrl(
+                "HTTP registry index URL has no containing directory".to_owned(),
+            )
+        })?;
+        let directory = &endpoint.target[..=directory_end];
+        format!(
+            "http://{}{}{}",
+            endpoint.host_header, directory, relative_path
+        )
+    } else if index_url.starts_with("https://") {
+        return Err(RegistryClientError::UnsupportedScheme("https".to_owned()));
+    } else {
+        let scheme = index_url.split_once(':').map_or("", |(scheme, _)| scheme);
+        return Err(RegistryClientError::UnsupportedScheme(scheme.to_owned()));
+    };
+    if resolved.len() > MAX_REGISTRY_URL_BYTES {
+        return Err(RegistryClientError::InvalidUrl(
+            "resolved registry URL exceeds 4096 bytes".to_owned(),
+        ));
+    }
+    Ok(resolved)
+}
+
+fn validate_normalized_index_path(value: &str) -> Result<(), RegistryClientError> {
+    if !value.starts_with('/')
+        || value.starts_with("//")
+        || value.contains(['\\', '%'])
+        || value
+            .trim_start_matches('/')
+            .split('/')
+            .any(|component| component.is_empty() || matches!(component, "." | ".."))
+    {
+        return Err(RegistryClientError::InvalidUrl(
+            "registry index path must be normalized and unescaped".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_relative_artifact_path(value: &str) -> Result<(), RegistryClientError> {
+    if value.is_empty()
+        || !value.is_ascii()
+        || value.starts_with('/')
+        || value.contains(['\\', '?', '#', '%'])
+        || value.bytes().any(|byte| byte.is_ascii_control())
+        || value
+            .split('/')
+            .any(|component| component.is_empty() || matches!(component, "." | ".."))
+    {
+        return Err(RegistryClientError::InvalidUrl(
+            "artifact path must be a normalized unescaped ASCII relative path".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn read_bounded(reader: impl Read, limit: usize) -> Result<Vec<u8>, RegistryClientError> {
+    let take_limit = u64::try_from(limit).unwrap_or(u64::MAX).saturating_add(1);
+    let mut bytes = Vec::new();
+    reader
+        .take(take_limit)
+        .read_to_end(&mut bytes)
+        .map_err(|error| io_error("read registry file", error))?;
+    if bytes.len() > limit {
+        return Err(RegistryClientError::ResponseTooLarge {
+            limit,
+            declared: None,
+        });
+    }
+    Ok(bytes)
+}
+
+fn parse_file_path(value: &str) -> Result<PathBuf, RegistryClientError> {
+    if !value.starts_with('/')
+        || value.contains(['?', '#', '%'])
+        || value.bytes().any(|byte| byte.is_ascii_control())
+    {
+        return Err(RegistryClientError::InvalidUrl(
+            "file URL must contain one unescaped absolute path".to_owned(),
+        ));
+    }
+    let path = Path::new(value);
+    if !path.is_absolute() {
+        return Err(RegistryClientError::InvalidUrl(
+            "file URL path must be absolute".to_owned(),
+        ));
+    }
+    Ok(path.to_owned())
+}
+
+#[derive(Clone, Debug)]
+struct HttpEndpoint {
+    address: SocketAddr,
+    host_header: String,
+    target: String,
+}
+
+fn parse_http_endpoint(value: &str) -> Result<HttpEndpoint, RegistryClientError> {
+    if value.contains(['#', '\r', '\n', ' ', '\t']) {
+        return Err(RegistryClientError::InvalidUrl(
+            "HTTP registry URL contains forbidden characters".to_owned(),
+        ));
+    }
+    let (authority, target) = value
+        .split_once('/')
+        .map_or((value, "/".to_owned()), |(authority, path)| {
+            (authority, format!("/{path}"))
+        });
+    if authority.is_empty() || authority.contains('@') || target.contains('?') {
+        return Err(RegistryClientError::InvalidUrl(
+            "HTTP registry URL authority or target is invalid".to_owned(),
+        ));
+    }
+    let (host, port) = if let Some(rest) = authority.strip_prefix('[') {
+        let close = rest
+            .find(']')
+            .ok_or_else(|| RegistryClientError::InvalidUrl("unterminated IPv6 host".to_owned()))?;
+        let host = &rest[..close];
+        let suffix = &rest[close + 1..];
+        let port = if suffix.is_empty() {
+            80
+        } else {
+            suffix
+                .strip_prefix(':')
+                .ok_or_else(|| {
+                    RegistryClientError::InvalidUrl("invalid IPv6 authority".to_owned())
+                })?
+                .parse()
+                .map_err(|_| RegistryClientError::InvalidUrl("invalid HTTP port".to_owned()))?
+        };
+        (host, port)
+    } else if let Some((host, port)) = authority.rsplit_once(':') {
+        if host.contains(':') {
+            return Err(RegistryClientError::InvalidUrl(
+                "IPv6 hosts must use brackets".to_owned(),
+            ));
+        }
+        let port = port
+            .parse()
+            .map_err(|_| RegistryClientError::InvalidUrl("invalid HTTP port".to_owned()))?;
+        (host, port)
+    } else {
+        (authority, 80)
+    };
+    let ip: IpAddr = host.parse().map_err(|_| {
+        RegistryClientError::NonLoopbackHost(
+            "HTTP registry host must be a numeric loopback address".to_owned(),
+        )
+    })?;
+    if !ip.is_loopback() {
+        return Err(RegistryClientError::NonLoopbackHost(host.to_owned()));
+    }
+    let address = SocketAddr::new(ip, port);
+    let host_header = if ip.is_ipv6() {
+        format!("[{ip}]:{port}")
+    } else {
+        format!("{ip}:{port}")
+    };
+    Ok(HttpEndpoint {
+        address,
+        host_header,
+        target,
+    })
+}
+
+#[derive(Debug)]
+struct ParsedHeaders {
+    status: u16,
+    content_length: Option<u64>,
+    transfer_encoding: bool,
+}
+
+fn parse_response_headers(value: &str) -> Result<ParsedHeaders, RegistryClientError> {
+    let mut lines = value
+        .strip_suffix("\r\n\r\n")
+        .ok_or_else(|| RegistryClientError::MalformedResponse("missing header terminator".into()))?
+        .split("\r\n");
+    let status_line = lines
+        .next()
+        .ok_or_else(|| RegistryClientError::MalformedResponse("missing status line".into()))?;
+    let mut status_parts = status_line.split_whitespace();
+    let version = status_parts.next().unwrap_or_default();
+    let status: u16 = status_parts
+        .next()
+        .ok_or_else(|| RegistryClientError::MalformedResponse("missing status".into()))?
+        .parse()
+        .map_err(|_| RegistryClientError::MalformedResponse("invalid status".into()))?;
+    if !matches!(version, "HTTP/1.0" | "HTTP/1.1") || status_parts.next().is_none() {
+        return Err(RegistryClientError::MalformedResponse(
+            "invalid HTTP status line".to_owned(),
+        ));
+    }
+    let mut content_length = None;
+    let mut transfer_encoding = false;
+    for line in lines {
+        if line.is_empty() || line.starts_with([' ', '\t']) {
+            return Err(RegistryClientError::MalformedResponse(
+                "empty or folded HTTP header".to_owned(),
+            ));
+        }
+        let (name, raw_value) = line.split_once(':').ok_or_else(|| {
+            RegistryClientError::MalformedResponse("header lacks colon".to_owned())
+        })?;
+        if name.is_empty()
+            || !name
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+        {
+            return Err(RegistryClientError::MalformedResponse(
+                "invalid HTTP header name".to_owned(),
+            ));
+        }
+        let header_value = raw_value.trim();
+        if name.eq_ignore_ascii_case("content-length") {
+            if content_length.is_some()
+                || header_value.is_empty()
+                || !header_value.bytes().all(|byte| byte.is_ascii_digit())
+            {
+                return Err(RegistryClientError::AmbiguousLength);
+            }
+            content_length = Some(
+                header_value
+                    .parse()
+                    .map_err(|_| RegistryClientError::AmbiguousLength)?,
+            );
+        } else if name.eq_ignore_ascii_case("transfer-encoding") {
+            transfer_encoding = true;
+        } else if name.eq_ignore_ascii_case("content-encoding")
+            && !header_value.eq_ignore_ascii_case("identity")
+        {
+            return Err(RegistryClientError::UnsupportedContentEncoding(
+                header_value.to_owned(),
+            ));
+        }
+    }
+    Ok(ParsedHeaders {
+        status,
+        content_length,
+        transfer_encoding,
+    })
+}
+
+fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
+fn io_error(context: &str, error: std::io::Error) -> RegistryClientError {
+    RegistryClientError::Io {
+        context: context.to_owned(),
+        message: error.to_string(),
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RegistryClientError {
+    UnsupportedScheme(String),
+    InvalidUrl(String),
+    NonLoopbackHost(String),
+    InvalidFile(String),
+    Io {
+        context: String,
+        message: String,
+    },
+    HeadersTooLarge {
+        limit: usize,
+    },
+    ResponseTooLarge {
+        limit: usize,
+        declared: Option<u64>,
+    },
+    TruncatedResponse {
+        expected: Option<usize>,
+        received: usize,
+    },
+    Redirect(u16),
+    HttpStatus(u16),
+    UnsupportedTransferEncoding,
+    UnsupportedContentEncoding(String),
+    AmbiguousLength,
+    MalformedResponse(String),
+}
+
+impl fmt::Display for RegistryClientError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedScheme(scheme) => {
+                write!(formatter, "unsupported registry URL scheme {scheme:?}")
+            }
+            Self::InvalidUrl(message)
+            | Self::InvalidFile(message)
+            | Self::MalformedResponse(message) => formatter.write_str(message),
+            Self::NonLoopbackHost(host) => {
+                write!(formatter, "HTTP registry host is not loopback: {host}")
+            }
+            Self::Io { context, message } => write!(formatter, "{context}: {message}"),
+            Self::HeadersTooLarge { limit } => {
+                write!(formatter, "registry response headers exceed {limit} bytes")
+            }
+            Self::ResponseTooLarge { limit, declared } => {
+                write!(
+                    formatter,
+                    "registry response exceeds {limit} bytes (declared {declared:?})"
+                )
+            }
+            Self::TruncatedResponse { expected, received } => write!(
+                formatter,
+                "registry response truncated (expected {expected:?}, received {received})"
+            ),
+            Self::Redirect(status) => {
+                write!(
+                    formatter,
+                    "registry redirects are forbidden (HTTP {status})"
+                )
+            }
+            Self::HttpStatus(status) => write!(formatter, "registry returned HTTP {status}"),
+            Self::UnsupportedTransferEncoding => {
+                formatter.write_str("registry transfer encodings are forbidden")
+            }
+            Self::UnsupportedContentEncoding(encoding) => {
+                write!(
+                    formatter,
+                    "unsupported registry content encoding {encoding:?}"
+                )
+            }
+            Self::AmbiguousLength => {
+                formatter.write_str("registry response has ambiguous body length")
+            }
+        }
+    }
+}
+
+impl std::error::Error for RegistryClientError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::TcpListener;
+    use std::thread;
+
+    fn serve_once(response: Vec<u8>) -> (String, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let address = listener.local_addr().expect("listener address");
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            stream
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .expect("read timeout");
+            let mut request = [0_u8; 4096];
+            let _ = stream.read(&mut request);
+            stream.write_all(&response).expect("write fixture response");
+        });
+        (format!("http://{address}/index.json"), handle)
+    }
+
+    fn fetch_response(response: &[u8], limit: usize) -> Result<Vec<u8>, RegistryClientError> {
+        let (url, handle) = serve_once(response.to_vec());
+        let result = RegistryClient::with_limits(limit, 4096, Duration::from_secs(2)).fetch(&url);
+        handle.join().expect("server joins");
+        result
+    }
+
+    fn fetch_archive_response(response: &[u8]) -> Result<Vec<u8>, RegistryClientError> {
+        let (url, handle) = serve_once(response.to_vec());
+        let result = RegistryClient::with_limits(4, 4096, Duration::from_secs(2))
+            .fetch_package_archive(&url);
+        handle.join().expect("server joins");
+        result
+    }
+
+    #[test]
+    fn loopback_http_requires_exact_content_length_and_no_redirects() {
+        assert_eq!(
+            fetch_response(b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello", 16)
+                .expect("bounded response"),
+            b"hello"
+        );
+        assert!(matches!(
+            fetch_response(b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nabc", 16),
+            Err(RegistryClientError::TruncatedResponse { .. })
+        ));
+        assert!(matches!(
+            fetch_response(
+                b"HTTP/1.1 302 Found\r\nLocation: /other\r\nContent-Length: 0\r\n\r\n",
+                16
+            ),
+            Err(RegistryClientError::Redirect(302))
+        ));
+    }
+
+    #[test]
+    fn loopback_http_finishes_at_content_length_without_waiting_for_close() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let address = listener.local_addr().expect("listener address");
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            stream
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .expect("read timeout");
+            let mut request = [0_u8; 4096];
+            let _ = stream.read(&mut request);
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello")
+                .expect("write complete framed response");
+            thread::sleep(Duration::from_millis(250));
+        });
+        let url = format!("http://{address}/index.json");
+
+        let body = RegistryClient::with_limits(16, 4096, Duration::from_millis(75))
+            .fetch(&url)
+            .expect("Content-Length completes the response before delayed close");
+        assert_eq!(body, b"hello");
+        handle.join().expect("server joins");
+    }
+
+    #[test]
+    fn loopback_http_uses_one_absolute_deadline_across_slow_reads() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let address = listener.local_addr().expect("listener address");
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            stream
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .expect("read timeout");
+            let mut request = [0_u8; 4096];
+            let _ = stream.read(&mut request);
+            if stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 32\r\n\r\n")
+                .is_err()
+            {
+                return;
+            }
+            for byte in b"0123456789abcdef0123456789abcdef" {
+                if stream.write_all(std::slice::from_ref(byte)).is_err() {
+                    break;
+                }
+                thread::sleep(Duration::from_millis(30));
+            }
+        });
+        let url = format!("http://{address}/index.json");
+        let started_at = Instant::now();
+
+        let result = RegistryClient::with_limits(64, 4096, Duration::from_millis(120)).fetch(&url);
+        let elapsed = started_at.elapsed();
+        assert!(
+            matches!(result, Err(RegistryClientError::Io { .. })),
+            "slow trickle must exceed the single fetch deadline: {result:?}"
+        );
+        assert!(
+            elapsed < Duration::from_millis(500),
+            "absolute deadline must not restart for each byte: {elapsed:?}"
+        );
+        handle.join().expect("server joins");
+    }
+
+    #[test]
+    fn loopback_http_rejects_oversize_chunked_and_ambiguous_lengths() {
+        assert!(matches!(
+            fetch_response(b"HTTP/1.1 200 OK\r\nContent-Length: 17\r\n\r\n", 16),
+            Err(RegistryClientError::ResponseTooLarge { .. })
+        ));
+        assert!(matches!(
+            fetch_response(
+                b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n",
+                16
+            ),
+            Err(RegistryClientError::UnsupportedTransferEncoding)
+        ));
+        assert!(matches!(
+            fetch_response(
+                b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nContent-Length: 0\r\n\r\n",
+                16
+            ),
+            Err(RegistryClientError::AmbiguousLength)
+        ));
+    }
+
+    #[test]
+    fn package_archive_fetch_uses_its_explicit_64_mib_contract_limit() {
+        assert_eq!(MAX_PACKAGE_ARCHIVE_BODY_BYTES, 64 * 1024 * 1024);
+        assert_eq!(
+            fetch_archive_response(b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello")
+                .expect("archive allowance exceeds document limit"),
+            b"hello"
+        );
+        let oversized = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n",
+            MAX_PACKAGE_ARCHIVE_BODY_BYTES + 1
+        );
+        assert_eq!(
+            fetch_archive_response(oversized.as_bytes()),
+            Err(RegistryClientError::ResponseTooLarge {
+                limit: MAX_PACKAGE_ARCHIVE_BODY_BYTES,
+                declared: Some((MAX_PACKAGE_ARCHIVE_BODY_BYTES + 1) as u64),
+            })
+        );
+    }
+
+    #[test]
+    fn transport_rejects_https_and_non_loopback_http_deterministically() {
+        let client = RegistryClient::default();
+        assert_eq!(
+            client.fetch("https://127.0.0.1/index.json"),
+            Err(RegistryClientError::UnsupportedScheme("https".to_owned()))
+        );
+        assert!(matches!(
+            client.fetch("http://192.0.2.1/index.json"),
+            Err(RegistryClientError::NonLoopbackHost(_))
+        ));
+        assert!(matches!(
+            client.fetch("http://localhost/index.json"),
+            Err(RegistryClientError::NonLoopbackHost(_))
+        ));
+    }
+
+    #[test]
+    fn artifact_urls_resolve_from_index_directory_without_escape_syntax() {
+        assert_eq!(
+            resolve_registry_artifact_url(
+                "http://127.0.0.1:8080/catalog/index.json",
+                "releases/a.json"
+            )
+            .expect("loopback join"),
+            "http://127.0.0.1:8080/catalog/releases/a.json"
+        );
+        assert_eq!(
+            resolve_registry_artifact_url("file:///tmp/axiom/catalog.json", "releases/a.json")
+                .expect("file join"),
+            "file:///tmp/axiom/releases/a.json"
+        );
+        for invalid in [
+            "",
+            "/absolute",
+            "../escape",
+            "a/../escape",
+            "./a",
+            "a//b",
+            r"a\b",
+            "a?query",
+            "a#fragment",
+            "a%2fb",
+            "a\nb",
+        ] {
+            assert!(
+                resolve_registry_artifact_url("http://127.0.0.1:8080/catalog/index.json", invalid)
+                    .is_err(),
+                "{invalid:?} must fail"
+            );
+        }
+        assert_eq!(
+            resolve_registry_artifact_url("https://127.0.0.1/index.json", "a.json"),
+            Err(RegistryClientError::UnsupportedScheme("https".to_owned()))
+        );
+        for invalid_base in [
+            "http://127.0.0.1:8080/catalog/../index.json",
+            "http://127.0.0.1:8080/catalog/%69ndex.json",
+            r"http://127.0.0.1:8080/catalog\index.json",
+            "file:///tmp/catalog/../index.json",
+        ] {
+            assert!(
+                resolve_registry_artifact_url(invalid_base, "a.json").is_err(),
+                "{invalid_base:?} must fail"
+            );
+        }
+    }
+
+    #[test]
+    fn file_transport_is_bounded_and_rejects_symlinks() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let path = directory.path().join("index.json");
+        std::fs::write(&path, b"hello").expect("write fixture");
+        let url = format!("file://{}", path.display());
+        assert_eq!(
+            RegistryClient::new(5).fetch(&url).expect("read exact file"),
+            b"hello"
+        );
+        assert!(matches!(
+            RegistryClient::new(4).fetch(&url),
+            Err(RegistryClientError::ResponseTooLarge { .. })
+        ));
+        assert_eq!(
+            RegistryClient::new(4)
+                .fetch_package_archive(&url)
+                .expect("archive fetch has an explicit larger allowance"),
+            b"hello"
+        );
+
+        #[cfg(unix)]
+        {
+            let link = directory.path().join("link.json");
+            std::os::unix::fs::symlink(&path, &link).expect("create symlink");
+            assert!(matches!(
+                RegistryClient::new(16).fetch(&format!("file://{}", link.display())),
+                Err(RegistryClientError::InvalidFile(_))
+            ));
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn file_transport_reads_the_opened_descriptor_not_a_replaced_path() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let path = directory.path().join("package.axp");
+        let old_path = directory.path().join("opened-package.axp");
+        let replacement = directory.path().join("replacement.axp");
+        std::fs::write(&path, b"authenticated").expect("write authenticated bytes");
+        std::fs::write(&replacement, b"replacement").expect("write replacement bytes");
+
+        let opened = open_registry_file(&path).expect("open anchored descriptor");
+        std::fs::rename(&path, &old_path).expect("preserve opened inode");
+        std::fs::rename(&replacement, &path).expect("replace pathname");
+
+        assert_eq!(
+            read_bounded(opened, 32).expect("read already-opened descriptor"),
+            b"authenticated"
+        );
+        assert_eq!(
+            std::fs::read(&path).expect("read replacement pathname"),
+            b"replacement"
+        );
+    }
+}

--- a/stage1/crates/axiomc/tests/package_resolver_cli.rs
+++ b/stage1/crates/axiomc/tests/package_resolver_cli.rs
@@ -1,0 +1,1990 @@
+use axiomc::lockfile::{ParsedLockfile, load_lockfile, write_lockfile_v2_atomic};
+use axiomc::package_trust::{
+    Ed25519Signer, INDEX_DOMAIN, ROOT_DOMAIN, TrustRootsEnvelope, VerificationExpectation,
+    canonical_json, metadata_transcript, parse_package_signature_json,
+};
+use axiomc::registry::{
+    PublishOptions, RegistryIndex, RegistryIndexOptions, build_registry_index, publish_package,
+};
+use ed25519_dalek::{Signer as _, SigningKey};
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::{Read, Write};
+use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, RwLock};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const REGISTRY_IDENTITY: &str = "registry:test";
+const SOURCE_IDENTITY: &str = "registry:test-source";
+const PUBLISHER_IDENTITY: &str = "publisher:foundation";
+const NAMESPACE: &str = "axiom";
+
+// These cases launch complete compiler processes and generate Ed25519-backed
+// registry metadata. Serialize them so constrained runners do not run several
+// full package graphs at once.
+static PACKAGE_RESOLVER_CLI_PROCESS: Mutex<()> = Mutex::new(());
+
+struct TestSigner(SigningKey);
+
+impl TestSigner {
+    fn new(seed: u8) -> Self {
+        Self(SigningKey::from_bytes(&[seed; 32]))
+    }
+}
+
+impl Ed25519Signer for TestSigner {
+    type Error = std::convert::Infallible;
+
+    fn public_key(&self) -> Result<[u8; 32], Self::Error> {
+        Ok(self.0.verifying_key().to_bytes())
+    }
+
+    fn sign(&self, message: &[u8]) -> Result<[u8; 64], Self::Error> {
+        Ok(self.0.sign(message).to_bytes())
+    }
+}
+
+struct TrustFixture {
+    roots: TrustRootsEnvelope,
+    expectation_template: VerificationExpectation,
+    package_signers: [TestSigner; 2],
+    index_signers: [TestSigner; 2],
+}
+
+struct RegistryVersion {
+    index: RegistryIndex,
+    expectation: VerificationExpectation,
+}
+
+struct HttpRegistry {
+    address: SocketAddr,
+    routes: Arc<RwLock<BTreeMap<String, Vec<u8>>>>,
+    requests: Arc<AtomicUsize>,
+    stop: Arc<AtomicBool>,
+    worker: Option<thread::JoinHandle<()>>,
+}
+
+impl HttpRegistry {
+    fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap_or_else(|error| {
+            panic!(
+                "numeric-loopback HTTP is required for package resolver acceptance coverage; \
+                 failed to bind 127.0.0.1:0: {error}"
+            )
+        });
+        listener
+            .set_nonblocking(true)
+            .expect("set package registry nonblocking");
+        let address = listener.local_addr().expect("package registry address");
+        let routes = Arc::new(RwLock::new(BTreeMap::new()));
+        let requests = Arc::new(AtomicUsize::new(0));
+        let stop = Arc::new(AtomicBool::new(false));
+        let worker_routes = Arc::clone(&routes);
+        let worker_requests = Arc::clone(&requests);
+        let worker_stop = Arc::clone(&stop);
+        let worker = thread::spawn(move || {
+            while !worker_stop.load(Ordering::Acquire) {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        worker_requests.fetch_add(1, Ordering::AcqRel);
+                        serve_http_request(&mut stream, &worker_routes);
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(2));
+                    }
+                    Err(error) => panic!("accept package registry request: {error}"),
+                }
+            }
+        });
+        Self {
+            address,
+            routes,
+            requests,
+            stop,
+            worker: Some(worker),
+        }
+    }
+
+    fn index_url(&self) -> String {
+        format!("http://{}/index.json", self.address)
+    }
+
+    fn install(&self, registry_root: &Path, index: &RegistryIndex) {
+        let mut routes = BTreeMap::from([("/index.json".to_owned(), index.as_bytes().to_vec())]);
+        for release in index.envelope()["signed"]["releases"]
+            .as_array()
+            .expect("registry index releases")
+        {
+            let target = release["target_path"]
+                .as_str()
+                .expect("release target path");
+            let parent = Path::new(target).parent().expect("release parent");
+            for relative in [
+                PathBuf::from(target),
+                parent.join("axiom.toml"),
+                parent.join("provenance.json"),
+                parent.join("package.axp.sig"),
+            ] {
+                let route = format!("/{}", relative.to_string_lossy());
+                let bytes = fs::read(registry_root.join(&relative))
+                    .unwrap_or_else(|error| panic!("read exact route {route}: {error}"));
+                routes.insert(route, bytes);
+            }
+        }
+        *self.routes.write().expect("write package registry routes") = routes;
+    }
+
+    fn request_count(&self) -> usize {
+        self.requests.load(Ordering::Acquire)
+    }
+
+    fn replace_route(&self, route: &str, bytes: &[u8]) {
+        let replaced = self
+            .routes
+            .write()
+            .expect("write package registry routes")
+            .insert(route.to_owned(), bytes.to_vec());
+        assert!(replaced.is_some(), "route {route:?} must already exist");
+    }
+}
+
+impl Drop for HttpRegistry {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Release);
+        if let Some(worker) = self.worker.take() {
+            worker.join().expect("join package registry");
+        }
+    }
+}
+
+fn serve_http_request(stream: &mut TcpStream, routes: &Arc<RwLock<BTreeMap<String, Vec<u8>>>>) {
+    stream
+        .set_read_timeout(Some(Duration::from_millis(250)))
+        .expect("set registry read timeout");
+    stream
+        .set_write_timeout(Some(Duration::from_secs(5)))
+        .expect("set registry write timeout");
+    let mut request = Vec::new();
+    let mut buffer = [0_u8; 1024];
+    let request_deadline = Instant::now() + Duration::from_secs(5);
+    while request.len() < 8192 && !request.windows(4).any(|window| window == b"\r\n\r\n") {
+        let read = match stream.read(&mut buffer) {
+            Ok(read) => read,
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                ) =>
+            {
+                assert!(
+                    Instant::now() < request_deadline,
+                    "timed out waiting for complete registry request"
+                );
+                continue;
+            }
+            Err(error) => panic!("read registry request: {error}"),
+        };
+        if read == 0 {
+            return;
+        }
+        request.extend_from_slice(&buffer[..read]);
+    }
+    let request = String::from_utf8(request).expect("registry request is ASCII");
+    let mut words = request
+        .lines()
+        .next()
+        .expect("registry request line")
+        .split_ascii_whitespace();
+    let method = words.next().unwrap_or_default();
+    let path = words.next().unwrap_or_default();
+    assert_eq!(method, "GET", "registry transport uses only GET");
+    let route = routes
+        .read()
+        .expect("read package registry routes")
+        .get(path)
+        .cloned();
+    let (status, body) = match route {
+        Some(body) => ("200 OK", body),
+        None => ("404 Not Found", b"not found\n".to_vec()),
+    };
+    let response = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: application/octet-stream\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    );
+    stream
+        .write_all(response.as_bytes())
+        .expect("write registry response head");
+    stream
+        .write_all(&body)
+        .expect("write exact registry response body");
+    stream.flush().expect("flush exact registry response");
+    stream
+        .shutdown(Shutdown::Write)
+        .expect("finish exact registry response");
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    output
+}
+
+fn sha256(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+fn signer_key_id(signer: &TestSigner) -> String {
+    trust_key(signer, "unused")["key_id"]
+        .as_str()
+        .expect("signer key id")
+        .to_owned()
+}
+
+fn trust_key(signer: &TestSigner, publisher: &str) -> Value {
+    let material = json!({
+        "algorithm": "ed25519",
+        "public_key_encoding": "lowercase-hex",
+        "public_key": hex_encode(&signer.public_key().expect("public key"))
+    });
+    json!({
+        "key_id": format!(
+            "sha256:{}",
+            sha256(&canonical_json(&material).expect("canonical key material"))
+        ),
+        "key_material": material,
+        "publisher_identity": publisher,
+        "status": "active",
+        "valid_from_sequence": 1,
+        "supersedes_key_ids": [],
+        "revocation": null
+    })
+}
+
+fn metadata_signature(transcript: &[u8], signer: &TestSigner) -> Value {
+    json!({
+        "key_id": signer_key_id(signer),
+        "algorithm": "ed25519",
+        "encoding": "lowercase-hex",
+        "value": hex_encode(&signer.sign(transcript).expect("sign metadata"))
+    })
+}
+
+fn root_envelope(signed: Value, signers: &[TestSigner]) -> Value {
+    let transcript = metadata_transcript(ROOT_DOMAIN, &signed).expect("root transcript");
+    json!({
+        "signed": signed,
+        "transcript": {
+            "encoding": "axiom-canonical-json-v1",
+            "domain": ROOT_DOMAIN,
+            "bytes_hex": hex_encode(&transcript),
+            "sha256": sha256(&transcript)
+        },
+        "signatures": signers
+            .iter()
+            .map(|signer| metadata_signature(&transcript, signer))
+            .collect::<Vec<_>>()
+    })
+}
+
+fn stage1_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(relative)
+}
+
+fn trust_fixture() -> TrustFixture {
+    let old_root = [TestSigner::new(1), TestSigner::new(2), TestSigner::new(9)];
+    let new_root = [TestSigner::new(3), TestSigner::new(4)];
+    let index_signers = [TestSigner::new(5), TestSigner::new(6)];
+    let package_signers = [TestSigner::new(7), TestSigner::new(8)];
+    let old_root_ids = old_root.iter().map(signer_key_id).collect::<Vec<_>>();
+    let new_root_ids = new_root.iter().map(signer_key_id).collect::<Vec<_>>();
+    let index_ids = index_signers.iter().map(signer_key_id).collect::<Vec<_>>();
+    let package_ids = package_signers
+        .iter()
+        .map(signer_key_id)
+        .collect::<Vec<_>>();
+    let old_signed = json!({
+        "specification": "axiom-package-trust-root-v1",
+        "root_version": 1,
+        "sequence": 1,
+        "issued_at": "2026-01-01T00:00:00Z",
+        "expires_at": "2027-01-01T00:00:00Z",
+        "consistent_snapshot": true,
+        "keys": old_root
+            .iter()
+            .map(|signer| trust_key(signer, "axiom://trust/root"))
+            .collect::<Vec<_>>(),
+        "publisher_identities": [{
+            "publisher_identity": "axiom://trust/root",
+            "display_name": "Old root"
+        }],
+        "namespace_grants": [{
+            "publisher_identity": "axiom://trust/root",
+            "namespace": "bootstrap",
+            "package_names": ["bootstrap"],
+            "registry_identities": [REGISTRY_IDENTITY],
+            "source_identities": [SOURCE_IDENTITY],
+            "role_id": "registry-index"
+        }],
+        "roles": [
+            {"role_id":"root","threshold":2,"key_ids":old_root_ids.clone(),"delegated_by":null},
+            {"role_id":"timestamp","threshold":2,"key_ids":old_root_ids.clone(),"delegated_by":"root"},
+            {"role_id":"snapshot","threshold":2,"key_ids":old_root_ids.clone(),"delegated_by":"timestamp"},
+            {"role_id":"registry-index","threshold":2,"key_ids":old_root_ids,"delegated_by":"snapshot"}
+        ],
+        "policy": {
+            "rollback_protection": "reject rollback",
+            "freeze_protection": "reject expiry",
+            "downgrade_protection": "reject downgrade",
+            "offline_locked": "require exact pins",
+            "metadata_expiry_required": true,
+            "registry_index_equivalence": "combined metadata role"
+        }
+    });
+    let candidate_signed = json!({
+        "specification": "axiom-package-trust-root-v1",
+        "root_version": 2,
+        "sequence": 2,
+        "issued_at": "2026-07-01T00:00:00Z",
+        "expires_at": "2027-01-01T00:00:00Z",
+        "consistent_snapshot": true,
+        "keys": new_root.iter().map(|signer| trust_key(signer, "axiom://trust/root"))
+            .chain(index_signers.iter().map(|signer| trust_key(signer, "axiom://registry/official")))
+            .chain(package_signers.iter().map(|signer| trust_key(signer, PUBLISHER_IDENTITY)))
+            .collect::<Vec<_>>(),
+        "publisher_identities": [{
+            "publisher_identity": PUBLISHER_IDENTITY,
+            "display_name": "Test publisher"
+        }],
+        "namespace_grants": [{
+            "publisher_identity": PUBLISHER_IDENTITY,
+            "namespace": NAMESPACE,
+            "package_names": ["core", "support"],
+            "registry_identities": [REGISTRY_IDENTITY],
+            "source_identities": [SOURCE_IDENTITY],
+            "role_id": "targets:axiom"
+        }],
+        "roles": [
+            {"role_id":"root","threshold":2,"key_ids":new_root_ids,"delegated_by":null},
+            {"role_id":"timestamp","threshold":2,"key_ids":index_ids,"delegated_by":"root"},
+            {"role_id":"snapshot","threshold":2,"key_ids":index_ids,"delegated_by":"timestamp"},
+            {"role_id":"registry-index","threshold":2,"key_ids":index_ids,"delegated_by":"snapshot"},
+            {"role_id":"targets","threshold":2,"key_ids":package_ids.clone(),"delegated_by":"root"},
+            {"role_id":"targets:axiom","threshold":2,"key_ids":package_ids.clone(),"delegated_by":"targets"}
+        ],
+        "policy": {
+            "rollback_protection": "reject rollback",
+            "freeze_protection": "reject expiry",
+            "downgrade_protection": "reject downgrade",
+            "offline_locked": "require exact pins",
+            "metadata_expiry_required": true,
+            "registry_index_equivalence": "combined metadata role"
+        }
+    });
+    let trusted_root = root_envelope(old_signed, &old_root);
+    let candidate_root = root_envelope(candidate_signed, &new_root);
+    let candidate_transcript =
+        metadata_transcript(ROOT_DOMAIN, &candidate_root["signed"]).expect("candidate transcript");
+    let roots = TrustRootsEnvelope(json!({
+        "schema_version": "axiom.package_trust_roots.v1",
+        "contract": "package.trust_roots",
+        "contract_status": "implemented",
+        "trusted_root": trusted_root,
+        "candidate_root": candidate_root,
+        "transition": {
+            "from_version": 1,
+            "to_version": 2,
+            "transition_time": "2026-07-02T00:00:00Z",
+            "candidate_signatures_by_old_root": old_root
+                .iter()
+                .map(|signer| metadata_signature(&candidate_transcript, signer))
+                .collect::<Vec<_>>(),
+            "candidate_signatures_by_new_root": new_root
+                .iter()
+                .map(|signer| metadata_signature(&candidate_transcript, signer))
+                .collect::<Vec<_>>()
+        }
+    }));
+    let contract: Value = serde_json::from_slice(
+        &fs::read(stage1_path("package-trust/contract/package-trust.json"))
+            .expect("read checked Package Trust contract"),
+    )
+    .expect("parse checked Package Trust contract");
+    let mut expectation = VerificationExpectation(contract["verification_expectation"].clone());
+    expectation.0["contract_status"] = json!("implemented");
+    expectation.0["verification_time"] = json!("2026-07-29T12:00:00Z");
+    expectation.0["required_signers"]["index_role_id"] = json!("registry-index");
+    expectation.0["required_signers"]["index_threshold"] = json!(2);
+    expectation.0["required_signers"]["package_role_id"] = json!("targets:axiom");
+    expectation.0["required_signers"]["package_threshold"] = json!(2);
+    expectation.0["required_signers"]["required_key_ids"] = json!(package_ids);
+    expectation.0["trusted_state"]["trusted_root_anchor"] = json!({
+        "root_version": 1,
+        "root_sequence": 1,
+        "root_transcript_sha256": roots["trusted_root"]["transcript"]["sha256"]
+    });
+    expectation.0["trusted_state"]["highest_root_version"] = json!(2);
+    expectation.0["trusted_state"]["highest_root_sequence"] = json!(2);
+    expectation.0["trusted_state"]["highest_index_generation"] = json!(1);
+    expectation.0["trusted_state"]["highest_index_sequence"] = json!(1);
+    expectation.0["trusted_state"]["minimum_package_version"] = json!("1.2.3");
+    expectation.0["trusted_state"]["seen_snapshots"] = json!([{
+        "generation": 1,
+        "sequence": 1,
+        "snapshot_id": "registry.test.publication-bootstrap",
+        "index_transcript_sha256": "00".repeat(32)
+    }]);
+    expectation.0["offline_lock"]["root_version"] =
+        roots["candidate_root"]["signed"]["root_version"].clone();
+    expectation.0["offline_lock"]["root_sequence"] =
+        roots["candidate_root"]["signed"]["sequence"].clone();
+    expectation.0["offline_lock"]["root_transcript_sha256"] =
+        roots["candidate_root"]["transcript"]["sha256"].clone();
+    TrustFixture {
+        roots,
+        expectation_template: expectation,
+        package_signers,
+        index_signers,
+    }
+}
+
+fn provenance_statement(target: &str, archive_hash: &str) -> Value {
+    json!({
+        "_type": "https://in-toto.io/Statement/v1",
+        "subject": [{"name": target, "digest": {"sha256": archive_hash}}],
+        "predicateType": "https://slsa.dev/provenance/v1",
+        "predicate": {
+            "buildDefinition": {
+                "buildType": "axiom:build/package-v1",
+                "externalParameters": {},
+                "internalParameters": {},
+                "resolvedDependencies": [{
+                    "uri": SOURCE_IDENTITY,
+                    "digest": {"sha256": "11".repeat(32)}
+                }]
+            },
+            "runDetails": {
+                "builder": {
+                    "id": "axiom:builder/test",
+                    "builderDependencies": [],
+                    "version": {"axiomc": "test"}
+                },
+                "metadata": {
+                    "invocationId": "urn:uuid:00000000-0000-4000-8000-000000000001",
+                    "startedOn": "2026-07-29T10:00:00Z",
+                    "finishedOn": "2026-07-29T10:00:01Z"
+                },
+                "byproducts": []
+            }
+        }
+    })
+}
+
+fn package_manifest(name: &str, version: &str) -> String {
+    format!(
+        "[package]\nname = {name:?}\nversion = {version:?}\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n"
+    )
+}
+
+fn package_lock(name: &str, version: &str) -> String {
+    format!(
+        "version = 1\n\n[[package]]\nname = {name:?}\nversion = {version:?}\nsource = \"path\"\n"
+    )
+}
+
+fn render_archive(manifest: &[u8], lock: &[u8], source: &[u8]) -> Vec<u8> {
+    let mut archive = b"AXIOM_PACKAGE_ARCHIVE_V1\n".to_vec();
+    for (path, content) in [
+        ("axiom.lock", lock),
+        ("axiom.toml", manifest),
+        ("src/main.ax", source),
+    ] {
+        archive.extend_from_slice(format!("--- file {path} {} ---\n", content.len()).as_bytes());
+        archive.extend_from_slice(content);
+        if !content.ends_with(b"\n") {
+            archive.push(b'\n');
+        }
+    }
+    archive
+}
+
+fn publish_fixture_package(
+    root: &Path,
+    registry_root: &Path,
+    fixture: &TrustFixture,
+    name: &str,
+    version: &str,
+    index_sequence: u64,
+    allow_overwrite: bool,
+    source_marker: &str,
+) {
+    let project = root.join(format!("{name}-{version}-{index_sequence}-{source_marker}"));
+    fs::create_dir_all(project.join("src")).expect("create package source");
+    let manifest = package_manifest(name, version);
+    let lock = package_lock(name, version);
+    let source = format!("print \"{name} {version} {source_marker}\"\n");
+    fs::write(project.join("axiom.toml"), &manifest).expect("write package manifest");
+    fs::write(project.join("axiom.lock"), &lock).expect("write package lock");
+    fs::write(project.join("src/main.ax"), &source).expect("write package source");
+    let archive = render_archive(manifest.as_bytes(), lock.as_bytes(), source.as_bytes());
+    let target = format!("{NAMESPACE}/{name}/{version}/package.axp");
+    let statement = provenance_statement(&target, &sha256(&archive));
+    let published = publish_package(
+        &project,
+        registry_root,
+        &PublishOptions {
+            allow_overwrite,
+            namespace: NAMESPACE,
+            registry_identity: REGISTRY_IDENTITY,
+            source_identity: SOURCE_IDENTITY,
+            publisher_identity: PUBLISHER_IDENTITY,
+            index_generation: 1,
+            index_sequence,
+            provenance_statement: &statement,
+            trust_roots: &fixture.roots,
+            verification_expectation: &fixture.expectation_template,
+            signers: &fixture.package_signers,
+        },
+    )
+    .expect("publish runtime-generated signed package");
+    assert_eq!(
+        fs::read(&published.archive).expect("read published archive"),
+        archive,
+        "the registry must serve the exact archive bytes generated at runtime"
+    );
+}
+
+fn publish_core(
+    root: &Path,
+    registry_root: &Path,
+    fixture: &TrustFixture,
+    version: &str,
+    index_sequence: u64,
+) {
+    publish_fixture_package(
+        root,
+        registry_root,
+        fixture,
+        "core",
+        version,
+        index_sequence,
+        false,
+        "original",
+    );
+}
+
+fn release_values(registry_root: &Path) -> Vec<Value> {
+    let mut signature_paths = Vec::new();
+    collect_named_files(registry_root, "package.axp.sig", &mut signature_paths);
+    let mut releases = signature_paths
+        .into_iter()
+        .map(|signature_path| {
+            let signature_bytes =
+                fs::read(&signature_path).expect("read published package signature");
+            let signature = parse_package_signature_json(&signature_bytes)
+                .expect("parse published package signature");
+            let canonical_signature =
+                canonical_json(&signature).expect("canonicalize published package signature");
+            let target = signature["package"]["target_path"]
+                .as_str()
+                .expect("signature target");
+            let release_dir =
+                registry_root.join(Path::new(target).parent().expect("release parent"));
+            json!({
+                "namespace": signature["package"]["namespace"],
+                "name": signature["package"]["name"],
+                "version": signature["package"]["version"],
+                "target_path": signature["package"]["target_path"],
+                "registry_identity": signature["registry"]["registry_identity"],
+                "source_identity": signature["registry"]["source_identity"],
+                "publisher_identity": signature["publisher"]["publisher_identity"],
+                "archive": {
+                    "length": signature["archive"]["size"],
+                    "digest": signature["archive"]["digest"]
+                },
+                "manifest": signature["manifest"],
+                "provenance": signature["provenance"],
+                "package_signature_sha256": sha256(&canonical_signature),
+                "yanked": release_dir.join("axiom-registry.toml").exists()
+            })
+        })
+        .collect::<Vec<_>>();
+    releases.sort_by(|left, right| {
+        left["namespace"]
+            .as_str()
+            .cmp(&right["namespace"].as_str())
+            .then(left["name"].as_str().cmp(&right["name"].as_str()))
+            .then(left["version"].as_str().cmp(&right["version"].as_str()))
+    });
+    releases
+}
+
+fn collect_named_files(root: &Path, name: &str, output: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries {
+        let path = entry.expect("read fixture directory entry").path();
+        if path.is_dir() {
+            collect_named_files(&path, name, output);
+        } else if path.file_name().and_then(|value| value.to_str()) == Some(name) {
+            output.push(path);
+        }
+    }
+}
+
+fn expectation_for_index(
+    fixture: &TrustFixture,
+    releases: &[Value],
+    generation: u64,
+    sequence: u64,
+    snapshot_id: &str,
+    previous_snapshot_sha256: &str,
+    trusted_index: Option<&RegistryIndex>,
+) -> VerificationExpectation {
+    let signed = json!({
+        "metadata_version": 2,
+        "registry_identity": REGISTRY_IDENTITY,
+        "source_identity": SOURCE_IDENTITY,
+        "generation": generation,
+        "sequence": sequence,
+        "issued_at": "2026-07-29T11:00:00Z",
+        "expires_at": "2026-12-31T00:00:00Z",
+        "consistent_snapshot": {
+            "enabled": true,
+            "snapshot_id": snapshot_id,
+            "metadata_path": format!("{generation}/{sequence}/index.v2.json"),
+            "previous_snapshot_sha256": previous_snapshot_sha256
+        },
+        "signature_role": "registry-index",
+        "releases": releases
+    });
+    let transcript =
+        metadata_transcript(INDEX_DOMAIN, &signed).expect("prospective index transcript");
+    let transcript_sha256 = sha256(&transcript);
+    let release = releases.first().expect("at least one registry release");
+    let mut expectation = fixture.expectation_template.0.clone();
+    expectation["request"] = json!({
+        "registry_identity": release["registry_identity"],
+        "source_identity": release["source_identity"],
+        "namespace": release["namespace"],
+        "name": release["name"],
+        "version": release["version"],
+        "target_path": release["target_path"],
+        "publisher_identity": release["publisher_identity"],
+        "archive": release["archive"],
+        "manifest": release["manifest"],
+        "provenance": release["provenance"]
+    });
+    if let Some(trusted) = trusted_index {
+        expectation["trusted_state"]["highest_index_generation"] =
+            trusted.envelope()["signed"]["generation"].clone();
+        expectation["trusted_state"]["highest_index_sequence"] =
+            trusted.envelope()["signed"]["sequence"].clone();
+        expectation["trusted_state"]["seen_snapshots"] = json!([{
+            "generation": trusted.envelope()["signed"]["generation"],
+            "sequence": trusted.envelope()["signed"]["sequence"],
+            "snapshot_id": trusted.envelope()["signed"]["consistent_snapshot"]["snapshot_id"],
+            "index_transcript_sha256": trusted.envelope()["transcript"]["sha256"]
+        }]);
+    } else {
+        expectation["trusted_state"]["highest_index_generation"] = json!(generation);
+        expectation["trusted_state"]["highest_index_sequence"] = json!(sequence);
+        expectation["trusted_state"]["seen_snapshots"] = json!([{
+            "generation": generation,
+            "sequence": sequence,
+            "snapshot_id": snapshot_id,
+            "index_transcript_sha256": transcript_sha256
+        }]);
+    }
+    expectation["offline_lock"] = json!({
+        "mode": "offline_locked",
+        "network_fallback": false,
+        "root_version": fixture.roots["candidate_root"]["signed"]["root_version"],
+        "root_sequence": fixture.roots["candidate_root"]["signed"]["sequence"],
+        "root_transcript_sha256": fixture.roots["candidate_root"]["transcript"]["sha256"],
+        "index_generation": generation,
+        "index_sequence": sequence,
+        "index_transcript_sha256": transcript_sha256,
+        "release": {
+            "registry_identity": release["registry_identity"],
+            "source_identity": release["source_identity"],
+            "namespace": release["namespace"],
+            "name": release["name"],
+            "version": release["version"],
+            "target_path": release["target_path"],
+            "publisher_identity": release["publisher_identity"],
+            "archive": release["archive"],
+            "manifest": release["manifest"],
+            "provenance_statement_sha256": release["provenance"]["statement"]["digest"]["value"],
+            "provenance_predicate_type": release["provenance"]["statement"]["value"]["predicateType"],
+            "provenance_subject": release["provenance"]["selected_subject"],
+            "package_signature_sha256": release["package_signature_sha256"]
+        }
+    });
+    VerificationExpectation(expectation)
+}
+
+fn build_index(
+    fixture: &TrustFixture,
+    registry_root: &Path,
+    sequence: u64,
+    previous: Option<&RegistryIndex>,
+) -> RegistryVersion {
+    let releases = release_values(registry_root);
+    let snapshot_id = format!("registry.test.1.{sequence}");
+    let previous_sha256 = previous
+        .map(|index| {
+            index.envelope()["transcript"]["sha256"]
+                .as_str()
+                .expect("previous index transcript")
+                .to_owned()
+        })
+        .unwrap_or_else(|| "00".repeat(32));
+    let build_expectation = expectation_for_index(
+        fixture,
+        &releases,
+        1,
+        sequence,
+        &snapshot_id,
+        &previous_sha256,
+        previous,
+    );
+    let index = build_registry_index(
+        registry_root,
+        &RegistryIndexOptions {
+            registry_identity: REGISTRY_IDENTITY,
+            source_identity: SOURCE_IDENTITY,
+            generation: 1,
+            sequence,
+            issued_at: "2026-07-29T11:00:00Z",
+            expires_at: "2026-12-31T00:00:00Z",
+            snapshot_id: &snapshot_id,
+            metadata_path: &format!("1/{sequence}/index.v2.json"),
+            previous_snapshot_sha256: &previous_sha256,
+            trust_roots: &fixture.roots,
+            verification_expectation: &build_expectation,
+            signers: &fixture.index_signers,
+        },
+    )
+    .expect("build runtime-generated signed registry index");
+    let expectation = expectation_for_index(
+        fixture,
+        &releases,
+        1,
+        sequence,
+        &snapshot_id,
+        &previous_sha256,
+        previous,
+    );
+    RegistryVersion { index, expectation }
+}
+
+fn write_project(
+    root: &Path,
+    index_url: &str,
+    expectation: &VerificationExpectation,
+    root_requirement: &str,
+    local_requirement: &str,
+) -> PathBuf {
+    let project = root.join("app");
+    let local = project.join("deps/local-util");
+    fs::create_dir_all(project.join("src")).expect("create app source");
+    fs::create_dir_all(local.join("src")).expect("create path dependency source");
+    fs::create_dir_all(project.join("trust")).expect("create app trust directory");
+    fs::write(
+        project.join("axiom.toml"),
+        format!(
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\n\n\
+             [build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n\
+             [registry]\nname = \"fixture\"\nindex = {index_url:?}\n\
+             trust_roots = \"trust/roots.json\"\nexpectation = \"trust/expectation.json\"\n\
+             cache = \".axiom/cache\"\nvendor = \"vendor\"\n\n\
+             [dependencies.local_util]\npath = \"deps/local-util\"\nversion = \"^0.4.0\"\n\n\
+             [dependencies.core]\nregistry = \"fixture\"\nnamespace = \"axiom\"\n\
+             package = \"core\"\nversion = {root_requirement:?}\n"
+        ),
+    )
+    .expect("write app manifest");
+    fs::write(
+        project.join("src/main.ax"),
+        "print \"package resolver app\"\n",
+    )
+    .expect("write app source");
+    fs::write(
+        project.join("src/smoke_test.ax"),
+        "print \"resolver test\"\n",
+    )
+    .expect("write app test source");
+    let mut app_manifest =
+        fs::read_to_string(project.join("axiom.toml")).expect("read app manifest for test target");
+    app_manifest.push_str(
+        "\n[[tests]]\nname = \"resolver-smoke\"\nentry = \"src/smoke_test.ax\"\n\
+         stdout = \"resolver test\\n\"\n",
+    );
+    fs::write(project.join("axiom.toml"), app_manifest).expect("write app test target");
+    fs::write(
+        local.join("axiom.toml"),
+        format!(
+            "[package]\nname = \"local-util\"\nversion = \"0.4.0\"\n\n\
+             [build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n\
+             [registry]\nname = \"fixture\"\nindex = {index_url:?}\n\
+             trust_roots = \"trust/roots.json\"\nexpectation = \"trust/expectation.json\"\n\
+             cache = \".axiom/cache\"\nvendor = \"vendor\"\n\n\
+             [dependencies.core]\nregistry = \"fixture\"\nnamespace = \"axiom\"\n\
+             package = \"core\"\nversion = {local_requirement:?}\n"
+        ),
+    )
+    .expect("write path dependency manifest");
+    fs::write(local.join("src/main.ax"), "print \"local util\"\n")
+        .expect("write path dependency source");
+    write_expectation(&project, expectation);
+    project
+}
+
+fn add_registry_dependency(project: &Path, alias: &str, package: &str, requirement: &str) {
+    let manifest_path = project.join("axiom.toml");
+    let mut manifest = fs::read_to_string(&manifest_path).expect("read root manifest");
+    manifest.push_str(&format!(
+        "\n[dependencies.{alias}]\nregistry = \"fixture\"\nnamespace = \"axiom\"\n\
+         package = {package:?}\nversion = {requirement:?}\n"
+    ));
+    fs::write(manifest_path, manifest).expect("add root registry dependency");
+}
+
+fn write_path_only_manifests(project: &Path) {
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"app\"\nversion = \"0.1.0\"\n\n\
+         [build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n\
+         [dependencies.local_util]\npath = \"deps/local-util\"\nversion = \"^0.4.0\"\n\n\
+         [[tests]]\nname = \"resolver-smoke\"\nentry = \"src/smoke_test.ax\"\n\
+         stdout = \"resolver test\\n\"\n",
+    )
+    .expect("write path-only app manifest");
+    fs::write(
+        project.join("deps/local-util/axiom.toml"),
+        "[package]\nname = \"local-util\"\nversion = \"0.4.0\"\n\n\
+         [build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n",
+    )
+    .expect("write path-only dependency manifest");
+}
+
+fn write_v1_path_lock(project: &Path, root_version: &str) {
+    fs::write(
+        project.join("axiom.lock"),
+        format!(
+            "version = 1\n\n\
+             [[package]]\nname = \"app\"\nversion = {root_version:?}\nsource = \"path\"\n\n\
+             [[package]]\nname = \"local-util\"\nversion = \"0.4.0\"\n\
+             source = \"path:deps/local-util\"\n"
+        ),
+    )
+    .expect("write path-only v1 lock");
+}
+
+fn prune_lock_to_path_only(project: &Path) {
+    let ParsedLockfile::V2(mut lockfile) = load_lockfile(project).expect("load fetched lock v2")
+    else {
+        panic!("fetch must produce axiom.lock v2");
+    };
+    lockfile.registry.clear();
+    lockfile
+        .package
+        .retain(|package| package.registry.is_none());
+    lockfile.edge.retain(|edge| {
+        lockfile
+            .package
+            .iter()
+            .any(|package| package.id == edge.from)
+            && lockfile.package.iter().any(|package| package.id == edge.to)
+    });
+    write_lockfile_v2_atomic(project, &lockfile).expect("write path-only v2 lock");
+}
+
+fn write_trust_roots(project: &Path, roots: &TrustRootsEnvelope) {
+    fs::write(
+        project.join("trust/roots.json"),
+        canonical_json(roots).expect("canonical trust roots"),
+    )
+    .expect("write trust roots");
+}
+
+fn write_expectation(project: &Path, expectation: &VerificationExpectation) {
+    fs::write(
+        project.join("trust/expectation.json"),
+        canonical_json(expectation).expect("canonical verification expectation"),
+    )
+    .expect("write verification expectation");
+}
+
+fn run_axiomc(project: &Path, args: &[&str]) -> Output {
+    let project_arg = project.to_str().expect("UTF-8 project path");
+    Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args(args.iter().map(|argument| {
+            if *argument == "." {
+                project_arg
+            } else {
+                argument
+            }
+        }))
+        .current_dir(project)
+        .output()
+        .expect("run axiomc package resolver command")
+}
+
+fn assert_json_success(output: &Output, operation: &str) -> Value {
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{operation} failed; stdout={}; stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let mut documents = serde_json::Deserializer::from_slice(&output.stdout).into_iter::<Value>();
+    let value = documents
+        .next()
+        .expect("one JSON document")
+        .expect("valid JSON document");
+    assert!(
+        documents.next().is_none(),
+        "{operation} stdout must contain exactly one JSON document"
+    );
+    value
+}
+
+fn assert_json_failure(output: &Output, operation: &str) -> Value {
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "{operation} should fail closed; stdout={}; stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "{operation} failure must be JSON: {error}; stdout={}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    })
+}
+
+fn assert_published_schema(value: &Value, relative: &str, operation: &str) {
+    let schema: Value = serde_json::from_slice(
+        &fs::read(stage1_path(relative))
+            .unwrap_or_else(|error| panic!("read {relative} for {operation}: {error}")),
+    )
+    .unwrap_or_else(|error| panic!("parse {relative} for {operation}: {error}"));
+    let validator = jsonschema::validator_for(&schema)
+        .unwrap_or_else(|error| panic!("compile {relative} for {operation}: {error}"));
+    if let Err(error) = validator.validate(value) {
+        panic!("{operation} must validate against {relative}: {error}; value={value}");
+    }
+}
+
+fn assert_error_code(value: &Value, expected: &str) {
+    assert_eq!(
+        value["error"]["code"], expected,
+        "failure must expose exact structured code {expected:?}: {value}"
+    );
+}
+
+fn assert_resolver_failure(
+    value: &Value,
+    expected_error_code: &str,
+    expected_kind: &str,
+    expected_trace_events: &[&str],
+) {
+    assert_published_schema(
+        value,
+        "schemas/axiom.stage1.v1.schema.json",
+        "resolver failure envelope",
+    );
+    assert_error_code(value, expected_error_code);
+    let trace = value["trace"]
+        .as_array()
+        .unwrap_or_else(|| panic!("resolver failure must expose a trace array: {value}"));
+    assert!(
+        !trace.is_empty(),
+        "resolver failure trace must contain decision evidence: {value}"
+    );
+    for expected in expected_trace_events {
+        assert!(
+            trace.iter().any(|entry| entry["event"] == *expected),
+            "resolver failure trace must contain {expected:?}: {trace:?}"
+        );
+    }
+    let resolver = value["resolver"]
+        .as_object()
+        .unwrap_or_else(|| panic!("resolver failure must expose its typed payload: {value}"));
+    assert_eq!(
+        resolver.get("kind"),
+        Some(&Value::String(expected_kind.to_owned())),
+        "resolver failure must preserve typed kind {expected_kind:?}: {resolver:?}"
+    );
+    assert_eq!(
+        resolver.get("trace"),
+        Some(&Value::Array(trace.clone())),
+        "top-level and typed resolver traces must describe the same failure"
+    );
+}
+
+fn assert_verification_rejection_code(
+    value: &Value,
+    expected_error_code: &str,
+    expected_resolver_kind: &str,
+    expected_rejection_code: &str,
+) {
+    assert_resolver_failure(
+        value,
+        expected_error_code,
+        expected_resolver_kind,
+        &["candidate_rejected"],
+    );
+    let rejection = value["trace"]
+        .as_array()
+        .expect("resolver trace")
+        .iter()
+        .find(|entry| entry["event"] == "candidate_rejected")
+        .unwrap_or_else(|| panic!("resolver trace must contain a candidate rejection: {value}"));
+    assert_eq!(
+        rejection["reason"]["reason"], "verification_failed",
+        "candidate rejection must be attributed to Package Trust: {rejection}"
+    );
+    assert_eq!(
+        rejection["reason"]["code"], expected_rejection_code,
+        "candidate rejection must preserve exact Package Trust code {expected_rejection_code:?}: {rejection}"
+    );
+}
+
+fn assert_trace_events(value: &Value, operation: &str, expected: &[&str]) {
+    let trace = value["trace"]
+        .as_array()
+        .unwrap_or_else(|| panic!("{operation} report must expose a trace array: {value}"));
+    for event in expected {
+        assert!(
+            trace.iter().any(|entry| entry["event"] == *event),
+            "{operation} trace must contain {event:?}: {trace:?}"
+        );
+    }
+}
+
+fn locked_registry_version(project: &Path) -> String {
+    let ParsedLockfile::V2(lockfile) = load_lockfile(project).expect("load lockfile v2") else {
+        panic!("registry fetch must create axiom.lock v2");
+    };
+    lockfile
+        .package
+        .iter()
+        .find(|package| package.registry.as_deref() == Some("fixture"))
+        .expect("locked registry package")
+        .version
+        .clone()
+}
+
+fn locked_registry_digest(project: &Path) -> String {
+    let ParsedLockfile::V2(lockfile) = load_lockfile(project).expect("load lockfile v2") else {
+        panic!("registry fetch must create axiom.lock v2");
+    };
+    lockfile
+        .package
+        .iter()
+        .find(|package| package.registry.as_deref() == Some("fixture"))
+        .and_then(|package| package.archive_sha256.clone())
+        .expect("locked registry archive digest")
+}
+
+fn first_file(root: &Path) -> PathBuf {
+    let mut files = Vec::new();
+    collect_all_files(root, &mut files);
+    files.sort();
+    files
+        .into_iter()
+        .next()
+        .unwrap_or_else(|| panic!("expected a materialized file below {}", root.display()))
+}
+
+fn collect_all_files(root: &Path, output: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries {
+        let path = entry.expect("read materialization entry").path();
+        if path.is_dir() {
+            collect_all_files(&path, output);
+        } else {
+            output.push(path);
+        }
+    }
+}
+
+fn first_directory(root: &Path) -> PathBuf {
+    let mut directories = fs::read_dir(root)
+        .unwrap_or_else(|error| panic!("read directory {}: {error}", root.display()))
+        .map(|entry| entry.expect("read directory entry").path())
+        .filter(|path| path.is_dir())
+        .collect::<Vec<_>>();
+    directories.sort();
+    directories
+        .into_iter()
+        .next()
+        .unwrap_or_else(|| panic!("expected a directory below {}", root.display()))
+}
+
+fn tamper_cache_blob(cache: &Path, digest: &str) {
+    fs::write(cache.join("blobs/sha256").join(digest), b"tampered blob")
+        .expect("tamper cache blob");
+}
+
+fn tamper_cache_tree(cache: &Path, digest: &str) {
+    let tree = cache
+        .join("trees/axiom-package-extractor-v1/sha256")
+        .join(digest);
+    fs::write(first_file(&tree), b"tampered extracted tree").expect("tamper cache tree");
+}
+
+fn tamper_cache_integrity(cache: &Path, digest: &str) {
+    let mut paths = Vec::new();
+    collect_named_files(
+        &cache.join("evidence/sha256").join(digest),
+        "integrity.json",
+        &mut paths,
+    );
+    paths.sort();
+    fs::write(paths.first().expect("cache integrity manifest"), b"{}")
+        .expect("tamper cache integrity manifest");
+}
+
+fn tamper_cache_evidence(cache: &Path, digest: &str) {
+    let mut paths = Vec::new();
+    collect_named_files(
+        &cache.join("evidence/sha256").join(digest),
+        "manifest",
+        &mut paths,
+    );
+    paths.sort();
+    fs::write(
+        paths.first().expect("cache manifest evidence"),
+        b"tampered evidence",
+    )
+    .expect("tamper cache evidence");
+}
+
+fn tamper_cache_commit(cache: &Path, digest: &str) {
+    let versioned = cache.join("commits/sha256").join(digest);
+    let path = if versioned.is_dir() {
+        first_file(&versioned)
+    } else {
+        cache.join("commits/sha256").join(format!("{digest}.json"))
+    };
+    fs::write(path, b"{}").expect("tamper cache commit");
+}
+
+fn vendor_snapshot_root(vendor: &Path) -> PathBuf {
+    let current = fs::read_to_string(vendor.join("CURRENT")).expect("read vendor CURRENT");
+    let digest = current
+        .strip_suffix('\n')
+        .expect("vendor CURRENT has one newline");
+    vendor.join("snapshots/sha256").join(digest)
+}
+
+fn tamper_vendor_tree(vendor: &Path) {
+    let package = first_directory(&vendor_snapshot_root(vendor).join("packages/sha256"));
+    fs::write(first_file(&package.join("tree")), b"tampered vendor tree")
+        .expect("tamper vendor tree");
+}
+
+fn tamper_vendor_manifest(vendor: &Path) {
+    fs::write(
+        vendor_snapshot_root(vendor).join("vendor-manifest.json"),
+        b"{}",
+    )
+    .expect("tamper vendor manifest");
+}
+
+fn tamper_vendor_current(vendor: &Path) {
+    fs::write(vendor.join("CURRENT"), format!("{}\n", "0".repeat(64)))
+        .expect("tamper vendor CURRENT");
+}
+
+fn remove_vendor_current(vendor: &Path) {
+    fs::remove_file(vendor.join("CURRENT")).expect("remove vendor CURRENT");
+}
+
+fn copy_directory(source: &Path, destination: &Path) {
+    fs::create_dir_all(destination).unwrap_or_else(|error| {
+        panic!(
+            "create copied directory {} from {}: {error}",
+            destination.display(),
+            source.display()
+        )
+    });
+    for entry in fs::read_dir(source).expect("read source directory") {
+        let entry = entry.expect("read source entry");
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        if source_path.is_dir() {
+            copy_directory(&source_path, &destination_path);
+        } else {
+            fs::copy(&source_path, &destination_path).unwrap_or_else(|error| {
+                panic!(
+                    "copy {} to {}: {error}",
+                    source_path.display(),
+                    destination_path.display()
+                )
+            });
+        }
+    }
+}
+
+fn restore_directory(source: &Path, destination: &Path) {
+    if destination.exists() {
+        fs::remove_dir_all(destination).expect("remove mutated directory");
+    }
+    copy_directory(source, destination);
+}
+
+fn build_locked_offline(project: &Path) -> Output {
+    run_axiomc(
+        project,
+        &[
+            "build",
+            ".",
+            "--backend",
+            "cranelift",
+            "--locked",
+            "--offline",
+            "--json",
+        ],
+    )
+}
+
+#[test]
+fn fetch_cache_vendor_and_offline_build_fail_closed_round_trip() {
+    let _guard = PACKAGE_RESOLVER_CLI_PROCESS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let server = HttpRegistry::start();
+    let temp = tempfile::tempdir().expect("create package resolver tempdir");
+    let fixture = trust_fixture();
+    let registry_root = temp.path().join("registry");
+    publish_core(temp.path(), &registry_root, &fixture, "1.2.3", 1);
+    let initial = build_index(&fixture, &registry_root, 1, None);
+    server.install(&registry_root, &initial.index);
+    let project = write_project(
+        temp.path(),
+        &server.index_url(),
+        &initial.expectation,
+        "^1.2.3",
+        "^1.2.3",
+    );
+    write_trust_roots(&project, &fixture.roots);
+
+    let fetch = run_axiomc(&project, &["pkg", "fetch", ".", "--json"]);
+    let fetch = assert_json_success(&fetch, "pkg fetch");
+    assert_eq!(fetch["schema_version"], "axiom.package_operation_report.v1");
+    assert_eq!(fetch["operation"], "fetch");
+    assert_eq!(fetch["transport_used"], true);
+    assert_trace_events(
+        &fetch,
+        "pkg fetch",
+        &[
+            "path_preserved",
+            "constraint_added",
+            "catalog_authenticated",
+            "candidate_considered",
+            "candidate_verified",
+            "selected",
+        ],
+    );
+    assert_eq!(locked_registry_version(&project), "1.2.3");
+    assert!(
+        fs::read_to_string(project.join("axiom.lock"))
+            .expect("read lockfile")
+            .contains("deps/local-util"),
+        "the path dependency remains a path package in lock v2"
+    );
+    assert!(
+        server.request_count() >= 5,
+        "index and exact release bytes fetched"
+    );
+
+    let requests_before_graph = server.request_count();
+    let graph = assert_json_success(
+        &run_axiomc(&project, &["pkg", "graph", ".", "--json"]),
+        "pkg graph",
+    );
+    assert_published_schema(
+        &graph,
+        "compiler-contracts/schemas/axiom.compiler.package_graph.runtime.v1.schema.json",
+        "runtime package graph",
+    );
+    assert_eq!(
+        graph["schema_version"],
+        "axiom.compiler.package_graph.runtime.v1"
+    );
+    assert_eq!(graph["contract"], "compiler.package_graph.runtime");
+    let graph_packages = graph["packages"].as_array().expect("graph packages");
+    assert_eq!(graph_packages.len(), 3, "root, path, and registry packages");
+    let app = graph_packages
+        .iter()
+        .find(|package| package["name"] == "app")
+        .expect("app graph package");
+    assert_eq!(app["lockfile"]["version"], 2);
+    assert_eq!(app["lockfile"]["status"], "current");
+    assert!(
+        app["dependencies"]
+            .as_array()
+            .expect("app dependencies")
+            .iter()
+            .any(|dependency| {
+                dependency["name"] == "local_util" && dependency["source_kind"] == "path"
+            }),
+        "pkg graph preserves the local path edge"
+    );
+    let core = graph_packages
+        .iter()
+        .find(|package| package["name"] == "core")
+        .expect("core graph package");
+    assert_eq!(core["source"], "registry:fixture/axiom/core");
+    assert!(core["trust"].is_object(), "registry package exposes trust");
+    assert_eq!(
+        core["materialization"]["package_trust_verified"], true,
+        "pkg graph exposes verified materialization evidence"
+    );
+    let ParsedLockfile::V2(graph_lockfile) = load_lockfile(&project).expect("load graph lock v2")
+    else {
+        panic!("pkg graph registry project must retain lockfile v2");
+    };
+    let locked_registry = graph_lockfile
+        .registry
+        .iter()
+        .find(|registry| registry.name == "fixture")
+        .expect("locked fixture registry");
+    let locked_core = graph_lockfile
+        .package
+        .iter()
+        .find(|package| package.id == core["id"].as_str().expect("core package id"))
+        .expect("locked core package");
+    assert_eq!(
+        core["trust"]["index_sha256"], locked_registry.index_sha256,
+        "pkg graph binds trust evidence to exact authenticated index bytes"
+    );
+    assert_eq!(
+        core["trust"]["verification_sha256"],
+        locked_core
+            .verification_sha256
+            .as_deref()
+            .expect("locked registry package verification digest"),
+        "pkg graph binds trust evidence to exact verification bytes"
+    );
+    assert_eq!(
+        server.request_count(),
+        requests_before_graph,
+        "pkg graph materializes from locked local state without transport"
+    );
+
+    let check = assert_json_success(
+        &run_axiomc(&project, &["check", ".", "--json"]),
+        "signed registry graph check",
+    );
+    assert_eq!(check["command"], "check");
+    assert_eq!(
+        check["packages"].as_array().expect("check packages").len(),
+        1,
+        "check reports the selected workspace package after loading the signed graph"
+    );
+    let test = assert_json_success(
+        &run_axiomc(&project, &["test", ".", "--json"]),
+        "signed registry graph test",
+    );
+    assert_eq!(test["command"], "test");
+    let run = assert_json_success(
+        &run_axiomc(&project, &["run", ".", "--backend", "cranelift", "--json"]),
+        "signed registry graph run",
+    );
+    assert_eq!(run["command"], "run");
+    assert_eq!(run["exit_code"], 0);
+    let sbom = assert_json_success(
+        &run_axiomc(&project, &["caps", ".", "--format", "sbom-json"]),
+        "signed registry graph capability SBOM",
+    );
+    let sbom_packages = sbom["packages"].as_array().expect("SBOM packages");
+    assert_eq!(
+        sbom_packages.len(),
+        3,
+        "capability SBOM consumes root, path, and registry packages"
+    );
+    let sbom_core = sbom_packages
+        .iter()
+        .find(|package| package["name"] == "core")
+        .expect("registry package in capability SBOM");
+    assert!(sbom_core["trust"].is_object());
+    assert_eq!(sbom_core["materialization"]["package_trust_verified"], true);
+    assert_eq!(
+        server.request_count(),
+        requests_before_graph,
+        "check, test, run, graph, and capability SBOM reuse locked local state"
+    );
+
+    let requests_after_online_fetch = server.request_count();
+    assert_json_success(&build_locked_offline(&project), "locked offline build");
+    assert_eq!(
+        server.request_count(),
+        requests_after_online_fetch,
+        "offline build must not use the loopback transport"
+    );
+
+    let cache = project.join(".axiom/cache");
+    let digest = locked_registry_digest(&project);
+    let cache_mutations: [(&str, fn(&Path, &str)); 5] = [
+        ("blob", tamper_cache_blob),
+        ("tree", tamper_cache_tree),
+        ("integrity", tamper_cache_integrity),
+        ("evidence", tamper_cache_evidence),
+        ("commit", tamper_cache_commit),
+    ];
+    for (label, mutate) in cache_mutations {
+        if cache.exists() {
+            fs::remove_dir_all(&cache).expect("remove prior cache fixture");
+        }
+        assert_json_success(
+            &run_axiomc(&project, &["pkg", "fetch", ".", "--json"]),
+            &format!("restore cache before {label} tamper"),
+        );
+        mutate(&cache, &digest);
+        let requests_before_offline_rejection = server.request_count();
+        let rejected = build_locked_offline(&project);
+        let rejected = assert_json_failure(&rejected, &format!("{label}-tampered offline build"));
+        assert!(
+            rejected.to_string().contains("package")
+                || rejected.to_string().contains("cache")
+                || rejected.to_string().contains("archive"),
+            "{label} tamper rejection is explicit: {rejected}"
+        );
+        assert_eq!(
+            server.request_count(),
+            requests_before_offline_rejection,
+            "{label} tamper rejection must not use transport"
+        );
+    }
+
+    fs::remove_dir_all(&cache).expect("remove last tampered cache");
+    let requests_before_missing_cache = server.request_count();
+    let missing = build_locked_offline(&project);
+    let missing_json = assert_json_failure(&missing, "missing-cache offline build");
+    assert!(
+        missing_json.to_string().contains("cache") || missing_json.to_string().contains("store"),
+        "missing cache rejection is explicit: {missing_json}"
+    );
+    assert_eq!(
+        server.request_count(),
+        requests_before_missing_cache,
+        "missing-cache offline build must not use transport"
+    );
+
+    assert_json_success(
+        &run_axiomc(&project, &["pkg", "fetch", ".", "--json"]),
+        "cache restoration fetch",
+    );
+    let requests_after_restoration = server.request_count();
+    let lock_path = project.join("axiom.lock");
+    let original_lock = fs::read_to_string(&lock_path).expect("read clean lockfile");
+    let tampered_lock = original_lock.replacen(&digest, &"0".repeat(64), 1);
+    assert_ne!(tampered_lock, original_lock, "lock fixture contains digest");
+    fs::write(&lock_path, tampered_lock).expect("tamper lockfile digest");
+    let lock_rejection = assert_json_failure(
+        &build_locked_offline(&project),
+        "tampered-lock offline build",
+    );
+    assert!(
+        lock_rejection.to_string().contains("lock")
+            || lock_rejection.to_string().contains("digest"),
+        "lock tamper rejection is explicit: {lock_rejection}"
+    );
+    assert_eq!(
+        server.request_count(),
+        requests_after_restoration,
+        "lock tamper rejection must not use transport"
+    );
+    fs::write(&lock_path, original_lock).expect("restore exact lockfile");
+
+    let requests_before_vendor = server.request_count();
+    let vendor = assert_json_success(
+        &run_axiomc(&project, &["pkg", "vendor", ".", "--json"]),
+        "pkg vendor",
+    );
+    assert_eq!(vendor["operation"], "vendor");
+    assert_eq!(vendor["transport_used"], false);
+    assert_eq!(
+        server.request_count(),
+        requests_before_vendor,
+        "pkg vendor has no transport handle and must not use network"
+    );
+    let vendor_root = project.join("vendor");
+    assert!(vendor_root.join("CURRENT").exists());
+    let clean_vendor = temp.path().join("clean-vendor");
+    copy_directory(&vendor_root, &clean_vendor);
+    fs::remove_dir_all(&cache).expect("remove cache after vendoring");
+    let vendored_build =
+        assert_json_success(&build_locked_offline(&project), "vendor-only offline build");
+    assert_eq!(vendored_build["locked"], true);
+    assert_eq!(vendored_build["offline"], true);
+    assert_eq!(
+        server.request_count(),
+        requests_after_restoration,
+        "vendor and vendor-only offline build must not use transport"
+    );
+
+    let vendor_mutations: [(&str, fn(&Path)); 4] = [
+        ("tree", tamper_vendor_tree),
+        ("manifest", tamper_vendor_manifest),
+        ("CURRENT", tamper_vendor_current),
+        ("missing CURRENT", remove_vendor_current),
+    ];
+    for (label, mutate) in vendor_mutations {
+        restore_directory(&clean_vendor, &vendor_root);
+        mutate(&vendor_root);
+        let requests_before_vendor_rejection = server.request_count();
+        let rejected = assert_json_failure(
+            &build_locked_offline(&project),
+            &format!("{label}-tampered vendor-only build"),
+        );
+        assert!(
+            rejected.to_string().contains("vendor")
+                || rejected.to_string().contains("package")
+                || rejected.to_string().contains("CURRENT"),
+            "{label} vendor rejection is explicit: {rejected}"
+        );
+        assert_eq!(
+            server.request_count(),
+            requests_before_vendor_rejection,
+            "{label} vendor rejection must not use transport"
+        );
+    }
+}
+
+#[test]
+fn update_exact_caret_yank_and_replay_are_deterministic() {
+    let _guard = PACKAGE_RESOLVER_CLI_PROCESS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let server = HttpRegistry::start();
+    let temp = tempfile::tempdir().expect("create package resolver tempdir");
+    let fixture = trust_fixture();
+    let registry_root = temp.path().join("registry");
+    publish_core(temp.path(), &registry_root, &fixture, "1.2.3", 1);
+    let initial = build_index(&fixture, &registry_root, 1, None);
+    server.install(&registry_root, &initial.index);
+    let project = write_project(
+        temp.path(),
+        &server.index_url(),
+        &initial.expectation,
+        "^1.2.3",
+        "^1.2.3",
+    );
+    write_trust_roots(&project, &fixture.roots);
+    assert_json_success(
+        &run_axiomc(&project, &["pkg", "fetch", ".", "--json"]),
+        "initial fetch",
+    );
+    assert_eq!(locked_registry_version(&project), "1.2.3");
+
+    publish_core(temp.path(), &registry_root, &fixture, "1.2.4", 2);
+    let newer = build_index(&fixture, &registry_root, 2, Some(&initial.index));
+    server.install(&registry_root, &newer.index);
+    let update = assert_json_success(
+        &run_axiomc(
+            &project,
+            &["pkg", "update", ".", "--package", "core", "--json"],
+        ),
+        "targeted caret update",
+    );
+    assert_eq!(update["operation"], "update");
+    assert_trace_events(
+        &update,
+        "pkg update",
+        &[
+            "path_preserved",
+            "constraint_added",
+            "catalog_authenticated",
+            "candidate_considered",
+            "candidate_verified",
+            "selected",
+        ],
+    );
+    assert_eq!(locked_registry_version(&project), "1.2.4");
+
+    let exact_project = write_project(
+        &temp.path().join("exact"),
+        &server.index_url(),
+        &newer.expectation,
+        "1.2.3",
+        "1.2.3",
+    );
+    write_trust_roots(&exact_project, &fixture.roots);
+    assert_json_success(
+        &run_axiomc(&exact_project, &["pkg", "fetch", ".", "--json"]),
+        "exact fetch",
+    );
+    assert_eq!(locked_registry_version(&exact_project), "1.2.3");
+
+    fs::write(
+        registry_root.join("axiom/core/1.2.4/axiom-registry.toml"),
+        "yanked = true\nyank_reason = \"fixture withdrawal\"\n",
+    )
+    .expect("yank core 1.2.4");
+    let yanked = build_index(&fixture, &registry_root, 3, Some(&newer.index));
+    server.install(&registry_root, &yanked.index);
+    assert_json_success(
+        &run_axiomc(&project, &["pkg", "update", ".", "--json"]),
+        "update away from yank",
+    );
+    assert_eq!(locked_registry_version(&project), "1.2.3");
+
+    server.install(&registry_root, &initial.index);
+    let first_replay = run_axiomc(&project, &["pkg", "update", ".", "--json"]);
+    let first_replay_json = assert_json_failure(&first_replay, "registry replay");
+    let second_replay = run_axiomc(&project, &["pkg", "update", ".", "--json"]);
+    let second_replay_json = assert_json_failure(&second_replay, "registry replay repeat");
+    assert_eq!(
+        first_replay_json, second_replay_json,
+        "registry replay rejection is byte-stable at the JSON value level"
+    );
+    assert_error_code(&first_replay_json, "registry_catalog_rejected");
+    assert!(
+        first_replay_json.to_string().contains("ROLLBACK_DETECTED")
+            || first_replay_json.to_string().contains("METADATA_REPLAYED"),
+        "replay rejection preserves Package Trust reason codes: {first_replay_json}"
+    );
+}
+
+#[test]
+fn path_only_v2_survives_removing_the_last_registry_dependency_and_config() {
+    let _guard = PACKAGE_RESOLVER_CLI_PROCESS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let server = HttpRegistry::start();
+    let temp = tempfile::tempdir().expect("create package resolver tempdir");
+    let fixture = trust_fixture();
+    let registry_root = temp.path().join("registry");
+    publish_core(temp.path(), &registry_root, &fixture, "1.2.3", 1);
+    let initial = build_index(&fixture, &registry_root, 1, None);
+    server.install(&registry_root, &initial.index);
+    let project = write_project(
+        temp.path(),
+        &server.index_url(),
+        &initial.expectation,
+        "^1.2.3",
+        "^1.2.3",
+    );
+    write_trust_roots(&project, &fixture.roots);
+    assert_json_success(
+        &run_axiomc(&project, &["pkg", "fetch", ".", "--json"]),
+        "registry-to-path-only setup fetch",
+    );
+
+    write_path_only_manifests(&project);
+    prune_lock_to_path_only(&project);
+    fs::remove_dir_all(project.join("trust")).expect("remove obsolete trust configuration");
+    fs::remove_dir_all(project.join(".axiom/cache")).expect("remove obsolete registry cache");
+    let ParsedLockfile::V2(path_only_lock) =
+        load_lockfile(&project).expect("load path-only lock v2")
+    else {
+        panic!("path-only lock must remain v2");
+    };
+    assert!(path_only_lock.registry.is_empty());
+    assert_eq!(path_only_lock.package.len(), 2);
+    assert!(
+        path_only_lock
+            .package
+            .iter()
+            .all(|package| package.registry.is_none())
+    );
+    let requests_before_locked_commands = server.request_count();
+
+    let graph = assert_json_success(
+        &run_axiomc(&project, &["pkg", "graph", ".", "--json"]),
+        "path-only v2 graph",
+    );
+    assert_eq!(
+        graph["packages"]
+            .as_array()
+            .expect("path-only graph packages")
+            .len(),
+        2
+    );
+    assert_json_success(
+        &run_axiomc(&project, &["check", ".", "--json"]),
+        "path-only v2 check",
+    );
+    assert_json_success(
+        &run_axiomc(&project, &["test", ".", "--json"]),
+        "path-only v2 test",
+    );
+    assert_json_success(
+        &run_axiomc(&project, &["run", ".", "--backend", "cranelift", "--json"]),
+        "path-only v2 run",
+    );
+    let sbom = assert_json_success(
+        &run_axiomc(&project, &["caps", ".", "--format", "sbom-json"]),
+        "path-only v2 capability SBOM",
+    );
+    assert_eq!(
+        sbom["packages"]
+            .as_array()
+            .expect("path-only SBOM packages")
+            .len(),
+        2
+    );
+    assert_json_success(
+        &build_locked_offline(&project),
+        "path-only v2 offline build",
+    );
+    let vendor = assert_json_success(
+        &run_axiomc(&project, &["pkg", "vendor", ".", "--json"]),
+        "path-only v2 vendor",
+    );
+    assert_eq!(vendor["transport_used"], false);
+    assert_eq!(
+        server.request_count(),
+        requests_before_locked_commands,
+        "path-only v2 commands require neither registry transport nor trust/cache files"
+    );
+}
+
+#[test]
+fn valid_v1_migrates_to_v2_but_stale_v1_is_rejected_without_rewrite() {
+    let _guard = PACKAGE_RESOLVER_CLI_PROCESS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let server = HttpRegistry::start();
+    let temp = tempfile::tempdir().expect("create package resolver tempdir");
+    let fixture = trust_fixture();
+    let registry_root = temp.path().join("registry");
+    publish_core(temp.path(), &registry_root, &fixture, "1.2.3", 1);
+    let initial = build_index(&fixture, &registry_root, 1, None);
+    server.install(&registry_root, &initial.index);
+
+    let current = write_project(
+        &temp.path().join("current-v1"),
+        &server.index_url(),
+        &initial.expectation,
+        "^1.2.3",
+        "^1.2.3",
+    );
+    write_trust_roots(&current, &fixture.roots);
+    write_v1_path_lock(&current, "0.1.0");
+    let migrated = assert_json_success(
+        &run_axiomc(&current, &["pkg", "fetch", ".", "--json"]),
+        "current v1 to v2 migration",
+    );
+    assert_eq!(migrated["operation"], "fetch");
+    assert_trace_events(
+        &migrated,
+        "v1 migration fetch",
+        &["path_preserved", "catalog_authenticated", "selected"],
+    );
+    assert!(
+        matches!(
+            load_lockfile(&current).expect("load migrated lock"),
+            ParsedLockfile::V2(_)
+        ),
+        "successful trusted fetch atomically migrates v1 to v2"
+    );
+
+    let stale = write_project(
+        &temp.path().join("stale-v1"),
+        &server.index_url(),
+        &initial.expectation,
+        "^1.2.3",
+        "^1.2.3",
+    );
+    write_trust_roots(&stale, &fixture.roots);
+    write_v1_path_lock(&stale, "9.9.9");
+    let stale_lock = fs::read(stale.join("axiom.lock")).expect("read stale v1 lock");
+    let rejected = assert_json_failure(
+        &run_axiomc(&stale, &["pkg", "fetch", ".", "--json"]),
+        "stale v1 migration",
+    );
+    assert_error_code(&rejected, "stale_v1_lockfile");
+    assert_eq!(
+        fs::read(stale.join("axiom.lock")).expect("reread stale v1 lock"),
+        stale_lock,
+        "stale v1 rejection must not rewrite the previous lock"
+    );
+    assert!(
+        !stale.join(".axiom/cache/commits/sha256").exists(),
+        "stale v1 rejection must occur before cache admission"
+    );
+}
+
+#[test]
+fn targeted_update_rejects_same_version_non_target_artifact_overwrite() {
+    let _guard = PACKAGE_RESOLVER_CLI_PROCESS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let server = HttpRegistry::start();
+    let temp = tempfile::tempdir().expect("create package resolver tempdir");
+    let fixture = trust_fixture();
+    let registry_root = temp.path().join("registry");
+    publish_core(temp.path(), &registry_root, &fixture, "1.2.3", 1);
+    publish_fixture_package(
+        temp.path(),
+        &registry_root,
+        &fixture,
+        "support",
+        "1.2.3",
+        1,
+        false,
+        "original",
+    );
+    let initial = build_index(&fixture, &registry_root, 1, None);
+    server.install(&registry_root, &initial.index);
+    let project = write_project(
+        temp.path(),
+        &server.index_url(),
+        &initial.expectation,
+        "^1.2.3",
+        "^1.2.3",
+    );
+    add_registry_dependency(&project, "support", "support", "^1.2.3");
+    write_trust_roots(&project, &fixture.roots);
+    assert_json_success(
+        &run_axiomc(&project, &["pkg", "fetch", ".", "--json"]),
+        "two-package initial fetch",
+    );
+    let initial_lock = fs::read(project.join("axiom.lock")).expect("read two-package lock");
+
+    publish_core(temp.path(), &registry_root, &fixture, "1.2.4", 2);
+    publish_fixture_package(
+        temp.path(),
+        &registry_root,
+        &fixture,
+        "support",
+        "1.2.3",
+        2,
+        true,
+        "overwritten",
+    );
+    let overwritten = build_index(&fixture, &registry_root, 2, Some(&initial.index));
+    server.install(&registry_root, &overwritten.index);
+    let rejected = assert_json_failure(
+        &run_axiomc(
+            &project,
+            &["pkg", "update", ".", "--package", "core", "--json"],
+        ),
+        "targeted update with overwritten frozen artifact",
+    );
+    assert_error_code(&rejected, "frozen_package_identity_changed");
+    assert_eq!(
+        fs::read(project.join("axiom.lock")).expect("reread two-package lock"),
+        initial_lock,
+        "targeted update must not rewrite any lock entry when a frozen artifact changed"
+    );
+}
+
+#[test]
+fn registry_artifact_and_signature_tampering_fail_before_lock_admission() {
+    let _guard = PACKAGE_RESOLVER_CLI_PROCESS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let server = HttpRegistry::start();
+    let temp = tempfile::tempdir().expect("create package resolver tempdir");
+    let fixture = trust_fixture();
+    let registry_root = temp.path().join("registry");
+    publish_core(temp.path(), &registry_root, &fixture, "1.2.3", 1);
+    let index = build_index(&fixture, &registry_root, 1, None);
+    let project = write_project(
+        temp.path(),
+        &server.index_url(),
+        &index.expectation,
+        "^1.2.3",
+        "^1.2.3",
+    );
+    write_trust_roots(&project, &fixture.roots);
+
+    for (label, route, bytes, expected) in [
+        (
+            "archive",
+            "/axiom/core/1.2.3/package.axp",
+            b"tampered archive bytes".as_slice(),
+            "archive_length_mismatch",
+        ),
+        (
+            "signature",
+            "/axiom/core/1.2.3/package.axp.sig",
+            b"{\"invalid\":true}".as_slice(),
+            "package_signature_invalid",
+        ),
+    ] {
+        server.install(&registry_root, &index.index);
+        server.replace_route(route, bytes);
+        let rejected = assert_json_failure(
+            &run_axiomc(&project, &["pkg", "fetch", ".", "--json"]),
+            &format!("{label}-tampered registry fetch"),
+        );
+        assert_verification_rejection_code(&rejected, "package_source_failed", "source", expected);
+        assert!(
+            !project.join("axiom.lock").exists(),
+            "{label} rejection must occur before lock admission"
+        );
+        assert!(
+            !project.join(".axiom/cache/commits/sha256").exists(),
+            "{label} rejection must occur before cache commit admission"
+        );
+    }
+}
+
+#[test]
+fn incompatible_direct_and_path_transitive_constraints_report_stable_conflict() {
+    let _guard = PACKAGE_RESOLVER_CLI_PROCESS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let server = HttpRegistry::start();
+    let temp = tempfile::tempdir().expect("create package resolver tempdir");
+    let fixture = trust_fixture();
+    let registry_root = temp.path().join("registry");
+    publish_core(temp.path(), &registry_root, &fixture, "1.2.3", 1);
+    publish_core(temp.path(), &registry_root, &fixture, "1.2.4", 1);
+    let index = build_index(&fixture, &registry_root, 1, None);
+    server.install(&registry_root, &index.index);
+    let project = write_project(
+        temp.path(),
+        &server.index_url(),
+        &index.expectation,
+        "1.2.4",
+        "1.2.3",
+    );
+    write_trust_roots(&project, &fixture.roots);
+
+    let first = run_axiomc(&project, &["pkg", "fetch", ".", "--json"]);
+    let first_json = assert_json_failure(&first, "conflicting fetch");
+    let second = run_axiomc(&project, &["pkg", "fetch", ".", "--json"]);
+    let second_json = assert_json_failure(&second, "conflicting fetch repeat");
+    assert_eq!(
+        first_json, second_json,
+        "constraint conflict is deterministic across identical CLI attempts"
+    );
+    assert_resolver_failure(
+        &first_json,
+        "resolution_conflict",
+        "conflict",
+        &["constraint_added", "conflict"],
+    );
+    assert!(
+        !project.join("axiom.lock").exists(),
+        "failed resolution must not partially write lock v2"
+    );
+}

--- a/stage1/crates/axiomc/tests/package_trust_cli.rs
+++ b/stage1/crates/axiomc/tests/package_trust_cli.rs
@@ -346,6 +346,8 @@ fn trust_fixture() -> TrustFixture {
     let mut expectation = VerificationExpectation(contract()["verification_expectation"].clone());
     expectation.0["contract_status"] = serde_json::json!("implemented");
     expectation.0["verification_time"] = serde_json::json!("2026-07-29T12:00:00Z");
+    expectation.0["request"]["registry_identity"] = serde_json::json!("registry:test");
+    expectation.0["request"]["source_identity"] = serde_json::json!("registry:test-source");
     expectation.0["required_signers"]["index_role_id"] = serde_json::json!("registry-index");
     expectation.0["required_signers"]["index_threshold"] = serde_json::json!(2);
     expectation.0["required_signers"]["package_role_id"] = serde_json::json!("targets:axiom");

--- a/stage1/crates/axiomc/tests/support/lib_unit.rs
+++ b/stage1/crates/axiomc/tests/support/lib_unit.rs
@@ -45,9 +45,7 @@ fn build_project(project_root: &Path) -> Result<crate::project::BuildOutput, Dia
     )
 }
 
-fn build_project_cranelift(
-    project_root: &Path,
-) -> Result<crate::project::BuildOutput, Diagnostic> {
+fn build_project_cranelift(project_root: &Path) -> Result<crate::project::BuildOutput, Diagnostic> {
     build_project_with_options(project_root, &BuildOptions::default())
 }
 
@@ -3168,7 +3166,11 @@ fn package_graph_metadata_lists_workspace_packages() {
     .expect("write root lockfile");
 
     let graph = package_graph_metadata(&project).expect("load package graph metadata");
-    assert_eq!(graph.schema_version, json_contract::JSON_SCHEMA_VERSION);
+    assert_eq!(
+        graph.schema_version,
+        "axiom.compiler.package_graph.runtime.v1"
+    );
+    assert_eq!(graph.contract, "compiler.package_graph.runtime");
     assert_eq!(graph.packages.len(), 3);
     let root = graph
         .packages
@@ -9705,7 +9707,7 @@ fn manifest_parses_richer_test_kinds() {
 }
 
 #[test]
-fn manifest_rejects_reserved_registry_publish_fields() {
+fn manifest_accepts_typed_registry_dependencies_and_rejects_unowned_publish_fields() {
     let dir = tempdir().expect("tempdir");
 
     let root_registry = dir.path().join("root-registry");
@@ -9713,13 +9715,21 @@ fn manifest_rejects_reserved_registry_publish_fields() {
     fs::write(
         root_registry.join("axiom.toml"),
         format!(
-            "{}\n[registry]\nsource = \"https://registry.example\"\n",
+            "{}\n[registry]\nname = \"default\"\nindex = \"https://registry.example.test/index.json\"\ntrust_roots = \"trust-roots.json\"\nexpectation = \"verification-expectation.json\"\n\n[dependencies]\ncore = {{ registry = \"default\", namespace = \"axiom\", version = \"^1.0.0\" }}\n",
             render_manifest("root-registry-app")
         ),
     )
     .expect("write manifest");
-    let err = load_manifest(&root_registry).expect_err("reserved registry should fail");
-    assert!(err.message.contains("[registry] is reserved"));
+    let manifest = load_manifest(&root_registry).expect("typed registry dependency should parse");
+    let registry = manifest.registry.expect("registry config");
+    assert_eq!(registry.name, "default");
+    assert_eq!(registry.index, "https://registry.example.test/index.json");
+    let dependency = manifest.dependencies.get("core").expect("core dependency");
+    assert_eq!(dependency.version.as_deref(), Some("^1.0.0"));
+    let registry_dependency = dependency.registry_source().expect("registry source");
+    assert_eq!(registry_dependency.registry, "default");
+    assert_eq!(registry_dependency.namespace, "axiom");
+    assert_eq!(registry_dependency.package, "core");
 
     let package_checksum = dir.path().join("package-checksum");
     create_project(&package_checksum, Some("package-checksum-app")).expect("create project");
@@ -9730,22 +9740,6 @@ fn manifest_rejects_reserved_registry_publish_fields() {
         .expect("write manifest");
     let err = load_manifest(&package_checksum).expect_err("reserved checksum should fail");
     assert!(err.message.contains("package.checksum is reserved"));
-
-    let dependency_version = dir.path().join("dependency-version");
-    create_project(&dependency_version, Some("dependency-version-app")).expect("create project");
-    fs::write(
-        dependency_version.join("axiom.toml"),
-        format!(
-            "{}\n[dependencies]\ncore = {{ version = \"1.0.0\", registry = \"default\" }}\n",
-            render_manifest("dependency-version-app")
-        ),
-    )
-    .expect("write manifest");
-    let err = load_manifest(&dependency_version).expect_err("reserved dependency should fail");
-    assert!(
-        err.message
-            .contains("dependencies.core.registry is reserved")
-    );
 
     let invalid_dependency_version = dir.path().join("invalid-dependency-version");
     create_project(
@@ -10701,11 +10695,8 @@ fn checked_in_proof_workload_examples_build_run_and_test() {
 #[test]
 #[cfg_attr(not(feature = "run-native-tests"), ignore)]
 fn conformance_corpus_reports_stable_results() {
-    let output = run_project_tests_with_options(
-        &conformance_fixture(),
-        &TestOptions::default(),
-    )
-    .expect("run stage1 conformance corpus");
+    let output = run_project_tests_with_options(&conformance_fixture(), &TestOptions::default())
+        .expect("run stage1 conformance corpus");
     assert_eq!(output.cases.len(), 154);
     let failures: Vec<_> = output
         .cases
@@ -11698,8 +11689,8 @@ fn build_project_folds_static_string_comparisons() {
         )
         .expect("write source");
 
-    let built = build_project_cranelift(&project)
-        .expect("build project with static string comparisons");
+    let built =
+        build_project_cranelift(&project).expect("build project with static string comparisons");
     assert!(
         built.generated_rust.is_none(),
         "default direct-native builds must not emit generated Rust"
@@ -11747,8 +11738,8 @@ fn build_project_emits_native_binary_with_imported_public_static_globals() {
         "pub static LIMIT: int = 40 + 2\npub static READY: bool = LIMIT == 42\n",
     )
     .expect("write values");
-    let built = build_project_cranelift(&project)
-        .expect("build project with imported static globals");
+    let built =
+        build_project_cranelift(&project).expect("build project with imported static globals");
     assert!(
         built.generated_rust.is_none(),
         "default direct-native builds must not emit generated Rust"

--- a/stage1/package-resolver/fixtures/lockfile-v2.json
+++ b/stage1/package-resolver/fixtures/lockfile-v2.json
@@ -1,0 +1,101 @@
+{
+  "version": 2,
+  "compatibility": {
+    "contract": "axiom.compatibility.v1",
+    "compiler": "0.1.0",
+    "edition_policy": "2026-policy-only"
+  },
+  "roots": [
+    "path:.#resolver-demo@0.1.0"
+  ],
+  "registry": [
+    {
+      "name": "fixture",
+      "source": "file:///registry/index.json",
+      "registry_identity": "axiom-registry-production",
+      "source_identity": "registry:axiom-production",
+      "trust_roots_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "expectation_sha256": "7777777777777777777777777777777777777777777777777777777777777777",
+      "current_root_version": 7,
+      "current_root_sequence": 19,
+      "current_root_transcript_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "index_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "index_transcript_sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "index_generation": 42,
+      "index_sequence": 1042,
+      "index_snapshot_id": "snapshot-42",
+      "index_signer_key_ids": [
+        "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+        "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+      ]
+    }
+  ],
+  "package": [
+    {
+      "id": "path:.#resolver-demo@0.1.0",
+      "name": "resolver-demo",
+      "version": "0.1.0",
+      "source": "path",
+      "compatibility": {
+        "contract": "axiom.compatibility.v1",
+        "compiler": "0.1.0",
+        "edition_policy": "2026-policy-only"
+      }
+    },
+    {
+      "id": "path:tools/local#local-tools@0.4.0",
+      "name": "local-tools",
+      "version": "0.4.0",
+      "source": "path:tools/local",
+      "compatibility": {
+        "contract": "axiom.compatibility.v1",
+        "compiler": "0.1.0",
+        "edition_policy": "2026-policy-only"
+      }
+    },
+    {
+      "id": "registry:fixture/axiom/core@1.2.3",
+      "name": "core",
+      "version": "1.2.3",
+      "source": "registry:fixture/axiom/core",
+      "registry": "fixture",
+      "namespace": "axiom",
+      "archive_sha256": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "archive_length": 4096,
+      "manifest_sha256": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "provenance_sha256": "9999999999999999999999999999999999999999999999999999999999999999",
+      "package_signature_sha256": "8888888888888888888888888888888888888888888888888888888888888888",
+      "verification_sha256": "6666666666666666666666666666666666666666666666666666666666666666",
+      "publisher_identity": "https://publishers.example/foundation",
+      "signer_key_ids": [
+        "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+        "sha256:4444444444444444444444444444444444444444444444444444444444444444"
+      ],
+      "cache_key": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "yanked_at_resolution": false,
+      "compatibility": {
+        "contract": "axiom.compatibility.v1",
+        "compiler": "0.1.0",
+        "edition_policy": "2026-policy-only"
+      }
+    }
+  ],
+  "edge": [
+    {
+      "from": "path:.#resolver-demo@0.1.0",
+      "alias": "core",
+      "to": "registry:fixture/axiom/core@1.2.3",
+      "requested": "^1.2.0",
+      "source_kind": "registry",
+      "reason": "highest_compatible"
+    },
+    {
+      "from": "path:.#resolver-demo@0.1.0",
+      "alias": "local-tools",
+      "to": "path:tools/local#local-tools@0.4.0",
+      "requested": "*",
+      "source_kind": "path",
+      "reason": "root_path_constraint"
+    }
+  ]
+}

--- a/stage1/package-resolver/fixtures/manifest-registry.json
+++ b/stage1/package-resolver/fixtures/manifest-registry.json
@@ -1,0 +1,26 @@
+{
+  "package": {
+    "name": "resolver-demo",
+    "version": "0.1.0"
+  },
+  "registry": {
+    "name": "fixture",
+    "index": "file:///registry/index.json",
+    "trust_roots": "registry/trust-roots.json",
+    "expectation": "registry/verification-request.json",
+    "cache": ".axiom/cache",
+    "vendor": "vendor"
+  },
+  "dependencies": {
+    "core": {
+      "registry": "fixture",
+      "namespace": "axiom",
+      "package": "core",
+      "version": "^1.2.0"
+    },
+    "local-tools": {
+      "path": "tools/local",
+      "version": "*"
+    }
+  }
+}

--- a/stage1/package-resolver/fixtures/resolution-v1.json
+++ b/stage1/package-resolver/fixtures/resolution-v1.json
@@ -1,0 +1,173 @@
+{
+  "schema_version": "axiom.package_resolution.v1",
+  "packages": [
+    {
+      "package": {
+        "registry": "fixture",
+        "source": "registry:axiom-production",
+        "namespace": "axiom",
+        "name": "core"
+      },
+      "version": {
+        "major": 1,
+        "minor": 2,
+        "patch": 3
+      },
+      "release_id": "axiom/core/1.2.3/package.axp",
+      "manifest_digest": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "signer_key_ids": [
+        "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+        "sha256:4444444444444444444444444444444444444444444444444444444444444444"
+      ],
+      "edition": "2026-policy-only",
+      "compatibility": "axiom.compatibility.v1",
+      "yanked": false
+    }
+  ],
+  "edges": [
+    {
+      "from": null,
+      "alias": "core",
+      "to": {
+        "registry": "fixture",
+        "source": "registry:axiom-production",
+        "namespace": "axiom",
+        "name": "core"
+      },
+      "requirement": {
+        "kind": "caret",
+        "version": {
+          "major": 1,
+          "minor": 2,
+          "patch": 0
+        }
+      },
+      "selected": {
+        "major": 1,
+        "minor": 2,
+        "patch": 3
+      }
+    }
+  ],
+  "path_dependencies": [
+    {
+      "from": null,
+      "alias": "local-tools",
+      "path": "tools/local",
+      "version": null
+    }
+  ],
+  "trace": [
+    {
+      "event": "path_preserved",
+      "from": null,
+      "alias": "local-tools",
+      "path": "tools/local"
+    },
+    {
+      "event": "constraint_added",
+      "from": null,
+      "package": {
+        "registry": "fixture",
+        "source": "registry:axiom-production",
+        "namespace": "axiom",
+        "name": "core"
+      },
+      "requirement": {
+        "kind": "caret",
+        "version": {
+          "major": 1,
+          "minor": 2,
+          "patch": 0
+        }
+      }
+    },
+    {
+      "event": "catalog_authenticated",
+      "package": {
+        "registry": "fixture",
+        "source": "registry:axiom-production",
+        "namespace": "axiom",
+        "name": "core"
+      },
+      "authentication_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "candidate_count": 2
+    },
+    {
+      "event": "candidate_considered",
+      "package": {
+        "registry": "fixture",
+        "source": "registry:axiom-production",
+        "namespace": "axiom",
+        "name": "core"
+      },
+      "version": {
+        "major": 1,
+        "minor": 3,
+        "patch": 0
+      },
+      "release_id": "axiom/core/1.3.0/package.axp"
+    },
+    {
+      "event": "candidate_rejected",
+      "package": {
+        "registry": "fixture",
+        "source": "registry:axiom-production",
+        "namespace": "axiom",
+        "name": "core"
+      },
+      "version": {
+        "major": 1,
+        "minor": 3,
+        "patch": 0
+      },
+      "reason": {
+        "reason": "yanked"
+      }
+    },
+    {
+      "event": "candidate_considered",
+      "package": {
+        "registry": "fixture",
+        "source": "registry:axiom-production",
+        "namespace": "axiom",
+        "name": "core"
+      },
+      "version": {
+        "major": 1,
+        "minor": 2,
+        "patch": 3
+      },
+      "release_id": "axiom/core/1.2.3/package.axp"
+    },
+    {
+      "event": "candidate_verified",
+      "package": {
+        "registry": "fixture",
+        "source": "registry:axiom-production",
+        "namespace": "axiom",
+        "name": "core"
+      },
+      "version": {
+        "major": 1,
+        "minor": 2,
+        "patch": 3
+      },
+      "manifest_digest": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+    },
+    {
+      "event": "selected",
+      "package": {
+        "registry": "fixture",
+        "source": "registry:axiom-production",
+        "namespace": "axiom",
+        "name": "core"
+      },
+      "version": {
+        "major": 1,
+        "minor": 2,
+        "patch": 3
+      }
+    }
+  ]
+}

--- a/stage1/schemas/axiom-lockfile-v2.schema.json
+++ b/stage1/schemas/axiom-lockfile-v2.schema.json
@@ -1,0 +1,438 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axiom.omt.global/schemas/axiom-lockfile-v2.schema.json",
+  "title": "Axiom lockfile v2",
+  "description": "Strict TOML-to-JSON contract for deterministic path and trusted registry resolution.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "compatibility",
+    "roots",
+    "package",
+    "edge"
+  ],
+  "properties": {
+    "version": {
+      "const": 2
+    },
+    "compatibility": {
+      "$ref": "#/$defs/compatibility"
+    },
+    "roots": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 2048
+      }
+    },
+    "registry": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/registry"
+      }
+    },
+    "package": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/package"
+      }
+    },
+    "edge": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/edge"
+      }
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "keyId": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "releaseVersion": {
+      "type": "string",
+      "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
+    },
+    "pathSource": {
+      "type": "string",
+      "maxLength": 4096,
+      "pattern": "^path(?::(?!/)(?!\\.{1,2}(?:/|$))(?!.*?/\\.{1,2}(?:/|$))(?!.*//)(?!.*\\\\)[^/\\\\\\r\\n]+(?:/[^/\\\\\\r\\n]+)*)?$"
+    },
+    "compatibility": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "contract",
+        "compiler",
+        "edition_policy"
+      ],
+      "properties": {
+        "contract": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "compiler": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "edition_policy": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        }
+      }
+    },
+    "registry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "source",
+        "registry_identity",
+        "source_identity",
+        "trust_roots_sha256",
+        "expectation_sha256",
+        "current_root_version",
+        "current_root_sequence",
+        "current_root_transcript_sha256",
+        "index_sha256",
+        "index_transcript_sha256",
+        "index_generation",
+        "index_sequence",
+        "index_snapshot_id",
+        "index_signer_key_ids"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9_-]{0,63}$"
+        },
+        "source": {
+          "type": "string",
+          "maxLength": 4096,
+          "pattern": "^(https://[^/?#@]+(?:/[^?#]*)?|file:///[^?#]+|http://(?:127(?:\\.(?:0|[1-9][0-9]?|1[0-9]{2}|2[0-4][0-9]|25[0-5])){3}|\\[::1\\])(?::(?:0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]))?(?:/[^?#]*)?)$"
+        },
+        "registry_identity": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048
+        },
+        "source_identity": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048
+        },
+        "trust_roots_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "expectation_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "current_root_version": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "current_root_sequence": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "current_root_transcript_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "index_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "index_transcript_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "index_generation": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "index_sequence": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "index_snapshot_id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048
+        },
+        "index_signer_key_ids": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/keyId"
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "package": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "name",
+        "version",
+        "source",
+        "compatibility"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "version": {
+          "$ref": "#/$defs/releaseVersion"
+        },
+        "source": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/pathSource"
+            },
+            {
+              "type": "string",
+              "maxLength": 4096,
+              "pattern": "^registry:[a-z0-9][a-z0-9_-]{0,63}/[a-z0-9][a-z0-9._-]{0,127}/[a-z0-9][a-z0-9._-]{0,127}$"
+            }
+          ]
+        },
+        "registry": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9_-]{0,63}$"
+        },
+        "namespace": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9._-]{0,127}$"
+        },
+        "archive_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "archive_length": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 67108864
+        },
+        "manifest_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "provenance_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "package_signature_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "verification_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "publisher_identity": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048
+        },
+        "signer_key_ids": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/keyId"
+          },
+          "uniqueItems": true
+        },
+        "cache_key": {
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        },
+        "yanked_at_resolution": {
+          "type": "boolean"
+        },
+        "compatibility": {
+          "$ref": "#/$defs/compatibility"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "source": {
+                "pattern": "^registry:"
+              }
+            },
+            "required": [
+              "source"
+            ]
+          },
+          "then": {
+            "required": [
+              "registry",
+              "namespace",
+              "archive_sha256",
+              "archive_length",
+              "manifest_sha256",
+              "provenance_sha256",
+              "package_signature_sha256",
+              "verification_sha256",
+              "publisher_identity",
+              "signer_key_ids",
+              "cache_key",
+              "yanked_at_resolution"
+            ]
+          },
+          "else": {
+            "not": {
+              "anyOf": [
+                {
+                  "required": [
+                    "registry"
+                  ]
+                },
+                {
+                  "required": [
+                    "namespace"
+                  ]
+                },
+                {
+                  "required": [
+                    "archive_sha256"
+                  ]
+                },
+                {
+                  "required": [
+                    "archive_length"
+                  ]
+                },
+                {
+                  "required": [
+                    "manifest_sha256"
+                  ]
+                },
+                {
+                  "required": [
+                    "provenance_sha256"
+                  ]
+                },
+                {
+                  "required": [
+                    "package_signature_sha256"
+                  ]
+                },
+                {
+                  "required": [
+                    "verification_sha256"
+                  ]
+                },
+                {
+                  "required": [
+                    "publisher_identity"
+                  ]
+                },
+                {
+                  "required": [
+                    "signer_key_ids"
+                  ]
+                },
+                {
+                  "required": [
+                    "cache_key"
+                  ]
+                },
+                {
+                  "required": [
+                    "yanked_at_resolution"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "edge": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "from",
+        "to",
+        "alias",
+        "requested",
+        "source_kind",
+        "reason"
+      ],
+      "properties": {
+        "from": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048
+        },
+        "to": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048
+        },
+        "alias": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "requested": {
+          "type": "string",
+          "maxLength": 256,
+          "pattern": "^(\\*|\\^?(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*))$"
+        },
+        "source_kind": {
+          "enum": [
+            "path",
+            "registry"
+          ]
+        },
+        "reason": {
+          "enum": [
+            "root_path_constraint",
+            "transitive_path_constraint",
+            "highest_compatible",
+            "exact_locked_replay",
+            "trusted_yanked_locked_replay"
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "source_kind": {
+                "const": "registry"
+              }
+            },
+            "required": [
+              "source_kind"
+            ]
+          },
+          "then": {
+            "properties": {
+              "requested": {
+                "pattern": "^\\^?(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/stage1/schemas/axiom-package-resolution-v1.schema.json
+++ b/stage1/schemas/axiom-package-resolution-v1.schema.json
@@ -1,0 +1,626 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axiom.omt.global/schemas/axiom-package-resolution-v1.schema.json",
+  "title": "Axiom package resolution v1",
+  "description": "Deterministic registry selection, preserved path dependencies, and ordered resolver trace.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "packages",
+    "edges",
+    "path_dependencies",
+    "trace"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "axiom.package_resolution.v1"
+    },
+    "packages": {
+      "type": "array",
+      "maxItems": 256,
+      "items": {
+        "$ref": "#/$defs/resolvedPackage"
+      }
+    },
+    "edges": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/resolvedEdge"
+      }
+    },
+    "path_dependencies": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/pathDependency"
+      }
+    },
+    "trace": {
+      "type": "array",
+      "maxItems": 65536,
+      "items": {
+        "$ref": "#/$defs/traceEvent"
+      }
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "keyId": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "version": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "major",
+        "minor",
+        "patch"
+      ],
+      "properties": {
+        "major": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "minor": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "patch": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "requirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "version"
+      ],
+      "properties": {
+        "kind": {
+          "enum": [
+            "exact",
+            "caret"
+          ]
+        },
+        "version": {
+          "$ref": "#/$defs/version"
+        }
+      }
+    },
+    "packageKey": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "registry",
+        "source",
+        "namespace",
+        "name"
+      ],
+      "properties": {
+        "registry": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048
+        },
+        "namespace": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        }
+      }
+    },
+    "optionalPackageKey": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/packageKey"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "resolvedPackage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "package",
+        "version",
+        "release_id",
+        "manifest_digest",
+        "signer_key_ids",
+        "edition",
+        "compatibility",
+        "yanked"
+      ],
+      "properties": {
+        "package": {
+          "$ref": "#/$defs/packageKey"
+        },
+        "version": {
+          "$ref": "#/$defs/version"
+        },
+        "release_id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 4096
+        },
+        "manifest_digest": {
+          "$ref": "#/$defs/sha256"
+        },
+        "signer_key_ids": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/keyId"
+          },
+          "uniqueItems": true
+        },
+        "edition": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "compatibility": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "yanked": {
+          "type": "boolean"
+        }
+      }
+    },
+    "resolvedEdge": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "from",
+        "alias",
+        "to",
+        "requirement",
+        "selected"
+      ],
+      "properties": {
+        "from": {
+          "$ref": "#/$defs/optionalPackageKey"
+        },
+        "alias": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "to": {
+          "$ref": "#/$defs/packageKey"
+        },
+        "requirement": {
+          "$ref": "#/$defs/requirement"
+        },
+        "selected": {
+          "$ref": "#/$defs/version"
+        }
+      }
+    },
+    "pathDependency": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "from",
+        "alias",
+        "path",
+        "version"
+      ],
+      "properties": {
+        "from": {
+          "$ref": "#/$defs/optionalPackageKey"
+        },
+        "alias": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 4096
+        },
+        "version": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/version"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "candidateRejection": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/rejectionConstraintMismatch"
+        },
+        {
+          "$ref": "#/$defs/rejectionFrozenMismatch"
+        },
+        {
+          "$ref": "#/$defs/rejectionYanked"
+        },
+        {
+          "$ref": "#/$defs/rejectionVerificationFailed"
+        },
+        {
+          "$ref": "#/$defs/rejectionIdentityMismatch"
+        },
+        {
+          "$ref": "#/$defs/rejectionCycle"
+        },
+        {
+          "$ref": "#/$defs/rejectionDownstreamConflict"
+        }
+      ]
+    },
+    "rejectionConstraintMismatch": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "reason"
+      ],
+      "properties": {
+        "reason": {
+          "const": "constraint_mismatch"
+        }
+      }
+    },
+    "rejectionFrozenMismatch": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "reason",
+        "required"
+      ],
+      "properties": {
+        "reason": {
+          "const": "frozen_mismatch"
+        },
+        "required": {
+          "$ref": "#/$defs/version"
+        }
+      }
+    },
+    "rejectionYanked": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "reason"
+      ],
+      "properties": {
+        "reason": {
+          "const": "yanked"
+        }
+      }
+    },
+    "rejectionVerificationFailed": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "reason",
+        "code"
+      ],
+      "properties": {
+        "reason": {
+          "const": "verification_failed"
+        },
+        "code": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        }
+      }
+    },
+    "rejectionIdentityMismatch": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "reason"
+      ],
+      "properties": {
+        "reason": {
+          "const": "identity_mismatch"
+        }
+      }
+    },
+    "rejectionCycle": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "reason",
+        "through"
+      ],
+      "properties": {
+        "reason": {
+          "const": "cycle"
+        },
+        "through": {
+          "$ref": "#/$defs/packageKey"
+        }
+      }
+    },
+    "rejectionDownstreamConflict": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "reason"
+      ],
+      "properties": {
+        "reason": {
+          "const": "downstream_conflict"
+        }
+      }
+    },
+    "traceEvent": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/eventPathPreserved"
+        },
+        {
+          "$ref": "#/$defs/eventConstraintAdded"
+        },
+        {
+          "$ref": "#/$defs/eventCatalogAuthenticated"
+        },
+        {
+          "$ref": "#/$defs/eventCandidateConsidered"
+        },
+        {
+          "$ref": "#/$defs/eventCandidateRejected"
+        },
+        {
+          "$ref": "#/$defs/eventCandidateVerified"
+        },
+        {
+          "$ref": "#/$defs/eventSelected"
+        },
+        {
+          "$ref": "#/$defs/eventBacktracked"
+        },
+        {
+          "$ref": "#/$defs/eventConflict"
+        }
+      ]
+    },
+    "eventPathPreserved": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "event",
+        "from",
+        "alias",
+        "path"
+      ],
+      "properties": {
+        "event": {
+          "const": "path_preserved"
+        },
+        "from": {
+          "$ref": "#/$defs/optionalPackageKey"
+        },
+        "alias": {
+          "type": "string",
+          "minLength": 1
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "eventConstraintAdded": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "event",
+        "from",
+        "package",
+        "requirement"
+      ],
+      "properties": {
+        "event": {
+          "const": "constraint_added"
+        },
+        "from": {
+          "$ref": "#/$defs/optionalPackageKey"
+        },
+        "package": {
+          "$ref": "#/$defs/packageKey"
+        },
+        "requirement": {
+          "$ref": "#/$defs/requirement"
+        }
+      }
+    },
+    "eventCatalogAuthenticated": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "event",
+        "package",
+        "authentication_id",
+        "candidate_count"
+      ],
+      "properties": {
+        "event": {
+          "const": "catalog_authenticated"
+        },
+        "package": {
+          "$ref": "#/$defs/packageKey"
+        },
+        "authentication_id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 4096
+        },
+        "candidate_count": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "eventCandidateConsidered": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "event",
+        "package",
+        "version",
+        "release_id"
+      ],
+      "properties": {
+        "event": {
+          "const": "candidate_considered"
+        },
+        "package": {
+          "$ref": "#/$defs/packageKey"
+        },
+        "version": {
+          "$ref": "#/$defs/version"
+        },
+        "release_id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 4096
+        }
+      }
+    },
+    "eventCandidateRejected": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "event",
+        "package",
+        "version",
+        "reason"
+      ],
+      "properties": {
+        "event": {
+          "const": "candidate_rejected"
+        },
+        "package": {
+          "$ref": "#/$defs/packageKey"
+        },
+        "version": {
+          "$ref": "#/$defs/version"
+        },
+        "reason": {
+          "$ref": "#/$defs/candidateRejection"
+        }
+      }
+    },
+    "eventCandidateVerified": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "event",
+        "package",
+        "version",
+        "manifest_digest"
+      ],
+      "properties": {
+        "event": {
+          "const": "candidate_verified"
+        },
+        "package": {
+          "$ref": "#/$defs/packageKey"
+        },
+        "version": {
+          "$ref": "#/$defs/version"
+        },
+        "manifest_digest": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "eventSelected": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "event",
+        "package",
+        "version"
+      ],
+      "properties": {
+        "event": {
+          "const": "selected"
+        },
+        "package": {
+          "$ref": "#/$defs/packageKey"
+        },
+        "version": {
+          "$ref": "#/$defs/version"
+        }
+      }
+    },
+    "eventBacktracked": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "event",
+        "package",
+        "version"
+      ],
+      "properties": {
+        "event": {
+          "const": "backtracked"
+        },
+        "package": {
+          "$ref": "#/$defs/packageKey"
+        },
+        "version": {
+          "$ref": "#/$defs/version"
+        }
+      }
+    },
+    "eventConflict": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "event",
+        "package",
+        "requirements"
+      ],
+      "properties": {
+        "event": {
+          "const": "conflict"
+        },
+        "package": {
+          "$ref": "#/$defs/packageKey"
+        },
+        "requirements": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/requirement"
+          },
+          "uniqueItems": true
+        }
+      }
+    }
+  }
+}

--- a/stage1/schemas/axiom.stage1.v1.schema.json
+++ b/stage1/schemas/axiom.stage1.v1.schema.json
@@ -266,6 +266,19 @@
     "error": {
       "$ref": "#/$defs/diagnostic"
     },
+    "trace": {
+      "$ref": "#/$defs/resolverTrace"
+    },
+    "resolver": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/resolverError"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "requested": {
       "type": "array",
       "items": {
@@ -832,9 +845,64 @@
         },
         "repair": {
           "$ref": "#/$defs/diagnostic_repair"
+        },
+        "trace": {
+          "$ref": "#/$defs/resolverTrace"
+        },
+        "resolver": {
+          "$ref": "#/$defs/resolverError"
         }
       },
       "additionalProperties": false
+    },
+    "resolverTrace": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/resolverTraceEvent"
+      }
+    },
+    "resolverTraceEvent": {
+      "type": "object",
+      "required": [
+        "event"
+      ],
+      "properties": {
+        "event": {
+          "enum": [
+            "path_preserved",
+            "constraint_added",
+            "catalog_authenticated",
+            "candidate_considered",
+            "candidate_rejected",
+            "candidate_verified",
+            "selected",
+            "backtracked",
+            "conflict"
+          ]
+        }
+      },
+      "additionalProperties": true
+    },
+    "resolverError": {
+      "type": "object",
+      "required": [
+        "kind"
+      ],
+      "properties": {
+        "kind": {
+          "enum": [
+            "invalid_request",
+            "invalid_catalog",
+            "source",
+            "conflict",
+            "budget_exceeded"
+          ]
+        },
+        "trace": {
+          "$ref": "#/$defs/resolverTrace"
+        }
+      },
+      "additionalProperties": true
     },
     "docItem": {
       "type": "object",

--- a/stage1/schemas/axiom.toml.schema.json
+++ b/stage1/schemas/axiom.toml.schema.json
@@ -64,6 +64,42 @@
       },
       "additionalProperties": false
     },
+    "registry": {
+      "type": "object",
+      "required": [
+        "name",
+        "index",
+        "trust_roots",
+        "expectation"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9_-]{0,63}$"
+        },
+        "index": {
+          "type": "string",
+          "pattern": "^(https://[^/?#@]+(?:/[^?#]*)?|file:///[^?#]+|http://(?:127(?:\\.(?:0|[1-9][0-9]?|1[0-9]{2}|2[0-4][0-9]|25[0-5])){3}|\\[::1\\])(?::(?:0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]))?(?:/[^?#]*)?)$"
+        },
+        "trust_roots": {
+          "type": "string",
+          "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$)).+$"
+        },
+        "expectation": {
+          "type": "string",
+          "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$)).+$"
+        },
+        "cache": {
+          "type": "string",
+          "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$)).+$"
+        },
+        "vendor": {
+          "type": "string",
+          "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$)).+$"
+        }
+      },
+      "additionalProperties": false
+    },
     "dependencies": {
       "type": "object",
       "additionalProperties": {
@@ -77,14 +113,41 @@
               "path"
             ],
             "properties": {
-          "path": {
-            "type": "string",
-            "minLength": 1
+              "path": {
+                "type": "string",
+                "minLength": 1
+              },
+              "version": {
+                "type": "string",
+                "pattern": "^(\\*|\\^?(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*))$"
+              }
+            },
+            "additionalProperties": false
           },
-          "version": {
-            "type": "string",
-            "pattern": "^(\\*|\\^?(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*))$"
-          }
+          {
+            "type": "object",
+            "required": [
+              "registry",
+              "namespace",
+              "version"
+            ],
+            "properties": {
+              "registry": {
+                "type": "string",
+                "pattern": "^[a-z0-9][a-z0-9_-]{0,63}$"
+              },
+              "namespace": {
+                "type": "string",
+                "pattern": "^[a-z0-9][a-z0-9._-]{0,127}$"
+              },
+              "package": {
+                "type": "string",
+                "pattern": "^[a-z0-9][a-z0-9._-]{0,127}$"
+              },
+              "version": {
+                "type": "string",
+                "pattern": "^\\^?(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
+              }
             },
             "additionalProperties": false
           }


### PR DESCRIPTION
## Summary

- Implement deterministic Package Resolver v1 for exact and caret requirements, lockfile v2, registry/path dependency graphs, fetch/update/vendor flows, and locked/offline operation.
- Add authenticated registry artifact handling, bounded archive extraction, cache/vendor snapshots, package graph contracts, CLI JSON output, resolver fixtures, and focused regression coverage.
- Add CAS lock admission, trusted package materialization, deterministic conflict/cycle/yank/replay behavior, and resolver-specific CI targets.

## Governing Issue

Refs #1459

## Validation

- `make stage1-package-resolver` passed with loopback permissions: package version 3, resolver 15, registry client 9, archive 8, store 14, manager 23, CLI 7, and package graph boundary checks.
- `make compatibility-v1 compatibility-v1-test` passed before publication from the merged #1519 baseline.
- `make stage1-package-trust-contract stage1-package-trust-contract-test` passed before publication from the merged #1519 baseline.
- `python3 scripts/ci/check-capability-ledger.py --checkout-root . --check-docs --json` passed.
- Full repository `cargo test -p axiomc --locked` remains a pre-existing integration-test harness failure in `tests/hir_unit.rs` and `tests/lib_unit.rs`; the focused library and resolver suites pass.
- `cargo-vet` is unavailable in this environment, so the local supply-chain wrapper could not run.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] No real secrets, runtime auth, or machine-local env files are committed
- [ ] Auto-merge is intentionally not enabled: this draft requires independent review and follow-up security review.

## Flow Contract

- Owner lane: package graph / resolver
- Repair owner: Codex implementation lane
- Autonomy class: implementation with independent review required before merge
- Risk class: high; registry trust, lockfile integrity, archive extraction, and offline materialization

## Flow Merge Readiness

- [ ] Independent non-author approval is present for this exact head
- [ ] No active blocking requested changes remain
- [ ] Remaining review findings are resolved

## Notes

This branch is based directly on the current `main` tree after Compatibility v1 / Package Trust v1 PR #1519 merged, so it does not depend on a deleted stacked base branch.

The local read-only review identified follow-up blockers before merge: the lockfile compare/hash/rename sequence still needs a true writer-side CAS or shared lock; the public resolution schema needs enforcement at the resolver boundary; and anchored cache/vendor descendants need handle-based no-follow operations to close the parent-component TOCTOU window. Operation-wide transport deadlines and Windows replace semantics also need explicit coverage.
