### PR TITLE
Cover the axiomc bin target in PR fast CI

### DIFF
--- a/.github/workflows/pr-fast-ci.yml
+++ b/.github/workflows/pr-fast-ci.yml
@@ -233,6 +233,15 @@ jobs:
         # runners do not produce false reds.
         run: RUST_MIN_STACK=8388608 cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib --features run-native-tests -- --test-threads=1
 
+      - name: Run axiomc bin suite
+        # SECURITY/COVERAGE (#1542): CI enumerates test targets by allowlist and
+        # the bin target was in none of them, so the CLI argument and help
+        # surface in main.rs never ran in CI. #1519 reworded a clap doc comment
+        # and left main red while every check stayed green. Keep this alongside
+        # the --lib lane; do not collapse the two into a bare `cargo test`,
+        # which would also pull in the 16.8k-line tests/cranelift_backend.rs.
+        run: RUST_MIN_STACK=8388608 cargo test --manifest-path stage1/Cargo.toml -p axiomc --bin axiomc --features run-native-tests -- --test-threads=1
+
   provider-abi-target-matrix:
     name: Provider ABI C Fixture (${{ matrix.target }})
     runs-on: ['self-hosted', 'linux', 'shell-only', 'public']

--- a/scripts/ci/test-pr-fast-ci-workflow.sh
+++ b/scripts/ci/test-pr-fast-ci-workflow.sh
@@ -79,6 +79,7 @@ full_lib_suite_section="$(
   ' "$workflow"
 )"
 full_lib_suite_linker=$(printf '%s\n' "$full_lib_suite_section" | grep -F 'Ensure Rust linker availability' || true)
+axiomc_bin_suite=$(printf '%s\n' "$full_lib_suite_section" | grep -F -- 'cargo test --manifest-path stage1/Cargo.toml -p axiomc --bin axiomc --features run-native-tests' || true)
 proof_workload_test=$(grep -nF 'bash scripts/ci/run-stage1-proof-test.sh' "$fast_checks_script" || true)
 stdlib_catalog_check=$(grep -nF 'scripts/ci/check-stdlib-catalog.py' "$fast_checks_script" || true)
 stdlib_catalog_regression=$(grep -nF 'scripts/ci/test-check-stdlib-catalog.py' "$fast_checks_script" || true)
@@ -187,6 +188,11 @@ fi
 
 if [[ -z "$runtime_abi_coverage_check" ]]; then
   echo "run-fast-checks must validate the direct-native runtime ABI coverage matrix" >&2
+  exit 1
+fi
+
+if [[ -z "$axiomc_bin_suite" ]]; then
+  echo "fast-checks must execute the axiomc bin target so CLI/help tests cannot disappear from PR CI (#1542)" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Add a dedicated `--bin axiomc` lane to `fast-checks` beside the existing `--lib` lane.
- Keep the lane explicitly scoped so fast CI covers the CLI binary without pulling in the large backend integration target.
- Add a workflow self-test assertion so the bin lane cannot silently disappear from PR CI.

## Governing Issue

Closes #1542

## Root cause

The PR workflow enumerates Cargo test targets by allowlist, but `axiomc`'s binary target was absent. The existing `--lib` lane therefore did not execute the CLI/help tests that caught the stale assertions on `main`.

## Validation

- `RUST_MIN_STACK=8388608 cargo test --manifest-path stage1/Cargo.toml -p axiomc --bin axiomc --features run-native-tests -- --test-threads=1` — 116 passed
- `bash scripts/ci/test-pr-fast-ci-workflow.sh` — passed
- `bash scripts/ci/test-pr-fast-ci-workflow.sh` — passed
- `python3 scripts/ci/extract-public-contract-v1.py --check` — passed
- `python3 scripts/ci/report-compiler-source-monoliths.py --check-ratchet` — passed
- `git diff --check` — passed

## Review and merge gates

- Owner lane: CI / repo quality
- Risk: low; this adds coverage only and does not change product behavior.
- Independent non-author review remains required before merge; Athena is requested.
- Auto-merge is intentionally left off for explicit human merge approval of the required CI-lane change.
