### PR TITLE
Expose selected versions in package graph decisions

### DIFF
--- a/docs/compiler-package-graph.md
+++ b/docs/compiler-package-graph.md
@@ -66,8 +66,8 @@ Each package node has:
 - Registry dependency data, when applicable: canonical registry/source
   identity, namespace, selected version, archive digest, publisher/signers,
   trust decision, and cache or vendor evidence.
-- Resolver decisions: requested constraint, selected package ID, source kind,
-  stable reason, and candidate/yank disposition.
+- Resolver decisions: requested constraint, explicit selected version and
+  package ID, source kind, stable reason, and candidate/yank disposition.
 
 The root package appears first. Remaining package nodes are sorted by locked
 source and then package name so independent implementations can compare graphs

--- a/docs/compiler-source-decomposition-plan.md
+++ b/docs/compiler-source-decomposition-plan.md
@@ -270,7 +270,7 @@ matching ceiling in this table in the same PR.
 | `stage1/crates/axiomc/src/cranelift_backend/host_crypto.rs` | 783 |
 | `stage1/crates/axiomc/src/cranelift_backend/host_net_http.rs` | 1121 |
 | `stage1/crates/axiomc/src/hir.rs` | 5904 |
-| `stage1/crates/axiomc/src/project.rs` | 13564 |
+| `stage1/crates/axiomc/src/project.rs` | 13571 |
 | `stage1/crates/axiomc/src/project/build_contract.rs` | 118 |
 | `stage1/crates/axiomc/src/main.rs` | 11917 |
 | `stage1/crates/axiomc/src/formatter.rs` | 191 |

--- a/stage1/compatibility/fixtures/current/contract.json
+++ b/stage1/compatibility/fixtures/current/contract.json
@@ -935,13 +935,13 @@
     {
       "id": "axiom://schema/axiom.compiler.package_graph.runtime.v1",
       "kind": "schema",
-      "signature": "published schema id=https://omt-global.github.io/axiom/schemas/axiom.compiler.package_graph.runtime.v1.schema.json; semantic_digest=dc2b6a6aceaf28537fb85c72c76bbf6a805e78f6abe9dd43a20f561152d7ecd3; envelope=axiom.compiler.package_graph.runtime.v1",
+      "signature": "published schema id=https://omt-global.github.io/axiom/schemas/axiom.compiler.package_graph.runtime.v1.schema.json; semantic_digest=1a7ea9f8036c8321a3e15fa1c370cef911a2106bd8cc368758db2abaa56d5341; envelope=axiom.compiler.package_graph.runtime.v1",
       "sources": [
         {
           "path": "stage1/compiler-contracts/schemas/axiom.compiler.package_graph.runtime.v1.schema.json",
           "role": "published_schema",
           "selector": "$id,properties.schema_version.const",
-          "sha256": "707ee3a51df91c3aefee6f56400c9396b4a20f94b59b73c6d8920201847e54ef"
+          "sha256": "ebf9ea142d79ead384f53e6830fadddb38ed95b3c3092ff2c7911c2c0bde7400"
         }
       ],
       "stability": "experimental",

--- a/stage1/compiler-contracts/schemas/axiom.compiler.package_graph.runtime.v1.schema.json
+++ b/stage1/compiler-contracts/schemas/axiom.compiler.package_graph.runtime.v1.schema.json
@@ -222,6 +222,10 @@
           "type": "string",
           "minLength": 1
         },
+        "selected_version": {
+          "type": "string",
+          "minLength": 1
+        },
         "reason": {
           "type": "string",
           "minLength": 1
@@ -244,6 +248,7 @@
               "package_id",
               "source_kind",
               "requested",
+              "selected_version",
               "reason"
             ],
             "properties": {
@@ -271,6 +276,7 @@
               "package_id",
               "source_kind",
               "requested",
+              "selected_version",
               "reason"
             ],
             "properties": {

--- a/stage1/compiler-contracts/snapshots/package-graph-runtime.json
+++ b/stage1/compiler-contracts/snapshots/package-graph-runtime.json
@@ -26,6 +26,7 @@
           "package_id": "registry:default/acme/dep@1.2.3",
           "source_kind": "registry",
           "requested": "^1.2.0",
+          "selected_version": "1.2.3",
           "reason": "highest_compatible"
         }
       ],

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -417,6 +417,8 @@ pub struct PackageGraphDependency {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub requested: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
 }
 
@@ -1865,6 +1867,11 @@ fn package_graph_metadata_with_graph(
                     package_id: graph.package_id(dependency_root).map(str::to_owned),
                     source_kind: edge.map(|edge| edge.source_kind.clone()),
                     requested: edge.map(|edge| edge.requested.clone()),
+                    selected_version: dependency
+                        .manifest
+                        .package
+                        .as_ref()
+                        .map(|package| package.version.clone()),
                     reason: edge.map(|edge| edge.reason.clone()),
                 })
             })

--- a/stage1/crates/axiomc/tests/package_resolver_cli.rs
+++ b/stage1/crates/axiomc/tests/package_resolver_cli.rs
@@ -1358,6 +1358,15 @@ fn fetch_cache_vendor_and_offline_build_fail_closed_round_trip() {
         .find(|package| package["name"] == "core")
         .expect("core graph package");
     assert_eq!(core["source"], "registry:fixture/axiom/core");
+    assert_eq!(
+        app["dependencies"]
+            .as_array()
+            .expect("app dependencies")
+            .iter()
+            .find(|dependency| dependency["name"] == "core")
+            .expect("registry dependency")["selected_version"],
+        "1.2.3"
+    );
     assert!(core["trust"].is_object(), "registry package exposes trust");
     assert_eq!(
         core["materialization"]["package_trust_verified"], true,


### PR DESCRIPTION
## Summary

- Expose the resolved `selected_version` on `axiomc pkg graph --json` dependency decisions.
- Require the field for registry edges and refresh the runtime schema, contract fixture, snapshot, documentation, and CLI regression coverage.
- Rebase the companion slice onto the current `main` head so the PR is no longer behind.

## Governing Issue

Refs #1459

## Validation

- [x] Relevant local checks passed
- [ ] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Validated on the rebased branch from `main` (`b3ec3cb8dadd811f1696b21a7166c1a401f16e32`):

- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test package_resolver_cli --locked` (7 passed; host-level loopback fixture)
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test schema_metadata --locked` (16 passed)
- `python3 scripts/ci/check-package-graph-boundary.py --json`
- `make stage1-package-graph-boundary`
- `python3 scripts/ci/extract-public-contract-v1.py --check`
- `git diff --check`

The local autoreview helper was not used to transmit this private diff to an external review backend. Independent review remains a required PR gate.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] PR author enabled auto-merge where GitHub allows it, or GitHub plan-limit evidence/unavailable reason is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Flow Contract

- Owner lane: compiler/package resolver
- Repair owner: Codex implementation lane
- Autonomy class: review-gated implementation
- Risk class: low; additive runtime metadata and contract update

## Flow Merge Readiness

- [ ] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] PR author did not approve their own change; independent review is required

## Merge Automation

- [ ] PR author enabled auto-merge with `gh pr merge --auto --squash`, or the reason it is unavailable/unsafe is noted below

Auto-merge will be enabled when the refreshed CI and independent review gates permit it.

## Notes

This is a bounded companion slice for #1459. It makes the selected registry version explicit in the agent-facing graph; it does not claim to complete the full package-resolver issue.
