### PR TITLE
Enforce compiler property execution evidence

### DIFF
--- a/scripts/ci/run-compiler-property-checks.sh
+++ b/scripts/ci/run-compiler-property-checks.sh
@@ -90,7 +90,32 @@ import sys
 payload = json.load(open(sys.argv[1], encoding="utf-8"))
 if payload.get("backend") != "cranelift":
     raise SystemExit(f"compiler property tests must run on cranelift, got {payload.get('backend')!r}")
-for case in payload.get("cases", []):
+cases = payload.get("cases")
+if not isinstance(cases, list) or not cases:
+    raise SystemExit("compiler property test run produced no cases")
+for case in cases:
+    if case.get("kind") != "property":
+        raise SystemExit(f"non-property case in --properties output: {case.get('kind')!r}")
+    if not isinstance(case.get("name"), str) or not case["name"]:
+        raise SystemExit("property case has no stable name")
+    if not isinstance(case.get("duration_ms"), int) or case["duration_ms"] < 0:
+        raise SystemExit(f"property case {case.get('name')} has invalid duration")
+    error = case.get("error") or {}
+    tolerated_unexecuted = (
+        case.get("ok") is False
+        and error.get("code") == "backend.runtime_lowering_required"
+    )
+    if case.get("binary") is None:
+        lowering = case.get("lowering") or {}
+        if not tolerated_unexecuted:
+            raise SystemExit(f"property case {case.get('name')} was not executed")
+        if lowering.get("schema_version") != "axiom.build-lowering-evidence.v1":
+            raise SystemExit(f"unexecuted property case {case.get('name')} lacks bounded lowering evidence schema")
+        if lowering.get("lowering_mode") != "runtime_lowering_required" or lowering.get("execution_mode") != "not_produced":
+            raise SystemExit(f"unexecuted property case {case.get('name')} has inconsistent lowering evidence")
+    elif case.get("ok") is True and case.get("exit_code") != 0:
+        raise SystemExit(f"executed property case {case.get('name')} reported success without exit_code 0")
+for case in cases:
     if case.get("generated_rust") is not None:
         raise SystemExit(f"compiler property case {case.get('name')} used generated Rust")
     if case.get("ok") is False and case.get("error", {}).get("code") != "backend.runtime_lowering_required":

--- a/scripts/ci/test-run-compiler-property-checks.sh
+++ b/scripts/ci/test-run-compiler-property-checks.sh
@@ -40,8 +40,14 @@ case "$mode" in
     fi
     if [[ "${AXIOM_FAKE_CARGO_JSON:-valid}" == "invalid" ]]; then
       printf '{"backend":"cranelift","ok":false'
+    elif [[ "${AXIOM_FAKE_CARGO_JSON:-valid}" == "missing-binary" ]]; then
+      printf '{"backend":"cranelift","ok":true,"cases":[{"kind":"property","name":"fake_property","generated_rust":null,"duration_ms":1,"binary":null}]}'
+    elif [[ "${AXIOM_FAKE_CARGO_JSON:-valid}" == "lowering-tolerated" ]]; then
+      printf '{"backend":"cranelift","ok":false,"cases":[{"kind":"property","name":"fake_property","generated_rust":null,"duration_ms":1,"binary":null,"ok":false,"error":{"code":"backend.runtime_lowering_required"},"lowering":{"schema_version":"axiom.build-lowering-evidence.v1","lowering_mode":"runtime_lowering_required","execution_mode":"not_produced"}}]}'
+    elif [[ "${AXIOM_FAKE_CARGO_JSON:-valid}" == "lowering-no-evidence" ]]; then
+      printf '{"backend":"cranelift","ok":false,"cases":[{"kind":"property","name":"fake_property","generated_rust":null,"duration_ms":1,"binary":null,"ok":false,"error":{"code":"backend.runtime_lowering_required"}}]}'
     else
-      printf '{"backend":"cranelift","ok":true,"cases":[{"name":"fake_property","generated_rust":null}]}'
+      printf '{"backend":"cranelift","ok":true,"cases":[{"kind":"property","name":"fake_property","generated_rust":null,"duration_ms":1,"binary":"/fake/property-bin"}]}'
     fi
     ;;
   *)
@@ -76,6 +82,21 @@ fi
 
 if PATH="$fake_bin:$PATH" TMPDIR="$run_tmp" AXIOM_FAKE_CARGO_JSON=invalid bash "$script" >/dev/null 2>&1; then
   echo "compiler property checks must fail on invalid JSON" >&2
+  exit 1
+fi
+
+if PATH="$fake_bin:$PATH" TMPDIR="$run_tmp" AXIOM_FAKE_CARGO_JSON=missing-binary bash "$script" >/dev/null 2>&1; then
+  echo "compiler property checks must fail when a property case was not executed" >&2
+  exit 1
+fi
+
+if ! PATH="$fake_bin:$PATH" TMPDIR="$run_tmp" AXIOM_FAKE_CARGO_JSON=lowering-tolerated bash "$script" >/dev/null 2>&1; then
+  echo "compiler property checks must accept tolerated unexecuted cases with bounded lowering evidence" >&2
+  exit 1
+fi
+
+if PATH="$fake_bin:$PATH" TMPDIR="$run_tmp" AXIOM_FAKE_CARGO_JSON=lowering-no-evidence bash "$script" >/dev/null 2>&1; then
+  echo "compiler property checks must fail tolerated failures that lack bounded lowering evidence" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Implements a bounded #1464 validation slice: the compiler-property CI gate now requires non-empty, stable property-case execution evidence and rejects a missing executable result.

The only permitted unexecuted case is the existing `backend.runtime_lowering_required` outcome, and it must include the bounded `axiom.build-lowering-evidence.v1` schema with consistent lowering/execution modes.

## Validation

- `bash scripts/ci/test-run-compiler-property-checks.sh`
- `bash scripts/ci/run-compiler-property-checks.sh`

The full property/benchmark implementation remains tracked in #1464.

<!-- ci-retrigger: refresh verified onto live base 6596f3b at head 7272c212 -->