### PR TITLE
Execute benchmark entrypoints from the Stage 1 harness

### DIFF
--- a/docs/performance-benchmarks.md
+++ b/docs/performance-benchmarks.md
@@ -101,7 +101,11 @@ make stage1-bench
 ```
 
 The report uses schema `axiom.stage1.benchmark_harness.v1` and includes per-step
-samples and medians for each workload. The default fixed examples are `hello`,
+samples and medians for each workload. It also includes a
+`benchmark_entrypoints` section containing the execution-backed
+`axiom.stage1.bench.v1` report for `stage1/examples/benchmarks`. The harness
+fails if the benchmark command returns malformed output, discovers no entrypoint,
+or reports a failed entrypoint. The default fixed examples are `hello`,
 `stdlib_time`, and `stdlib_sync`; callers can invoke the underlying script
 directly to change the round count, workload list, or output path:
 

--- a/scripts/ci/run-fast-checks.sh
+++ b/scripts/ci/run-fast-checks.sh
@@ -19,6 +19,7 @@ bash "$script_repo_root/scripts/ci/test-run-stage1-stdlib-smoke.sh"
 bash "$script_repo_root/scripts/ci/test-run-stage1-proof-test.sh"
 python3 "$script_repo_root/scripts/ci/test-validate-stage1-smoke-report.py"
 python3 "$script_repo_root/scripts/ci/test-stage1-benchmark-workloads.py"
+python3 "$script_repo_root/scripts/ci/test-run-stage1-bench.py"
 bash "$script_repo_root/scripts/ci/test-run-extended-stage1-checks.sh"
 bash "$script_repo_root/scripts/ci/test-run-compiler-property-checks.sh"
 python3 "$script_repo_root/scripts/ci/check-stage1-full-lib-triage.py" \

--- a/scripts/ci/run-stage1-bench.py
+++ b/scripts/ci/run-stage1-bench.py
@@ -13,6 +13,7 @@ from typing import Any
 REPO_ROOT = Path(__file__).resolve().parents[2]
 AXIOMC = ["cargo", "run", "--quiet", "--manifest-path", "stage1/Cargo.toml", "-p", "axiomc", "--"]
 DEFAULT_EXAMPLES = ["hello", "stdlib_time", "stdlib_sync"]
+BENCHMARK_PROJECT = Path("stage1/examples/benchmarks")
 
 
 def run_timed(cmd: list[str]) -> tuple[float, str]:
@@ -61,6 +62,45 @@ def measure(example: str, rounds: int) -> dict[str, Any]:
     return {"project": str(project), "timings": timings}
 
 
+def measure_benchmark_entrypoints(rounds: int) -> dict[str, Any]:
+    """Execute checked-in benchmark entrypoints and retain their structured report."""
+    command = AXIOMC + [
+        "bench",
+        str(BENCHMARK_PROJECT),
+        "--warmup",
+        "1",
+        "--iterations",
+        str(rounds),
+        "--retries",
+        "0",
+        "--json",
+    ]
+    elapsed_ms, stdout = run_timed(command)
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"axiomc bench returned invalid JSON: {exc}") from exc
+
+    if not isinstance(payload, dict):
+        raise SystemExit("axiomc bench returned a non-object report")
+    benches = payload.get("benches")
+    if payload.get("schema_version") != "axiom.stage1.bench.v1":
+        raise SystemExit("axiomc bench returned an unsupported report schema")
+    if not isinstance(benches, list) or not benches:
+        raise SystemExit("axiomc bench discovered no benchmark entrypoints")
+    if payload.get("failed") != 0 or any(
+        not isinstance(bench, dict) or bench.get("ok") is not True for bench in benches
+    ):
+        raise SystemExit("axiomc bench reported a failed benchmark entrypoint")
+
+    return {
+        "project": str(BENCHMARK_PROJECT),
+        "command": command,
+        "elapsed_ms": round(elapsed_ms, 3),
+        "report": payload,
+    }
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Record stage1 parser/check/build/run benchmark timings as JSON.")
     parser.add_argument("--rounds", type=int, default=3)
@@ -82,6 +122,7 @@ def main() -> int:
         "rounds": args.rounds,
         "commands": ["parse", "check", "build", "run"],
         "workloads": {example: measure(example, args.rounds) for example in args.examples},
+        "benchmark_entrypoints": measure_benchmark_entrypoints(args.rounds),
     }
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(json.dumps(report, indent=2) + "\n")

--- a/scripts/ci/test-run-stage1-bench.py
+++ b/scripts/ci/test-run-stage1-bench.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT = Path(__file__).with_name("run-stage1-bench.py")
+SPEC = importlib.util.spec_from_file_location("run_stage1_bench", SCRIPT)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class Stage1BenchHarnessTests(unittest.TestCase):
+    def test_benchmark_command_requests_execution_report(self):
+        payload = {
+            "schema_version": "axiom.stage1.bench.v1",
+            "benches": [{"id": "src/example_bench", "ok": True}],
+            "failed": 0,
+        }
+        with patch.object(
+            MODULE,
+            "run_timed",
+            return_value=(12.5, json.dumps(payload)),
+        ) as run_timed:
+            report = MODULE.measure_benchmark_entrypoints(3)
+
+        command = run_timed.call_args.args[0]
+        self.assertEqual(command[-1], "--json")
+        self.assertIn("bench", command)
+        self.assertIn("--iterations", command)
+        self.assertIn("3", command)
+        self.assertEqual(report["report"], payload)
+        self.assertEqual(report["elapsed_ms"], 12.5)
+
+    def test_benchmark_command_rejects_failed_entrypoints(self):
+        payload = {
+            "schema_version": "axiom.stage1.bench.v1",
+            "benches": [{"id": "src/example_bench", "ok": False}],
+            "failed": 1,
+        }
+        with patch.object(
+            MODULE,
+            "run_timed",
+            return_value=(1.0, json.dumps(payload)),
+        ), self.assertRaisesRegex(SystemExit, "failed benchmark"):
+            MODULE.measure_benchmark_entrypoints(1)
+
+    def test_benchmark_command_rejects_missing_entrypoints(self):
+        payload = {
+            "schema_version": "axiom.stage1.bench.v1",
+            "benches": [],
+            "failed": 0,
+        }
+        with patch.object(
+            MODULE,
+            "run_timed",
+            return_value=(1.0, json.dumps(payload)),
+        ), self.assertRaisesRegex(SystemExit, "no benchmark entrypoints"):
+            MODULE.measure_benchmark_entrypoints(1)
+
+    def test_benchmark_command_rejects_non_object_reports(self):
+        with patch.object(
+            MODULE,
+            "run_timed",
+            return_value=(1.0, json.dumps(["not", "a", "report"])),
+        ), self.assertRaisesRegex(SystemExit, "non-object report"):
+            MODULE.measure_benchmark_entrypoints(1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Extend the existing Stage 1 benchmark harness to execute the checked-in `*_bench.ax` entrypoints through `axiomc bench`.
- Preserve the structured `axiom.stage1.bench.v1` report and fail closed on malformed, empty, or unsuccessful benchmark results.
- Add focused harness tests, fast-check wiring, and documentation for the new report section.

## Governing Issue

Refs #1464

## Validation

- [x] Relevant local checks passed
- [ ] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Validation run:

- `python3 scripts/ci/test-run-stage1-bench.py`
- `python3 -m py_compile scripts/ci/run-stage1-bench.py scripts/ci/test-run-stage1-bench.py`
- `python3 scripts/ci/run-stage1-bench.py --rounds 1 --output /private/tmp/axiomlang-issue1464-bench.json`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --bin axiomc benchmark::tests --locked`
- `git diff --check`

The existing numeric comparison gate remains in extended validation; this PR only adds execution-backed entrypoint evidence to the report and does not change baseline thresholds.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] PR author enabled auto-merge where GitHub allows it, or GitHub plan-limit evidence/unavailable reason is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Flow Contract

- Owner lane: Ares
- Repair owner: Codex
- Autonomy class: Class 2 - Review-gated autonomous
- Risk class: Medium

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] PR author enabled auto-merge where GitHub allows it, or recorded why it is unavailable/unsafe

Next actor: `athena-omt` (or another authorized non-author reviewer) must independently review the pushed head before merge.

## Merge Automation

- [ ] PR author enabled auto-merge with `gh pr merge --auto --squash`, or the reason it is unavailable/unsafe is noted below

Auto-merge is intentionally not enabled before the required independent review.

## Notes

- This PR wires the already-implemented execution-backed benchmark command into the existing Stage 1 harness. Full property-generation, shrinking, isolation, and parallelism work from #1464 remains open.
