### PR TITLE
Bound benchmark entrypoint execution

### DIFF
--- a/docs/compiler-source-decomposition-plan.md
+++ b/docs/compiler-source-decomposition-plan.md
@@ -247,7 +247,7 @@ matching ceiling in this table in the same PR.
 | Tracked item | Ceiling |
 | --- | ---: |
 | `summary.top_file_line_share` | 0.5767 |
-| `summary.top_file_lines` | 71004 |
+| `summary.top_file_lines` | 71054 |
 | `stage1/crates/axiomc/src/cranelift_backend.rs` | 20076 |
 | `stage1/crates/axiomc/src/cranelift_backend/static_output_purity.rs` | 279 |
 | `stage1/crates/axiomc/src/cranelift_backend/host_env_proc_clock.rs` | 586 |
@@ -258,9 +258,9 @@ matching ceiling in this table in the same PR.
 | `stage1/crates/axiomc/src/cranelift_backend/host_crypto.rs` | 783 |
 | `stage1/crates/axiomc/src/cranelift_backend/host_net_http.rs` | 1121 |
 | `stage1/crates/axiomc/src/hir.rs` | 5849 |
-| `stage1/crates/axiomc/src/project.rs` | 13505 |
+| `stage1/crates/axiomc/src/project.rs` | 13548 |
 | `stage1/crates/axiomc/src/project/build_contract.rs` | 118 |
-| `stage1/crates/axiomc/src/main.rs` | 11875 |
+| `stage1/crates/axiomc/src/main.rs` | 11882 |
 | `stage1/crates/axiomc/src/formatter.rs` | 191 |
 | `stage1/crates/axiomc/src/formatter_tests.rs` | 122 |
 | `stage1/crates/axiomc/src/codegen.rs` | 7919 |

--- a/stage1/compatibility/fixtures/current/contract.json
+++ b/stage1/compatibility/fixtures/current/contract.json
@@ -98,7 +98,7 @@
           "path": "stage1/crates/axiomc/src/main.rs",
           "role": "cli_command_graph_parity",
           "selector": "Command and nested command variant names",
-          "sha256": "af28b41a8db43be2b8df05259edbe800da349a895347754f240fda64af4494e9"
+          "sha256": "9ee7567a62157697c4aa1d702a892ace62040ef6db53c0b635e24676f524a1ea"
         }
       ],
       "stability": "experimental",

--- a/stage1/crates/axiomc/src/benchmark.rs
+++ b/stage1/crates/axiomc/src/benchmark.rs
@@ -6,6 +6,7 @@ use axiomc::project::{run_project_tests_with_options, TestOptions};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 pub const BASELINE_SCHEMA_VERSION: &str = "axiom.stage1.bench.baseline.v1";
 
@@ -15,6 +16,7 @@ pub struct BenchOptions {
     pub iterations: usize,
     pub baseline: Option<PathBuf>,
     pub max_regression_percent: f64,
+    pub timeout: Duration,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -25,6 +27,7 @@ pub struct BenchReport {
     pub iterations: usize,
     pub baseline: Option<String>,
     pub max_regression_percent: f64,
+    pub timeout_ms: u64,
     pub benches: Vec<BenchResult>,
     pub passed: usize,
     pub failed: usize,
@@ -82,6 +85,12 @@ pub fn run_benchmarks(
             "max regression percent must be a finite non-negative number",
         ));
     }
+    if options.timeout.is_zero() {
+        return Err(Diagnostic::new(
+            "bench",
+            "benchmark timeout must be greater than zero",
+        ));
+    }
 
     let baselines = match &options.baseline {
         Some(path) => load_baseline(path)?,
@@ -119,6 +128,7 @@ pub fn run_benchmarks(
             .as_ref()
             .map(|path| path.display().to_string()),
         max_regression_percent: options.max_regression_percent,
+        timeout_ms: options.timeout.as_millis() as u64,
         failed: benches.len().saturating_sub(passed),
         passed,
         benches,
@@ -139,7 +149,7 @@ fn run_one_benchmark(
 ) -> BenchResult {
     let mut failure = None;
     for _ in 0..options.warmup {
-        if let Err(error) = execute_benchmark(project_root, &benchmark.id) {
+        if let Err(error) = execute_benchmark(project_root, &benchmark.id, options.timeout) {
             failure = Some(error.to_string());
             break;
         }
@@ -148,7 +158,7 @@ fn run_one_benchmark(
     let mut samples_ms = Vec::with_capacity(options.iterations);
     if failure.is_none() {
         for _ in 0..options.iterations {
-            match execute_benchmark(project_root, &benchmark.id) {
+            match execute_benchmark(project_root, &benchmark.id, options.timeout) {
                 Ok(duration_ms) => samples_ms.push(duration_ms),
                 Err(error) => {
                     failure = Some(error.to_string());
@@ -198,12 +208,17 @@ fn run_one_benchmark(
     }
 }
 
-fn execute_benchmark(project_root: &Path, benchmark_id: &str) -> Result<u64, Diagnostic> {
+fn execute_benchmark(
+    project_root: &Path,
+    benchmark_id: &str,
+    timeout: Duration,
+) -> Result<u64, Diagnostic> {
     let output = run_project_tests_with_options(
         project_root,
         &TestOptions {
             filter: Some(benchmark_id.to_string()),
             include_benchmarks: true,
+            run_limits: Some(axiomc::project::RunLimits::benchmark(timeout)),
             ..TestOptions::default()
         },
     )?;
@@ -361,8 +376,11 @@ fn exceeds_regression_limit(regression_percent: Option<f64>, max_regression_perc
 
 #[cfg(test)]
 mod tests {
-    use super::{exceeds_regression_limit, sample_variance};
+    use super::{BenchOptions, exceeds_regression_limit, run_benchmarks, sample_variance};
+    use axiomc::project::RunLimits;
     use serde_json::Value;
+    use std::path::Path;
+    use std::time::Duration;
 
     #[test]
     fn sample_variance_uses_the_unbiased_denominator() {
@@ -391,5 +409,29 @@ mod tests {
             .expect("compile benchmark baseline schema")
             .validate(&baseline)
             .expect("baseline fixture matches schema");
+    }
+
+    #[test]
+    fn benchmark_budget_tracks_the_requested_timeout() {
+        let limits = RunLimits::benchmark(Duration::from_millis(1_500));
+        assert_eq!(limits.timeout, Duration::from_millis(1_500));
+        assert_eq!(limits.max_output_bytes, 1024 * 1024);
+        assert_eq!(limits.max_cpu_seconds, 2);
+    }
+
+    #[test]
+    fn benchmark_rejects_an_unbounded_timeout() {
+        let error = run_benchmarks(
+            Path::new("missing"),
+            &BenchOptions {
+                warmup: 0,
+                iterations: 1,
+                baseline: None,
+                max_regression_percent: 20.0,
+                timeout: Duration::ZERO,
+            },
+        )
+        .expect_err("zero timeout should be rejected");
+        assert!(error.message.contains("timeout must be greater than zero"));
     }
 }

--- a/stage1/crates/axiomc/src/main.rs
+++ b/stage1/crates/axiomc/src/main.rs
@@ -50,6 +50,7 @@ use std::os::fd::{AsRawFd, FromRawFd};
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Component, Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 
 mod agent_task_cli;
 mod benchmark;
@@ -317,6 +318,9 @@ enum Command {
         /// Maximum accepted median regression when --baseline is supplied.
         #[arg(long, default_value_t = 20.0)]
         max_regression_percent: f64,
+        /// Maximum runtime for each benchmark entrypoint execution.
+        #[arg(long, default_value_t = 30)]
+        timeout_seconds: u64,
         /// Emit an axiom.stage1.v1 JSON envelope for agent/tool consumption.
         #[arg(long)]
         json: bool,
@@ -818,6 +822,7 @@ fn main() {
                 include_benchmarks,
                 properties_only: properties,
                 conformance,
+                run_limits: None,
             };
             if list {
                 match list_project_tests_with_options(&path, &options) {
@@ -1374,6 +1379,7 @@ fn main() {
             iterations,
             baseline,
             max_regression_percent,
+            timeout_seconds,
             json,
         } => match run_benchmarks(
             &path,
@@ -1382,6 +1388,7 @@ fn main() {
                 iterations,
                 baseline,
                 max_regression_percent,
+                timeout: Duration::from_secs(timeout_seconds),
             },
         ) {
             Ok(report) => {

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -79,6 +79,18 @@ impl RunLimits {
             max_cpu_seconds: 5,
         }
     }
+
+    pub const fn benchmark(timeout: Duration) -> Self {
+        Self {
+            timeout,
+            max_output_bytes: 1024 * 1024,
+            max_file_bytes: 8 * 1024 * 1024,
+            max_cpu_seconds: {
+                let seconds = timeout.as_secs().saturating_add(1);
+                if seconds == 0 { 1 } else { seconds }
+            },
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -523,6 +535,8 @@ pub struct TestOptions {
     pub include_benchmarks: bool,
     pub properties_only: bool,
     pub conformance: bool,
+    /// Optional execution budget for test cases that need bounded runtime behavior.
+    pub run_limits: Option<RunLimits>,
 }
 
 pub fn check_project(project_root: &Path) -> Result<CheckOutput, Diagnostic> {
@@ -832,6 +846,20 @@ struct BoundedCommandOutput {
     status: std::process::ExitStatus,
     stdout: Vec<u8>,
     stderr: Vec<u8>,
+}
+
+fn run_test_command(
+    command: &mut Command,
+    limits: Option<RunLimits>,
+) -> io::Result<std::process::Output> {
+    match limits {
+        Some(limits) => run_bounded_command(command, limits).map(|output| std::process::Output {
+            status: output.status,
+            stdout: output.stdout,
+            stderr: output.stderr,
+        }),
+        None => command.output(),
+    }
 }
 
 fn run_bounded_command(
@@ -1179,6 +1207,7 @@ fn run_project_tests_with_graph(
                 manifest,
                 test,
                 options.backend,
+                options.run_limits,
                 &mut parse_cache,
             ));
         }
@@ -4846,6 +4875,7 @@ fn run_test_case(
     manifest: &Manifest,
     test: &crate::manifest::TestTarget,
     backend: NativeBackendKind,
+    run_limits: Option<RunLimits>,
     parse_cache: &mut ModuleParseCache,
 ) -> TestCaseResult {
     if test.expected_error.is_some() {
@@ -4916,7 +4946,7 @@ fn run_test_case(
             .and_then(|command| run_command_with_stdin(command, stdin))
     } else {
         command_for_build_output(&binary, &build_output_dir)
-            .and_then(|mut command| command.output())
+            .and_then(|mut command| run_test_command(&mut command, run_limits))
     };
 
     match command_result {
@@ -10785,6 +10815,19 @@ mod tests {
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
     use tempfile::tempdir;
+
+    #[cfg(unix)]
+    #[test]
+    fn bounded_test_command_enforces_benchmark_timeout() {
+        let mut command = Command::new("sh");
+        command.args(["-c", "sleep 2"]);
+        let error = run_test_command(
+            &mut command,
+            Some(RunLimits::benchmark(Duration::from_millis(50))),
+        )
+        .expect_err("sleeping command should exceed benchmark timeout");
+        assert_eq!(error.kind(), ErrorKind::TimedOut);
+    }
 
     #[test]
     fn http_fixture_bind_accepts_only_loopback_socket_addresses() {


### PR DESCRIPTION
## Summary
- Add an explicit `--timeout-seconds` budget to `axiomc bench` (default 30 seconds).
- Execute benchmark entrypoints through the existing bounded command runner, including output, file, CPU, and wall-clock limits.
- Include `timeout_ms` in the stable benchmark JSON report and reject an unbounded zero timeout.
- Add unit coverage for budget derivation and actual timeout enforcement.

## Governing Issue
Refs #1464 (bounded benchmark execution slice; the remaining property/shrink/retry work is intentionally separate)

## Dependency
This PR is stacked on #1529 so its source-derived compatibility fixture does not duplicate #1529's lockfile fixture regeneration. Merge #1529 first, then this PR can retarget `main` without carrying overlapping generated changes.

## Validation
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc benchmark::tests --bin axiomc`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc project::tests::bounded_test_command_enforces_benchmark_timeout --lib`
- `cargo check --manifest-path stage1/Cargo.toml -p axiomc`
- `python3 scripts/ci/extract-public-contract-v1.py --check`
- `python3 scripts/ci/test-check-compatibility-v1.py`
- `python3 scripts/ci/report-compiler-source-monoliths.py --check-ratchet`
- `cargo run --quiet --manifest-path stage1/Cargo.toml -p axiomc -- bench stage1/examples/benchmarks --warmup 0 --iterations 1 --timeout-seconds 2 --json`
- `git diff --check`

## Bootstrap Governance
- [x] No auth, session, cache, or machine-local secret state added.
- [x] Change is scoped to the governing issue and follows repository policy.

## Flow Contract
- Owner lane: Ares / Daedalus
- Repair owner: author
- Autonomy class: 2
- Risk class: medium

## Flow Merge Readiness
- [x] Local validation is recorded above.
- [ ] Independent review is still required after publication.
- [ ] Required GitHub checks must pass on the final head.

## Merge Automation
- Auto-merge may be enabled after #1529, required checks, and independent review are satisfied.

## Notes
- Benchmark stdin/HTTP fixture paths retain their existing specialized execution helpers; this slice applies the bounded runner to ordinary benchmark entrypoints.
