### PR TITLE
Add runtime current-directory access

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Axiom
 
-<!-- capability-ledger:v1 commands=31 stdlib_modules=34 stdlib_functions=303 capabilities=9 backend=cranelift -->
+<!-- capability-ledger:v1 commands=31 stdlib_modules=34 stdlib_functions=304 capabilities=9 backend=cranelift -->
 
 Axiom is an agent-native typed intent and semantic construction system. It
 defines what must be true, which effects are allowed, what evidence proves a

--- a/docs/book.md
+++ b/docs/book.md
@@ -1,6 +1,6 @@
 # The Axiom Book
 
-<!-- capability-ledger:v1 commands=31 stdlib_modules=34 stdlib_functions=303 capabilities=9 backend=cranelift -->
+<!-- capability-ledger:v1 commands=31 stdlib_modules=34 stdlib_functions=304 capabilities=9 backend=cranelift -->
 
 This book is the tutorial path for the Rust-only stage1 toolchain. It teaches
 the current supported Axiom surface from first package to agent-oriented

--- a/docs/bootstrap/versioning.md
+++ b/docs/bootstrap/versioning.md
@@ -1,6 +1,6 @@
 # Release Versioning
 
-<!-- capability-ledger:v1 commands=31 stdlib_modules=34 stdlib_functions=303 capabilities=9 backend=cranelift -->
+<!-- capability-ledger:v1 commands=31 stdlib_modules=34 stdlib_functions=304 capabilities=9 backend=cranelift -->
 
 This bootstrap standardizes on Semantic Versioning with immutable exact tags and automatically promoted compatibility aliases.
 

--- a/docs/compiler-source-decomposition-plan.md
+++ b/docs/compiler-source-decomposition-plan.md
@@ -184,6 +184,13 @@ making Rust module paths canonical; this PR keeps the compiler semantic source
 of truth at the project boundary and refuses to weaken the public/private or
 doctest gates to avoid the ratchet.
 
+The runtime current-directory slice in #1477 adds capability-gated lowering
+across the HIR, direct-native evaluator, host environment lowering, generated
+Rust compatibility path, and native backend hub. Its measured growth is
+recorded in the ceilings below; the next extraction should move the shared
+current-directory lowering into a dedicated host sibling before another
+runtime-host surface grows these files.
+
 The Package Trust v1 runtime adds the target-neutral Ed25519 trust engine in
 `package_trust.rs`, migrates local publication and signed-index operations in
 `registry.rs`, and exposes the operator CLI in `main.rs`. The ceilings below
@@ -250,20 +257,20 @@ matching ceiling in this table in the same PR.
 | `summary.top_file_lines` | 71278 |
 | `stage1/crates/axiomc/src/cranelift_backend.rs` | 20120 |
 | `stage1/crates/axiomc/src/cranelift_backend/static_output_purity.rs` | 282 |
-| `stage1/crates/axiomc/src/cranelift_backend/host_env_proc_clock.rs` | 572 |
+| `stage1/crates/axiomc/src/cranelift_backend/host_env_proc_clock.rs` | 620 |
 | `stage1/crates/axiomc/src/cranelift_backend/host_json_serdes.rs` | 257 |
 | `stage1/crates/axiomc/src/cranelift_backend/intrinsics.rs` | 921 |
-| `stage1/crates/axiomc/src/cranelift_backend/evaluator.rs` | 4247 |
+| `stage1/crates/axiomc/src/cranelift_backend/evaluator.rs` | 4260 |
 | `stage1/crates/axiomc/src/cranelift_backend/host_fs.rs` | 984 |
 | `stage1/crates/axiomc/src/cranelift_backend/host_crypto.rs` | 783 |
 | `stage1/crates/axiomc/src/cranelift_backend/host_net_http.rs` | 1121 |
-| `stage1/crates/axiomc/src/hir.rs` | 5888 |
+| `stage1/crates/axiomc/src/hir.rs` | 5904 |
 | `stage1/crates/axiomc/src/project.rs` | 13564 |
 | `stage1/crates/axiomc/src/project/build_contract.rs` | 118 |
 | `stage1/crates/axiomc/src/main.rs` | 11892 |
 | `stage1/crates/axiomc/src/formatter.rs` | 191 |
 | `stage1/crates/axiomc/src/formatter_tests.rs` | 122 |
-| `stage1/crates/axiomc/src/codegen.rs` | 8012 |
+| `stage1/crates/axiomc/src/codegen.rs` | 8020 |
 | `stage1/crates/axiomc/src/syntax.rs` | 6396 |
 | `stage1/crates/axiomc/src/hir/async_runtime.rs` | 188 |
 | `stage1/crates/axiomc/src/hir/capabilities.rs` | 773 |

--- a/docs/performance-benchmarks.md
+++ b/docs/performance-benchmarks.md
@@ -1,6 +1,6 @@
 # Performance Benchmarks
 
-<!-- capability-ledger:v1 commands=31 stdlib_modules=34 stdlib_functions=303 capabilities=9 backend=cranelift -->
+<!-- capability-ledger:v1 commands=31 stdlib_modules=34 stdlib_functions=304 capabilities=9 backend=cranelift -->
 
 The `axiomc bench` harness discovers `*_bench.ax` files and executes each
 entrypoint for every warmup and measured iteration. It emits per-sample timing,

--- a/docs/stage1-agent-grade-compiler.md
+++ b/docs/stage1-agent-grade-compiler.md
@@ -1,6 +1,6 @@
 # Stage1 Agent-Grade Compiler Plan
 
-<!-- capability-ledger:v1 commands=31 stdlib_modules=34 stdlib_functions=303 capabilities=9 backend=cranelift -->
+<!-- capability-ledger:v1 commands=31 stdlib_modules=34 stdlib_functions=304 capabilities=9 backend=cranelift -->
 
 This doc is the implementation spec for turning `stage1/` into Axiom's first
 workable compiler for agent use. `docs/stage1.md` stays as the shorter status

--- a/docs/stage1-language-issue-disposition.md
+++ b/docs/stage1-language-issue-disposition.md
@@ -1,6 +1,6 @@
 # Stage1 Language Issue Disposition
 
-<!-- capability-ledger:v1 commands=31 stdlib_modules=34 stdlib_functions=303 capabilities=9 backend=cranelift -->
+<!-- capability-ledger:v1 commands=31 stdlib_modules=34 stdlib_functions=304 capabilities=9 backend=cranelift -->
 
 This document records the historical disposition for the broad Phase A language
 issues opened as #216 through #225. It is an evidence guide, not current live

--- a/docs/stage1-stdlib-status.md
+++ b/docs/stage1-stdlib-status.md
@@ -1,6 +1,6 @@
 # Stage1 stdlib status
 
-<!-- capability-ledger:v1 commands=31 stdlib_modules=34 stdlib_functions=303 capabilities=9 backend=cranelift -->
+<!-- capability-ledger:v1 commands=31 stdlib_modules=34 stdlib_functions=304 capabilities=9 backend=cranelift -->
 
 This page maps historical phase-c roadmap issues to the current compiler-owned
 stdlib inventory. Issue numbers are historical evidence, not live issue-state

--- a/docs/stage1.md
+++ b/docs/stage1.md
@@ -1,6 +1,6 @@
 # Stage1 bootstrap
 
-<!-- capability-ledger:v1 commands=31 stdlib_modules=34 stdlib_functions=303 capabilities=9 backend=cranelift -->
+<!-- capability-ledger:v1 commands=31 stdlib_modules=34 stdlib_functions=304 capabilities=9 backend=cranelift -->
 
 The Rust bootstrap compiler in `stage1/` is the supported Axiom toolchain.
 The Python `stage0` interpreter, bytecode compiler, bytecode format, bytecode

--- a/stage1/compatibility/fixtures/current/contract.json
+++ b/stage1/compatibility/fixtures/current/contract.json
@@ -59,13 +59,13 @@
       "migration": {
         "action": "Existing stdlib modules and functions remain valid. Consumers adopting the Unicode scalar helpers should use scalar_count for code-point cardinality and scalar_at for bounds-checked scalar access."
       },
-      "signature": "axiom.compiler.stdlib_catalog.v1; catalog_semantic_digest=5ce3d78f5725c3ff1c663090e0ca116d5dff19c9c3b99d7577cc699ad7fe8ec5; modules=34; symbols=303",
+      "signature": "axiom.compiler.stdlib_catalog.v1; catalog_semantic_digest=d120dc235e4ecfc96b512e6c0c2f9d9a24f84dac800d04600c6d0782dd7716ee; modules=34; symbols=304",
       "sources": [
         {
           "path": "stage1/compiler-contracts/snapshots/stdlib-catalog.json",
           "role": "stdlib_catalog",
           "selector": "modules[*].name,symbols[*].signature",
-          "sha256": "365cfd5554c5a86bc15086735c6826e7e8dda6e670e882e8e504d3d9482c8b69"
+          "sha256": "1c1cb5b87d78f8b7ace5db35ceda705231afdc6e60c43c10d0d4293380d5d977"
         }
       ],
       "stability": "experimental",
@@ -95,13 +95,13 @@
           "path": "stage1/compiler-contracts/snapshots/capability-ledger.json",
           "role": "cli_top_level_parity",
           "selector": "commands[*].name",
-          "sha256": "687996cbcdc650ca77a3cd6e8a2493cd4a296e4a71cb51087f5274d796f8581a"
+          "sha256": "d0bc447b9116fc1e9ab918f6cbb2206ad0ec7b102491ef0a55501b142f74a799"
         },
         {
           "path": "stage1/crates/axiomc/src/main.rs",
           "role": "cli_command_graph_parity",
           "selector": "Command and nested command variant names",
-          "sha256": "e5f87856b59f0b8e130997e06f69043fa5434167582a93dbce45078023ea6c67"
+          "sha256": "e08158de6ab9be048749982a377a3888aaaa5b34905a03afe71bea52f042b6e2"
         }
       ],
       "stability": "experimental",

--- a/stage1/compiler-contracts/snapshots/capability-ledger.json
+++ b/stage1/compiler-contracts/snapshots/capability-ledger.json
@@ -1454,6 +1454,7 @@
       ],
       "evidenceTier": "static_spike",
       "functions": [
+        "cwd",
         "get_env"
       ],
       "module": "std/env.ax",
@@ -1886,7 +1887,7 @@
     },
     "runtimeAbiRows": 34,
     "schemas": 60,
-    "stdlibFunctions": 303,
+    "stdlibFunctions": 304,
     "stdlibModules": 34,
     "supportedNativeBackend": "cranelift"
   },

--- a/stage1/compiler-contracts/snapshots/stdlib-catalog.json
+++ b/stage1/compiler-contracts/snapshots/stdlib-catalog.json
@@ -1132,12 +1132,23 @@
       "module_loading": {
         "kind": "embedded_source",
         "source_path": "stage1/crates/axiomc/src/stdlib.rs",
-        "source_digest": "d1e5afc328dea72918a418669870437ec4552f71495f55d65244d27cab5237ce"
+        "source_digest": "0a60861766769c99230cf199e8c65a1bb721783e9f17adc74a31964b7ff4fe83"
       },
       "capabilities": [
         "env"
       ],
       "symbols": [
+        {
+          "name": "cwd",
+          "signature": "fn cwd(): Option<string>",
+          "effect": "capability:env",
+          "binding": "axiom://provider/stage1-v1/env/cwd",
+          "binding_kind": "provider_contract",
+          "provider": {
+            "id": "axiom://provider/stage1-v1/env/cwd",
+            "kind": "declared_provider"
+          }
+        },
         {
           "name": "get_env",
           "signature": "fn get_env(key: string): Option<string>",
@@ -3785,7 +3796,7 @@
       "symbols": []
     }
   ],
-  "release_digest": "3d590d957613d3679c1467f1ca6b84e9978db7a3bac8dc47bd6ec5d073969dba",
+  "release_digest": "fb6f4db3b4c664f2b001edee117ffedae64d07af40eb05563e4ade7a2804758c",
   "rollback_boundary": "stage1/crates/axiomc/src/stdlib.rs remains the bootstrap loader until #1436 qualifies a catalog consumer.",
   "acceptance_boundary": {
     "status": "pending",

--- a/stage1/crates/axiomc-backend-cranelift/src/lib.rs
+++ b/stage1/crates/axiomc-backend-cranelift/src/lib.rs
@@ -183,6 +183,7 @@ pub enum I64Expr {
     EnvLen {
         key: String,
     },
+    CwdLen,
     StdinLen {
         max_bytes: u32,
     },
@@ -465,6 +466,12 @@ pub enum I64Stmt {
     WriteEnvValue {
         stream: OutputStream,
         key: String,
+        append_newline: bool,
+    },
+    /// Write the runtime current working directory to `stream`. Callers gate
+    /// this behind a successful `CwdLen` presence check.
+    WriteCwdValue {
+        stream: OutputStream,
         append_newline: bool,
     },
     WriteArgCountLine {
@@ -1365,6 +1372,7 @@ fn collect_i64_output_lines(stmts: &[I64Stmt], lines: &mut Vec<(OutputStream, St
             I64Stmt::WriteI64Text { .. }
             | I64Stmt::WriteI64Line { .. }
             | I64Stmt::WriteEnvValue { .. }
+            | I64Stmt::WriteCwdValue { .. }
             | I64Stmt::WriteArgCountLine { .. }
             | I64Stmt::WriteStdinRemaining { .. } => {}
             I64Stmt::If {
@@ -1808,6 +1816,17 @@ fn emit_i64_stmt(
             key,
             *append_newline,
         ),
+        I64Stmt::WriteCwdValue {
+            stream,
+            append_newline,
+        } => emit_i64_write_cwd_value(
+            builder,
+            runtime_refs,
+            write_ref,
+            module.target_config().pointer_type(),
+            *stream,
+            *append_newline,
+        ),
         I64Stmt::WriteArgCountLine { stream } => emit_i64_write_arg_count_line(
             builder,
             runtime_args.ok_or_else(|| CraneliftBackendError::new("main argc is unavailable"))?,
@@ -2080,6 +2099,55 @@ fn emit_i64_write_env_value(
     }
     let line = i64_stdio_audit_line(stream, None, "ok");
     emit_i64_host_audit_line(builder, runtime_refs, &line)?;
+    builder.ins().jump(done_block, &[]);
+
+    builder.switch_to_block(done_block);
+    builder.seal_block(done_block);
+    Ok(())
+}
+
+fn emit_i64_write_cwd_value(
+    builder: &mut FunctionBuilder<'_>,
+    runtime_refs: I64RuntimeRefs,
+    write_ref: FuncRef,
+    pointer_type: cranelift_codegen::ir::Type,
+    stream: OutputStream,
+    append_newline: bool,
+) -> Result<(), CraneliftBackendError> {
+    let path_ptr = emit_i64_path_ptr(builder, ".")?;
+    let resolved_slot = builder.create_sized_stack_slot(StackSlotData::new(
+        StackSlotKind::ExplicitSlot,
+        I64_REALPATH_BUFFER_BYTES,
+        0,
+    ));
+    let resolved_ptr = builder.ins().stack_addr(pointer_type, resolved_slot, 0);
+    let call = builder
+        .ins()
+        .call(runtime_refs.realpath, &[path_ptr, resolved_ptr]);
+    let value_ptr = builder.inst_results(call)[0];
+
+    let present_block = builder.create_block();
+    let done_block = builder.create_block();
+    let missing = builder.ins().icmp_imm(IntCC::Equal, value_ptr, 0);
+    builder
+        .ins()
+        .brif(missing, done_block, &[], present_block, &[]);
+
+    builder.switch_to_block(present_block);
+    builder.seal_block(present_block);
+    let call = builder.ins().call(runtime_refs.strlen, &[value_ptr]);
+    let length = builder.inst_results(call)[0];
+    let fd = builder.ins().iconst(types::I32, output_stream_fd(stream));
+    builder.ins().call(write_ref, &[fd, value_ptr, length]);
+    if append_newline {
+        let newline_slot =
+            builder.create_sized_stack_slot(StackSlotData::new(StackSlotKind::ExplicitSlot, 1, 0));
+        let newline = builder.ins().iconst(types::I8, i64::from(b'\n'));
+        builder.ins().stack_store(newline, newline_slot, 0);
+        let newline_ptr = builder.ins().stack_addr(pointer_type, newline_slot, 0);
+        let one = builder.ins().iconst(pointer_type, 1);
+        builder.ins().call(write_ref, &[fd, newline_ptr, one]);
+    }
     builder.ins().jump(done_block, &[]);
 
     builder.switch_to_block(done_block);
@@ -3109,6 +3177,11 @@ fn emit_i64_expr(
         I64Expr::EnvLen { key } => {
             emit_i64_env_len_expr(builder, runtime_refs.getenv, runtime_refs.strlen, key)
         }
+        I64Expr::CwdLen => emit_i64_cwd_len_expr(
+            builder,
+            runtime_refs.realpath,
+            runtime_refs.strlen,
+        ),
         I64Expr::StdinLen { max_bytes } => {
             emit_i64_stdin_len_expr(builder, runtime_refs, *max_bytes)
         }
@@ -4242,6 +4315,51 @@ fn emit_i64_env_len_expr(
     let call = builder.ins().call(strlen_ref, &[value_ptr]);
     let length = builder.inst_results(call)[0];
     builder.ins().jump(merge_block, &[BlockArg::Value(length)]);
+
+    builder.switch_to_block(merge_block);
+    builder.seal_block(merge_block);
+    Ok(builder.block_params(merge_block)[0])
+}
+
+fn emit_i64_cwd_len_expr(
+    builder: &mut FunctionBuilder<'_>,
+    realpath_ref: FuncRef,
+    strlen_ref: FuncRef,
+) -> Result<cranelift_codegen::ir::Value, CraneliftBackendError> {
+    let path_ptr = emit_i64_path_ptr(builder, ".")?;
+    let resolved_slot = builder.create_sized_stack_slot(StackSlotData::new(
+        StackSlotKind::ExplicitSlot,
+        I64_REALPATH_BUFFER_BYTES,
+        0,
+    ));
+    let resolved_ptr = builder.ins().stack_addr(types::I64, resolved_slot, 0);
+    let call = builder.ins().call(realpath_ref, &[path_ptr, resolved_ptr]);
+    let value_ptr = builder.inst_results(call)[0];
+
+    let missing_block = builder.create_block();
+    let present_block = builder.create_block();
+    let merge_block = builder.create_block();
+    builder.append_block_param(merge_block, types::I64);
+
+    let missing = builder.ins().icmp_imm(IntCC::Equal, value_ptr, 0);
+    builder
+        .ins()
+        .brif(missing, missing_block, &[], present_block, &[]);
+
+    builder.switch_to_block(missing_block);
+    builder.seal_block(missing_block);
+    let missing_result = builder.ins().iconst(types::I64, -1);
+    builder
+        .ins()
+        .jump(merge_block, &[BlockArg::Value(missing_result)]);
+
+    builder.switch_to_block(present_block);
+    builder.seal_block(present_block);
+    let call = builder.ins().call(strlen_ref, &[value_ptr]);
+    let length = builder.inst_results(call)[0];
+    builder
+        .ins()
+        .jump(merge_block, &[BlockArg::Value(length)]);
 
     builder.switch_to_block(merge_block);
     builder.seal_block(merge_block);

--- a/stage1/crates/axiomc-backend-cranelift/src/lib.rs
+++ b/stage1/crates/axiomc-backend-cranelift/src/lib.rs
@@ -103,6 +103,7 @@ struct I64RuntimeRefs {
     closedir: FuncRef,
     realpath: FuncRef,
     strncmp: FuncRef,
+    pointer_type: cranelift_codegen::ir::Type,
     getaddrinfo: Option<FuncRef>,
     freeaddrinfo: Option<FuncRef>,
     sockets: Option<I64SocketRefs>,
@@ -1251,6 +1252,7 @@ fn emit_i64_exit_object(
                     None
                 }
             },
+            pointer_type: module.target_config().pointer_type(),
             sockets: {
                 #[cfg(not(windows))]
                 {
@@ -1636,6 +1638,7 @@ fn define_i64_function(
                     None
                 }
             },
+            pointer_type: module.target_config().pointer_type(),
             sockets: {
                 #[cfg(not(windows))]
                 {
@@ -3181,6 +3184,7 @@ fn emit_i64_expr(
             builder,
             runtime_refs.realpath,
             runtime_refs.strlen,
+            runtime_refs.pointer_type,
         ),
         I64Expr::StdinLen { max_bytes } => {
             emit_i64_stdin_len_expr(builder, runtime_refs, *max_bytes)
@@ -4325,6 +4329,7 @@ fn emit_i64_cwd_len_expr(
     builder: &mut FunctionBuilder<'_>,
     realpath_ref: FuncRef,
     strlen_ref: FuncRef,
+    pointer_type: cranelift_codegen::ir::Type,
 ) -> Result<cranelift_codegen::ir::Value, CraneliftBackendError> {
     let path_ptr = emit_i64_path_ptr(builder, ".")?;
     let resolved_slot = builder.create_sized_stack_slot(StackSlotData::new(
@@ -4332,7 +4337,7 @@ fn emit_i64_cwd_len_expr(
         I64_REALPATH_BUFFER_BYTES,
         0,
     ));
-    let resolved_ptr = builder.ins().stack_addr(types::I64, resolved_slot, 0);
+    let resolved_ptr = builder.ins().stack_addr(pointer_type, resolved_slot, 0);
     let call = builder.ins().call(realpath_ref, &[path_ptr, resolved_ptr]);
     let value_ptr = builder.inst_results(call)[0];
 

--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -3754,7 +3754,7 @@ fn axiom_http_serve_once(bind: String, body: String) -> bool {
     out.push_str("#[allow(dead_code)]\n");
     out.push_str("fn axiom_env_cwd() -> Option<String> {\n");
     out.push_str("    let value = std::env::current_dir().ok().and_then(|path| path.into_os_string().into_string().ok());\n");
-    out.push_str("    axiom_host_audit(\"env_cwd\", \"argc=0\", if value.is_some() { \"ok\" } else { \"error\" });\n");
+    out.push_str("    axiom_host_audit(\"env_cwd\", \"argc=0\".to_string(), if value.is_some() { \"ok\" } else { \"error\" });\n");
     out.push_str("    axiom_capability_audit(\"env_cwd\", \"env\", \"argc=0\", if value.is_some() { \"some\" } else { \"error\" });\n");
     out.push_str("    value\n");
     out.push_str("}\n\n");

--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -3752,6 +3752,13 @@ fn axiom_http_serve_once(bind: String, body: String) -> bool {
     out.push_str("    value\n");
     out.push_str("}\n\n");
     out.push_str("#[allow(dead_code)]\n");
+    out.push_str("fn axiom_env_cwd() -> Option<String> {\n");
+    out.push_str("    let value = std::env::current_dir().ok().and_then(|path| path.into_os_string().into_string().ok());\n");
+    out.push_str("    axiom_host_audit(\"env_cwd\", \"argc=0\", if value.is_some() { \"ok\" } else { \"error\" });\n");
+    out.push_str("    axiom_capability_audit(\"env_cwd\", \"env\", \"argc=0\", if value.is_some() { \"some\" } else { \"error\" });\n");
+    out.push_str("    value\n");
+    out.push_str("}\n\n");
+    out.push_str("#[allow(dead_code)]\n");
     out.push_str("fn axiom_crypto_sha256(input: String) -> String {\n");
     out.push_str("    let arg_summary = format!(\"input_len={}\", input.len());\n");
     out.push_str(
@@ -7222,6 +7229,7 @@ fn render_expr(expr: &Expr) -> String {
         Expr::Call { name, args, .. } if name == "env_get" => {
             format!("axiom_env_get({})", render_expr(&args[0]))
         }
+        Expr::Call { name, .. } if name == "env_cwd" => String::from("axiom_env_cwd()"),
         Expr::Call { name, args, .. } if name == "crypto_sha256" => {
             format!("axiom_crypto_sha256({})", render_expr(&args[0]))
         }

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -82,6 +82,7 @@ pub(crate) struct I64StaticBindings {
     map_key_array_string_indexes: HashMap<String, I64MapKeyArrayStringIndex>,
     process_status_wrappers: HashSet<String>,
     env_get_wrappers: HashSet<String>,
+    env_cwd_wrappers: HashSet<String>,
     env_allowed_names: HashSet<String>,
     env_unrestricted: bool,
     time_wrappers: HashSet<String>,
@@ -703,6 +704,18 @@ fn lower_i64_top_level_output_program(
     static_bindings.fs_root = Some(fs_root.to_path_buf());
     static_bindings.env_allowed_names = capabilities.env_vars.iter().cloned().collect();
     static_bindings.env_unrestricted = capabilities.env_unrestricted;
+    static_bindings.env_get_wrappers = program
+        .functions
+        .iter()
+        .filter(|function| function.path == "<stdlib>/env.ax" && function.source_name == "get_env")
+        .map(|function| function.name.clone())
+        .collect();
+    static_bindings.env_cwd_wrappers = program
+        .functions
+        .iter()
+        .filter(|function| function.path == "<stdlib>/env.ax" && function.source_name == "cwd")
+        .map(|function| function.name.clone())
+        .collect();
     static_bindings.net_unrestricted = capabilities.net && capabilities.net_hosts.is_empty();
     static_bindings.net_allowed_hosts = capabilities.net_hosts.iter().cloned().collect();
     static_bindings.fs_read_wrappers = program
@@ -884,6 +897,12 @@ fn lower_i64_exit_program(
         .functions
         .iter()
         .filter(|function| function.path == "<stdlib>/env.ax" && function.source_name == "get_env")
+        .map(|function| function.name.clone())
+        .collect();
+    static_bindings.env_cwd_wrappers = program
+        .functions
+        .iter()
+        .filter(|function| function.path == "<stdlib>/env.ax" && function.source_name == "cwd")
         .map(|function| function.name.clone())
         .collect();
     static_bindings.time_wrappers = program
@@ -1372,6 +1391,7 @@ fn lower_i64_exit_program(
         .collect();
     let process_status_wrappers = &static_bindings.process_status_wrappers;
     let env_get_wrappers = &static_bindings.env_get_wrappers;
+    let env_cwd_wrappers = &static_bindings.env_cwd_wrappers;
     let time_wrappers = &static_bindings.time_wrappers;
     let fs_shim_wrappers = &static_bindings.fs_shim_wrappers;
     let net_shim_wrappers = &static_bindings.net_shim_wrappers;
@@ -1398,6 +1418,7 @@ fn lower_i64_exit_program(
             function.name != main.name
                 && !process_status_wrappers.contains(&function.name)
                 && !env_get_wrappers.contains(&function.name)
+                && !env_cwd_wrappers.contains(&function.name)
                 && !time_wrappers.contains(&function.name)
                 && !fs_shim_wrappers.contains(&function.name)
                 && !net_shim_wrappers.contains(&function.name)
@@ -7625,6 +7646,9 @@ fn lower_i64_runtime_string_option_len_expr(
 ) -> Option<CraneliftI64Expr> {
     if let Some(key) = i64_env_get_key(expr, static_bindings) {
         return i64_env_len_expr(&key, static_bindings);
+    }
+    if i64_env_cwd_call(expr, static_bindings) {
+        return i64_env_cwd_len_expr(static_bindings);
     }
     let Expr::Call {
         name: call_name,

--- a/stage1/crates/axiomc/src/cranelift_backend/evaluator.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend/evaluator.rs
@@ -852,6 +852,9 @@ pub(crate) fn eval_call(
     if name == "env_get" {
         return eval_env_get_call(args, functions, env, lines);
     }
+    if name == "env_cwd" {
+        return eval_env_cwd_call(args);
+    }
     if name == "fs_read" {
         return eval_fs_read_call(args, functions, env, lines);
     }
@@ -3314,6 +3317,16 @@ pub(crate) fn eval_env_get_call(
         return Ok(spike_option(None));
     }
     Ok(spike_option(env::var(name).ok().map(SpikeValue::Text)))
+}
+
+pub(crate) fn eval_env_cwd_call(args: &[Expr]) -> Result<SpikeValue, Diagnostic> {
+    if !args.is_empty() {
+        return Err(unsupported("env_cwd expects no arguments"));
+    }
+    Ok(spike_option(std::env::current_dir()
+        .ok()
+        .and_then(|path| path.into_os_string().into_string().ok())
+        .map(SpikeValue::Text)))
 }
 
 pub(crate) fn spike_env_name_allowed(env: &SpikeEnv, name: &str) -> bool {

--- a/stage1/crates/axiomc/src/cranelift_backend/host_env_proc_clock.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend/host_env_proc_clock.rs
@@ -24,8 +24,16 @@ pub(crate) fn lower_i64_env_option_match_stmt(
     if !matches!(inner.as_ref(), Type::String | Type::Str) {
         return None;
     }
-    let key = i64_env_get_key(expr, static_bindings)?;
-    let env_len = i64_env_len_expr(&key, static_bindings)?;
+    let key = i64_env_get_key(expr, static_bindings);
+    let cwd = i64_env_cwd_call(expr, static_bindings);
+    if key.is_none() && !cwd {
+        return None;
+    }
+    let env_len = if cwd {
+        i64_env_cwd_len_expr(static_bindings)?
+    } else {
+        i64_env_len_expr(key.as_deref()?, static_bindings)?
+    };
     let (some_arm, none_arm) = i64_option_stmt_match_arms(arms)?;
     let mut some_static_bindings = static_bindings.clone();
     if !some_arm.ignore_payloads
@@ -42,11 +50,18 @@ pub(crate) fn lower_i64_env_option_match_stmt(
                     lhs: env_len,
                     rhs: CraneliftI64Expr::Literal(0),
                 }),
-                then_body: vec![CraneliftI64Stmt::WriteEnvValue {
-                    stream: OutputStream::Stdout,
-                    key: key.clone(),
-                    append_newline: true,
-                }],
+                then_body: if cwd {
+                    vec![CraneliftI64Stmt::WriteCwdValue {
+                        stream: OutputStream::Stdout,
+                        append_newline: true,
+                    }]
+                } else {
+                    vec![CraneliftI64Stmt::WriteEnvValue {
+                        stream: OutputStream::Stdout,
+                        key: key.clone()?,
+                        append_newline: true,
+                    }]
+                },
                 else_body: lower_i64_runtime_stmts(
                     &none_arm.body,
                     locals,
@@ -242,17 +257,26 @@ pub(crate) fn lower_i64_env_option_match_value_expr(
     if !matches!(inner.as_ref(), Type::String | Type::Str) {
         return None;
     }
-    let key = i64_env_get_key(matched, static_bindings)?;
+    let key = i64_env_get_key(matched, static_bindings);
+    let cwd = i64_env_cwd_call(matched, static_bindings);
+    if key.is_none() && !cwd {
+        return None;
+    }
     let (some_arm, none_arm) = i64_option_match_arms(arms)?;
     let binding = some_arm
         .bindings
         .first()
         .filter(|binding| binding.as_str() != "_");
-    let env_len = i64_env_len_expr(&key, static_bindings)?;
+    let env_len = if cwd {
+        i64_env_cwd_len_expr(static_bindings)?
+    } else {
+        i64_env_len_expr(key.as_deref()?, static_bindings)?
+    };
     let then_result = lower_i64_env_some_arm_expr(
         &some_arm.expr,
         binding.map(String::as_str),
-        &key,
+        key.as_deref(),
+        cwd,
         local_indexes,
         local_conditions,
         helper_signatures,
@@ -279,7 +303,8 @@ pub(crate) fn lower_i64_env_option_match_value_expr(
 pub(crate) fn lower_i64_env_some_arm_expr(
     expr: &Expr,
     binding: Option<&str>,
-    key: &str,
+    key: Option<&str>,
+    cwd: bool,
     local_indexes: &HashMap<String, usize>,
     local_conditions: &HashMap<String, CraneliftI64Condition>,
     helper_signatures: &HashMap<&str, I64HelperSignature>,
@@ -291,7 +316,11 @@ pub(crate) fn lower_i64_env_some_arm_expr(
         && let [Expr::VarRef { name, .. }] = args.as_slice()
         && name == binding
     {
-        return i64_env_len_expr(key, static_bindings);
+        return if cwd {
+            i64_env_cwd_len_expr(static_bindings)
+        } else {
+            i64_env_len_expr(key?, static_bindings)
+        };
     }
     lower_i64_return_value_expr(
         expr,
@@ -320,6 +349,18 @@ pub(crate) fn i64_env_len_expr(key: &str, static_bindings: &I64StaticBindings) -
     )
 }
 
+pub(crate) fn i64_env_cwd_len_expr(
+    static_bindings: &I64StaticBindings,
+) -> Option<CraneliftI64Expr> {
+    i64_audited_env_expr(
+        "env_cwd",
+        0,
+        CraneliftI64Expr::CwdLen,
+        static_bindings,
+        CraneliftI64AuditSuccess::NonNegative,
+    )
+}
+
 pub(crate) fn i64_env_get_key(expr: &Expr, static_bindings: &I64StaticBindings) -> Option<String> {
     let Expr::Call { name, args, .. } = expr else {
         return None;
@@ -331,6 +372,13 @@ pub(crate) fn i64_env_get_key(expr: &Expr, static_bindings: &I64StaticBindings) 
         return None;
     };
     i64_string_text(key, static_bindings)
+}
+
+pub(crate) fn i64_env_cwd_call(expr: &Expr, static_bindings: &I64StaticBindings) -> bool {
+    let Expr::Call { name, args, .. } = expr else {
+        return false;
+    };
+    args.is_empty() && (name == "env_cwd" || static_bindings.env_cwd_wrappers.contains(name))
 }
 
 pub(crate) fn lower_i64_clock_intrinsic_expr(

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -3850,6 +3850,22 @@ fn lower_expr_with_expected_inner(
                     ty: Type::Option(Box::new(Type::String)),
                 });
             }
+            if name == "env_cwd" {
+                require_capability(ctx.capabilities, CapabilityKind::Env, name, *line, *column)?;
+                if !args.is_empty() {
+                    return Err(Diagnostic::new(
+                        "type",
+                        format!("env_cwd expects 0 arguments, got {}", args.len()),
+                    )
+                    .with_span(*line, *column));
+                }
+                return Ok(Expr::Call {
+                    span: SourceSpan::point(*line, *column),
+                    name: name.clone(),
+                    args: Vec::new(),
+                    ty: Type::Option(Box::new(Type::String)),
+                });
+            }
             if name == "crypto_sha256" {
                 require_capability(
                     ctx.capabilities,

--- a/stage1/crates/axiomc/src/main.rs
+++ b/stage1/crates/axiomc/src/main.rs
@@ -3983,7 +3983,7 @@ fn effect_for_call(name: &str) -> Option<(&'static str, &'static str, &'static s
             Some(("clock.now", "read", "clock"))
         }
         "clock_sleep_ms" | "sleep" => Some(("clock.sleep", "sleep", "clock")),
-        "env_get" | "get_env" => Some(("env.read", "read", "env")),
+        "env_get" | "get_env" | "env_cwd" | "cwd" => Some(("env.read", "read", "env")),
         "fs_read" | "read_file" => Some(("fs.read", "read", "fs")),
         "fs_write" | "fs_create" | "fs_append" | "fs_mkdir" | "fs_mkdir_all" | "fs_remove_file"
         | "fs_remove_dir" | "fs_replace" | "write_file" | "create_file" | "append_file"
@@ -6427,7 +6427,7 @@ fn capability_for_call(name: &str) -> Option<&'static str> {
     match name {
         "clock_now_ms" | "clock_elapsed_ms" | "clock_sleep_ms" | "now_ms" | "now"
         | "elapsed_ms" | "sleep" => Some("clock"),
-        "env_get" | "get_env" => Some("env"),
+        "env_get" | "get_env" | "env_cwd" | "cwd" => Some("env"),
         "fs_read" | "read_file" => Some("fs"),
         "fs_write" | "fs_create" | "fs_append" | "fs_mkdir" | "fs_mkdir_all" | "fs_remove_file"
         | "fs_remove_dir" | "fs_replace" | "write_file" | "create_file" | "append_file"

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -6409,7 +6409,7 @@ fn stdlib_wrapper_capabilities(
         ("async.ax", _) => Some(vec![CapabilityKind::Async]),
         ("time.ax", "now_ms" | "now" | "elapsed_ms" | "sleep") => Some(vec![CapabilityKind::Clock]),
         ("async_time.ax", _) => Some(vec![CapabilityKind::Clock, CapabilityKind::Async]),
-        ("env.ax", "get_env") => Some(vec![CapabilityKind::Env]),
+        ("env.ax", "get_env" | "cwd") => Some(vec![CapabilityKind::Env]),
         ("fs.ax", "read_file" | "file_exists" | "file_size") => {
             Some(vec![CapabilityKind::Fs])
         }
@@ -7109,7 +7109,7 @@ fn intrinsic_capability(name: &str) -> Option<CapabilityKind> {
         "clock_now_ms" => Some(CapabilityKind::Clock),
         "clock_elapsed_ms" => Some(CapabilityKind::Clock),
         "clock_sleep_ms" => Some(CapabilityKind::Clock),
-        "env_get" => Some(CapabilityKind::Env),
+        "env_get" | "env_cwd" => Some(CapabilityKind::Env),
         "crypto_sha256" => Some(CapabilityKind::Crypto),
         "crypto_hmac_sha256" => Some(CapabilityKind::Crypto),
         "crypto_hmac_sha512" => Some(CapabilityKind::Crypto),

--- a/stage1/crates/axiomc/src/stdlib.rs
+++ b/stage1/crates/axiomc/src/stdlib.rs
@@ -14,7 +14,8 @@
 //! * `std/time.ax` — `Duration`, `Instant`, `now_ms()`, `now()`,
 //!   `elapsed_ms(start)`, and `sleep(duration)` on top of `clock_now_ms`,
 //!   `clock_elapsed_ms`, and `clock_sleep_ms` (clock).
-//! * `std/env.ax` — `get_env(key)` on top of `env_get` (env).
+//! * `std/env.ax` — runtime environment and current-directory access on top of
+//!   `env_get` and `env_cwd` (env).
 //! * `std/fs.ax` — `read_file(path)` on top of `fs_read` (fs) plus write-side helpers behind `fs:write`.
 //! * `std/net.ax` — `resolve(host)` on top of `net_resolve`, plus a bounded
 //!   loopback-only TCP/UDP socket floor on top of `net_tcp_*` and `net_udp_*`
@@ -132,7 +133,8 @@ pub fn sleep(duration: Duration): int {\nreturn clock_sleep_ms(duration.ms)\n}\n
     ),
     (
         "env.ax",
-        "pub fn get_env(key: string): Option<string> {\nreturn env_get(key)\n}\n",
+        "pub fn get_env(key: string): Option<string> {\nreturn env_get(key)\n}\n\
+pub fn cwd(): Option<string> {\nreturn env_cwd()\n}\n",
     ),
     (
         "fs.ax",

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -8556,6 +8556,70 @@ fn cranelift_backend_runtime_env_match_prints_string_payload_at_runtime() {
     assert!(!present_stdout.contains("build-time-sentinel"));
 }
 
+#[cfg(not(windows))]
+#[test]
+fn cranelift_backend_builds_once_and_reads_cwd_at_each_run() {
+    if which::which("cc").is_err() {
+        eprintln!("skipping cranelift backend cwd smoke test because cc is unavailable");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("cwd-runtime");
+    write_env_cwd_project(&project);
+    let first_cwd = temp.path().join("first-run");
+    let second_cwd = temp.path().join("second-run");
+    fs::create_dir_all(&first_cwd).expect("create first cwd");
+    fs::create_dir_all(&second_cwd).expect("create second cwd");
+    let first_cwd = fs::canonicalize(&first_cwd).expect("canonicalize first cwd");
+    let second_cwd = fs::canonicalize(&second_cwd).expect("canonicalize second cwd");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args([
+            "build",
+            project.to_str().expect("project path"),
+            "--backend",
+            "cranelift",
+            "--json",
+        ])
+        .output()
+        .expect("run axiomc build --backend cranelift");
+    assert!(
+        output.status.success(),
+        "cranelift cwd build failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
+    assert_eq!(payload["backend"], "cranelift");
+    assert_eq!(payload["generated_rust"], Value::Null);
+    let binary = payload["binary"].as_str().expect("binary path");
+    let audit_log = temp.path().join("cwd-audit.jsonl");
+
+    let first = Command::new(binary)
+        .current_dir(&first_cwd)
+        .env("AXIOM_HOST_AUDIT_LOG", &audit_log)
+        .output()
+        .expect("run binary from first cwd");
+    assert!(first.status.success());
+    assert_eq!(String::from_utf8_lossy(&first.stdout), format!("{}\n", first_cwd.display()));
+
+    let second = Command::new(binary)
+        .current_dir(&second_cwd)
+        .env("AXIOM_HOST_AUDIT_LOG", &audit_log)
+        .output()
+        .expect("run binary from second cwd");
+    assert!(second.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&second.stdout),
+        format!("{}\n", second_cwd.display())
+    );
+
+    let audit = fs::read_to_string(&audit_log).expect("read cwd audit log");
+    assert!(audit.contains("\"intrinsic\":\"env_cwd\""), "{audit}");
+    assert!(audit.contains("\"outcome\":\"ok\""), "{audit}");
+}
+
 #[test]
 fn cranelift_backend_rejects_env_denial_before_backend_lowering() {
     let temp = tempfile::tempdir().expect("tempdir");
@@ -16321,6 +16385,25 @@ fn write_env_read_project(project: &Path) {
         "import \"std/env.ax\"\nmatch get_env(\"AXIOM_CRANELIFT_ENV_READ\") {\nSome(value) {\nprint value\n}\nNone {\nprint \"missing value\"\n}\n}\nmatch get_env(\"__AXIOM_CRANELIFT_ENV_MISSING__\") {\nSome(value) {\nprint value\n}\nNone {\nprint \"missing\"\n}\n}\n",
     )
     .expect("write env source");
+}
+
+fn write_env_cwd_project(project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create cwd project src");
+    fs::write(
+        project.join("axiom.toml"),
+        "[package]\nname = \"cranelift-env-cwd\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.ax\"\nout_dir = \"dist\"\n\n[capabilities]\nfs = false\nnet = false\nprocess = false\nenv = true\nclock = false\ncrypto = false\n",
+    )
+    .expect("write cwd manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        "version = 1\n\n[[package]]\nname = \"cranelift-env-cwd\"\nversion = \"0.1.0\"\nsource = \"path\"\n",
+    )
+    .expect("write cwd lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        "import \"std/env.ax\"\nmatch cwd() {\nSome(value) {\nprint value\n}\nNone {\nprint \"missing\"\n}\n}\n",
+    )
+    .expect("write cwd source");
 }
 
 fn write_env_allowlist_output_project(project: &Path) {


### PR DESCRIPTION
## Summary

- Add `cwd()` to `std/env.ax` as a capability-gated runtime current-directory helper.
- Add generated-Rust auditing and direct-native Cranelift lowering, including runtime payload output.
- Add an A/B test proving one compiled binary observes the current directory at each run.

## Governing Issue

Refs #1477

## Validation

- [x] Relevant local checks passed
- [ ] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Passed:

- `cargo check --manifest-path stage1/Cargo.toml -p axiomc --locked`
- focused `cwd()` Cranelift runtime test
- existing runtime environment payload test
- stdlib catalog, capability ledger, and public contract checks
- `git diff --check`

The full `cranelift_backend` integration suite currently has 32 unrelated baseline failures because its generated fixtures still use the removed `[unsafe_rationale]` manifest table; 148/180 tests passed, including both environment runtime tests and the new cwd test. The compiler source monolith ratchet also reports pre-existing ceilings above the current branch baseline.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] PR author enabled auto-merge where GitHub allows it, or GitHub plan-limit evidence/unavailable reason is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Flow Contract

- Owner lane: compiler runtime / native backend
- Repair owner: PR author for implementation; independent reviewer for approval
- Autonomy class: bounded issue slice
- Risk class: capability-gated runtime ABI and native code generation

## Flow Merge Readiness

- [ ] Every blocker has a next actor and next action
- [ ] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] PR author enabled auto-merge where GitHub allows it

## Merge Automation

- [x] PR author enabled auto-merge with `gh pr merge --auto --squash`

## Notes

- Independent non-author review is required before merge; the author will not approve or merge this PR.
- The local autoreview gate could not complete because the external Codex review transport disconnected; it is not treated as an approval.
