### PR TITLE
Serialize lockfile compare-and-replace writers

### DIFF
--- a/docs/compiler-source-decomposition-plan.md
+++ b/docs/compiler-source-decomposition-plan.md
@@ -247,7 +247,7 @@ matching ceiling in this table in the same PR.
 | Tracked item | Ceiling |
 | --- | ---: |
 | `summary.top_file_line_share` | 0.5767 |
-| `summary.top_file_lines` | 71038 |
+| `summary.top_file_lines` | 71088 |
 | `stage1/crates/axiomc/src/cranelift_backend.rs` | 20076 |
 | `stage1/crates/axiomc/src/cranelift_backend/static_output_purity.rs` | 281 |
 | `stage1/crates/axiomc/src/cranelift_backend/host_env_proc_clock.rs` | 586 |
@@ -258,9 +258,9 @@ matching ceiling in this table in the same PR.
 | `stage1/crates/axiomc/src/cranelift_backend/host_crypto.rs` | 783 |
 | `stage1/crates/axiomc/src/cranelift_backend/host_net_http.rs` | 1121 |
 | `stage1/crates/axiomc/src/hir.rs` | 5859 |
-| `stage1/crates/axiomc/src/project.rs` | 13505 |
+| `stage1/crates/axiomc/src/project.rs` | 13548 |
 | `stage1/crates/axiomc/src/project/build_contract.rs` | 118 |
-| `stage1/crates/axiomc/src/main.rs` | 11875 |
+| `stage1/crates/axiomc/src/main.rs` | 11882 |
 | `stage1/crates/axiomc/src/formatter.rs` | 191 |
 | `stage1/crates/axiomc/src/formatter_tests.rs` | 122 |
 | `stage1/crates/axiomc/src/codegen.rs` | 7942 |

--- a/stage1/compatibility/fixtures/current/contract.json
+++ b/stage1/compatibility/fixtures/current/contract.json
@@ -125,7 +125,7 @@
           "path": "stage1/crates/axiomc/src/lockfile.rs",
           "role": "lockfile_runtime_parity",
           "selector": "LockfileV2 and validate_lockfile_v2",
-          "sha256": "5d8d4422b12408dac5d4711948522d39e95863b51c538e1fd8d5777f1de28606"
+          "sha256": "5e5f08ffda12662262015d389895ccfe3f92341ba2a80cdfb27d02e610f3fae2"
         },
         {
           "path": "stage1/package-resolver/fixtures/lockfile-v2.json",

--- a/stage1/compatibility/fixtures/current/contract.json
+++ b/stage1/compatibility/fixtures/current/contract.json
@@ -101,7 +101,7 @@
           "path": "stage1/crates/axiomc/src/main.rs",
           "role": "cli_command_graph_parity",
           "selector": "Command and nested command variant names",
-          "sha256": "af28b41a8db43be2b8df05259edbe800da349a895347754f240fda64af4494e9"
+          "sha256": "9ee7567a62157697c4aa1d702a892ace62040ef6db53c0b635e24676f524a1ea"
         }
       ],
       "stability": "experimental",

--- a/stage1/crates/axiomc/src/benchmark.rs
+++ b/stage1/crates/axiomc/src/benchmark.rs
@@ -6,6 +6,7 @@ use axiomc::project::{run_project_tests_with_options, TestOptions};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 pub const BASELINE_SCHEMA_VERSION: &str = "axiom.stage1.bench.baseline.v1";
 
@@ -15,6 +16,7 @@ pub struct BenchOptions {
     pub iterations: usize,
     pub baseline: Option<PathBuf>,
     pub max_regression_percent: f64,
+    pub timeout: Duration,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -25,6 +27,7 @@ pub struct BenchReport {
     pub iterations: usize,
     pub baseline: Option<String>,
     pub max_regression_percent: f64,
+    pub timeout_ms: u64,
     pub benches: Vec<BenchResult>,
     pub passed: usize,
     pub failed: usize,
@@ -82,6 +85,12 @@ pub fn run_benchmarks(
             "max regression percent must be a finite non-negative number",
         ));
     }
+    if options.timeout.is_zero() {
+        return Err(Diagnostic::new(
+            "bench",
+            "benchmark timeout must be greater than zero",
+        ));
+    }
 
     let baselines = match &options.baseline {
         Some(path) => load_baseline(path)?,
@@ -119,6 +128,7 @@ pub fn run_benchmarks(
             .as_ref()
             .map(|path| path.display().to_string()),
         max_regression_percent: options.max_regression_percent,
+        timeout_ms: options.timeout.as_millis() as u64,
         failed: benches.len().saturating_sub(passed),
         passed,
         benches,
@@ -139,7 +149,7 @@ fn run_one_benchmark(
 ) -> BenchResult {
     let mut failure = None;
     for _ in 0..options.warmup {
-        if let Err(error) = execute_benchmark(project_root, &benchmark.id) {
+        if let Err(error) = execute_benchmark(project_root, &benchmark.id, options.timeout) {
             failure = Some(error.to_string());
             break;
         }
@@ -148,7 +158,7 @@ fn run_one_benchmark(
     let mut samples_ms = Vec::with_capacity(options.iterations);
     if failure.is_none() {
         for _ in 0..options.iterations {
-            match execute_benchmark(project_root, &benchmark.id) {
+            match execute_benchmark(project_root, &benchmark.id, options.timeout) {
                 Ok(duration_ms) => samples_ms.push(duration_ms),
                 Err(error) => {
                     failure = Some(error.to_string());
@@ -198,12 +208,17 @@ fn run_one_benchmark(
     }
 }
 
-fn execute_benchmark(project_root: &Path, benchmark_id: &str) -> Result<u64, Diagnostic> {
+fn execute_benchmark(
+    project_root: &Path,
+    benchmark_id: &str,
+    timeout: Duration,
+) -> Result<u64, Diagnostic> {
     let output = run_project_tests_with_options(
         project_root,
         &TestOptions {
             filter: Some(benchmark_id.to_string()),
             include_benchmarks: true,
+            run_limits: Some(axiomc::project::RunLimits::benchmark(timeout)),
             ..TestOptions::default()
         },
     )?;
@@ -361,8 +376,11 @@ fn exceeds_regression_limit(regression_percent: Option<f64>, max_regression_perc
 
 #[cfg(test)]
 mod tests {
-    use super::{exceeds_regression_limit, sample_variance};
+    use super::{BenchOptions, exceeds_regression_limit, run_benchmarks, sample_variance};
+    use axiomc::project::RunLimits;
     use serde_json::Value;
+    use std::path::Path;
+    use std::time::Duration;
 
     #[test]
     fn sample_variance_uses_the_unbiased_denominator() {
@@ -391,5 +409,29 @@ mod tests {
             .expect("compile benchmark baseline schema")
             .validate(&baseline)
             .expect("baseline fixture matches schema");
+    }
+
+    #[test]
+    fn benchmark_budget_tracks_the_requested_timeout() {
+        let limits = RunLimits::benchmark(Duration::from_millis(1_500));
+        assert_eq!(limits.timeout, Duration::from_millis(1_500));
+        assert_eq!(limits.max_output_bytes, 1024 * 1024);
+        assert_eq!(limits.max_cpu_seconds, 2);
+    }
+
+    #[test]
+    fn benchmark_rejects_an_unbounded_timeout() {
+        let error = run_benchmarks(
+            Path::new("missing"),
+            &BenchOptions {
+                warmup: 0,
+                iterations: 1,
+                baseline: None,
+                max_regression_percent: 20.0,
+                timeout: Duration::ZERO,
+            },
+        )
+        .expect_err("zero timeout should be rejected");
+        assert!(error.message.contains("timeout must be greater than zero"));
     }
 }

--- a/stage1/crates/axiomc/src/lockfile.rs
+++ b/stage1/crates/axiomc/src/lockfile.rs
@@ -15,6 +15,7 @@ pub const LOCKFILE_V1_VERSION: u32 = 1;
 pub const LOCKFILE_V2_VERSION: u32 = 2;
 pub const REGISTRY_LOCKFILE_V2_REQUIRED: &str = "registry dependency graphs require axiom.lock version 2 under --locked; regenerate it with `axiomc pkg update`";
 const MAX_LOCKFILE_BYTES: usize = 4 * 1024 * 1024;
+const LOCKFILE_WRITER_LOCK_NAME: &str = ".axiom.lock.writer.lock";
 static LOCKFILE_TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -279,6 +280,193 @@ fn open_lockfile_no_follow(path: &Path) -> io::Result<File> {
         .open(path)
 }
 
+#[cfg(unix)]
+fn open_lockfile_writer_lock(path: &Path) -> io::Result<File> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        // The sidecar is a persistent lock identity. Refuse a substituted
+        // final component and keep the descriptor out of child processes.
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(path)
+}
+
+#[cfg(windows)]
+fn open_lockfile_writer_lock(path: &Path) -> io::Result<File> {
+    use std::os::windows::fs::OpenOptionsExt;
+
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn open_lockfile_writer_lock(_path: &Path) -> io::Result<File> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "secure lockfile writer locking requires platform file-lock support",
+    ))
+}
+
+#[cfg(unix)]
+fn lock_lockfile_writer(file: &File) -> io::Result<()> {
+    use std::os::unix::io::AsRawFd;
+
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) } < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+fn lock_lockfile_writer(file: &File) -> io::Result<()> {
+    use std::os::windows::io::AsRawHandle;
+    use std::ptr;
+
+    #[repr(C)]
+    struct Overlapped {
+        internal: usize,
+        internal_high: usize,
+        offset: u32,
+        offset_high: u32,
+        event: *mut std::ffi::c_void,
+    }
+
+    #[link(name = "kernel32")]
+    unsafe extern "system" {
+        fn LockFileEx(
+            file: *mut std::ffi::c_void,
+            flags: u32,
+            reserved: u32,
+            bytes_low: u32,
+            bytes_high: u32,
+            overlapped: *mut Overlapped,
+        ) -> i32;
+    }
+
+    const LOCKFILE_EXCLUSIVE_LOCK: u32 = 0x0000_0002;
+    let mut overlapped = Overlapped {
+        internal: 0,
+        internal_high: 0,
+        offset: 0,
+        offset_high: 0,
+        event: ptr::null_mut(),
+    };
+    if unsafe {
+        LockFileEx(
+            file.as_raw_handle(),
+            LOCKFILE_EXCLUSIVE_LOCK,
+            0,
+            u32::MAX,
+            u32::MAX,
+            &mut overlapped,
+        )
+    } == 0
+    {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn lock_lockfile_writer(_file: &File) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "secure lockfile writer locking requires platform file-lock support",
+    ))
+}
+
+#[cfg(unix)]
+fn unlock_lockfile_writer(file: &File) -> io::Result<()> {
+    use std::os::unix::io::AsRawFd;
+
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_UN) } < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+fn unlock_lockfile_writer(file: &File) -> io::Result<()> {
+    use std::os::windows::io::AsRawHandle;
+    use std::ptr;
+
+    #[repr(C)]
+    struct Overlapped {
+        internal: usize,
+        internal_high: usize,
+        offset: u32,
+        offset_high: u32,
+        event: *mut std::ffi::c_void,
+    }
+
+    #[link(name = "kernel32")]
+    unsafe extern "system" {
+        fn UnlockFileEx(
+            file: *mut std::ffi::c_void,
+            reserved: u32,
+            bytes_low: u32,
+            bytes_high: u32,
+            overlapped: *mut Overlapped,
+        ) -> i32;
+    }
+
+    let mut overlapped = Overlapped {
+        internal: 0,
+        internal_high: 0,
+        offset: 0,
+        offset_high: 0,
+        event: ptr::null_mut(),
+    };
+    if unsafe { UnlockFileEx(file.as_raw_handle(), 0, u32::MAX, u32::MAX, &mut overlapped) } == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn unlock_lockfile_writer(_file: &File) -> io::Result<()> {
+    Ok(())
+}
+
+struct LockfileWriterGuard {
+    file: File,
+}
+
+impl Drop for LockfileWriterGuard {
+    fn drop(&mut self) {
+        let _ = unlock_lockfile_writer(&self.file);
+    }
+}
+
+fn acquire_lockfile_writer_guard(target: &Path) -> Result<LockfileWriterGuard, Diagnostic> {
+    let lock_path = target.with_file_name(LOCKFILE_WRITER_LOCK_NAME);
+    let file = open_lockfile_writer_lock(&lock_path).map_err(|error| {
+        lockfile_error(
+            &lock_path,
+            format!("failed to open axiom.lock writer lock: {error}"),
+        )
+    })?;
+    lock_lockfile_writer(&file).map_err(|error| {
+        lockfile_error(
+            &lock_path,
+            format!("failed to acquire axiom.lock writer lock: {error}"),
+        )
+    })?;
+    Ok(LockfileWriterGuard { file })
+}
+
 #[cfg(windows)]
 fn open_lockfile_no_follow(path: &Path) -> io::Result<File> {
     use std::os::windows::fs::OpenOptionsExt;
@@ -403,6 +591,11 @@ fn write_lockfile_v2_atomic_cas_impl(
     before_compare: impl FnOnce() -> Result<(), Diagnostic>,
 ) -> Result<(), Diagnostic> {
     let target = lockfile_path(project_root);
+    // Serialize all cooperating writers across the compare-and-rename
+    // interval. The digest check remains the public CAS contract, while the
+    // sidecar lock closes the writer-vs-writer gap between the final read and
+    // replacement.
+    let _writer_guard = acquire_lockfile_writer_guard(&target)?;
     if let Some(expected_sha256) = expected_sha256 {
         validate_sha256(&target, "expected axiom.lock SHA-256", expected_sha256)?;
     }
@@ -1794,6 +1987,9 @@ fn normalize_path(path: impl AsRef<Path>) -> PathBuf {
 mod tests {
     use super::*;
     use std::fs;
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::{Duration, Instant};
     use tempfile::tempdir;
 
     fn write_manifest(root: &Path, body: &str) {
@@ -2826,6 +3022,37 @@ version = "^1.2.0"
                 .to_string_lossy()
                 .starts_with(".axiom.lock.tmp.")
         }));
+    }
+
+    #[test]
+    fn atomic_writer_serializes_compare_and_replace_with_sidecar_lock() {
+        let dir = tempdir().expect("tempdir");
+        let target = lockfile_path(dir.path());
+        let (ready_sender, ready_receiver) = mpsc::channel();
+        let (release_sender, release_receiver) = mpsc::channel();
+        let lock_target = target.clone();
+        let lock_holder = thread::spawn(move || {
+            let guard = acquire_lockfile_writer_guard(&lock_target).expect("acquire writer lock");
+            ready_sender.send(()).expect("signal writer lock");
+            release_receiver.recv().expect("wait for writer release");
+            drop(guard);
+        });
+        ready_receiver.recv().expect("wait for lock holder");
+
+        let release = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(100));
+            release_sender.send(()).expect("release writer lock");
+        });
+        let started = Instant::now();
+        write_lockfile_v2_atomic_cas(dir.path(), &sample_lockfile_v2(), None)
+            .expect("writer waits for the shared lock and then commits");
+        assert!(
+            started.elapsed() >= Duration::from_millis(75),
+            "writer bypassed the shared lock: {:?}",
+            started.elapsed()
+        );
+        release.join().expect("release thread joins");
+        lock_holder.join().expect("lock holder joins");
     }
 
     #[test]

--- a/stage1/crates/axiomc/src/main.rs
+++ b/stage1/crates/axiomc/src/main.rs
@@ -50,6 +50,7 @@ use std::os::fd::{AsRawFd, FromRawFd};
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Component, Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 
 mod agent_task_cli;
 mod benchmark;
@@ -317,6 +318,9 @@ enum Command {
         /// Maximum accepted median regression when --baseline is supplied.
         #[arg(long, default_value_t = 20.0)]
         max_regression_percent: f64,
+        /// Maximum runtime for each benchmark entrypoint execution.
+        #[arg(long, default_value_t = 30)]
+        timeout_seconds: u64,
         /// Emit an axiom.stage1.v1 JSON envelope for agent/tool consumption.
         #[arg(long)]
         json: bool,
@@ -818,6 +822,7 @@ fn main() {
                 include_benchmarks,
                 properties_only: properties,
                 conformance,
+                run_limits: None,
             };
             if list {
                 match list_project_tests_with_options(&path, &options) {
@@ -1374,6 +1379,7 @@ fn main() {
             iterations,
             baseline,
             max_regression_percent,
+            timeout_seconds,
             json,
         } => match run_benchmarks(
             &path,
@@ -1382,6 +1388,7 @@ fn main() {
                 iterations,
                 baseline,
                 max_regression_percent,
+                timeout: Duration::from_secs(timeout_seconds),
             },
         ) {
             Ok(report) => {

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -79,6 +79,18 @@ impl RunLimits {
             max_cpu_seconds: 5,
         }
     }
+
+    pub const fn benchmark(timeout: Duration) -> Self {
+        Self {
+            timeout,
+            max_output_bytes: 1024 * 1024,
+            max_file_bytes: 8 * 1024 * 1024,
+            max_cpu_seconds: {
+                let seconds = timeout.as_secs().saturating_add(1);
+                if seconds == 0 { 1 } else { seconds }
+            },
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -523,6 +535,8 @@ pub struct TestOptions {
     pub include_benchmarks: bool,
     pub properties_only: bool,
     pub conformance: bool,
+    /// Optional execution budget for test cases that need bounded runtime behavior.
+    pub run_limits: Option<RunLimits>,
 }
 
 pub fn check_project(project_root: &Path) -> Result<CheckOutput, Diagnostic> {
@@ -832,6 +846,20 @@ struct BoundedCommandOutput {
     status: std::process::ExitStatus,
     stdout: Vec<u8>,
     stderr: Vec<u8>,
+}
+
+fn run_test_command(
+    command: &mut Command,
+    limits: Option<RunLimits>,
+) -> io::Result<std::process::Output> {
+    match limits {
+        Some(limits) => run_bounded_command(command, limits).map(|output| std::process::Output {
+            status: output.status,
+            stdout: output.stdout,
+            stderr: output.stderr,
+        }),
+        None => command.output(),
+    }
 }
 
 fn run_bounded_command(
@@ -1179,6 +1207,7 @@ fn run_project_tests_with_graph(
                 manifest,
                 test,
                 options.backend,
+                options.run_limits,
                 &mut parse_cache,
             ));
         }
@@ -4846,6 +4875,7 @@ fn run_test_case(
     manifest: &Manifest,
     test: &crate::manifest::TestTarget,
     backend: NativeBackendKind,
+    run_limits: Option<RunLimits>,
     parse_cache: &mut ModuleParseCache,
 ) -> TestCaseResult {
     if test.expected_error.is_some() {
@@ -4916,7 +4946,7 @@ fn run_test_case(
             .and_then(|command| run_command_with_stdin(command, stdin))
     } else {
         command_for_build_output(&binary, &build_output_dir)
-            .and_then(|mut command| command.output())
+            .and_then(|mut command| run_test_command(&mut command, run_limits))
     };
 
     match command_result {
@@ -10785,6 +10815,19 @@ mod tests {
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
     use tempfile::tempdir;
+
+    #[cfg(unix)]
+    #[test]
+    fn bounded_test_command_enforces_benchmark_timeout() {
+        let mut command = Command::new("sh");
+        command.args(["-c", "sleep 2"]);
+        let error = run_test_command(
+            &mut command,
+            Some(RunLimits::benchmark(Duration::from_millis(50))),
+        )
+        .expect_err("sleeping command should exceed benchmark timeout");
+        assert_eq!(error.kind(), ErrorKind::TimedOut);
+    }
 
     #[test]
     fn http_fixture_bind_accepts_only_loopback_socket_addresses() {


### PR DESCRIPTION
## Summary

- Serialize cooperating `axiom.lock` writers across the final compare-and-rename interval with a persistent sidecar lock.
- Use `flock` on Unix and native Windows `LockFileEx`/`UnlockFileEx` while retaining no-follow and close-on-exec protections for the sidecar.
- Add a cross-thread regression test proving a writer cannot bypass the shared lock, while preserving stale-digest CAS failures.
- Include the stacked #1533 benchmark execution slice: bounded benchmark entrypoint runtime, stable `timeout_ms` reporting, and timeout enforcement coverage.

## Governing Issues

Refs #1459
Refs #1464

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are running on the combined head
- [x] Skipped checks are explained below

Commands run:

- `rustfmt --edition 2024 stage1/crates/axiomc/src/lockfile.rs`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib lockfile::tests` — 28 passed
- `cargo check --manifest-path stage1/Cargo.toml -p axiomc`
- `python3 scripts/ci/extract-public-contract-v1.py --check`
- `python3 scripts/ci/test-check-compatibility-v1.py`
- `python3 scripts/ci/report-compiler-source-monoliths.py --check-ratchet`
- `git diff --check`

The Windows native lock branch is intended for the Windows CI/target validation path; this environment does not have a Windows Rust target configured.

## Bootstrap Governance

- [x] Changes are scoped to the linked issues
- [x] No real secrets, runtime auth, or machine-local env files are committed
- [ ] Independent review remains required before this combined head may merge to `main`

## Flow Contract

- Owner lane: Daedalus / package graph
- Repair owner: PR author
- Autonomy class: Class 2 / review-gated
- Risk class: security-sensitive lockfile publication plus bounded benchmark execution

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required; request `pheidon` and `athena-omt`
- [ ] Auto-merge may proceed only after independent review and protected checks

## Merge Automation

- Auto-merge is enabled, but must remain gated by independent code-owner review and protected checks.

## Notes

- #1533 was intentionally stacked here to avoid duplicating the source-derived compatibility fixture; its changes merged only into this feature branch, not `main`.
- The repository autoreview helper was attempted, but its model service connection dropped before producing findings; GitHub independent review remains mandatory.
