### PR TITLE
Harden direct-native fs_replace authority

### DIFF
--- a/stage1/crates/axiomc-backend-cranelift/src/lib.rs
+++ b/stage1/crates/axiomc-backend-cranelift/src/lib.rs
@@ -6075,6 +6075,7 @@ fn emit_i64_replace_file_expr(
 
         let failed_block = builder.create_block();
         let create_block = builder.create_block();
+        let create_failed_block = builder.create_block();
         let chmod_block = builder.create_block();
         let write_block = builder.create_block();
         let sync_block = builder.create_block();
@@ -6106,7 +6107,13 @@ fn emit_i64_replace_file_expr(
         let create_failed = builder.ins().icmp_imm(IntCC::SignedLessThan, file, 0);
         builder
             .ins()
-            .brif(create_failed, failed_block, &[], chmod_block, &[]);
+            .brif(create_failed, create_failed_block, &[], chmod_block, &[]);
+
+        builder.switch_to_block(create_failed_block);
+        builder.seal_block(create_failed_block);
+        builder.ins().call(runtime_refs.close, &[parent_fd]);
+        let failed = builder.ins().iconst(types::I64, -1);
+        builder.ins().jump(merge_block, &[BlockArg::Value(failed)]);
 
         builder.switch_to_block(chmod_block);
         builder.seal_block(chmod_block);
@@ -7215,6 +7222,54 @@ mod tests {
         assert!(
             !temp_fixture.exists(),
             "runtime replace should not leave the temp fixture"
+        );
+    }
+
+    #[test]
+    fn links_i64_exit_program_with_replace_file_rejects_temp_collision() {
+        if std::env::var_os("AXIOM_SKIP_CRANELIFT_LINK_TEST").is_some() {
+            return;
+        }
+        if Command::new("cc").arg("--version").output().is_err() {
+            eprintln!("skipping cranelift link test because cc is unavailable");
+            return;
+        }
+        let temp = tempfile::tempdir().expect("tempdir");
+        let fixture = temp.path().join("fixture.txt");
+        let collision = temp.path().join(".axiom-replace-0000000000001234");
+        fs::write(&fixture, "base").expect("write replace base fixture");
+        fs::write(&collision, "collision").expect("plant colliding temp fixture");
+        let object = temp.path().join("i64-exit-replace-collision.o");
+        let binary = temp.path().join("i64-exit-replace-collision");
+        compile_i64_exit_program(
+            I64ExitProgram {
+                functions: Vec::new(),
+                locals: Vec::new(),
+                stmts: Vec::new(),
+                body: I64ExitBody::Return(I64Expr::ReplaceFile {
+                    root: temp.path().display().to_string(),
+                    parent_components: Vec::new(),
+                    destination_name: "fixture.txt".to_string(),
+                    content: String::from("runtime-replace"),
+                }),
+            },
+            &object,
+            &binary,
+        )
+        .expect("compile i64 replace collision exit program");
+
+        let output = Command::new(&binary)
+            .env("AXIOM_TEST_RANDOM_U64", "4660")
+            .output()
+            .expect("run replace collision binary");
+        assert_eq!(output.status.code(), Some(255));
+        assert_eq!(
+            fs::read_to_string(&fixture).expect("read unchanged replace fixture"),
+            "base"
+        );
+        assert_eq!(
+            fs::read_to_string(&collision).expect("read colliding temp fixture"),
+            "collision"
         );
     }
 

--- a/stage1/crates/axiomc-backend-cranelift/src/lib.rs
+++ b/stage1/crates/axiomc-backend-cranelift/src/lib.rs
@@ -79,8 +79,12 @@ struct I64RuntimeRefs {
     atoll: FuncRef,
     open: FuncRef,
     creat: FuncRef,
+    #[cfg(not(windows))]
+    mkstemp: FuncRef,
     lseek: FuncRef,
     close: FuncRef,
+    #[cfg(not(windows))]
+    fsync: FuncRef,
     access: FuncRef,
     #[cfg(windows)]
     system: FuncRef,
@@ -788,6 +792,17 @@ fn emit_i64_exit_object(
         .map_err(|message| {
             CraneliftBackendError::new(format!("declare creat import: {message}"))
         })?;
+    #[cfg(not(windows))]
+    let mkstemp_id = {
+        let mut signature = module.make_signature();
+        signature.params.push(AbiParam::new(pointer_type));
+        signature.returns.push(AbiParam::new(types::I32));
+        module
+            .declare_function("mkstemp", Linkage::Import, &signature)
+            .map_err(|message| {
+                CraneliftBackendError::new(format!("declare mkstemp import: {message}"))
+            })?
+    };
     let mut lseek_sig = module.make_signature();
     lseek_sig.params.push(AbiParam::new(types::I32));
     lseek_sig.params.push(AbiParam::new(types::I64));
@@ -806,6 +821,17 @@ fn emit_i64_exit_object(
         .map_err(|message| {
             CraneliftBackendError::new(format!("declare close import: {message}"))
         })?;
+    #[cfg(not(windows))]
+    let fsync_id = {
+        let mut signature = module.make_signature();
+        signature.params.push(AbiParam::new(types::I32));
+        signature.returns.push(AbiParam::new(types::I32));
+        module
+            .declare_function("fsync", Linkage::Import, &signature)
+            .map_err(|message| {
+                CraneliftBackendError::new(format!("declare fsync import: {message}"))
+            })?
+    };
     let mut access_sig = module.make_signature();
     access_sig.params.push(AbiParam::new(pointer_type));
     access_sig.params.push(AbiParam::new(types::I32));
@@ -1058,8 +1084,10 @@ fn emit_i64_exit_object(
                 atoll_id,
                 open_id,
                 creat_id,
+                mkstemp_id,
                 lseek_id,
                 close_id,
+                fsync_id,
                 access_id,
                 fork_id,
                 execv_id,
@@ -1160,8 +1188,12 @@ fn emit_i64_exit_object(
         let atoll_ref = module.declare_func_in_func(atoll_id, builder.func);
         let open_ref = module.declare_func_in_func(open_id, builder.func);
         let creat_ref = module.declare_func_in_func(creat_id, builder.func);
+        #[cfg(not(windows))]
+        let mkstemp_ref = module.declare_func_in_func(mkstemp_id, builder.func);
         let lseek_ref = module.declare_func_in_func(lseek_id, builder.func);
         let close_ref = module.declare_func_in_func(close_id, builder.func);
+        #[cfg(not(windows))]
+        let fsync_ref = module.declare_func_in_func(fsync_id, builder.func);
         let access_ref = module.declare_func_in_func(access_id, builder.func);
         #[cfg(windows)]
         let system_ref = module.declare_func_in_func(system_id, builder.func);
@@ -1208,8 +1240,12 @@ fn emit_i64_exit_object(
             atoll: atoll_ref,
             open: open_ref,
             creat: creat_ref,
+            #[cfg(not(windows))]
+            mkstemp: mkstemp_ref,
             lseek: lseek_ref,
             close: close_ref,
+            #[cfg(not(windows))]
+            fsync: fsync_ref,
             access: access_ref,
             #[cfg(windows)]
             system: system_ref,
@@ -1476,8 +1512,12 @@ fn define_i64_function(
     atoll_id: FuncId,
     open_id: FuncId,
     creat_id: FuncId,
+    #[cfg(not(windows))]
+    mkstemp_id: FuncId,
     lseek_id: FuncId,
     close_id: FuncId,
+    #[cfg(not(windows))]
+    fsync_id: FuncId,
     access_id: FuncId,
     #[cfg(windows)] system_id: FuncId,
     #[cfg(not(windows))] fork_id: FuncId,
@@ -1546,8 +1586,12 @@ fn define_i64_function(
         let atoll_ref = module.declare_func_in_func(atoll_id, builder.func);
         let open_ref = module.declare_func_in_func(open_id, builder.func);
         let creat_ref = module.declare_func_in_func(creat_id, builder.func);
+        #[cfg(not(windows))]
+        let mkstemp_ref = module.declare_func_in_func(mkstemp_id, builder.func);
         let lseek_ref = module.declare_func_in_func(lseek_id, builder.func);
         let close_ref = module.declare_func_in_func(close_id, builder.func);
+        #[cfg(not(windows))]
+        let fsync_ref = module.declare_func_in_func(fsync_id, builder.func);
         let access_ref = module.declare_func_in_func(access_id, builder.func);
         #[cfg(windows)]
         let system_ref = module.declare_func_in_func(system_id, builder.func);
@@ -1594,8 +1638,12 @@ fn define_i64_function(
             atoll: atoll_ref,
             open: open_ref,
             creat: creat_ref,
+            #[cfg(not(windows))]
+            mkstemp: mkstemp_ref,
             lseek: lseek_ref,
             close: close_ref,
+            #[cfg(not(windows))]
+            fsync: fsync_ref,
             access: access_ref,
             #[cfg(windows)]
             system: system_ref,
@@ -5829,47 +5877,126 @@ fn emit_i64_replace_file_expr(
     temp_path: &str,
     content: &str,
 ) -> Result<cranelift_codegen::ir::Value, CraneliftBackendError> {
-    let write_result = emit_i64_write_file_expr(builder, runtime_refs, temp_path, content)?;
+    #[cfg(windows)]
+    {
+        let _ = (runtime_refs, path, temp_path, content);
+        return Ok(builder.ins().iconst(types::I64, -1));
+    }
 
-    let rename_block = builder.create_block();
-    let success_block = builder.create_block();
-    let failed_block = builder.create_block();
-    let merge_block = builder.create_block();
-    builder.append_block_param(merge_block, types::I64);
+    #[cfg(not(windows))]
+    {
+        let temp_ptr = emit_i64_path_ptr(builder, temp_path)?;
+        let path_ptr = emit_i64_path_ptr(builder, path)?;
+        let content_len = u32::try_from(content.len())
+            .map_err(|_| CraneliftBackendError::new("filesystem replace content is too large"))?;
+        let content_slot = builder.create_sized_stack_slot(StackSlotData::new(
+            StackSlotKind::ExplicitSlot,
+            content_len.max(1),
+            0,
+        ));
+        for (offset, byte) in content.bytes().enumerate() {
+            let byte_value = builder.ins().iconst(types::I8, i64::from(byte));
+            builder
+                .ins()
+                .stack_store(byte_value, content_slot, offset as i32);
+        }
+        let content_ptr = builder.ins().stack_addr(types::I64, content_slot, 0);
+        let content_count = builder.ins().iconst(types::I64, i64::from(content_len));
 
-    let write_ok = builder.ins().icmp_imm(IntCC::Equal, write_result, 0);
-    builder
-        .ins()
-        .brif(write_ok, rename_block, &[], failed_block, &[]);
+        // mkstemp replaces the XXXXXX suffix with a random, exclusive 0600
+        // inode and never follows a pre-existing symlink at that name.
+        let create_call = builder.ins().call(runtime_refs.mkstemp, &[temp_ptr]);
+        let file = builder.inst_results(create_call)[0];
+        let failed_block = builder.create_block();
+        let write_block = builder.create_block();
+        let sync_block = builder.create_block();
+        let close_block = builder.create_block();
+        let rename_block = builder.create_block();
+        let success_block = builder.create_block();
+        let merge_block = builder.create_block();
+        builder.append_block_param(close_block, types::I64);
+        builder.append_block_param(merge_block, types::I64);
 
-    builder.switch_to_block(rename_block);
-    builder.seal_block(rename_block);
-    let temp_ptr = emit_i64_path_ptr(builder, temp_path)?;
-    let path_ptr = emit_i64_path_ptr(builder, path)?;
-    let rename_call = builder
-        .ins()
-        .call(runtime_refs.rename, &[temp_ptr, path_ptr]);
-    let rename_result = builder.inst_results(rename_call)[0];
-    let rename_ok = builder.ins().icmp_imm(IntCC::Equal, rename_result, 0);
-    builder
-        .ins()
-        .brif(rename_ok, success_block, &[], failed_block, &[]);
+        let create_failed = builder.ins().icmp_imm(IntCC::SignedLessThan, file, 0);
+        builder
+            .ins()
+            .brif(create_failed, failed_block, &[], write_block, &[]);
 
-    builder.switch_to_block(success_block);
-    builder.seal_block(success_block);
-    let success = builder.ins().iconst(types::I64, 0);
-    builder.ins().jump(merge_block, &[BlockArg::Value(success)]);
+        builder.switch_to_block(write_block);
+        builder.seal_block(write_block);
+        let write_call = builder
+            .ins()
+            .call(runtime_refs.write, &[file, content_ptr, content_count]);
+        let written = builder.inst_results(write_call)[0];
+        let full_write = builder.ins().icmp(IntCC::Equal, written, content_count);
+        let failed = builder.ins().iconst(types::I64, -1);
+        builder.ins().brif(
+            full_write,
+            sync_block,
+            &[],
+            close_block,
+            &[BlockArg::Value(failed)],
+        );
 
-    builder.switch_to_block(failed_block);
-    builder.seal_block(failed_block);
-    let temp_ptr = emit_i64_path_ptr(builder, temp_path)?;
-    builder.ins().call(runtime_refs.unlink, &[temp_ptr]);
-    let failed = builder.ins().iconst(types::I64, -1);
-    builder.ins().jump(merge_block, &[BlockArg::Value(failed)]);
+        builder.switch_to_block(sync_block);
+        builder.seal_block(sync_block);
+        let sync_call = builder.ins().call(runtime_refs.fsync, &[file]);
+        let sync_result = builder.inst_results(sync_call)[0];
+        let sync_ok = builder.ins().icmp_imm(IntCC::Equal, sync_result, 0);
+        let success_value = builder.ins().iconst(types::I64, 0);
+        let failed_value = builder.ins().iconst(types::I64, -1);
+        builder.ins().brif(
+            sync_ok,
+            close_block,
+            &[BlockArg::Value(success_value)],
+            close_block,
+            &[BlockArg::Value(failed_value)],
+        );
 
-    builder.switch_to_block(merge_block);
-    builder.seal_block(merge_block);
-    Ok(builder.block_params(merge_block)[0])
+        builder.switch_to_block(close_block);
+        builder.seal_block(close_block);
+        let close_result = builder.block_params(close_block)[0];
+        let close_call = builder.ins().call(runtime_refs.close, &[file]);
+        let close_status = builder.inst_results(close_call)[0];
+        let close_ok = builder
+            .ins()
+            .icmp_imm(IntCC::Equal, close_status, 0);
+        let effect_ok = builder.ins().icmp_imm(IntCC::Equal, close_result, 0);
+        let ready_to_rename = builder.ins().band(close_ok, effect_ok);
+        builder.ins().brif(
+            ready_to_rename,
+            rename_block,
+            &[],
+            failed_block,
+            &[],
+        );
+
+        builder.switch_to_block(rename_block);
+        builder.seal_block(rename_block);
+        let rename_call = builder
+            .ins()
+            .call(runtime_refs.rename, &[temp_ptr, path_ptr]);
+        let rename_result = builder.inst_results(rename_call)[0];
+        let rename_ok = builder.ins().icmp_imm(IntCC::Equal, rename_result, 0);
+        builder
+            .ins()
+            .brif(rename_ok, success_block, &[], failed_block, &[]);
+
+        builder.switch_to_block(success_block);
+        builder.seal_block(success_block);
+        let success = builder.ins().iconst(types::I64, 0);
+        builder.ins().jump(merge_block, &[BlockArg::Value(success)]);
+
+        builder.switch_to_block(failed_block);
+        builder.seal_block(failed_block);
+        builder.ins().call(runtime_refs.unlink, &[temp_ptr]);
+        let failed = builder.ins().iconst(types::I64, -1);
+        builder.ins().jump(merge_block, &[BlockArg::Value(failed)]);
+
+        builder.switch_to_block(merge_block);
+        builder.seal_block(merge_block);
+        Ok(builder.block_params(merge_block)[0])
+    }
 }
 
 fn emit_i64_remove_file_expr(
@@ -6832,7 +6959,7 @@ mod tests {
         }
         let temp = tempfile::tempdir().expect("tempdir");
         let fixture = temp.path().join("fixture.txt");
-        let temp_fixture = temp.path().join(".fixture.txt.axiom-replace.tmp");
+        let temp_fixture = temp.path().join(".fixture.txt.axiom-replace-XXXXXX");
         fs::write(&fixture, "base").expect("write replace base fixture");
         let object = temp.path().join("i64-exit-replace-file.o");
         let binary = temp.path().join("i64-exit-replace-file");

--- a/stage1/crates/axiomc-backend-cranelift/src/lib.rs
+++ b/stage1/crates/axiomc-backend-cranelift/src/lib.rs
@@ -80,7 +80,13 @@ struct I64RuntimeRefs {
     open: FuncRef,
     creat: FuncRef,
     #[cfg(not(windows))]
-    mkstemp: FuncRef,
+    openat: FuncRef,
+    #[cfg(not(windows))]
+    fchmod: FuncRef,
+    #[cfg(not(windows))]
+    renameat: FuncRef,
+    #[cfg(not(windows))]
+    unlinkat: FuncRef,
     lseek: FuncRef,
     close: FuncRef,
     #[cfg(not(windows))]
@@ -270,8 +276,9 @@ pub enum I64Expr {
         content: String,
     },
     ReplaceFile {
-        path: String,
-        temp_path: String,
+        root: String,
+        parent_components: Vec<String>,
+        destination_name: String,
         content: String,
     },
     CreateFile {
@@ -793,14 +800,56 @@ fn emit_i64_exit_object(
             CraneliftBackendError::new(format!("declare creat import: {message}"))
         })?;
     #[cfg(not(windows))]
-    let mkstemp_id = {
+    let openat_id = {
         let mut signature = module.make_signature();
+        signature.params.push(AbiParam::new(types::I32));
+        signature.params.push(AbiParam::new(pointer_type));
+        signature.params.push(AbiParam::new(types::I32));
+        signature.params.push(AbiParam::new(types::I32));
+        signature.returns.push(AbiParam::new(types::I32));
+        module
+            .declare_function("openat", Linkage::Import, &signature)
+            .map_err(|message| {
+                CraneliftBackendError::new(format!("declare openat import: {message}"))
+            })?
+    };
+    #[cfg(not(windows))]
+    let renameat_id = {
+        let mut signature = module.make_signature();
+        signature.params.push(AbiParam::new(types::I32));
+        signature.params.push(AbiParam::new(pointer_type));
+        signature.params.push(AbiParam::new(types::I32));
         signature.params.push(AbiParam::new(pointer_type));
         signature.returns.push(AbiParam::new(types::I32));
         module
-            .declare_function("mkstemp", Linkage::Import, &signature)
+            .declare_function("renameat", Linkage::Import, &signature)
             .map_err(|message| {
-                CraneliftBackendError::new(format!("declare mkstemp import: {message}"))
+                CraneliftBackendError::new(format!("declare renameat import: {message}"))
+            })?
+    };
+    #[cfg(not(windows))]
+    let fchmod_id = {
+        let mut signature = module.make_signature();
+        signature.params.push(AbiParam::new(types::I32));
+        signature.params.push(AbiParam::new(types::I32));
+        signature.returns.push(AbiParam::new(types::I32));
+        module
+            .declare_function("fchmod", Linkage::Import, &signature)
+            .map_err(|message| {
+                CraneliftBackendError::new(format!("declare fchmod import: {message}"))
+            })?
+    };
+    #[cfg(not(windows))]
+    let unlinkat_id = {
+        let mut signature = module.make_signature();
+        signature.params.push(AbiParam::new(types::I32));
+        signature.params.push(AbiParam::new(pointer_type));
+        signature.params.push(AbiParam::new(types::I32));
+        signature.returns.push(AbiParam::new(types::I32));
+        module
+            .declare_function("unlinkat", Linkage::Import, &signature)
+            .map_err(|message| {
+                CraneliftBackendError::new(format!("declare unlinkat import: {message}"))
             })?
     };
     let mut lseek_sig = module.make_signature();
@@ -1084,7 +1133,10 @@ fn emit_i64_exit_object(
                 atoll_id,
                 open_id,
                 creat_id,
-                mkstemp_id,
+                openat_id,
+                fchmod_id,
+                renameat_id,
+                unlinkat_id,
                 lseek_id,
                 close_id,
                 fsync_id,
@@ -1189,7 +1241,13 @@ fn emit_i64_exit_object(
         let open_ref = module.declare_func_in_func(open_id, builder.func);
         let creat_ref = module.declare_func_in_func(creat_id, builder.func);
         #[cfg(not(windows))]
-        let mkstemp_ref = module.declare_func_in_func(mkstemp_id, builder.func);
+        let openat_ref = module.declare_func_in_func(openat_id, builder.func);
+        #[cfg(not(windows))]
+        let fchmod_ref = module.declare_func_in_func(fchmod_id, builder.func);
+        #[cfg(not(windows))]
+        let renameat_ref = module.declare_func_in_func(renameat_id, builder.func);
+        #[cfg(not(windows))]
+        let unlinkat_ref = module.declare_func_in_func(unlinkat_id, builder.func);
         let lseek_ref = module.declare_func_in_func(lseek_id, builder.func);
         let close_ref = module.declare_func_in_func(close_id, builder.func);
         #[cfg(not(windows))]
@@ -1241,7 +1299,13 @@ fn emit_i64_exit_object(
             open: open_ref,
             creat: creat_ref,
             #[cfg(not(windows))]
-            mkstemp: mkstemp_ref,
+            openat: openat_ref,
+            #[cfg(not(windows))]
+            fchmod: fchmod_ref,
+            #[cfg(not(windows))]
+            renameat: renameat_ref,
+            #[cfg(not(windows))]
+            unlinkat: unlinkat_ref,
             lseek: lseek_ref,
             close: close_ref,
             #[cfg(not(windows))]
@@ -1513,7 +1577,13 @@ fn define_i64_function(
     open_id: FuncId,
     creat_id: FuncId,
     #[cfg(not(windows))]
-    mkstemp_id: FuncId,
+    openat_id: FuncId,
+    #[cfg(not(windows))]
+    fchmod_id: FuncId,
+    #[cfg(not(windows))]
+    renameat_id: FuncId,
+    #[cfg(not(windows))]
+    unlinkat_id: FuncId,
     lseek_id: FuncId,
     close_id: FuncId,
     #[cfg(not(windows))]
@@ -1587,7 +1657,13 @@ fn define_i64_function(
         let open_ref = module.declare_func_in_func(open_id, builder.func);
         let creat_ref = module.declare_func_in_func(creat_id, builder.func);
         #[cfg(not(windows))]
-        let mkstemp_ref = module.declare_func_in_func(mkstemp_id, builder.func);
+        let openat_ref = module.declare_func_in_func(openat_id, builder.func);
+        #[cfg(not(windows))]
+        let fchmod_ref = module.declare_func_in_func(fchmod_id, builder.func);
+        #[cfg(not(windows))]
+        let renameat_ref = module.declare_func_in_func(renameat_id, builder.func);
+        #[cfg(not(windows))]
+        let unlinkat_ref = module.declare_func_in_func(unlinkat_id, builder.func);
         let lseek_ref = module.declare_func_in_func(lseek_id, builder.func);
         let close_ref = module.declare_func_in_func(close_id, builder.func);
         #[cfg(not(windows))]
@@ -1639,7 +1715,13 @@ fn define_i64_function(
             open: open_ref,
             creat: creat_ref,
             #[cfg(not(windows))]
-            mkstemp: mkstemp_ref,
+            openat: openat_ref,
+            #[cfg(not(windows))]
+            fchmod: fchmod_ref,
+            #[cfg(not(windows))]
+            renameat: renameat_ref,
+            #[cfg(not(windows))]
+            unlinkat: unlinkat_ref,
             lseek: lseek_ref,
             close: close_ref,
             #[cfg(not(windows))]
@@ -3382,10 +3464,18 @@ fn emit_i64_expr(
             emit_i64_append_file_expr(builder, runtime_refs, path, content)
         }
         I64Expr::ReplaceFile {
-            path,
-            temp_path,
+            root,
+            parent_components,
+            destination_name,
             content,
-        } => emit_i64_replace_file_expr(builder, runtime_refs, path, temp_path, content),
+        } => emit_i64_replace_file_expr(
+            builder,
+            runtime_refs,
+            root,
+            parent_components,
+            destination_name,
+            content,
+        ),
         I64Expr::CreateFile { path } => emit_i64_create_file_expr(builder, runtime_refs, path),
         I64Expr::RemoveFile { path } => emit_i64_remove_file_expr(builder, runtime_refs, path),
         I64Expr::MakeDir { path } => emit_i64_make_dir_expr(builder, runtime_refs, path),
@@ -5873,20 +5963,100 @@ fn emit_i64_create_file_expr(
 fn emit_i64_replace_file_expr(
     builder: &mut FunctionBuilder<'_>,
     runtime_refs: I64RuntimeRefs,
-    path: &str,
-    temp_path: &str,
+    root: &str,
+    parent_components: &[String],
+    destination_name: &str,
     content: &str,
 ) -> Result<cranelift_codegen::ir::Value, CraneliftBackendError> {
     #[cfg(windows)]
     {
-        let _ = (runtime_refs, path, temp_path, content);
+        let _ = (runtime_refs, root, parent_components, destination_name, content);
         return Ok(builder.ins().iconst(types::I64, -1));
     }
 
     #[cfg(not(windows))]
     {
-        let temp_ptr = emit_i64_path_ptr(builder, temp_path)?;
-        let path_ptr = emit_i64_path_ptr(builder, path)?;
+        // Keep every operation anchored to a descriptor opened beneath the
+        // authorized root.  In particular, do not construct a pathname for
+        // the temporary file: the final create and publish both use *at(2)
+        // and therefore cannot be redirected by a concurrent rename or a
+        // pre-planted symlink.
+        let root_ptr = emit_i64_path_ptr(builder, root)?;
+        let destination_ptr = emit_i64_path_ptr(builder, destination_name)?;
+        let temp_slot = builder.create_sized_stack_slot(StackSlotData::new(
+            StackSlotKind::ExplicitSlot,
+            32,
+            0,
+        ));
+        let temp_ptr = builder.ins().stack_addr(types::I64, temp_slot, 0);
+        for (offset, byte) in b".axiom-replace-".iter().enumerate() {
+            let value = builder.ins().iconst(types::I8, i64::from(*byte));
+            builder.ins().stack_store(value, temp_slot, offset as i32);
+        }
+        let random = emit_i64_random_u64_expr(
+            builder,
+            runtime_refs,
+            "fs_replace",
+            "axiomc",
+        )?;
+        for index in 0..16 {
+            let shift = 60 - index * 4;
+            let nibble = builder.ins().ushr_imm(random, shift);
+            let nibble = builder.ins().band_imm(nibble, 0x0f);
+            let decimal = builder.ins().iadd_imm(nibble, i64::from(b'0'));
+            let alpha = builder.ins().iadd_imm(nibble, i64::from(b'a' - 10));
+            let is_decimal = builder.ins().icmp_imm(IntCC::UnsignedLessThan, nibble, 10);
+            let value = builder.ins().select(is_decimal, decimal, alpha);
+            let value = builder.ins().ireduce(types::I8, value);
+            builder
+                .ins()
+                .stack_store(value, temp_slot, (15 + index) as i32);
+        }
+        let terminator = builder.ins().iconst(types::I8, 0);
+        builder.ins().stack_store(terminator, temp_slot, 31);
+
+        let directory_flag = if cfg!(target_os = "macos") {
+            0x0010_0000
+        } else {
+            0x0001_0000
+        };
+        let nofollow_flag = if cfg!(target_os = "macos") {
+            0x0000_0100
+        } else {
+            0x0002_0000
+        };
+        let create_flag = if cfg!(target_os = "macos") {
+            0x0000_0200
+        } else {
+            0x0000_0040
+        };
+        let exclusive_flag = if cfg!(target_os = "macos") {
+            0x0000_0800
+        } else {
+            0x0000_0080
+        };
+        let root_flags = builder.ins().iconst(
+            types::I32,
+            i64::from(directory_flag | nofollow_flag),
+        );
+        let root_open = builder.ins().call(runtime_refs.open, &[root_ptr, root_flags]);
+        let mut parent_fd = builder.inst_results(root_open)[0];
+        let walk_flags = builder.ins().iconst(
+            types::I32,
+            i64::from(directory_flag | nofollow_flag),
+        );
+        for component in parent_components {
+            let component_ptr = emit_i64_path_ptr(builder, component)?;
+            let zero_mode = builder.ins().iconst(types::I32, 0);
+            let next_open = builder.ins().call(
+                runtime_refs.openat,
+                &[parent_fd, component_ptr, walk_flags, zero_mode],
+            );
+            let next_fd = builder.inst_results(next_open)[0];
+            builder.ins().call(runtime_refs.close, &[parent_fd]);
+            parent_fd = next_fd;
+        }
+
         let content_len = u32::try_from(content.len())
             .map_err(|_| CraneliftBackendError::new("filesystem replace content is too large"))?;
         let content_slot = builder.create_sized_stack_slot(StackSlotData::new(
@@ -5903,24 +6073,50 @@ fn emit_i64_replace_file_expr(
         let content_ptr = builder.ins().stack_addr(types::I64, content_slot, 0);
         let content_count = builder.ins().iconst(types::I64, i64::from(content_len));
 
-        // mkstemp replaces the XXXXXX suffix with a random, exclusive 0600
-        // inode and never follows a pre-existing symlink at that name.
-        let create_call = builder.ins().call(runtime_refs.mkstemp, &[temp_ptr]);
-        let file = builder.inst_results(create_call)[0];
         let failed_block = builder.create_block();
+        let create_block = builder.create_block();
+        let chmod_block = builder.create_block();
         let write_block = builder.create_block();
         let sync_block = builder.create_block();
         let close_block = builder.create_block();
         let rename_block = builder.create_block();
+        let publish_sync_block = builder.create_block();
         let success_block = builder.create_block();
         let merge_block = builder.create_block();
-        builder.append_block_param(close_block, types::I64);
+        builder.append_block_param(close_block, types::I32);
         builder.append_block_param(merge_block, types::I64);
 
+        let parent_valid = builder.ins().icmp_imm(IntCC::SignedGreaterThanOrEqual, parent_fd, 0);
+        builder
+            .ins()
+            .brif(parent_valid, create_block, &[], failed_block, &[]);
+
+        builder.switch_to_block(create_block);
+        builder.seal_block(create_block);
+        let create_flags = builder.ins().iconst(
+            types::I32,
+            i64::from(1 | create_flag | exclusive_flag | nofollow_flag),
+        );
+        let create_mode = builder.ins().iconst(types::I32, 0o600);
+        let create_call = builder.ins().call(
+            runtime_refs.openat,
+            &[parent_fd, temp_ptr, create_flags, create_mode],
+        );
+        let file = builder.inst_results(create_call)[0];
         let create_failed = builder.ins().icmp_imm(IntCC::SignedLessThan, file, 0);
         builder
             .ins()
-            .brif(create_failed, failed_block, &[], write_block, &[]);
+            .brif(create_failed, failed_block, &[], chmod_block, &[]);
+
+        builder.switch_to_block(chmod_block);
+        builder.seal_block(chmod_block);
+        let restrictive_mode = builder.ins().iconst(types::I32, 0o600);
+        let chmod_call = builder
+            .ins()
+            .call(runtime_refs.fchmod, &[file, restrictive_mode]);
+        let chmod_result = builder.inst_results(chmod_call)[0];
+        let chmod_ok = builder.ins().icmp_imm(IntCC::Equal, chmod_result, 0);
+        builder.ins().brif(chmod_ok, write_block, &[], failed_block, &[]);
 
         builder.switch_to_block(write_block);
         builder.seal_block(write_block);
@@ -5929,7 +6125,7 @@ fn emit_i64_replace_file_expr(
             .call(runtime_refs.write, &[file, content_ptr, content_count]);
         let written = builder.inst_results(write_call)[0];
         let full_write = builder.ins().icmp(IntCC::Equal, written, content_count);
-        let failed = builder.ins().iconst(types::I64, -1);
+        let failed = builder.ins().iconst(types::I32, -1);
         builder.ins().brif(
             full_write,
             sync_block,
@@ -5943,8 +6139,8 @@ fn emit_i64_replace_file_expr(
         let sync_call = builder.ins().call(runtime_refs.fsync, &[file]);
         let sync_result = builder.inst_results(sync_call)[0];
         let sync_ok = builder.ins().icmp_imm(IntCC::Equal, sync_result, 0);
-        let success_value = builder.ins().iconst(types::I64, 0);
-        let failed_value = builder.ins().iconst(types::I64, -1);
+        let success_value = builder.ins().iconst(types::I32, 0);
+        let failed_value = builder.ins().iconst(types::I32, -1);
         builder.ins().brif(
             sync_ok,
             close_block,
@@ -5973,14 +6169,24 @@ fn emit_i64_replace_file_expr(
 
         builder.switch_to_block(rename_block);
         builder.seal_block(rename_block);
-        let rename_call = builder
-            .ins()
-            .call(runtime_refs.rename, &[temp_ptr, path_ptr]);
+        let rename_call = builder.ins().call(
+            runtime_refs.renameat,
+            &[parent_fd, temp_ptr, parent_fd, destination_ptr],
+        );
         let rename_result = builder.inst_results(rename_call)[0];
         let rename_ok = builder.ins().icmp_imm(IntCC::Equal, rename_result, 0);
         builder
             .ins()
-            .brif(rename_ok, success_block, &[], failed_block, &[]);
+            .brif(rename_ok, publish_sync_block, &[], failed_block, &[]);
+
+        builder.switch_to_block(publish_sync_block);
+        builder.seal_block(publish_sync_block);
+        let parent_sync = builder.ins().call(runtime_refs.fsync, &[parent_fd]);
+        let parent_sync_result = builder.inst_results(parent_sync)[0];
+        let parent_sync_ok = builder.ins().icmp_imm(IntCC::Equal, parent_sync_result, 0);
+        builder
+            .ins()
+            .brif(parent_sync_ok, success_block, &[], failed_block, &[]);
 
         builder.switch_to_block(success_block);
         builder.seal_block(success_block);
@@ -5989,7 +6195,11 @@ fn emit_i64_replace_file_expr(
 
         builder.switch_to_block(failed_block);
         builder.seal_block(failed_block);
-        builder.ins().call(runtime_refs.unlink, &[temp_ptr]);
+        let unlink_flags = builder.ins().iconst(types::I32, 0);
+        builder
+            .ins()
+            .call(runtime_refs.unlinkat, &[parent_fd, temp_ptr, unlink_flags]);
+        builder.ins().call(runtime_refs.close, &[parent_fd]);
         let failed = builder.ins().iconst(types::I64, -1);
         builder.ins().jump(merge_block, &[BlockArg::Value(failed)]);
 
@@ -6969,8 +7179,9 @@ mod tests {
                 locals: Vec::new(),
                 stmts: Vec::new(),
                 body: I64ExitBody::Return(I64Expr::ReplaceFile {
-                    path: fixture.display().to_string(),
-                    temp_path: temp_fixture.display().to_string(),
+                    root: temp.path().display().to_string(),
+                    parent_components: Vec::new(),
+                    destination_name: "fixture.txt".to_string(),
                     content: String::from("runtime-replace"),
                 }),
             },
@@ -6990,7 +7201,13 @@ mod tests {
         let output = Command::new(&binary)
             .output()
             .expect("run replace file binary");
-        assert_eq!(output.status.code(), Some(0));
+        assert_eq!(
+            output.status.code(),
+            Some(0),
+            "stdout={} stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
         assert_eq!(
             fs::read_to_string(&fixture).expect("read runtime replace fixture"),
             "runtime-replace"

--- a/stage1/crates/axiomc/src/cranelift_backend/host_fs.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend/host_fs.rs
@@ -502,7 +502,7 @@ pub(crate) fn lower_i64_fs_write_intrinsic_expr(
             );
         };
         let temp_path = parent.join(format!(
-            ".{}.axiom-replace.tmp",
+            ".{}.axiom-replace-XXXXXX",
             file_name.to_string_lossy()
         ));
         return i64_audited_fs_expr(

--- a/stage1/crates/axiomc/src/cranelift_backend/host_fs.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend/host_fs.rs
@@ -501,10 +501,11 @@ pub(crate) fn lower_i64_fs_write_intrinsic_expr(
                 static_bindings,
             );
         };
-        let temp_path = parent.join(format!(
-            ".{}.axiom-replace-XXXXXX",
-            file_name.to_string_lossy()
-        ));
+        let relative_parent = parent.strip_prefix(fs_root).ok()?.to_path_buf();
+        let parent_components = relative_parent
+            .components()
+            .map(|component| component.as_os_str().to_string_lossy().into_owned())
+            .collect();
         return i64_audited_fs_expr(
             name,
             path_len,
@@ -514,8 +515,9 @@ pub(crate) fn lower_i64_fs_write_intrinsic_expr(
                 &candidate,
                 parent,
                 CraneliftI64Expr::ReplaceFile {
-                    path: candidate.display().to_string(),
-                    temp_path: temp_path.display().to_string(),
+                    root: fs_root.display().to_string(),
+                    parent_components,
+                    destination_name: file_name.to_string_lossy().into_owned(),
                     content,
                 },
             )?,

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -4452,7 +4452,7 @@ fn cranelift_backend_lowers_fs_write_to_runtime_exit_code() {
     let runtime_file = project.join("scratch/data.txt");
     let append_file = project.join("scratch/append.txt");
     let replace_file = project.join("scratch/replace.txt");
-    let replace_temp_file = project.join("scratch/.replace.txt.axiom-replace.tmp");
+    let replace_temp_file = project.join("scratch/.replace.txt.axiom-replace-XXXXXX");
     let removed_file = project.join("scratch/remove.txt");
     let created_file = project.join("scratch/created.txt");
     let runtime_dir = project.join("scratch/native-dir");
@@ -4495,6 +4495,19 @@ fn cranelift_backend_lowers_fs_write_to_runtime_exit_code() {
         !audit_log.exists(),
         "build should not create the native fs audit log"
     );
+    #[cfg(unix)]
+    let replace_sentinel = project
+        .parent()
+        .expect("project parent")
+        .join("replace-sentinel.txt");
+    #[cfg(unix)]
+    let planted_temp = project.join("scratch/.replace.txt.axiom-replace.tmp");
+    #[cfg(unix)]
+    {
+        fs::write(&replace_sentinel, "sentinel-safe").expect("write replace sentinel");
+        std::os::unix::fs::symlink(&replace_sentinel, &planted_temp)
+            .expect("plant legacy replace temp symlink");
+    }
     let run = Command::new(binary)
         .env("AXIOM_HOST_AUDIT_LOG", &audit_log)
         .output()
@@ -4512,6 +4525,19 @@ fn cranelift_backend_lowers_fs_write_to_runtime_exit_code() {
     assert_eq!(
         fs::read_to_string(&replace_file).expect("read fs_replace runtime fixture"),
         "runtime-replace"
+    );
+    #[cfg(unix)]
+    assert_eq!(
+        fs::read_to_string(&replace_sentinel).expect("read replace sentinel"),
+        "sentinel-safe"
+    );
+    #[cfg(unix)]
+    assert!(
+        fs::symlink_metadata(&planted_temp)
+            .expect("stat planted replace temp")
+            .file_type()
+            .is_symlink(),
+        "a preplanted legacy temp symlink must never be followed"
     );
     assert!(
         !removed_file.exists(),


### PR DESCRIPTION
## Summary

- Replace direct-native `fs_replace`'s predictable pathname flow with descriptor-relative authority.
- Open the authorized root and each parent directory with no-follow directory flags, then create a randomized temporary inode with exclusive `openat` semantics.
- Apply restrictive `0600` permissions through the opened descriptor, write and `fsync` the file, publish with `renameat`, `fsync` the parent directory, and clean failed attempts with `unlinkat`.
- Fail closed on Windows until an equivalent native handle backend exists.
- Preserve regression coverage proving a preplanted legacy temp symlink cannot modify an external sentinel.

## Governing Issue

Closes #1570

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Focused validation:

- `cargo check --manifest-path stage1/Cargo.toml -p axiomc` — passed
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc-backend-cranelift` — 29 passed
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend cranelift_backend_lowers_fs_write_to_runtime_exit_code` — passed
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend cranelift_backend_denies_fs_write_symlink_escape_at_runtime` — passed
- `bash scripts/ci/run-fast-checks.sh` — passed through the direct-native proof workload validation
- `git diff --check` — passed

The backend suite also includes a deterministic collision test proving that an existing exclusive-temp name is left untouched and the destination is not published.

The full Cranelift integration suite reported 149 passed and 32 unrelated baseline failures. Those failures are manifest-schema/lowering fixture failures caused by existing fixtures using unsupported `[unsafe_rationale]` sections; the focused filesystem tests and all backend unit tests pass.

The implementation now covers the issue's descriptor-relative parent walking/rename and parent-directory durability requirements. The direct-native integration fixture exercises nested parent traversal and verifies that a preplanted legacy temp symlink and its external sentinel remain untouched.

Autoreview was attempted but blocked by the private-diff authorization boundary; no external review result is claimed.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] PR author enabled auto-merge where GitHub allows it, or GitHub plan-limit evidence/unavailable reason is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Flow Contract

- Owner lane: Pheidon / direct-native runtime filesystem authority
- Repair owner: Codex
- Autonomy class: 2
- Risk class: security

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] PR author enabled auto-merge where GitHub allows it, or recorded why it is unavailable/unsafe

## Merge Automation

- [x] PR author enabled auto-merge with `gh pr merge --auto --squash`, or the reason it is unavailable/unsafe is noted below

## Notes

- This PR prevents the reported preplanted predictable-temp symlink escape and completes descriptor-relative creation, publication, cleanup, and durability for direct-native replacement.
- GitHub review and required-check gates remain external blockers until satisfied.
