### PR TITLE
Bound LSP and DAP message framing

### DIFF
--- a/stage1/crates/axiomc/src/dap.rs
+++ b/stage1/crates/axiomc/src/dap.rs
@@ -1,4 +1,5 @@
 use crate::diagnostics::Diagnostic;
+use crate::protocol_framing;
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
 use std::fs;
@@ -410,37 +411,8 @@ fn read_message<R>(input: &mut R) -> Result<Option<String>, Diagnostic>
 where
     R: BufRead,
 {
-    let mut content_length = None;
-    loop {
-        let mut line = String::new();
-        let bytes = input
-            .read_line(&mut line)
-            .map_err(|err| Diagnostic::new("dap", format!("failed to read DAP header: {err}")))?;
-        if bytes == 0 {
-            return Ok(None);
-        }
-        let trimmed = line.trim_end_matches(['\r', '\n']);
-        if trimmed.is_empty() {
-            break;
-        }
-        if let Some((name, value)) = trimmed.split_once(':') {
-            if name.trim().eq_ignore_ascii_case("Content-Length") {
-                content_length = Some(value.trim().parse::<usize>().map_err(|err| {
-                    Diagnostic::new("dap", format!("invalid Content-Length header: {err}"))
-                })?);
-            }
-        }
-    }
-
-    let length = content_length
-        .ok_or_else(|| Diagnostic::new("dap", "missing Content-Length header in DAP message"))?;
-    let mut body = vec![0; length];
-    input
-        .read_exact(&mut body)
-        .map_err(|err| Diagnostic::new("dap", format!("failed to read DAP body: {err}")))?;
-    String::from_utf8(body)
-        .map(Some)
-        .map_err(|err| Diagnostic::new("dap", format!("DAP body is not UTF-8: {err}")))
+    protocol_framing::read_message(input)
+        .map_err(|error| Diagnostic::new("dap", format!("invalid DAP frame: {error}")))
 }
 
 fn write_message<W>(output: &mut W, payload: &Value) -> Result<(), Diagnostic>
@@ -457,6 +429,12 @@ where
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    fn dap_frame_error(input: impl Into<Vec<u8>>) -> String {
+        read_message(&mut std::io::Cursor::new(input.into()))
+            .expect_err("frame should be rejected")
+            .message
+    }
 
     fn request(seq: i64, command: &str, arguments: Value) -> String {
         json!({
@@ -587,6 +565,88 @@ mod tests {
         let output = String::from_utf8(output).expect("utf8 output");
         assert!(output.starts_with("Content-Length: "));
         assert!(output.contains(r#""adapterID":"axiom""#));
+    }
+
+    #[test]
+    fn stdio_framing_rejects_invalid_content_lengths_before_allocation() {
+        let cases = [
+            (
+                b"Content-Length: 1\r\ncontent-length: 1\r\n\r\nx".to_vec(),
+                "invalid DAP frame: duplicate Content-Length header".to_string(),
+            ),
+            (
+                b"X-Axiom: test\r\n\r\n".to_vec(),
+                "invalid DAP frame: missing Content-Length header".to_string(),
+            ),
+            (
+                b"Content-Length: nope\r\n\r\n".to_vec(),
+                "invalid DAP frame: malformed Content-Length header".to_string(),
+            ),
+            (
+                format!("Content-Length: {}\r\n\r\n", "9".repeat(100)).into_bytes(),
+                "invalid DAP frame: Content-Length header overflows usize".to_string(),
+            ),
+            (
+                b"Content-Length: 4\r\n\r\nabc".to_vec(),
+                "invalid DAP frame: truncated body: expected 4 bytes".to_string(),
+            ),
+            (
+                format!(
+                    "Content-Length: {}\r\n\r\n",
+                    protocol_framing::MAX_BODY_BYTES + 1
+                )
+                .into_bytes(),
+                format!(
+                    "invalid DAP frame: Content-Length {} exceeds {} byte limit",
+                    protocol_framing::MAX_BODY_BYTES + 1,
+                    protocol_framing::MAX_BODY_BYTES
+                ),
+            ),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(dap_frame_error(input), expected);
+        }
+    }
+
+    #[test]
+    fn stdio_framing_bounds_each_header_total_headers_and_header_count() {
+        let oversized_line = format!(
+            "X:{}\r\nContent-Length: 0\r\n\r\n",
+            "x".repeat(protocol_framing::MAX_HEADER_LINE_BYTES)
+        );
+        assert_eq!(
+            dap_frame_error(oversized_line.into_bytes()),
+            format!(
+                "invalid DAP frame: header line exceeds {} byte limit",
+                protocol_framing::MAX_HEADER_LINE_BYTES
+            )
+        );
+
+        let maximum_line = format!(
+            "X:{}\r\n",
+            "x".repeat(protocol_framing::MAX_HEADER_LINE_BYTES - 4)
+        );
+        let mut oversized_headers = maximum_line
+            .repeat(protocol_framing::MAX_HEADER_BYTES / protocol_framing::MAX_HEADER_LINE_BYTES);
+        oversized_headers.push_str("\r\n");
+        assert_eq!(
+            dap_frame_error(oversized_headers.into_bytes()),
+            format!(
+                "invalid DAP frame: headers exceed {} byte limit",
+                protocol_framing::MAX_HEADER_BYTES
+            )
+        );
+
+        let mut too_many_headers = "X-Axiom: test\r\n".repeat(protocol_framing::MAX_HEADER_COUNT);
+        too_many_headers.push_str("Content-Length: 0\r\n\r\n");
+        assert_eq!(
+            dap_frame_error(too_many_headers.into_bytes()),
+            format!(
+                "invalid DAP frame: header count exceeds {}",
+                protocol_framing::MAX_HEADER_COUNT
+            )
+        );
     }
 
     #[test]

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -25,6 +25,7 @@ pub mod package_store;
 pub mod package_trust;
 pub mod package_version;
 pub mod project;
+mod protocol_framing;
 pub mod registry;
 pub mod registry_client;
 pub mod stdlib;

--- a/stage1/crates/axiomc/src/lsp.rs
+++ b/stage1/crates/axiomc/src/lsp.rs
@@ -3,6 +3,7 @@ use crate::hir;
 use crate::manifest::load_manifest;
 use crate::mir;
 use crate::project::{analyze_package_for_lsp, package_graph_metadata, project_capabilities};
+use crate::protocol_framing;
 use crate::syntax;
 use serde_json::{Value, json};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
@@ -1094,38 +1095,8 @@ fn read_message<R>(input: &mut R) -> Result<Option<String>, Diagnostic>
 where
     R: BufRead,
 {
-    let mut content_length = None;
-    loop {
-        let mut line = String::new();
-        let bytes = input
-            .read_line(&mut line)
-            .map_err(|err| Diagnostic::new("lsp", format!("failed to read LSP header: {err}")))?;
-        if bytes == 0 {
-            return Ok(None);
-        }
-        let trimmed = line.trim_end_matches(['\r', '\n']);
-        if trimmed.is_empty() {
-            break;
-        }
-        if let Some((name, value)) = trimmed.split_once(':') {
-            if !name.trim().eq_ignore_ascii_case("Content-Length") {
-                continue;
-            }
-            content_length = Some(value.trim().parse::<usize>().map_err(|err| {
-                Diagnostic::new("lsp", format!("invalid Content-Length header: {err}"))
-            })?);
-        }
-    }
-
-    let length = content_length
-        .ok_or_else(|| Diagnostic::new("lsp", "missing Content-Length header in LSP message"))?;
-    let mut body = vec![0; length];
-    input
-        .read_exact(&mut body)
-        .map_err(|err| Diagnostic::new("lsp", format!("failed to read LSP body: {err}")))?;
-    String::from_utf8(body)
-        .map(Some)
-        .map_err(|err| Diagnostic::new("lsp", format!("LSP body is not UTF-8: {err}")))
+    protocol_framing::read_message(input)
+        .map_err(|error| Diagnostic::new("lsp", format!("invalid LSP frame: {error}")))
 }
 
 fn write_message<W>(output: &mut W, payload: &Value) -> Result<(), Diagnostic>
@@ -1244,6 +1215,12 @@ fn percent_decode(input: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn lsp_frame_error(input: impl Into<Vec<u8>>) -> String {
+        read_message(&mut std::io::Cursor::new(input.into()))
+            .expect_err("frame should be rejected")
+            .message
+    }
 
     fn notification(method: &str, params: Value) -> String {
         json!({
@@ -1620,6 +1597,88 @@ mod tests {
         let output = String::from_utf8(output).expect("utf8 output");
         assert!(output.starts_with("Content-Length: "));
         assert!(output.contains(r#""id":8"#));
+    }
+
+    #[test]
+    fn stdio_framing_rejects_invalid_content_lengths_before_allocation() {
+        let cases = [
+            (
+                b"Content-Length: 1\r\ncontent-length: 1\r\n\r\nx".to_vec(),
+                "invalid LSP frame: duplicate Content-Length header".to_string(),
+            ),
+            (
+                b"X-Axiom: test\r\n\r\n".to_vec(),
+                "invalid LSP frame: missing Content-Length header".to_string(),
+            ),
+            (
+                b"Content-Length: nope\r\n\r\n".to_vec(),
+                "invalid LSP frame: malformed Content-Length header".to_string(),
+            ),
+            (
+                format!("Content-Length: {}\r\n\r\n", "9".repeat(100)).into_bytes(),
+                "invalid LSP frame: Content-Length header overflows usize".to_string(),
+            ),
+            (
+                b"Content-Length: 4\r\n\r\nabc".to_vec(),
+                "invalid LSP frame: truncated body: expected 4 bytes".to_string(),
+            ),
+            (
+                format!(
+                    "Content-Length: {}\r\n\r\n",
+                    protocol_framing::MAX_BODY_BYTES + 1
+                )
+                .into_bytes(),
+                format!(
+                    "invalid LSP frame: Content-Length {} exceeds {} byte limit",
+                    protocol_framing::MAX_BODY_BYTES + 1,
+                    protocol_framing::MAX_BODY_BYTES
+                ),
+            ),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(lsp_frame_error(input), expected);
+        }
+    }
+
+    #[test]
+    fn stdio_framing_bounds_each_header_total_headers_and_header_count() {
+        let oversized_line = format!(
+            "X:{}\r\nContent-Length: 0\r\n\r\n",
+            "x".repeat(protocol_framing::MAX_HEADER_LINE_BYTES)
+        );
+        assert_eq!(
+            lsp_frame_error(oversized_line.into_bytes()),
+            format!(
+                "invalid LSP frame: header line exceeds {} byte limit",
+                protocol_framing::MAX_HEADER_LINE_BYTES
+            )
+        );
+
+        let maximum_line = format!(
+            "X:{}\r\n",
+            "x".repeat(protocol_framing::MAX_HEADER_LINE_BYTES - 4)
+        );
+        let mut oversized_headers = maximum_line
+            .repeat(protocol_framing::MAX_HEADER_BYTES / protocol_framing::MAX_HEADER_LINE_BYTES);
+        oversized_headers.push_str("\r\n");
+        assert_eq!(
+            lsp_frame_error(oversized_headers.into_bytes()),
+            format!(
+                "invalid LSP frame: headers exceed {} byte limit",
+                protocol_framing::MAX_HEADER_BYTES
+            )
+        );
+
+        let mut too_many_headers = "X-Axiom: test\r\n".repeat(protocol_framing::MAX_HEADER_COUNT);
+        too_many_headers.push_str("Content-Length: 0\r\n\r\n");
+        assert_eq!(
+            lsp_frame_error(too_many_headers.into_bytes()),
+            format!(
+                "invalid LSP frame: header count exceeds {}",
+                protocol_framing::MAX_HEADER_COUNT
+            )
+        );
     }
 
     #[test]

--- a/stage1/crates/axiomc/src/protocol_framing.rs
+++ b/stage1/crates/axiomc/src/protocol_framing.rs
@@ -1,0 +1,203 @@
+use std::fmt;
+use std::io::{self, BufRead};
+
+pub(crate) const MAX_HEADER_LINE_BYTES: usize = 8 * 1024;
+pub(crate) const MAX_HEADER_BYTES: usize = 32 * 1024;
+pub(crate) const MAX_HEADER_COUNT: usize = 64;
+pub(crate) const MAX_BODY_BYTES: usize = 16 * 1024 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum FrameReadError {
+    HeaderRead(String),
+    HeaderLineTooLarge,
+    HeadersTooLarge,
+    TooManyHeaders,
+    HeaderAllocationFailed,
+    TruncatedHeaders,
+    MalformedHeader,
+    MissingContentLength,
+    DuplicateContentLength,
+    MalformedContentLength,
+    ContentLengthOverflow,
+    BodyTooLarge { declared: usize },
+    BodyAllocationFailed,
+    TruncatedBody { expected: usize },
+    BodyRead(String),
+    InvalidUtf8Body,
+}
+
+impl fmt::Display for FrameReadError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::HeaderRead(error) => write!(formatter, "failed to read header: {error}"),
+            Self::HeaderLineTooLarge => write!(
+                formatter,
+                "header line exceeds {MAX_HEADER_LINE_BYTES} byte limit"
+            ),
+            Self::HeadersTooLarge => {
+                write!(formatter, "headers exceed {MAX_HEADER_BYTES} byte limit")
+            }
+            Self::TooManyHeaders => {
+                write!(formatter, "header count exceeds {MAX_HEADER_COUNT}")
+            }
+            Self::HeaderAllocationFailed => write!(formatter, "failed to allocate header buffer"),
+            Self::TruncatedHeaders => write!(formatter, "truncated headers"),
+            Self::MalformedHeader => write!(formatter, "malformed header line"),
+            Self::MissingContentLength => write!(formatter, "missing Content-Length header"),
+            Self::DuplicateContentLength => write!(formatter, "duplicate Content-Length header"),
+            Self::MalformedContentLength => write!(formatter, "malformed Content-Length header"),
+            Self::ContentLengthOverflow => {
+                write!(formatter, "Content-Length header overflows usize")
+            }
+            Self::BodyTooLarge { declared } => write!(
+                formatter,
+                "Content-Length {declared} exceeds {MAX_BODY_BYTES} byte limit"
+            ),
+            Self::BodyAllocationFailed => write!(formatter, "failed to allocate body buffer"),
+            Self::TruncatedBody { expected } => {
+                write!(formatter, "truncated body: expected {expected} bytes")
+            }
+            Self::BodyRead(error) => write!(formatter, "failed to read body: {error}"),
+            Self::InvalidUtf8Body => write!(formatter, "body is not UTF-8"),
+        }
+    }
+}
+
+enum HeaderLine {
+    Eof,
+    Bytes(Vec<u8>),
+}
+
+pub(crate) fn read_message<R>(input: &mut R) -> Result<Option<String>, FrameReadError>
+where
+    R: BufRead,
+{
+    let mut header_bytes = 0usize;
+    let mut header_count = 0usize;
+    let mut content_length = None;
+
+    loop {
+        let mut line = match read_header_line(input, &mut header_bytes)? {
+            HeaderLine::Eof if header_bytes == 0 => return Ok(None),
+            HeaderLine::Eof => return Err(FrameReadError::TruncatedHeaders),
+            HeaderLine::Bytes(line) => line,
+        };
+
+        while line
+            .last()
+            .is_some_and(|byte| matches!(byte, b'\r' | b'\n'))
+        {
+            line.pop();
+        }
+        if line.is_empty() {
+            break;
+        }
+
+        header_count = header_count
+            .checked_add(1)
+            .ok_or(FrameReadError::TooManyHeaders)?;
+        if header_count > MAX_HEADER_COUNT {
+            return Err(FrameReadError::TooManyHeaders);
+        }
+
+        let line = std::str::from_utf8(&line).map_err(|_| FrameReadError::MalformedHeader)?;
+        let (name, value) = line
+            .split_once(':')
+            .ok_or(FrameReadError::MalformedHeader)?;
+        if name.trim().is_empty() {
+            return Err(FrameReadError::MalformedHeader);
+        }
+        if !name.trim().eq_ignore_ascii_case("Content-Length") {
+            continue;
+        }
+        if content_length.is_some() {
+            return Err(FrameReadError::DuplicateContentLength);
+        }
+        content_length = Some(parse_content_length(value)?);
+    }
+
+    let length = content_length.ok_or(FrameReadError::MissingContentLength)?;
+    if length > MAX_BODY_BYTES {
+        return Err(FrameReadError::BodyTooLarge { declared: length });
+    }
+
+    let mut body = Vec::new();
+    body.try_reserve_exact(length)
+        .map_err(|_| FrameReadError::BodyAllocationFailed)?;
+    body.resize(length, 0);
+    match input.read_exact(&mut body) {
+        Ok(()) => {}
+        Err(error) if error.kind() == io::ErrorKind::UnexpectedEof => {
+            return Err(FrameReadError::TruncatedBody { expected: length });
+        }
+        Err(error) => return Err(FrameReadError::BodyRead(error.to_string())),
+    }
+
+    String::from_utf8(body)
+        .map(Some)
+        .map_err(|_| FrameReadError::InvalidUtf8Body)
+}
+
+fn read_header_line<R>(
+    input: &mut R,
+    header_bytes: &mut usize,
+) -> Result<HeaderLine, FrameReadError>
+where
+    R: BufRead,
+{
+    let mut line = Vec::new();
+    loop {
+        let buffer = input
+            .fill_buf()
+            .map_err(|error| FrameReadError::HeaderRead(error.to_string()))?;
+        if buffer.is_empty() {
+            return if line.is_empty() {
+                Ok(HeaderLine::Eof)
+            } else {
+                Err(FrameReadError::TruncatedHeaders)
+            };
+        }
+
+        let bytes_to_take = buffer
+            .iter()
+            .position(|byte| *byte == b'\n')
+            .map_or(buffer.len(), |newline| newline + 1);
+        let line_length = line
+            .len()
+            .checked_add(bytes_to_take)
+            .ok_or(FrameReadError::HeaderLineTooLarge)?;
+        if line_length > MAX_HEADER_LINE_BYTES {
+            return Err(FrameReadError::HeaderLineTooLarge);
+        }
+        let total_length = header_bytes
+            .checked_add(bytes_to_take)
+            .ok_or(FrameReadError::HeadersTooLarge)?;
+        if total_length > MAX_HEADER_BYTES {
+            return Err(FrameReadError::HeadersTooLarge);
+        }
+
+        line.try_reserve_exact(bytes_to_take)
+            .map_err(|_| FrameReadError::HeaderAllocationFailed)?;
+        line.extend_from_slice(&buffer[..bytes_to_take]);
+        input.consume(bytes_to_take);
+        *header_bytes = total_length;
+
+        if line.last() == Some(&b'\n') {
+            return Ok(HeaderLine::Bytes(line));
+        }
+    }
+}
+
+fn parse_content_length(value: &str) -> Result<usize, FrameReadError> {
+    let value = value.trim();
+    if value.is_empty() || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(FrameReadError::MalformedContentLength);
+    }
+
+    value.bytes().try_fold(0usize, |length, byte| {
+        length
+            .checked_mul(10)
+            .and_then(|length| length.checked_add(usize::from(byte - b'0')))
+            .ok_or(FrameReadError::ContentLengthOverflow)
+    })
+}


### PR DESCRIPTION
## Summary

- route LSP and DAP through one shared Content-Length framing reader
- cap line, aggregate header, header count, and body size before allocation
- reject duplicate, missing, malformed, overflowing, truncated, oversized, and invalid-UTF-8 frames with stable endpoint diagnostics

## Governing Issue

Closes #1573
Refs #1586

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected where applicable (not applicable)
- [ ] PR author enabled auto-merge, or fallback reason is recorded below
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Flow Contract

- Owner lane: Ares/Hephaestus tooling
- Repair owner: issue #1573 feature branch
- Autonomy class: Class 2, review-gated
- Risk class: high

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [ ] Auto-merge is enabled or recorded unavailable/unsafe below

## Merge Automation

- [ ] Auto-merge is intentionally deferred while this draft awaits non-author review and required CI.

## Notes

Validation:

- `RUST_MIN_STACK=8388608 cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib stdio` — 11 passed
- `RUST_MIN_STACK=8388608 cargo test --manifest-path stage1/Cargo.toml -p axiomc --test lsp_stdio` — 1 passed
- `rustfmt --edition 2021 --check stage1/crates/axiomc/src/protocol_framing.rs`
- `git diff --check`

Whole-file rustfmt on legacy `lsp.rs`/`dap.rs` would reformat unrelated baseline code, so it was not applied. The external autoreview helper was not run because private-source export was not authorized. An independent in-thread reliability reviewer inspected the final diff and reported it clean.