### PR TITLE
Align loop control flow across HIR and native backends

### DIFF
--- a/docs/compiler-source-decomposition-plan.md
+++ b/docs/compiler-source-decomposition-plan.md
@@ -259,7 +259,7 @@ matching ceiling in this table in the same PR.
 | Tracked item | Ceiling |
 | --- | ---: |
 | `summary.top_file_line_share` | 0.5767 |
-| `summary.top_file_lines` | 71278 |
+| `summary.top_file_lines` | 71314 |
 | `stage1/crates/axiomc/src/cranelift_backend.rs` | 20120 |
 | `stage1/crates/axiomc/src/cranelift_backend/static_output_purity.rs` | 282 |
 | `stage1/crates/axiomc/src/cranelift_backend/host_env_proc_clock.rs` | 620 |
@@ -269,19 +269,19 @@ matching ceiling in this table in the same PR.
 | `stage1/crates/axiomc/src/cranelift_backend/host_fs.rs` | 984 |
 | `stage1/crates/axiomc/src/cranelift_backend/host_crypto.rs` | 783 |
 | `stage1/crates/axiomc/src/cranelift_backend/host_net_http.rs` | 1121 |
-| `stage1/crates/axiomc/src/hir.rs` | 5904 |
+| `stage1/crates/axiomc/src/hir.rs` | 5992 |
 | `stage1/crates/axiomc/src/project.rs` | 13564 |
 | `stage1/crates/axiomc/src/project/build_contract.rs` | 118 |
 | `stage1/crates/axiomc/src/main.rs` | 11917 |
 | `stage1/crates/axiomc/src/formatter.rs` | 191 |
 | `stage1/crates/axiomc/src/formatter_tests.rs` | 122 |
-| `stage1/crates/axiomc/src/codegen.rs` | 8020 |
+| `stage1/crates/axiomc/src/codegen.rs` | 8040 |
 | `stage1/crates/axiomc/src/syntax.rs` | 6396 |
 | `stage1/crates/axiomc/src/hir/async_runtime.rs` | 188 |
 | `stage1/crates/axiomc/src/hir/capabilities.rs` | 773 |
 | `stage1/crates/axiomc/src/hir/const_arrays.rs` | 330 |
 | `stage1/crates/axiomc/src/hir/const_functions.rs` | 117 |
-| `stage1/crates/axiomc/src/hir/control_flow.rs` | 37 |
+| `stage1/crates/axiomc/src/hir/control_flow.rs` | 114 |
 | `stage1/crates/axiomc/src/hir/definitions.rs` | 686 |
 | `stage1/crates/axiomc/src/hir/diagnostics.rs` | 28 |
 | `stage1/crates/axiomc/src/hir/expressions.rs` | 205 |

--- a/stage1/crates/axiomc-backend-cranelift/src/lib.rs
+++ b/stage1/crates/axiomc-backend-cranelift/src/lib.rs
@@ -1,5 +1,5 @@
 use cranelift_codegen::ir::{
-    AbiParam, ArgumentPurpose, BlockArg, FuncRef, InstBuilder, MemFlags, StackSlotData,
+    AbiParam, ArgumentPurpose, Block, BlockArg, FuncRef, InstBuilder, MemFlags, StackSlotData,
     StackSlotKind, TrapCode, Value, condcodes::IntCC, types,
 };
 use cranelift_codegen::isa;
@@ -507,6 +507,8 @@ pub enum I64Stmt {
         cond: I64Condition,
         body: Vec<I64Stmt>,
     },
+    Break,
+    Continue,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1287,6 +1289,7 @@ fn emit_i64_exit_object(
             write_ref,
             &output_data_ids,
             &program.stmts,
+            None,
         )?;
         emit_i64_exit_body(
             &mut module,
@@ -1386,7 +1389,10 @@ fn collect_i64_output_lines(stmts: &[I64Stmt], lines: &mut Vec<(OutputStream, St
                 collect_i64_output_lines(else_body, lines);
             }
             I64Stmt::While { body, .. } => collect_i64_output_lines(body, lines),
-            I64Stmt::Assign(_) | I64Stmt::CallAssign { .. } => {}
+            I64Stmt::Assign(_)
+            | I64Stmt::CallAssign { .. }
+            | I64Stmt::Break
+            | I64Stmt::Continue => {}
         }
     }
 }
@@ -1688,6 +1694,7 @@ fn define_i64_function(
             write_ref,
             output_data_ids,
             &function.stmts,
+            None,
         )?;
         emit_i64_value_body(
             module,
@@ -1726,6 +1733,12 @@ fn i64_function_refs(
         .collect()
 }
 
+#[derive(Clone, Copy)]
+struct I64LoopTargets {
+    break_block: Block,
+    continue_block: Block,
+}
+
 fn emit_i64_stmts(
     module: &mut ObjectModule,
     builder: &mut FunctionBuilder<'_>,
@@ -1736,8 +1749,13 @@ fn emit_i64_stmts(
     write_ref: FuncRef,
     output_data_ids: &[I64OutputData],
     stmts: &[I64Stmt],
-) -> Result<(), CraneliftBackendError> {
+    loop_targets: Option<I64LoopTargets>,
+) -> Result<bool, CraneliftBackendError> {
+    let mut reachable = true;
     for stmt in stmts {
+        if !reachable {
+            break;
+        }
         emit_i64_stmt(
             module,
             builder,
@@ -1748,9 +1766,27 @@ fn emit_i64_stmts(
             write_ref,
             output_data_ids,
             stmt,
+            loop_targets,
         )?;
+        reachable = i64_stmt_can_fall_through(stmt);
     }
-    Ok(())
+    Ok(reachable)
+}
+
+fn i64_stmt_can_fall_through(stmt: &I64Stmt) -> bool {
+    match stmt {
+        I64Stmt::Break | I64Stmt::Continue => false,
+        I64Stmt::If {
+            then_body,
+            else_body,
+            ..
+        } => {
+            then_body.last().is_none_or(i64_stmt_can_fall_through)
+                || else_body.last().is_none_or(i64_stmt_can_fall_through)
+        }
+        I64Stmt::While { .. } => true,
+        _ => true,
+    }
 }
 
 fn emit_i64_stmt(
@@ -1763,6 +1799,7 @@ fn emit_i64_stmt(
     write_ref: FuncRef,
     output_data_ids: &[I64OutputData],
     stmt: &I64Stmt,
+    loop_targets: Option<I64LoopTargets>,
 ) -> Result<(), CraneliftBackendError> {
     match stmt {
         I64Stmt::Assign(assign) => {
@@ -1908,7 +1945,7 @@ fn emit_i64_stmt(
 
             builder.switch_to_block(then_block);
             builder.seal_block(then_block);
-            emit_i64_stmts(
+            let then_reachable = emit_i64_stmts(
                 module,
                 builder,
                 locals,
@@ -1918,12 +1955,15 @@ fn emit_i64_stmt(
                 write_ref,
                 output_data_ids,
                 then_body,
+                loop_targets,
             )?;
-            builder.ins().jump(after_if, &[]);
+            if then_reachable {
+                builder.ins().jump(after_if, &[]);
+            }
 
             builder.switch_to_block(else_block);
             builder.seal_block(else_block);
-            emit_i64_stmts(
+            let else_reachable = emit_i64_stmts(
                 module,
                 builder,
                 locals,
@@ -1933,8 +1973,11 @@ fn emit_i64_stmt(
                 write_ref,
                 output_data_ids,
                 else_body,
+                loop_targets,
             )?;
-            builder.ins().jump(after_if, &[]);
+            if else_reachable {
+                builder.ins().jump(after_if, &[]);
+            }
 
             builder.switch_to_block(after_if);
             builder.seal_block(after_if);
@@ -1954,7 +1997,7 @@ fn emit_i64_stmt(
 
             builder.switch_to_block(loop_body);
             builder.seal_block(loop_body);
-            emit_i64_stmts(
+            let body_reachable = emit_i64_stmts(
                 module,
                 builder,
                 locals,
@@ -1964,12 +2007,30 @@ fn emit_i64_stmt(
                 write_ref,
                 output_data_ids,
                 body,
+                Some(I64LoopTargets {
+                    break_block: after_loop,
+                    continue_block: loop_header,
+                }),
             )?;
-            builder.ins().jump(loop_header, &[]);
+            if body_reachable {
+                builder.ins().jump(loop_header, &[]);
+            }
             builder.seal_block(loop_header);
 
             builder.switch_to_block(after_loop);
             builder.seal_block(after_loop);
+            Ok(())
+        }
+        I64Stmt::Break => {
+            let targets = loop_targets
+                .ok_or_else(|| CraneliftBackendError::new("break is outside a loop"))?;
+            builder.ins().jump(targets.break_block, &[]);
+            Ok(())
+        }
+        I64Stmt::Continue => {
+            let targets = loop_targets
+                .ok_or_else(|| CraneliftBackendError::new("continue is outside a loop"))?;
+            builder.ins().jump(targets.continue_block, &[]);
             Ok(())
         }
     }
@@ -2769,6 +2830,7 @@ fn emit_i64_exit_body(
                 write_ref,
                 output_data_ids,
                 &block.stmts,
+                None,
             )?;
             emit_i64_return(builder, locals, function_refs, runtime_refs, &block.result)
         }
@@ -2820,6 +2882,7 @@ fn emit_i64_exit_body(
                 write_ref,
                 output_data_ids,
                 &then_block.stmts,
+                None,
             )?;
             emit_i64_return(
                 builder,
@@ -2841,6 +2904,7 @@ fn emit_i64_exit_body(
                 write_ref,
                 output_data_ids,
                 &else_block.stmts,
+                None,
             )?;
             emit_i64_return(
                 builder,
@@ -2887,6 +2951,7 @@ fn emit_i64_value_body(
                 write_ref,
                 output_data_ids,
                 &block.stmts,
+                None,
             )?;
             emit_i64_value_return(
                 builder,
@@ -2962,6 +3027,7 @@ fn emit_i64_value_body(
                 write_ref,
                 output_data_ids,
                 &then_block.stmts,
+                None,
             )?;
             emit_i64_value_return(
                 builder,
@@ -2985,6 +3051,7 @@ fn emit_i64_value_body(
                 write_ref,
                 output_data_ids,
                 &else_block.stmts,
+                None,
             )?;
             emit_i64_value_return(
                 builder,
@@ -4318,7 +4385,9 @@ fn emit_i64_env_len_expr(
     builder.seal_block(present_block);
     let call = builder.ins().call(strlen_ref, &[value_ptr]);
     let length = builder.inst_results(call)[0];
-    builder.ins().jump(merge_block, &[BlockArg::Value(length)]);
+    builder
+        .ins()
+        .jump(merge_block, &[BlockArg::Value(length)]);
 
     builder.switch_to_block(merge_block);
     builder.seal_block(merge_block);
@@ -4362,9 +4431,7 @@ fn emit_i64_cwd_len_expr(
     builder.seal_block(present_block);
     let call = builder.ins().call(strlen_ref, &[value_ptr]);
     let length = builder.inst_results(call)[0];
-    builder
-        .ins()
-        .jump(merge_block, &[BlockArg::Value(length)]);
+    builder.ins().jump(merge_block, &[BlockArg::Value(length)]);
 
     builder.switch_to_block(merge_block);
     builder.seal_block(merge_block);

--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -5229,6 +5229,7 @@ unsafe extern "C" {
         debug,
         &[],
         &main_mutable_locals,
+        None,
     );
     out.push_str("    });\n");
     out.push_str("    match result {\n");
@@ -6053,6 +6054,7 @@ fn render_function(
             debug,
             &[],
             &mutable_locals,
+            None,
         );
         out.push_str("    })\n");
     } else {
@@ -6066,6 +6068,7 @@ fn render_function(
             debug,
             &[],
             &mutable_locals,
+            None,
         );
     }
     out.push_str("}\n");
@@ -6360,6 +6363,7 @@ fn render_stmt_block(
     debug: bool,
     active_defers: &[(String, SourceSpan)],
     mutable_locals: &HashSet<String>,
+    loop_defer_floor: Option<usize>,
 ) {
     let mut local_defers: Vec<(String, SourceSpan)> = Vec::new();
     for stmt in stmts {
@@ -6373,6 +6377,7 @@ fn render_stmt_block(
             debug,
             active_defers,
             mutable_locals,
+            loop_defer_floor,
             &mut local_defers,
         );
     }
@@ -6406,6 +6411,7 @@ fn render_stmt(
     debug: bool,
     active_defers: &[(String, SourceSpan)],
     mutable_locals: &HashSet<String>,
+    loop_defer_floor: Option<usize>,
     local_defers: &mut Vec<(String, SourceSpan)>,
 ) {
     let pad = "    ".repeat(indent);
@@ -6502,6 +6508,7 @@ fn render_stmt(
                 debug,
                 &scoped_defers,
                 mutable_locals,
+                loop_defer_floor,
             );
             if let Some(else_block) = else_block {
                 out.push_str(&format!(
@@ -6518,6 +6525,7 @@ fn render_stmt(
                     debug,
                     &scoped_defers,
                     mutable_locals,
+                    loop_defer_floor,
                 );
                 out.push_str(&format!(
                     "{pad}}}
@@ -6539,6 +6547,7 @@ fn render_stmt(
 ",
                 render_expr(cond)
             ));
+            let loop_defer_floor = Some(scoped_defers.len());
             render_stmt_block(
                 body,
                 type_context,
@@ -6549,6 +6558,7 @@ fn render_stmt(
                 debug,
                 &scoped_defers,
                 mutable_locals,
+                loop_defer_floor,
             );
             out.push_str(&format!(
                 "{pad}}}
@@ -6558,13 +6568,19 @@ fn render_stmt(
         Stmt::Break { span } => {
             render_source_marker(source_path, *span, out, indent, debug);
             render_deferred_exprs(out, indent, source_path, debug, local_defers);
-            render_deferred_exprs(out, indent, source_path, debug, active_defers);
+            let loop_defers = loop_defer_floor
+                .and_then(|floor| active_defers.get(floor..))
+                .unwrap_or(&[]);
+            render_deferred_exprs(out, indent, source_path, debug, loop_defers);
             out.push_str(&format!("{pad}break;\n"));
         }
         Stmt::Continue { span } => {
             render_source_marker(source_path, *span, out, indent, debug);
             render_deferred_exprs(out, indent, source_path, debug, local_defers);
-            render_deferred_exprs(out, indent, source_path, debug, active_defers);
+            let loop_defers = loop_defer_floor
+                .and_then(|floor| active_defers.get(floor..))
+                .unwrap_or(&[]);
+            render_deferred_exprs(out, indent, source_path, debug, loop_defers);
             out.push_str(&format!("{pad}continue;\n"));
         }
         Stmt::Match { expr, arms, span } => {
@@ -6587,6 +6603,7 @@ fn render_stmt(
                     debug,
                     &scoped_defers,
                     mutable_locals,
+                    loop_defer_floor,
                 );
             }
             if arms.iter().all(|arm| arm.enum_name.is_empty()) {
@@ -6643,6 +6660,7 @@ fn render_match_arm(
     debug: bool,
     active_defers: &[(String, SourceSpan)],
     mutable_locals: &HashSet<String>,
+    loop_defer_floor: Option<usize>,
 ) {
     let pad = "    ".repeat(indent);
     if arm.enum_name.is_empty() {
@@ -6657,6 +6675,7 @@ fn render_match_arm(
             debug,
             active_defers,
             mutable_locals,
+            loop_defer_floor,
         );
         out.push_str(&format!("{pad}}},\n"));
         return;
@@ -6695,6 +6714,7 @@ fn render_match_arm(
         debug,
         active_defers,
         mutable_locals,
+        loop_defer_floor,
     );
     out.push_str(&format!("{pad}}},\n"));
 }

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -4391,6 +4391,8 @@ fn lower_i64_runtime_stmt(
                 allow_stdio_effects,
             )?,
         }),
+        Stmt::Break { .. } => Some(CraneliftI64Stmt::Break),
+        Stmt::Continue { .. } => Some(CraneliftI64Stmt::Continue),
         _ => None,
     }
 }

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -40,6 +40,7 @@ use self::const_arrays::{
     validate_const_array_lengths_in_program,
 };
 use self::const_functions::validate_const_function_body;
+use self::control_flow::ControlFlow;
 use self::definitions::{
     VariantInfo, collect_enum_definitions, collect_struct_definitions, collect_trait_definitions,
     collect_type_names, validate_recursive_type_cycles, validate_trait_bounds_in_program,
@@ -120,6 +121,12 @@ struct LowerContext<'a> {
     current_property: bool,
     current_borrow_return_params: HashSet<String>,
     loop_depth: usize,
+}
+
+#[derive(Default)]
+struct LoopFlow {
+    break_states: Vec<HashMap<String, Binding>>,
+    continue_states: Vec<HashMap<String, Binding>>,
 }
 
 const OWNERSHIP_CLOSURE_MOVE_CAPTURED_NON_COPY: &str = "closure_move_captured_non_copy";
@@ -266,11 +273,11 @@ fn lower_with_capabilities_impl(
     let mut env = HashMap::new();
     let stmts = if recover {
         let (stmts, mut block_diagnostics, _) =
-            lower_block_recovering(&program.stmts, &mut env, &ctx);
+            lower_block_recovering(&program.stmts, &mut env, &ctx, None);
         diagnostics.append(&mut block_diagnostics);
         stmts
     } else {
-        lower_block(&program.stmts, &mut env, &ctx)
+        lower_block(&program.stmts, &mut env, &ctx, None)
             .map_err(single_diagnostic)?
             .0
     };
@@ -568,17 +575,17 @@ fn lower_function(
             .collect(),
         loop_depth: 0,
     };
-    let (body, _, guaranteed_return) = if function.is_extern {
-        (Vec::new(), env.clone(), true)
+    let (body, _, flow) = if function.is_extern {
+        (Vec::new(), env.clone(), ControlFlow::return_value())
     } else {
         let (body, diagnostics, guaranteed_return) =
-            lower_block_recovering(&function.body, &mut env, &ctx);
+            lower_block_recovering(&function.body, &mut env, &ctx, None);
         if !diagnostics.is_empty() {
             return Err(primary_diagnostic(diagnostics));
         }
         (body, env.clone(), guaranteed_return)
     };
-    if !guaranteed_return {
+    if !flow.always_returns() {
         return Err(Diagnostic::new(
             "control",
             format!(
@@ -616,38 +623,47 @@ fn lower_block(
     block: &[syntax::Stmt],
     env: &mut HashMap<String, Binding>,
     ctx: &LowerContext<'_>,
-) -> Result<(Vec<Stmt>, HashMap<String, Binding>, bool), Diagnostic> {
+    mut loop_flow: Option<&mut LoopFlow>,
+) -> Result<(Vec<Stmt>, HashMap<String, Binding>, ControlFlow), Diagnostic> {
     let scope_names = env.keys().cloned().collect::<HashSet<_>>();
     let mut lowered = Vec::new();
-    let mut guaranteed_return = false;
+    let mut flow = ControlFlow::fallthrough();
     for stmt in block {
-        if guaranteed_return {
+        if !flow.fallthrough {
             return Err(Diagnostic::new(
                 "control",
                 "unreachable statements after a terminating control-flow statement are not yet supported in stage1",
             )
             .with_span(stmt.line(), stmt.column()));
         }
-        let lowered_stmt = lower_stmt(stmt, env, ctx)?;
-        guaranteed_return = lowered_stmt.always_returns();
+        let lowered_stmt = lower_stmt(stmt, env, ctx, loop_flow.as_deref_mut())?;
+        let stmt_flow = lowered_stmt.control_flow();
+        flow = ControlFlow {
+            fallthrough: false,
+            returns: flow.returns,
+            breaks: flow.breaks,
+            continues: flow.continues,
+        }
+        .union(stmt_flow);
         lowered.push(lowered_stmt);
     }
     let mut after = env.clone();
     release_scope_borrows(&mut after, &scope_names);
-    Ok((lowered, after, guaranteed_return))
+    Ok((lowered, after, flow))
 }
 
 fn lower_block_recovering(
     block: &[syntax::Stmt],
     env: &mut HashMap<String, Binding>,
     ctx: &LowerContext<'_>,
-) -> (Vec<Stmt>, Vec<Diagnostic>, bool) {
+    mut loop_flow: Option<&mut LoopFlow>,
+) -> (Vec<Stmt>, Vec<Diagnostic>, ControlFlow) {
     let scope_names = env.keys().cloned().collect::<HashSet<_>>();
     let mut lowered = Vec::new();
     let mut diagnostics = Vec::new();
-    let mut guaranteed_return = false;
+    let mut flow = ControlFlow::fallthrough();
     for stmt in block {
-        if guaranteed_return {
+        if !flow.fallthrough {
             diagnostics.push(
                 Diagnostic::new(
                     "control",
@@ -658,9 +674,16 @@ fn lower_block_recovering(
             continue;
         }
         let mut candidate_env = env.clone();
-        match lower_stmt(stmt, &mut candidate_env, ctx) {
+        match lower_stmt(stmt, &mut candidate_env, ctx, loop_flow.as_deref_mut()) {
             Ok(lowered_stmt) => {
-                guaranteed_return = lowered_stmt.always_returns();
+                let stmt_flow = lowered_stmt.control_flow();
+                flow = ControlFlow {
+                    fallthrough: false,
+                    returns: flow.returns,
+                    breaks: flow.breaks,
+                    continues: flow.continues,
+                }
+                .union(stmt_flow);
                 *env = candidate_env;
                 lowered.push(lowered_stmt);
             }
@@ -671,7 +694,7 @@ fn lower_block_recovering(
         }
     }
     release_scope_borrows(env, &scope_names);
-    (lowered, diagnostics, guaranteed_return)
+    (lowered, diagnostics, flow)
 }
 
 fn insert_type_error_binding_for_failed_stmt(
@@ -761,6 +784,7 @@ fn lower_stmt(
     stmt: &syntax::Stmt,
     env: &mut HashMap<String, Binding>,
     ctx: &LowerContext<'_>,
+    mut loop_flow: Option<&mut LoopFlow>,
 ) -> Result<Stmt, Diagnostic> {
     match stmt {
         syntax::Stmt::Let {
@@ -987,7 +1011,8 @@ fn lower_stmt(
             if let Some(known_cond) = static_bool_value(&lowered_cond) {
                 if known_cond {
                     let mut then_env = env.clone();
-                    let (then_block, then_after, _) = lower_block(then_block, &mut then_env, ctx)?;
+                    let (then_block, then_after, _) =
+                        lower_block(then_block, &mut then_env, ctx, loop_flow.as_deref_mut())?;
                     *env = then_after;
                     return Ok(Stmt::If {
                         cond: lowered_cond,
@@ -998,7 +1023,8 @@ fn lower_stmt(
                 }
                 if let Some(else_block) = else_block {
                     let mut else_env = env.clone();
-                    let (block, after, _) = lower_block(else_block, &mut else_env, ctx)?;
+                    let (block, after, _) =
+                        lower_block(else_block, &mut else_env, ctx, loop_flow.as_deref_mut())?;
                     *env = after;
                     return Ok(Stmt::If {
                         cond: lowered_cond,
@@ -1016,22 +1042,23 @@ fn lower_stmt(
             }
             let before = env.clone();
             let mut then_env = before.clone();
-            let (then_block, then_after, then_returns) =
-                lower_block(then_block, &mut then_env, ctx)?;
-            let (else_block, else_after, else_returns) = if let Some(else_block) = else_block {
+            let (then_block, then_after, then_flow) =
+                lower_block(then_block, &mut then_env, ctx, loop_flow.as_deref_mut())?;
+            let (else_block, else_after, else_flow) = if let Some(else_block) = else_block {
                 let mut else_env = before.clone();
-                let (block, after, returns) = lower_block(else_block, &mut else_env, ctx)?;
-                (Some(block), Some(after), returns)
+                let (block, after, flow) =
+                    lower_block(else_block, &mut else_env, ctx, loop_flow.as_deref_mut())?;
+                (Some(block), Some(after), flow)
             } else {
-                (None, None, false)
+                (None, None, ControlFlow::fallthrough())
             };
             merge_branch_state(
                 env,
                 &before,
                 &then_after,
-                then_returns,
+                then_flow,
                 else_after.as_ref(),
-                else_returns,
+                else_flow,
             );
             Ok(Stmt::If {
                 cond: lowered_cond,
@@ -1065,35 +1092,49 @@ fn lower_stmt(
             let mut body_env = before.clone();
             let mut loop_ctx = ctx.clone();
             loop_ctx.loop_depth += 1;
-            let (body, body_after, body_returns) =
-                lower_block(body, &mut body_env, &loop_ctx)?;
+            let mut inner_loop_flow = LoopFlow::default();
+            let (body, body_after, body_flow) =
+                lower_block(body, &mut body_env, &loop_ctx, Some(&mut inner_loop_flow))?;
             // AG1.1: reject moves of outer non-Copy variables inside the loop
             // body — on subsequent iterations the value would not be available.
-            if !body_returns {
+            if body_flow.fallthrough || !inner_loop_flow.continue_states.is_empty() {
+                let mut loop_backedge_states = Vec::new();
+                if body_flow.fallthrough {
+                    loop_backedge_states.push(&body_after);
+                }
+                loop_backedge_states.extend(inner_loop_flow.continue_states.iter());
                 for (name, pre_binding) in &before {
                     if pre_binding.moved || pre_binding.ty.is_copy() {
                         continue;
                     }
-                    if let Some(post_binding) = body_after.get(name) {
-                        let moved_projection_in_body = post_binding
-                            .moved_projections
-                            .iter()
-                            .any(|projection| !pre_binding.moved_projections.contains(projection));
-                        if post_binding.moved || moved_projection_in_body {
-                            return Err(ownership_error(
-                                OWNERSHIP_LOOP_MOVE_OUTER_NON_COPY,
-                                format!(
-                                    "cannot move non-copy value `{}` inside loop body — \
-                                     value would not be available on subsequent iterations",
-                                    name
-                                ),
-                            )
-                            .with_span(*line, *column));
-                        }
+                    if loop_backedge_states.iter().any(|state| {
+                        state.get(name).is_some_and(|post_binding| {
+                            let moved_projection_in_body =
+                                post_binding.moved_projections.iter().any(|projection| {
+                                    !pre_binding.moved_projections.contains(projection)
+                                });
+                            post_binding.moved || moved_projection_in_body
+                        })
+                    }) {
+                        return Err(ownership_error(
+                            OWNERSHIP_LOOP_MOVE_OUTER_NON_COPY,
+                            format!(
+                                "cannot move non-copy value `{}` inside loop body — \
+                                 value would not be available on subsequent iterations",
+                                name
+                            ),
+                        )
+                        .with_span(*line, *column));
                     }
                 }
             }
-            merge_loop_state(env, &before, &body_after, body_returns);
+            merge_loop_state(
+                env,
+                &before,
+                &body_after,
+                body_flow,
+                &inner_loop_flow.break_states,
+            );
             Ok(Stmt::While {
                 cond: lowered_cond,
                 body,
@@ -1197,7 +1238,15 @@ fn lower_stmt(
                     });
                 }
             }
-            lower_match_stmt(expr, arms, *line, *column, env, ctx)
+            lower_match_stmt(
+                expr,
+                arms,
+                *line,
+                *column,
+                env,
+                ctx,
+                loop_flow.as_deref_mut(),
+            )
         }
         syntax::Stmt::Match {
             expr,
@@ -1206,7 +1255,15 @@ fn lower_stmt(
             column,
         } => {
             let arms = arms.iter().map(MatchArmInput::from).collect();
-            lower_match_stmt(expr, arms, *line, *column, env, ctx)
+            lower_match_stmt(
+                expr,
+                arms,
+                *line,
+                *column,
+                env,
+                ctx,
+                loop_flow.as_deref_mut(),
+            )
         }
         syntax::Stmt::Defer { expr, line, column } => {
             let lowered_expr = lower_expr(expr, env, ctx)?;
@@ -1225,6 +1282,9 @@ fn lower_stmt(
                         .with_span(*line, *column),
                 );
             }
+            if let Some(loop_flow) = loop_flow.as_deref_mut() {
+                loop_flow.break_states.push(env.clone());
+            }
             Ok(Stmt::Break {
                 span: SourceSpan::point(*line, *column),
             })
@@ -1235,6 +1295,9 @@ fn lower_stmt(
                     Diagnostic::new("control", "continue is only valid inside a while loop")
                         .with_span(*line, *column),
                 );
+            }
+            if let Some(loop_flow) = loop_flow.as_deref_mut() {
+                loop_flow.continue_states.push(env.clone());
             }
             Ok(Stmt::Continue {
                 span: SourceSpan::point(*line, *column),
@@ -1294,26 +1357,26 @@ fn merge_branch_state(
     env: &mut HashMap<String, Binding>,
     before: &HashMap<String, Binding>,
     then_after: &HashMap<String, Binding>,
-    then_returns: bool,
+    then_flow: ControlFlow,
     else_after: Option<&HashMap<String, Binding>>,
-    else_returns: bool,
+    else_flow: ControlFlow,
 ) {
     env.clear();
     for (name, binding) in before {
-        let then_moved = if then_returns {
-            binding.moved
-        } else {
+        let then_moved = if then_flow.fallthrough {
             then_after
                 .get(name)
                 .map(|entry| entry.moved)
                 .unwrap_or(binding.moved)
-        };
-        let else_moved = if else_returns {
-            binding.moved
         } else {
+            binding.moved
+        };
+        let else_moved = if else_flow.fallthrough {
             else_after
                 .and_then(|branch| branch.get(name).map(|entry| entry.moved))
                 .unwrap_or(binding.moved)
+        } else {
+            binding.moved
         };
         env.insert(
             name.clone(),
@@ -1323,9 +1386,9 @@ fn merge_branch_state(
                 moved_projections: merge_projection_sets(
                     binding,
                     then_after.get(name),
-                    then_returns,
+                    then_flow,
                     else_after.and_then(|branch| branch.get(name)),
-                    else_returns,
+                    else_flow,
                 ),
                 borrow_kind: binding.borrow_kind,
                 borrow_origin: binding.borrow_origin.clone(),
@@ -1333,19 +1396,19 @@ fn merge_branch_state(
                 borrowed_owners: binding.borrowed_owners.clone(),
                 active_borrow_count: merge_borrow_count(
                     binding.active_borrow_count,
-                    then_returns,
+                    !then_flow.fallthrough,
                     then_after.get(name).map(|entry| entry.active_borrow_count),
-                    else_returns,
+                    !else_flow.fallthrough,
                     else_after
                         .and_then(|branch| branch.get(name).map(|entry| entry.active_borrow_count)),
                 ),
                 active_mut_borrow_count: merge_borrow_count(
                     binding.active_mut_borrow_count,
-                    then_returns,
+                    !then_flow.fallthrough,
                     then_after
                         .get(name)
                         .map(|entry| entry.active_mut_borrow_count),
-                    else_returns,
+                    !else_flow.fallthrough,
                     else_after.and_then(|branch| {
                         branch.get(name).map(|entry| entry.active_mut_borrow_count)
                     }),
@@ -1359,17 +1422,17 @@ fn merge_branch_state(
 fn merge_projection_sets(
     before: &Binding,
     then_after: Option<&Binding>,
-    then_returns: bool,
+    then_flow: ControlFlow,
     else_after: Option<&Binding>,
-    else_returns: bool,
+    else_flow: ControlFlow,
 ) -> HashSet<ProjectionPath> {
     let mut moved = before.moved_projections.clone();
-    if !then_returns {
+    if then_flow.fallthrough {
         if let Some(binding) = then_after {
             moved.extend(binding.moved_projections.iter().cloned());
         }
     }
-    if !else_returns {
+    if else_flow.fallthrough {
         if let Some(binding) = else_after {
             moved.extend(binding.moved_projections.iter().cloned());
         }
@@ -1381,44 +1444,69 @@ fn merge_loop_state(
     env: &mut HashMap<String, Binding>,
     before: &HashMap<String, Binding>,
     body_after: &HashMap<String, Binding>,
-    body_returns: bool,
+    body_flow: ControlFlow,
+    break_states: &[HashMap<String, Binding>],
 ) {
     // AG1.1: the loop body may execute zero times, so post-loop ownership
-    // state preserves the pre-loop moved flags.  Moves of outer non-Copy
-    // values inside the body are rejected earlier (before this function is
-    // called), so the only moved-state change that can reach here is for
-    // values that were already moved before the loop.  Borrow counts still
-    // take the max of pre-loop and body-after to stay conservative.
+    // state preserves the pre-loop moved flags.  Moves on a break edge are
+    // visible after the loop, while moves on a backedge are rejected earlier.
     env.clear();
     for (name, binding) in before {
+        let exit_bindings = break_states.iter().filter_map(|state| state.get(name));
+        let moved_on_break = exit_bindings.clone().any(|entry| entry.moved);
+        let moved_projections_on_break = exit_bindings
+            .flat_map(|entry| entry.moved_projections.iter().cloned())
+            .collect::<HashSet<_>>();
+        let body_borrow_count = if body_flow.fallthrough {
+            body_after
+                .get(name)
+                .map(|entry| entry.active_borrow_count)
+                .unwrap_or(binding.active_borrow_count)
+        } else {
+            binding.active_borrow_count
+        };
+        let body_mut_borrow_count = if body_flow.fallthrough {
+            body_after
+                .get(name)
+                .map(|entry| entry.active_mut_borrow_count)
+                .unwrap_or(binding.active_mut_borrow_count)
+        } else {
+            binding.active_mut_borrow_count
+        };
+        let break_borrow_count = break_states
+            .iter()
+            .filter_map(|state| state.get(name))
+            .map(|entry| entry.active_borrow_count)
+            .max()
+            .unwrap_or(binding.active_borrow_count);
+        let break_mut_borrow_count = break_states
+            .iter()
+            .filter_map(|state| state.get(name))
+            .map(|entry| entry.active_mut_borrow_count)
+            .max()
+            .unwrap_or(binding.active_mut_borrow_count);
         env.insert(
             name.clone(),
             Binding {
                 ty: binding.ty.clone(),
-                moved: binding.moved,
-                moved_projections: binding.moved_projections.clone(),
+                moved: binding.moved || moved_on_break,
+                moved_projections: binding
+                    .moved_projections
+                    .union(&moved_projections_on_break)
+                    .cloned()
+                    .collect(),
                 borrow_kind: binding.borrow_kind,
                 borrow_origin: binding.borrow_origin.clone(),
                 net_origin: binding.net_origin.clone(),
                 borrowed_owners: binding.borrowed_owners.clone(),
-                active_borrow_count: if body_returns {
-                    binding.active_borrow_count
-                } else {
-                    let body_count = body_after
-                        .get(name)
-                        .map(|entry| entry.active_borrow_count)
-                        .unwrap_or(binding.active_borrow_count);
-                    binding.active_borrow_count.max(body_count)
-                },
-                active_mut_borrow_count: if body_returns {
-                    binding.active_mut_borrow_count
-                } else {
-                    let body_count = body_after
-                        .get(name)
-                        .map(|entry| entry.active_mut_borrow_count)
-                        .unwrap_or(binding.active_mut_borrow_count);
-                    binding.active_mut_borrow_count.max(body_count)
-                },
+                active_borrow_count: binding
+                    .active_borrow_count
+                    .max(body_borrow_count)
+                    .max(break_borrow_count),
+                active_mut_borrow_count: binding
+                    .active_mut_borrow_count
+                    .max(body_mut_borrow_count)
+                    .max(break_mut_borrow_count),
                 active_borrows: binding.active_borrows.clone(),
             },
         );
@@ -1428,18 +1516,18 @@ fn merge_loop_state(
 fn merge_match_state(
     env: &mut HashMap<String, Binding>,
     before: &HashMap<String, Binding>,
-    arm_states: &[(HashMap<String, Binding>, bool)],
+    arm_states: &[(HashMap<String, Binding>, ControlFlow)],
 ) {
     env.clear();
     for (name, binding) in before {
-        let moved = arm_states.iter().any(|(after, returns)| {
-            if *returns {
-                binding.moved
-            } else {
+        let moved = arm_states.iter().any(|(after, flow)| {
+            if flow.fallthrough {
                 after
                     .get(name)
                     .map(|entry| entry.moved)
                     .unwrap_or(binding.moved)
+            } else {
+                binding.moved
             }
         });
         env.insert(
@@ -1454,22 +1542,22 @@ fn merge_match_state(
                 borrowed_owners: binding.borrowed_owners.clone(),
                 active_borrow_count: arm_states
                     .iter()
-                    .filter_map(|(after, returns)| {
-                        if *returns {
-                            Some(binding.active_borrow_count)
-                        } else {
+                    .filter_map(|(after, flow)| {
+                        if flow.fallthrough {
                             after.get(name).map(|entry| entry.active_borrow_count)
+                        } else {
+                            Some(binding.active_borrow_count)
                         }
                     })
                     .max()
                     .unwrap_or(binding.active_borrow_count),
                 active_mut_borrow_count: arm_states
                     .iter()
-                    .filter_map(|(after, returns)| {
-                        if *returns {
-                            Some(binding.active_mut_borrow_count)
-                        } else {
+                    .filter_map(|(after, flow)| {
+                        if flow.fallthrough {
                             after.get(name).map(|entry| entry.active_mut_borrow_count)
+                        } else {
+                            Some(binding.active_mut_borrow_count)
                         }
                     })
                     .max()
@@ -1483,11 +1571,11 @@ fn merge_match_state(
 fn merge_match_projection_sets(
     before: &Binding,
     name: &str,
-    arm_states: &[(HashMap<String, Binding>, bool)],
+    arm_states: &[(HashMap<String, Binding>, ControlFlow)],
 ) -> HashSet<ProjectionPath> {
     let mut moved = before.moved_projections.clone();
-    for (after, returns) in arm_states {
-        if *returns {
+    for (after, flow) in arm_states {
+        if !flow.fallthrough {
             continue;
         }
         if let Some(binding) = after.get(name) {

--- a/stage1/crates/axiomc/src/hir/control_flow.rs
+++ b/stage1/crates/axiomc/src/hir/control_flow.rs
@@ -1,37 +1,114 @@
 use super::Stmt;
 use super::expressions::static_bool_value;
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(super) struct ControlFlow {
+    pub(super) fallthrough: bool,
+    pub(super) returns: bool,
+    pub(super) breaks: bool,
+    pub(super) continues: bool,
+}
+
+impl ControlFlow {
+    pub(super) const fn fallthrough() -> Self {
+        Self {
+            fallthrough: true,
+            returns: false,
+            breaks: false,
+            continues: false,
+        }
+    }
+
+    pub(super) const fn return_value() -> Self {
+        Self {
+            fallthrough: false,
+            returns: true,
+            breaks: false,
+            continues: false,
+        }
+    }
+
+    pub(super) const fn break_value() -> Self {
+        Self {
+            fallthrough: false,
+            returns: false,
+            breaks: true,
+            continues: false,
+        }
+    }
+
+    pub(super) const fn continue_value() -> Self {
+        Self {
+            fallthrough: false,
+            returns: false,
+            breaks: false,
+            continues: true,
+        }
+    }
+
+    pub(super) const fn union(self, other: Self) -> Self {
+        Self {
+            fallthrough: self.fallthrough || other.fallthrough,
+            returns: self.returns || other.returns,
+            breaks: self.breaks || other.breaks,
+            continues: self.continues || other.continues,
+        }
+    }
+
+    pub(super) const fn always_returns(self) -> bool {
+        self.returns && !self.fallthrough && !self.breaks && !self.continues
+    }
+}
+
 impl Stmt {
-    pub(super) fn always_returns(&self) -> bool {
+    pub(super) fn control_flow(&self) -> ControlFlow {
         match self {
-            Stmt::Return { .. } | Stmt::Panic { .. } => true,
-            Stmt::Defer { .. } | Stmt::Assign { .. } => false,
-            Stmt::Break { .. } | Stmt::Continue { .. } => true,
+            Stmt::Return { .. } | Stmt::Panic { .. } => ControlFlow::return_value(),
+            Stmt::Defer { .. } | Stmt::Assign { .. } => ControlFlow::fallthrough(),
+            Stmt::Break { .. } => ControlFlow::break_value(),
+            Stmt::Continue { .. } => ControlFlow::continue_value(),
             Stmt::If {
                 cond,
                 then_block,
                 else_block: Some(else_block),
                 ..
             } => match static_bool_value(cond) {
-                Some(true) => block_always_returns(then_block),
-                Some(false) => block_always_returns(else_block),
-                None => block_always_returns(then_block) && block_always_returns(else_block),
+                Some(true) => block_control_flow(then_block),
+                Some(false) => block_control_flow(else_block),
+                None => block_control_flow(then_block).union(block_control_flow(else_block)),
             },
             Stmt::If {
                 cond,
                 then_block,
                 else_block: None,
                 ..
-            } => {
-                static_bool_value(cond).is_some_and(|value| value)
-                    && block_always_returns(then_block)
-            }
-            Stmt::Match { arms, .. } => arms.iter().all(|arm| block_always_returns(&arm.body)),
-            _ => false,
+            } => match static_bool_value(cond) {
+                Some(true) => block_control_flow(then_block),
+                _ => ControlFlow::fallthrough(),
+            },
+            Stmt::While { .. } => ControlFlow::fallthrough(),
+            Stmt::Match { arms, .. } => arms
+                .iter()
+                .map(|arm| block_control_flow(&arm.body))
+                .fold(ControlFlow::default(), ControlFlow::union),
+            _ => ControlFlow::fallthrough(),
         }
     }
 }
 
-fn block_always_returns(block: &[Stmt]) -> bool {
-    block.last().is_some_and(Stmt::always_returns)
+fn block_control_flow(block: &[Stmt]) -> ControlFlow {
+    let mut flow = ControlFlow::fallthrough();
+    for stmt in block {
+        if !flow.fallthrough {
+            break;
+        }
+        flow = ControlFlow {
+            fallthrough: false,
+            returns: flow.returns,
+            breaks: flow.breaks,
+            continues: flow.continues,
+        }
+        .union(stmt.control_flow());
+    }
+    flow
 }

--- a/stage1/crates/axiomc/src/hir/matches.rs
+++ b/stage1/crates/axiomc/src/hir/matches.rs
@@ -55,6 +55,7 @@ pub(super) fn lower_match_stmt(
     column: usize,
     env: &mut HashMap<String, Binding>,
     ctx: &LowerContext<'_>,
+    mut loop_flow: Option<&mut LoopFlow>,
 ) -> Result<Stmt, Diagnostic> {
     let lowered_expr = lower_expr(expr, env, ctx)?;
     let match_borrowed_owners = expr_borrowed_owners(&lowered_expr, env, ctx);
@@ -80,14 +81,13 @@ pub(super) fn lower_match_stmt(
             match_borrow_kind,
             match_borrowed_owners,
             reuse_existing_match_binding,
+            loop_flow,
         );
     };
     let before = env.clone();
     let mut seen = HashMap::new();
     let mut lowered_arms = Vec::new();
     let mut arm_states = Vec::new();
-    let mut ignored_body_cache: HashMap<String, (Vec<Stmt>, HashMap<String, Binding>, bool)> =
-        HashMap::new();
     for arm in arms {
         let variant_def = variant_defs
             .iter()
@@ -272,18 +272,8 @@ pub(super) fn lower_match_stmt(
                 },
             );
         }
-        let (body, after, returns) = if arm.ignore_payloads && arm.bindings.is_empty() {
-            let cache_key = format!("{:?}", arm.body);
-            if let Some((body, after, returns)) = ignored_body_cache.get(&cache_key) {
-                (body.clone(), after.clone(), *returns)
-            } else {
-                let lowered = lower_block(&arm.body, &mut arm_env, ctx)?;
-                ignored_body_cache.insert(cache_key, lowered.clone());
-                lowered
-            }
-        } else {
-            lower_block(&arm.body, &mut arm_env, ctx)?
-        };
+        let (body, after, flow) =
+            lower_block(&arm.body, &mut arm_env, ctx, loop_flow.as_deref_mut())?;
         lowered_arms.push(MatchArm {
             enum_name: enum_name.clone(),
             variant: arm.variant.clone(),
@@ -293,7 +283,7 @@ pub(super) fn lower_match_stmt(
             borrow_region_facts: arm_borrow_region_facts,
             body,
         });
-        arm_states.push((after, returns));
+        arm_states.push((after, flow));
     }
     let missing = variant_defs
         .iter()
@@ -334,6 +324,7 @@ fn lower_const_match_stmt(
     match_borrow_kind: Option<BorrowKind>,
     match_borrowed_owners: HashSet<BorrowedOwner>,
     reuse_existing_match_binding: bool,
+    mut loop_flow: Option<&mut LoopFlow>,
 ) -> Result<Stmt, Diagnostic> {
     if lowered_expr.ty() != &Type::Int {
         return Err(Diagnostic::new(
@@ -368,7 +359,8 @@ fn lower_const_match_stmt(
             );
         }
         let mut arm_env = before.clone();
-        let (body, after, returns) = lower_block(&arm.body, &mut arm_env, ctx)?;
+        let (body, after, flow) =
+            lower_block(&arm.body, &mut arm_env, ctx, loop_flow.as_deref_mut())?;
         lowered_arms.push(MatchArm {
             enum_name: String::new(),
             variant: value.to_string(),
@@ -378,7 +370,7 @@ fn lower_const_match_stmt(
             borrow_region_facts: Vec::new(),
             body,
         });
-        arm_states.push((after, returns));
+        arm_states.push((after, flow));
     }
     merge_match_state(env, &before, &arm_states);
     if let Some(borrow_kind) = match_borrow_kind
@@ -541,7 +533,7 @@ pub(super) fn lower_match_expr(
             is_named: arm.is_named,
             expr: lowered_arm_expr,
         });
-        arm_states.push((arm_env, false));
+        arm_states.push((arm_env, ControlFlow::fallthrough()));
     }
     let missing = variant_defs
         .iter()

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -83,6 +83,113 @@ fn cranelift_backend_builds_hello_binary() {
 
 #[cfg(not(windows))]
 #[test]
+fn cranelift_backend_lowers_nested_break_and_continue() {
+    if which::which("cc").is_err() {
+        eprintln!("skipping cranelift loop-control test because cc is unavailable");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("loop-control");
+    fs::create_dir_all(project.join("src")).expect("create project src");
+    fs::write(
+        project.join("axiom.toml"),
+        r#"[package]
+name = "cranelift-loop-control"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[[tests]]
+name = "loop-control"
+entry = "src/main_test.ax"
+stdout = "src/main_test.stdout"
+kind = "unit"
+"#,
+    )
+    .expect("write manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        r#"version = 1
+
+[[package]]
+name = "cranelift-loop-control"
+version = "0.1.0"
+source = "path"
+"#,
+    )
+    .expect("write lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        r#"let outer: int = 0
+while outer < 2 {
+let inner: int = 0
+while inner < 3 {
+inner = inner + 1
+if inner == 1 {
+continue
+}
+break
+}
+outer = outer + 1
+}
+print outer
+"#,
+    )
+    .expect("write source");
+    fs::write(
+        project.join("src/main_test.ax"),
+        "let value: int = 0\nwhile value < 1 {\nvalue = value + 1\ncontinue\n}\nprint value\n",
+    )
+    .expect("write test source");
+    fs::write(project.join("src/main_test.stdout"), "1\n").expect("write test golden");
+
+    let check = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args(["check", project.to_str().expect("project path"), "--json"])
+        .output()
+        .expect("run default axiomc check");
+    assert!(
+        check.status.success(),
+        "default Cranelift check failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&check.stdout),
+        String::from_utf8_lossy(&check.stderr)
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args(["build", project.to_str().expect("project path"), "--json"])
+        .output()
+        .expect("run default axiomc build");
+    assert!(
+        output.status.success(),
+        "default Cranelift build failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
+    assert_eq!(payload["backend"], "cranelift");
+    let binary = payload["binary"].as_str().expect("binary path");
+    let run = Command::new(binary)
+        .output()
+        .expect("run loop-control binary");
+    assert!(run.status.success(), "loop-control binary failed: {run:?}");
+    assert_eq!(String::from_utf8_lossy(&run.stdout), "2\n");
+
+    let test = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args(["test", project.to_str().expect("project path"), "--json"])
+        .output()
+        .expect("run default axiomc test");
+    assert!(
+        test.status.success(),
+        "default Cranelift test failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&test.stdout),
+        String::from_utf8_lossy(&test.stderr)
+    );
+}
+
+#[cfg(not(windows))]
+#[test]
 fn cranelift_backend_pure_artifact_is_invariant_to_build_env_and_stdin() {
     if which::which("cc").is_err() {
         eprintln!("skipping cranelift backend smoke test because cc is unavailable");
@@ -8602,7 +8709,10 @@ fn cranelift_backend_builds_once_and_reads_cwd_at_each_run() {
         .output()
         .expect("run binary from first cwd");
     assert!(first.status.success());
-    assert_eq!(String::from_utf8_lossy(&first.stdout), format!("{}\n", first_cwd.display()));
+    assert_eq!(
+        String::from_utf8_lossy(&first.stdout),
+        format!("{}\n", first_cwd.display())
+    );
 
     let second = Command::new(binary)
         .current_dir(&second_cwd)

--- a/stage1/crates/axiomc/tests/support/hir_unit.rs
+++ b/stage1/crates/axiomc/tests/support/hir_unit.rs
@@ -5,6 +5,61 @@ fn parse(source: &str) -> syntax::Program {
     syntax::parse_program(source, Path::new("main.ax")).expect("parse fixture")
 }
 
+#[test]
+fn hir_propagates_move_state_from_break_edges() {
+    let parsed = parse(
+        r#"
+fn main(): int {
+let value: string = "owned"
+while true {
+let moved: string = value
+break
+}
+print value
+return 0
+}
+"#,
+    );
+
+    let error = lower(&parsed).expect_err("break exit must preserve moved state");
+    assert!(error.message.contains("use of moved value \"value\""));
+}
+
+#[test]
+fn hir_rejects_move_on_continue_backedge_and_unreachable_statements() {
+    let parsed = parse(
+        r#"
+fn main(): int {
+let value: string = "owned"
+while true {
+let moved: string = value
+continue
+print 1
+}
+return 0
+}
+"#,
+    );
+
+    let error = lower(&parsed).expect_err("continue backedge must not reuse a moved value");
+    assert!(error.message.contains("unreachable statements"));
+
+    let parsed = parse(
+        r#"
+fn main(): int {
+let value: string = "owned"
+while true {
+let moved: string = value
+continue
+}
+return 0
+}
+"#,
+    );
+    let error = lower(&parsed).expect_err("continue backedge must reject the move");
+    assert!(error.message.contains("cannot move non-copy value"));
+}
+
 fn collect_borrow_region_facts(stmts: &[Stmt]) -> Vec<BorrowRegionFact> {
     let mut facts = Vec::new();
     for stmt in stmts {

--- a/stage1/crates/axiomc/tests/support/lib_unit.rs
+++ b/stage1/crates/axiomc/tests/support/lib_unit.rs
@@ -1055,6 +1055,54 @@ print demo()
 }
 
 #[test]
+fn generated_rust_unwinds_only_the_loop_scope_on_control_edges() {
+    let source = r#"fn trace(label: string): int {
+print label
+return 0
+}
+
+fn demo(): int {
+defer trace("outer")
+let index: int = 0
+while index < 2 {
+defer trace("loop")
+index = index + 1
+if index == 1 {
+continue
+}
+break
+}
+return 0
+}
+
+print demo()
+"#;
+    let parsed = parse_program(source, Path::new("main.ax")).expect("parse");
+    let hir = hir::lower(&parsed).expect("lower");
+    let mir = mir::lower(&hir);
+    let rendered = render_rust(&mir);
+    let demo_pos = rendered.find("fn demo").expect("demo rendered");
+    let continue_pos = rendered[demo_pos..]
+        .find("continue;")
+        .map(|offset| demo_pos + offset)
+        .expect("continue rendered");
+    let break_pos = rendered[demo_pos..]
+        .find("break;")
+        .map(|offset| demo_pos + offset)
+        .expect("break rendered");
+    let outer_pos = rendered
+        .rfind("let _ = trace(String::from(\"outer\"));")
+        .expect("outer defer rendered");
+    assert!(rendered[..continue_pos].contains("let _ = trace(String::from(\"loop\"));"));
+    assert!(rendered[..break_pos].contains("let _ = trace(String::from(\"loop\"));"));
+    assert!(!rendered[continue_pos..break_pos].contains("trace(String::from(\"outer\"))"));
+    assert!(
+        outer_pos > break_pos,
+        "outer defer must remain at function exit"
+    );
+}
+
+#[test]
 fn run_project_executes_defer_on_return_panic_and_nested_scope() {
     let dir = tempdir().expect("tempdir");
     fs::write(dir.path().join("axiom.toml"), render_manifest("defer-demo"))


### PR DESCRIPTION
## Summary

- Represent `break`, `continue`, `return`, and `fallthrough` as distinct HIR outcomes.
- Preserve moved-state facts across loop exits and backedges, and unwind only loop-local defers on control edges.
- Lower loop controls in Cranelift with explicit targets rather than relying on generic fallthrough behavior.
- Add HIR, defer-unwinding, and nested-loop native-backend regressions.
- Update the measured compiler-source decomposition ceilings required by the new control-flow implementation.

## Governing Issue

Closes #1584

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Focused validation:

- `cargo check --manifest-path stage1/Cargo.toml -p axiomc` — passed
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib hir_ -- --nocapture` — 33 passed
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib generated_rust_unwinds_only_the_loop_scope_on_control_edges -- --nocapture` — passed
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend cranelift_backend_lowers_nested_break_and_continue -- --nocapture` — passed
- `bash scripts/ci/run-fast-checks.sh` — passed through direct-native proof workload validation
- `git diff --check` — passed

The full suites retain the repository's pre-existing registry loopback bind restriction and incompatible `[unsafe_rationale]` fixture metadata failures; neither is in this change's control-flow scope.

Autoreview was not run because the private-diff authorization boundary prohibits transmitting this source diff to an external reviewer without explicit authorization.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] PR author enabled auto-merge where GitHub allows it, or GitHub plan-limit evidence/unavailable reason is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Flow Contract

- Owner lane: Pheidon / HIR and native control-flow consistency
- Repair owner: Codex
- Autonomy class: 2
- Risk class: compiler correctness

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] PR author enabled auto-merge where GitHub allows it, or recorded why it is unavailable/unsafe

## Merge Automation

- [x] PR author enabled auto-merge with `gh pr merge --auto --squash`, or the reason it is unavailable/unsafe is noted below

## Notes

- This change keeps the existing language surface and aligns ownership/defer semantics across HIR, generated Rust, and Cranelift lowering.
- Review and required-check gates remain external blockers until satisfied.
