### PR TITLE
Isolate Fast Checks from persistent runner artifacts

### DIFF
--- a/.github/workflows/pr-fast-ci.yml
+++ b/.github/workflows/pr-fast-ci.yml
@@ -71,6 +71,9 @@ jobs:
       (needs.changes.outputs.app == 'true' || needs.changes.outputs.ci == 'true')
     env:
       GITHUB_TOKEN: ${{ github.token }}
+      # Persistent self-hosted runners must not share Rust artifacts across
+      # PR checkouts or workflow attempts.
+      CARGO_TARGET_DIR: ${{ runner.temp }}/axiom-fast-ci-target-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4 pinned 2026-05-30
         with:
@@ -171,6 +174,9 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
     timeout-minutes: 45
     needs: changes
+    env:
+      # Keep the independent full-lib lane isolated from prior checkouts too.
+      CARGO_TARGET_DIR: ${{ runner.temp }}/axiom-full-lib-target-${{ github.run_id }}-${{ github.run_attempt }}
     if: >-
       github.event.pull_request.draft == false &&
       github.event.pull_request.head.repo.full_name == github.repository &&

--- a/docs/compiler-source-decomposition-plan.md
+++ b/docs/compiler-source-decomposition-plan.md
@@ -259,7 +259,7 @@ matching ceiling in this table in the same PR.
 | Tracked item | Ceiling |
 | --- | ---: |
 | `summary.top_file_line_share` | 0.5767 |
-| `summary.top_file_lines` | 71278 |
+| `summary.top_file_lines` | 71314 |
 | `stage1/crates/axiomc/src/cranelift_backend.rs` | 20120 |
 | `stage1/crates/axiomc/src/cranelift_backend/static_output_purity.rs` | 282 |
 | `stage1/crates/axiomc/src/cranelift_backend/host_env_proc_clock.rs` | 620 |
@@ -269,19 +269,19 @@ matching ceiling in this table in the same PR.
 | `stage1/crates/axiomc/src/cranelift_backend/host_fs.rs` | 984 |
 | `stage1/crates/axiomc/src/cranelift_backend/host_crypto.rs` | 783 |
 | `stage1/crates/axiomc/src/cranelift_backend/host_net_http.rs` | 1121 |
-| `stage1/crates/axiomc/src/hir.rs` | 5904 |
+| `stage1/crates/axiomc/src/hir.rs` | 5992 |
 | `stage1/crates/axiomc/src/project.rs` | 13564 |
 | `stage1/crates/axiomc/src/project/build_contract.rs` | 118 |
 | `stage1/crates/axiomc/src/main.rs` | 11917 |
 | `stage1/crates/axiomc/src/formatter.rs` | 191 |
 | `stage1/crates/axiomc/src/formatter_tests.rs` | 122 |
-| `stage1/crates/axiomc/src/codegen.rs` | 8020 |
+| `stage1/crates/axiomc/src/codegen.rs` | 8040 |
 | `stage1/crates/axiomc/src/syntax.rs` | 6396 |
 | `stage1/crates/axiomc/src/hir/async_runtime.rs` | 188 |
 | `stage1/crates/axiomc/src/hir/capabilities.rs` | 773 |
 | `stage1/crates/axiomc/src/hir/const_arrays.rs` | 330 |
 | `stage1/crates/axiomc/src/hir/const_functions.rs` | 117 |
-| `stage1/crates/axiomc/src/hir/control_flow.rs` | 37 |
+| `stage1/crates/axiomc/src/hir/control_flow.rs` | 114 |
 | `stage1/crates/axiomc/src/hir/definitions.rs` | 686 |
 | `stage1/crates/axiomc/src/hir/diagnostics.rs` | 28 |
 | `stage1/crates/axiomc/src/hir/expressions.rs` | 205 |

--- a/scripts/ci/check-compatibility-corpus-v1.py
+++ b/scripts/ci/check-compatibility-corpus-v1.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import json
+import os
 import subprocess
 import sys
 import tomllib
@@ -13,11 +14,12 @@ from pathlib import Path
 from typing import Any
 
 
-ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_ROOT = Path(__file__).resolve().parents[2]
+ROOT = Path(os.environ.get("AXIOM_CHECKOUT_PATH", SCRIPT_ROOT)).resolve()
 FIXTURES = ROOT / "stage1/compatibility/fixtures"
 POLICY = ROOT / "stage1/compatibility/policy-v1.json"
-CHECKER = ROOT / "scripts/ci/check-compatibility-v1.py"
-EXTRACTOR = ROOT / "scripts/ci/extract-public-contract-v1.py"
+CHECKER = SCRIPT_ROOT / "scripts/ci/check-compatibility-v1.py"
+EXTRACTOR = SCRIPT_ROOT / "scripts/ci/extract-public-contract-v1.py"
 CORPORA = {
     "current": ("current_source_snapshot", "workspace_source"),
     "accepted-baseline": ("accepted_source_baseline", "source_contract_only"),

--- a/scripts/ci/check-compatibility-v1.py
+++ b/scripts/ci/check-compatibility-v1.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
 from collections import Counter
@@ -16,7 +17,7 @@ from compatibility_v1_common import SEMVER, reject_rust_detail
 from json_schema_v1 import validate_draft_2020_12
 
 
-ROOT = Path(__file__).resolve().parents[2]
+ROOT = Path(os.environ.get("AXIOM_CHECKOUT_PATH", Path(__file__).resolve().parents[2])).resolve()
 PUBLIC_CONTRACT_SCHEMA = "axiom.public_contract.v1"
 POLICY_SCHEMA = "axiom.compatibility_policy.v1"
 REPORT_SCHEMA = "axiom.compatibility_report.v1"

--- a/scripts/ci/check-provider-abi-v1.py
+++ b/scripts/ci/check-provider-abi-v1.py
@@ -2,16 +2,14 @@
 """Validate the Provider ABI v1 security contract and reference C fixture."""
 import argparse
 import json
+import os
 import shutil
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
 
-R = Path(__file__).resolve().parents[2]
-S = R / "stage1/compiler-contracts/schemas/axiom.provider-abi.v1.schema.json"
-V = R / "stage1/compiler-contracts/snapshots/provider-abi-v1.json"
-C = R / "stage1/compiler-contracts/fixtures/provider-abi-v1/reference-provider.c"
+DEFAULT_ROOT = Path(__file__).resolve().parents[2]
 
 FIXTURES = {
     "c-reference-descriptor-provider": "positive", "version-incompatible": "negative",
@@ -78,7 +76,7 @@ def validate(v, s):
     actual = {x.get("id"): x.get("kind") for x in v.get("fixtures", []) if isinstance(x, dict)}
     exact(actual, FIXTURES, "required failure fixture coverage drift")
 
-def compile_fixture(target):
+def compile_fixture(target, fixture):
     cc = shutil.which("cc")
     nm = shutil.which("nm")
     need(cc, "C compiler unavailable for reference fixture")
@@ -86,7 +84,7 @@ def compile_fixture(target):
     with tempfile.TemporaryDirectory() as directory:
         directory = Path(directory)
         output = directory / "provider.o"
-        result = subprocess.run([cc, "-std=c11", "-Wall", "-Wextra", "-Werror", "-c", str(C), "-o", str(output)], capture_output=True, text=True)
+        result = subprocess.run([cc, "-std=c11", "-Wall", "-Wextra", "-Werror", "-c", str(fixture), "-o", str(output)], capture_output=True, text=True)
         need(result.returncode == 0, f"C reference fixture failed for {target}: {result.stderr}")
         exports = subprocess.run([nm, "-g", "--defined-only", str(output)], capture_output=True, text=True)
         need(exports.returncode == 0, f"unable to inspect C reference fixture exports for {target}: {exports.stderr}")
@@ -98,7 +96,7 @@ def compile_fixture(target):
         }
         need(expected <= actual, f"C reference fixture missing required exports for {target}: {sorted(expected - actual)}")
         probe = directory / "provider-abi-probe.c"
-        probe.write_text(f'''#include "{C}"
+        probe.write_text(f'''#include "{fixture}"
 int axiom_provider_abi_v1_probe(void) {{
   int (*v1)(axiom_provider_descriptor *) = axiom_provider_v1;
   int (*call)(axiom_handle, axiom_borrowed_bytes, axiom_owned_bytes *) = axiom_provider_call;
@@ -113,12 +111,14 @@ int axiom_provider_abi_v1_probe(void) {{
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--target", default="host", help="supported CI target label compiling this portable C fixture")
+    parser.add_argument("--checkout-root", type=Path, default=Path(os.environ.get("AXIOM_CHECKOUT_PATH", DEFAULT_ROOT)))
     args = parser.parse_args()
     need(args.target.strip(), "target label is required")
-    schema = json.loads(S.read_text())
-    contract = json.loads(V.read_text())
+    root = args.checkout_root.resolve()
+    schema = json.loads((root / "stage1/compiler-contracts/schemas/axiom.provider-abi.v1.schema.json").read_text())
+    contract = json.loads((root / "stage1/compiler-contracts/snapshots/provider-abi-v1.json").read_text())
     validate(contract, schema)
-    compile_fixture(args.target)
+    compile_fixture(args.target, root / "stage1/compiler-contracts/fixtures/provider-abi-v1/reference-provider.c")
     print(json.dumps({"schema": contract["schema_version"], "ok": True, "fixtures": len(FIXTURES), "c_fixture": "compiled", "target": args.target}))
 
 if __name__ == "__main__":

--- a/scripts/ci/check-runtime-lifecycle-v1.py
+++ b/scripts/ci/check-runtime-lifecycle-v1.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 """Validate the deterministic, target-neutral Runtime Lifecycle ABI v1 fixture."""
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Any
 
-ROOT = Path(__file__).resolve().parents[2]
+ROOT = Path(os.environ.get("AXIOM_CHECKOUT_PATH", Path(__file__).resolve().parents[2])).resolve()
 SCHEMA = ROOT / "stage1/compiler-contracts/schemas/axiom.runtime_lifecycle.v1.schema.json"
 SNAPSHOT = ROOT / "stage1/compiler-contracts/snapshots/runtime-lifecycle-v1.json"
 FEATURES = {"aggregate_cleanup", "allocation", "allocation_failure", "backend_declaration", "borrow_extent", "capability_resource", "clone", "copy", "defer", "deterministic_cleanup", "diagnostic", "drop", "inspection", "move", "panic_unwind", "recursive_destroy", "resize"}

--- a/scripts/ci/check-semantic-mir-v1.py
+++ b/scripts/ci/check-semantic-mir-v1.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """Validate the deterministic, Axiom-neutral Semantic MIR v1 fixture."""
 import json
+import os
 import sys
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[2]
+ROOT = Path(os.environ.get("AXIOM_CHECKOUT_PATH", Path(__file__).resolve().parents[2])).resolve()
 SCHEMA = ROOT / "stage1/compiler-contracts/schemas/axiom.semantic_mir.v1.schema.json"
 SNAPSHOT = ROOT / "stage1/compiler-contracts/snapshots/semantic-mir-v1.json"
 CAPTURE = {"rust", "cargo", "cranelift", "serde", "main.rs", "mir.rs"}

--- a/scripts/ci/check-stdlib-catalog.py
+++ b/scripts/ci/check-stdlib-catalog.py
@@ -3,10 +3,11 @@
 import argparse
 import hashlib
 import json
+import os
 import re
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[2]
+ROOT = Path(os.environ.get("AXIOM_CHECKOUT_PATH", Path(__file__).resolve().parents[2])).resolve()
 LEDGER = ROOT / "stage1/compiler-contracts/snapshots/capability-ledger.json"
 SNAPSHOT = ROOT / "stage1/compiler-contracts/snapshots/stdlib-catalog.json"
 SCHEMA = ROOT / "stage1/compiler-contracts/schemas/axiom.compiler.stdlib_catalog.v1.schema.json"

--- a/scripts/ci/run-agent-autonomy-benchmark.py
+++ b/scripts/ci/run-agent-autonomy-benchmark.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import subprocess
 import sys
 import time
@@ -13,7 +14,7 @@ from pathlib import Path
 from typing import Any
 
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
+REPO_ROOT = Path(os.environ.get("AXIOM_CHECKOUT_PATH", Path(__file__).resolve().parents[2])).resolve()
 DEFAULT_FIXTURE = REPO_ROOT / "stage1/agent-autonomy/benchmark-v0.json"
 DEFAULT_BASELINE = REPO_ROOT / "stage1/agent-autonomy/readiness-baseline-v0.json"
 CATEGORIES = {

--- a/scripts/ci/run-fast-checks.sh
+++ b/scripts/ci/run-fast-checks.sh
@@ -3,11 +3,24 @@ set -euo pipefail
 
 script_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 repo_root="${AXIOM_CHECKOUT_PATH:-$script_repo_root}"
+repo_root="$(cd "$repo_root" && pwd)"
+
+if [[ ! -f "$repo_root/stage1/Cargo.toml" ]]; then
+  echo "error: AXIOM_CHECKOUT_PATH must identify an axiomlang checkout: $repo_root" >&2
+  exit 1
+fi
+
 cd "$repo_root"
 
-target_dir="${CARGO_TARGET_DIR:-${RUNNER_TEMP:-/tmp}/axiom-fast-ci-target}"
+target_dir="${CARGO_TARGET_DIR:-$repo_root/target/fast-ci}"
+if [[ "$target_dir" != /* ]]; then
+  target_dir="$repo_root/$target_dir"
+fi
 mkdir -p "$target_dir"
+target_dir="$(cd "$target_dir" && pwd)"
 export CARGO_TARGET_DIR="$target_dir"
+echo "Fast Checks data checkout: $repo_root"
+echo "Fast Checks Cargo target directory: $CARGO_TARGET_DIR"
 
 bash "$script_repo_root/scripts/ci/check-python-exit-docs.sh"
 bash "$script_repo_root/scripts/ci/validate-capability-manifests.sh"

--- a/scripts/ci/test-check-compatibility-v1.sh
+++ b/scripts/ci/test-check-compatibility-v1.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+script_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+repo_root="${AXIOM_CHECKOUT_PATH:-$script_repo_root}"
+repo_root="$(cd "$repo_root" && pwd)"
 cd "$repo_root"
 
-python3 scripts/ci/test-check-compatibility-v1.py
-python3 scripts/ci/test-check-compatibility-corpus-v1.py
-python3 scripts/ci/check-compatibility-corpus-v1.py --json
-cargo test --manifest-path stage1/Cargo.toml -p axiomc --test compatibility_v1 --test migration_plan_cli
+python3 "$script_repo_root/scripts/ci/test-check-compatibility-v1.py"
+python3 "$script_repo_root/scripts/ci/test-check-compatibility-corpus-v1.py"
+python3 "$script_repo_root/scripts/ci/check-compatibility-corpus-v1.py" --json
+cargo test --manifest-path "$repo_root/stage1/Cargo.toml" -p axiomc --test compatibility_v1 --test migration_plan_cli

--- a/scripts/ci/test-pr-fast-ci-workflow.sh
+++ b/scripts/ci/test-pr-fast-ci-workflow.sh
@@ -64,6 +64,14 @@ fast_checks_trusted_base_ref=$(awk '
     exit
   }
 ' "$workflow")
+fast_checks_head_checkout=$(awk '
+  /^  fast-checks:$/ { in_job=1; next }
+  in_job && /^  [A-Za-z0-9_-]+:$/ { exit }
+  in_job && /ref: \$\{\{ github\.event\.pull_request\.head\.sha \}\}/ { print NR }
+' "$workflow" | head -n1)
+fast_checks_data_path=$(grep -nF 'AXIOM_CHECKOUT_PATH="$GITHUB_WORKSPACE"' "$workflow" || true)
+fast_checks_target_dir=$(grep -nF 'CARGO_TARGET_DIR: ${{ runner.temp }}/axiom-fast-ci-target-${{ github.run_id }}-${{ github.run_attempt }}' "$workflow" || true)
+fast_checks_root_target=$(grep -nF 'target_dir="${CARGO_TARGET_DIR:-$repo_root/target/fast-ci}"' "$fast_checks_script" || true)
 benchmark_gate_reference=$(grep -nE 'check-stage1-benchmarks\.py|stage1-comparison-report\.json' "$workflow" || true)
 runtime_abi_status_check=$(grep -nF 'scripts/ci/render-direct-native-runtime-abi-status.py' "$fast_checks_script" || true)
 runtime_abi_coverage_check=$(grep -nF -- '--coverage-matrix' "$fast_checks_script" || true)
@@ -154,6 +162,30 @@ if [[ -z "$fast_checks_trusted_base_ref" ]]; then
   echo "fast-checks must pin the .trusted-ci checkout to github.event.pull_request.base.sha; pinning it to head.sha runs PR-authored scripts under a trusted label (#1543 regression of #1211)" >&2
   exit 1
 fi
+
+if [[ -z "$fast_checks_head_checkout" || -z "$fast_checks_data_path" ]]; then
+  echo "fast-checks must check out the PR head as data and pass GITHUB_WORKSPACE as AXIOM_CHECKOUT_PATH" >&2
+  exit 1
+fi
+
+if [[ -z "$fast_checks_target_dir" || -z "$fast_checks_root_target" ]]; then
+  echo "fast-checks must isolate Cargo targets per workflow attempt and use a checkout-local fallback" >&2
+  exit 1
+fi
+
+for checker in \
+  check-provider-abi-v1.py \
+  check-stdlib-catalog.py \
+  check-semantic-mir-v1.py \
+  check-runtime-lifecycle-v1.py \
+  run-agent-autonomy-benchmark.py \
+  check-compatibility-v1.py \
+  check-compatibility-corpus-v1.py; do
+  if ! grep -qF 'AXIOM_CHECKOUT_PATH' "$repo_root/scripts/ci/$checker"; then
+    echo "$checker must honor AXIOM_CHECKOUT_PATH so Fast Checks read PR data" >&2
+    exit 1
+  fi
+done
 
 RESULTS='changes=success fast-checks=skipped validate-pr-description=skipped validate-secrets=skipped' \
   IS_FORK_PR=false \

--- a/stage1/crates/axiomc-backend-cranelift/src/lib.rs
+++ b/stage1/crates/axiomc-backend-cranelift/src/lib.rs
@@ -79,8 +79,18 @@ struct I64RuntimeRefs {
     atoll: FuncRef,
     open: FuncRef,
     creat: FuncRef,
+    #[cfg(not(windows))]
+    openat: FuncRef,
+    #[cfg(not(windows))]
+    fchmod: FuncRef,
+    #[cfg(not(windows))]
+    renameat: FuncRef,
+    #[cfg(not(windows))]
+    unlinkat: FuncRef,
     lseek: FuncRef,
     close: FuncRef,
+    #[cfg(not(windows))]
+    fsync: FuncRef,
     access: FuncRef,
     #[cfg(windows)]
     system: FuncRef,
@@ -266,8 +276,9 @@ pub enum I64Expr {
         content: String,
     },
     ReplaceFile {
-        path: String,
-        temp_path: String,
+        root: String,
+        parent_components: Vec<String>,
+        destination_name: String,
         content: String,
     },
     CreateFile {
@@ -790,6 +801,59 @@ fn emit_i64_exit_object(
         .map_err(|message| {
             CraneliftBackendError::new(format!("declare creat import: {message}"))
         })?;
+    #[cfg(not(windows))]
+    let openat_id = {
+        let mut signature = module.make_signature();
+        signature.params.push(AbiParam::new(types::I32));
+        signature.params.push(AbiParam::new(pointer_type));
+        signature.params.push(AbiParam::new(types::I32));
+        signature.params.push(AbiParam::new(types::I32));
+        signature.returns.push(AbiParam::new(types::I32));
+        module
+            .declare_function("openat", Linkage::Import, &signature)
+            .map_err(|message| {
+                CraneliftBackendError::new(format!("declare openat import: {message}"))
+            })?
+    };
+    #[cfg(not(windows))]
+    let renameat_id = {
+        let mut signature = module.make_signature();
+        signature.params.push(AbiParam::new(types::I32));
+        signature.params.push(AbiParam::new(pointer_type));
+        signature.params.push(AbiParam::new(types::I32));
+        signature.params.push(AbiParam::new(pointer_type));
+        signature.returns.push(AbiParam::new(types::I32));
+        module
+            .declare_function("renameat", Linkage::Import, &signature)
+            .map_err(|message| {
+                CraneliftBackendError::new(format!("declare renameat import: {message}"))
+            })?
+    };
+    #[cfg(not(windows))]
+    let fchmod_id = {
+        let mut signature = module.make_signature();
+        signature.params.push(AbiParam::new(types::I32));
+        signature.params.push(AbiParam::new(types::I32));
+        signature.returns.push(AbiParam::new(types::I32));
+        module
+            .declare_function("fchmod", Linkage::Import, &signature)
+            .map_err(|message| {
+                CraneliftBackendError::new(format!("declare fchmod import: {message}"))
+            })?
+    };
+    #[cfg(not(windows))]
+    let unlinkat_id = {
+        let mut signature = module.make_signature();
+        signature.params.push(AbiParam::new(types::I32));
+        signature.params.push(AbiParam::new(pointer_type));
+        signature.params.push(AbiParam::new(types::I32));
+        signature.returns.push(AbiParam::new(types::I32));
+        module
+            .declare_function("unlinkat", Linkage::Import, &signature)
+            .map_err(|message| {
+                CraneliftBackendError::new(format!("declare unlinkat import: {message}"))
+            })?
+    };
     let mut lseek_sig = module.make_signature();
     lseek_sig.params.push(AbiParam::new(types::I32));
     lseek_sig.params.push(AbiParam::new(types::I64));
@@ -808,6 +872,17 @@ fn emit_i64_exit_object(
         .map_err(|message| {
             CraneliftBackendError::new(format!("declare close import: {message}"))
         })?;
+    #[cfg(not(windows))]
+    let fsync_id = {
+        let mut signature = module.make_signature();
+        signature.params.push(AbiParam::new(types::I32));
+        signature.returns.push(AbiParam::new(types::I32));
+        module
+            .declare_function("fsync", Linkage::Import, &signature)
+            .map_err(|message| {
+                CraneliftBackendError::new(format!("declare fsync import: {message}"))
+            })?
+    };
     let mut access_sig = module.make_signature();
     access_sig.params.push(AbiParam::new(pointer_type));
     access_sig.params.push(AbiParam::new(types::I32));
@@ -1060,8 +1135,13 @@ fn emit_i64_exit_object(
                 atoll_id,
                 open_id,
                 creat_id,
+                openat_id,
+                fchmod_id,
+                renameat_id,
+                unlinkat_id,
                 lseek_id,
                 close_id,
+                fsync_id,
                 access_id,
                 fork_id,
                 execv_id,
@@ -1162,8 +1242,18 @@ fn emit_i64_exit_object(
         let atoll_ref = module.declare_func_in_func(atoll_id, builder.func);
         let open_ref = module.declare_func_in_func(open_id, builder.func);
         let creat_ref = module.declare_func_in_func(creat_id, builder.func);
+        #[cfg(not(windows))]
+        let openat_ref = module.declare_func_in_func(openat_id, builder.func);
+        #[cfg(not(windows))]
+        let fchmod_ref = module.declare_func_in_func(fchmod_id, builder.func);
+        #[cfg(not(windows))]
+        let renameat_ref = module.declare_func_in_func(renameat_id, builder.func);
+        #[cfg(not(windows))]
+        let unlinkat_ref = module.declare_func_in_func(unlinkat_id, builder.func);
         let lseek_ref = module.declare_func_in_func(lseek_id, builder.func);
         let close_ref = module.declare_func_in_func(close_id, builder.func);
+        #[cfg(not(windows))]
+        let fsync_ref = module.declare_func_in_func(fsync_id, builder.func);
         let access_ref = module.declare_func_in_func(access_id, builder.func);
         #[cfg(windows)]
         let system_ref = module.declare_func_in_func(system_id, builder.func);
@@ -1210,8 +1300,18 @@ fn emit_i64_exit_object(
             atoll: atoll_ref,
             open: open_ref,
             creat: creat_ref,
+            #[cfg(not(windows))]
+            openat: openat_ref,
+            #[cfg(not(windows))]
+            fchmod: fchmod_ref,
+            #[cfg(not(windows))]
+            renameat: renameat_ref,
+            #[cfg(not(windows))]
+            unlinkat: unlinkat_ref,
             lseek: lseek_ref,
             close: close_ref,
+            #[cfg(not(windows))]
+            fsync: fsync_ref,
             access: access_ref,
             #[cfg(windows)]
             system: system_ref,
@@ -1482,8 +1582,18 @@ fn define_i64_function(
     atoll_id: FuncId,
     open_id: FuncId,
     creat_id: FuncId,
+    #[cfg(not(windows))]
+    openat_id: FuncId,
+    #[cfg(not(windows))]
+    fchmod_id: FuncId,
+    #[cfg(not(windows))]
+    renameat_id: FuncId,
+    #[cfg(not(windows))]
+    unlinkat_id: FuncId,
     lseek_id: FuncId,
     close_id: FuncId,
+    #[cfg(not(windows))]
+    fsync_id: FuncId,
     access_id: FuncId,
     #[cfg(windows)] system_id: FuncId,
     #[cfg(not(windows))] fork_id: FuncId,
@@ -1552,8 +1662,18 @@ fn define_i64_function(
         let atoll_ref = module.declare_func_in_func(atoll_id, builder.func);
         let open_ref = module.declare_func_in_func(open_id, builder.func);
         let creat_ref = module.declare_func_in_func(creat_id, builder.func);
+        #[cfg(not(windows))]
+        let openat_ref = module.declare_func_in_func(openat_id, builder.func);
+        #[cfg(not(windows))]
+        let fchmod_ref = module.declare_func_in_func(fchmod_id, builder.func);
+        #[cfg(not(windows))]
+        let renameat_ref = module.declare_func_in_func(renameat_id, builder.func);
+        #[cfg(not(windows))]
+        let unlinkat_ref = module.declare_func_in_func(unlinkat_id, builder.func);
         let lseek_ref = module.declare_func_in_func(lseek_id, builder.func);
         let close_ref = module.declare_func_in_func(close_id, builder.func);
+        #[cfg(not(windows))]
+        let fsync_ref = module.declare_func_in_func(fsync_id, builder.func);
         let access_ref = module.declare_func_in_func(access_id, builder.func);
         #[cfg(windows)]
         let system_ref = module.declare_func_in_func(system_id, builder.func);
@@ -1600,8 +1720,18 @@ fn define_i64_function(
             atoll: atoll_ref,
             open: open_ref,
             creat: creat_ref,
+            #[cfg(not(windows))]
+            openat: openat_ref,
+            #[cfg(not(windows))]
+            fchmod: fchmod_ref,
+            #[cfg(not(windows))]
+            renameat: renameat_ref,
+            #[cfg(not(windows))]
+            unlinkat: unlinkat_ref,
             lseek: lseek_ref,
             close: close_ref,
+            #[cfg(not(windows))]
+            fsync: fsync_ref,
             access: access_ref,
             #[cfg(windows)]
             system: system_ref,
@@ -3401,10 +3531,18 @@ fn emit_i64_expr(
             emit_i64_append_file_expr(builder, runtime_refs, path, content)
         }
         I64Expr::ReplaceFile {
-            path,
-            temp_path,
+            root,
+            parent_components,
+            destination_name,
             content,
-        } => emit_i64_replace_file_expr(builder, runtime_refs, path, temp_path, content),
+        } => emit_i64_replace_file_expr(
+            builder,
+            runtime_refs,
+            root,
+            parent_components,
+            destination_name,
+            content,
+        ),
         I64Expr::CreateFile { path } => emit_i64_create_file_expr(builder, runtime_refs, path),
         I64Expr::RemoveFile { path } => emit_i64_remove_file_expr(builder, runtime_refs, path),
         I64Expr::MakeDir { path } => emit_i64_make_dir_expr(builder, runtime_refs, path),
@@ -5892,51 +6030,257 @@ fn emit_i64_create_file_expr(
 fn emit_i64_replace_file_expr(
     builder: &mut FunctionBuilder<'_>,
     runtime_refs: I64RuntimeRefs,
-    path: &str,
-    temp_path: &str,
+    root: &str,
+    parent_components: &[String],
+    destination_name: &str,
     content: &str,
 ) -> Result<cranelift_codegen::ir::Value, CraneliftBackendError> {
-    let write_result = emit_i64_write_file_expr(builder, runtime_refs, temp_path, content)?;
+    #[cfg(windows)]
+    {
+        let _ = (runtime_refs, root, parent_components, destination_name, content);
+        return Ok(builder.ins().iconst(types::I64, -1));
+    }
 
-    let rename_block = builder.create_block();
-    let success_block = builder.create_block();
-    let failed_block = builder.create_block();
-    let merge_block = builder.create_block();
-    builder.append_block_param(merge_block, types::I64);
+    #[cfg(not(windows))]
+    {
+        // Keep every operation anchored to a descriptor opened beneath the
+        // authorized root.  In particular, do not construct a pathname for
+        // the temporary file: the final create and publish both use *at(2)
+        // and therefore cannot be redirected by a concurrent rename or a
+        // pre-planted symlink.
+        let root_ptr = emit_i64_path_ptr(builder, root)?;
+        let destination_ptr = emit_i64_path_ptr(builder, destination_name)?;
+        let temp_slot = builder.create_sized_stack_slot(StackSlotData::new(
+            StackSlotKind::ExplicitSlot,
+            32,
+            0,
+        ));
+        let temp_ptr = builder.ins().stack_addr(types::I64, temp_slot, 0);
+        for (offset, byte) in b".axiom-replace-".iter().enumerate() {
+            let value = builder.ins().iconst(types::I8, i64::from(*byte));
+            builder.ins().stack_store(value, temp_slot, offset as i32);
+        }
+        let random = emit_i64_random_u64_expr(
+            builder,
+            runtime_refs,
+            "fs_replace",
+            "axiomc",
+        )?;
+        for index in 0..16 {
+            let shift = 60 - index * 4;
+            let nibble = builder.ins().ushr_imm(random, shift);
+            let nibble = builder.ins().band_imm(nibble, 0x0f);
+            let decimal = builder.ins().iadd_imm(nibble, i64::from(b'0'));
+            let alpha = builder.ins().iadd_imm(nibble, i64::from(b'a' - 10));
+            let is_decimal = builder.ins().icmp_imm(IntCC::UnsignedLessThan, nibble, 10);
+            let value = builder.ins().select(is_decimal, decimal, alpha);
+            let value = builder.ins().ireduce(types::I8, value);
+            builder
+                .ins()
+                .stack_store(value, temp_slot, (15 + index) as i32);
+        }
+        let terminator = builder.ins().iconst(types::I8, 0);
+        builder.ins().stack_store(terminator, temp_slot, 31);
 
-    let write_ok = builder.ins().icmp_imm(IntCC::Equal, write_result, 0);
-    builder
-        .ins()
-        .brif(write_ok, rename_block, &[], failed_block, &[]);
+        let directory_flag = if cfg!(target_os = "macos") {
+            0x0010_0000
+        } else {
+            0x0001_0000
+        };
+        let nofollow_flag = if cfg!(target_os = "macos") {
+            0x0000_0100
+        } else {
+            0x0002_0000
+        };
+        let create_flag = if cfg!(target_os = "macos") {
+            0x0000_0200
+        } else {
+            0x0000_0040
+        };
+        let exclusive_flag = if cfg!(target_os = "macos") {
+            0x0000_0800
+        } else {
+            0x0000_0080
+        };
+        let root_flags = builder.ins().iconst(
+            types::I32,
+            i64::from(directory_flag | nofollow_flag),
+        );
+        let root_open = builder.ins().call(runtime_refs.open, &[root_ptr, root_flags]);
+        let mut parent_fd = builder.inst_results(root_open)[0];
+        let walk_flags = builder.ins().iconst(
+            types::I32,
+            i64::from(directory_flag | nofollow_flag),
+        );
+        for component in parent_components {
+            let component_ptr = emit_i64_path_ptr(builder, component)?;
+            let zero_mode = builder.ins().iconst(types::I32, 0);
+            let next_open = builder.ins().call(
+                runtime_refs.openat,
+                &[parent_fd, component_ptr, walk_flags, zero_mode],
+            );
+            let next_fd = builder.inst_results(next_open)[0];
+            builder.ins().call(runtime_refs.close, &[parent_fd]);
+            parent_fd = next_fd;
+        }
 
-    builder.switch_to_block(rename_block);
-    builder.seal_block(rename_block);
-    let temp_ptr = emit_i64_path_ptr(builder, temp_path)?;
-    let path_ptr = emit_i64_path_ptr(builder, path)?;
-    let rename_call = builder
-        .ins()
-        .call(runtime_refs.rename, &[temp_ptr, path_ptr]);
-    let rename_result = builder.inst_results(rename_call)[0];
-    let rename_ok = builder.ins().icmp_imm(IntCC::Equal, rename_result, 0);
-    builder
-        .ins()
-        .brif(rename_ok, success_block, &[], failed_block, &[]);
+        let content_len = u32::try_from(content.len())
+            .map_err(|_| CraneliftBackendError::new("filesystem replace content is too large"))?;
+        let content_slot = builder.create_sized_stack_slot(StackSlotData::new(
+            StackSlotKind::ExplicitSlot,
+            content_len.max(1),
+            0,
+        ));
+        for (offset, byte) in content.bytes().enumerate() {
+            let byte_value = builder.ins().iconst(types::I8, i64::from(byte));
+            builder
+                .ins()
+                .stack_store(byte_value, content_slot, offset as i32);
+        }
+        let content_ptr = builder.ins().stack_addr(types::I64, content_slot, 0);
+        let content_count = builder.ins().iconst(types::I64, i64::from(content_len));
 
-    builder.switch_to_block(success_block);
-    builder.seal_block(success_block);
-    let success = builder.ins().iconst(types::I64, 0);
-    builder.ins().jump(merge_block, &[BlockArg::Value(success)]);
+        let failed_block = builder.create_block();
+        let create_block = builder.create_block();
+        let create_failed_block = builder.create_block();
+        let chmod_block = builder.create_block();
+        let write_block = builder.create_block();
+        let sync_block = builder.create_block();
+        let close_block = builder.create_block();
+        let rename_block = builder.create_block();
+        let publish_sync_block = builder.create_block();
+        let success_block = builder.create_block();
+        let merge_block = builder.create_block();
+        builder.append_block_param(close_block, types::I32);
+        builder.append_block_param(merge_block, types::I64);
 
-    builder.switch_to_block(failed_block);
-    builder.seal_block(failed_block);
-    let temp_ptr = emit_i64_path_ptr(builder, temp_path)?;
-    builder.ins().call(runtime_refs.unlink, &[temp_ptr]);
-    let failed = builder.ins().iconst(types::I64, -1);
-    builder.ins().jump(merge_block, &[BlockArg::Value(failed)]);
+        let parent_valid = builder.ins().icmp_imm(IntCC::SignedGreaterThanOrEqual, parent_fd, 0);
+        builder
+            .ins()
+            .brif(parent_valid, create_block, &[], failed_block, &[]);
 
-    builder.switch_to_block(merge_block);
-    builder.seal_block(merge_block);
-    Ok(builder.block_params(merge_block)[0])
+        builder.switch_to_block(create_block);
+        builder.seal_block(create_block);
+        let create_flags = builder.ins().iconst(
+            types::I32,
+            i64::from(1 | create_flag | exclusive_flag | nofollow_flag),
+        );
+        let create_mode = builder.ins().iconst(types::I32, 0o600);
+        let create_call = builder.ins().call(
+            runtime_refs.openat,
+            &[parent_fd, temp_ptr, create_flags, create_mode],
+        );
+        let file = builder.inst_results(create_call)[0];
+        let create_failed = builder.ins().icmp_imm(IntCC::SignedLessThan, file, 0);
+        builder
+            .ins()
+            .brif(create_failed, create_failed_block, &[], chmod_block, &[]);
+
+        builder.switch_to_block(create_failed_block);
+        builder.seal_block(create_failed_block);
+        builder.ins().call(runtime_refs.close, &[parent_fd]);
+        let failed = builder.ins().iconst(types::I64, -1);
+        builder.ins().jump(merge_block, &[BlockArg::Value(failed)]);
+
+        builder.switch_to_block(chmod_block);
+        builder.seal_block(chmod_block);
+        let restrictive_mode = builder.ins().iconst(types::I32, 0o600);
+        let chmod_call = builder
+            .ins()
+            .call(runtime_refs.fchmod, &[file, restrictive_mode]);
+        let chmod_result = builder.inst_results(chmod_call)[0];
+        let chmod_ok = builder.ins().icmp_imm(IntCC::Equal, chmod_result, 0);
+        builder.ins().brif(chmod_ok, write_block, &[], failed_block, &[]);
+
+        builder.switch_to_block(write_block);
+        builder.seal_block(write_block);
+        let write_call = builder
+            .ins()
+            .call(runtime_refs.write, &[file, content_ptr, content_count]);
+        let written = builder.inst_results(write_call)[0];
+        let full_write = builder.ins().icmp(IntCC::Equal, written, content_count);
+        let failed = builder.ins().iconst(types::I32, -1);
+        builder.ins().brif(
+            full_write,
+            sync_block,
+            &[],
+            close_block,
+            &[BlockArg::Value(failed)],
+        );
+
+        builder.switch_to_block(sync_block);
+        builder.seal_block(sync_block);
+        let sync_call = builder.ins().call(runtime_refs.fsync, &[file]);
+        let sync_result = builder.inst_results(sync_call)[0];
+        let sync_ok = builder.ins().icmp_imm(IntCC::Equal, sync_result, 0);
+        let success_value = builder.ins().iconst(types::I32, 0);
+        let failed_value = builder.ins().iconst(types::I32, -1);
+        builder.ins().brif(
+            sync_ok,
+            close_block,
+            &[BlockArg::Value(success_value)],
+            close_block,
+            &[BlockArg::Value(failed_value)],
+        );
+
+        builder.switch_to_block(close_block);
+        builder.seal_block(close_block);
+        let close_result = builder.block_params(close_block)[0];
+        let close_call = builder.ins().call(runtime_refs.close, &[file]);
+        let close_status = builder.inst_results(close_call)[0];
+        let close_ok = builder
+            .ins()
+            .icmp_imm(IntCC::Equal, close_status, 0);
+        let effect_ok = builder.ins().icmp_imm(IntCC::Equal, close_result, 0);
+        let ready_to_rename = builder.ins().band(close_ok, effect_ok);
+        builder.ins().brif(
+            ready_to_rename,
+            rename_block,
+            &[],
+            failed_block,
+            &[],
+        );
+
+        builder.switch_to_block(rename_block);
+        builder.seal_block(rename_block);
+        let rename_call = builder.ins().call(
+            runtime_refs.renameat,
+            &[parent_fd, temp_ptr, parent_fd, destination_ptr],
+        );
+        let rename_result = builder.inst_results(rename_call)[0];
+        let rename_ok = builder.ins().icmp_imm(IntCC::Equal, rename_result, 0);
+        builder
+            .ins()
+            .brif(rename_ok, publish_sync_block, &[], failed_block, &[]);
+
+        builder.switch_to_block(publish_sync_block);
+        builder.seal_block(publish_sync_block);
+        let parent_sync = builder.ins().call(runtime_refs.fsync, &[parent_fd]);
+        let parent_sync_result = builder.inst_results(parent_sync)[0];
+        let parent_sync_ok = builder.ins().icmp_imm(IntCC::Equal, parent_sync_result, 0);
+        builder
+            .ins()
+            .brif(parent_sync_ok, success_block, &[], failed_block, &[]);
+
+        builder.switch_to_block(success_block);
+        builder.seal_block(success_block);
+        let success = builder.ins().iconst(types::I64, 0);
+        builder.ins().jump(merge_block, &[BlockArg::Value(success)]);
+
+        builder.switch_to_block(failed_block);
+        builder.seal_block(failed_block);
+        let unlink_flags = builder.ins().iconst(types::I32, 0);
+        builder
+            .ins()
+            .call(runtime_refs.unlinkat, &[parent_fd, temp_ptr, unlink_flags]);
+        builder.ins().call(runtime_refs.close, &[parent_fd]);
+        let failed = builder.ins().iconst(types::I64, -1);
+        builder.ins().jump(merge_block, &[BlockArg::Value(failed)]);
+
+        builder.switch_to_block(merge_block);
+        builder.seal_block(merge_block);
+        Ok(builder.block_params(merge_block)[0])
+    }
 }
 
 fn emit_i64_remove_file_expr(
@@ -6899,7 +7243,7 @@ mod tests {
         }
         let temp = tempfile::tempdir().expect("tempdir");
         let fixture = temp.path().join("fixture.txt");
-        let temp_fixture = temp.path().join(".fixture.txt.axiom-replace.tmp");
+        let temp_fixture = temp.path().join(".fixture.txt.axiom-replace-XXXXXX");
         fs::write(&fixture, "base").expect("write replace base fixture");
         let object = temp.path().join("i64-exit-replace-file.o");
         let binary = temp.path().join("i64-exit-replace-file");
@@ -6909,8 +7253,9 @@ mod tests {
                 locals: Vec::new(),
                 stmts: Vec::new(),
                 body: I64ExitBody::Return(I64Expr::ReplaceFile {
-                    path: fixture.display().to_string(),
-                    temp_path: temp_fixture.display().to_string(),
+                    root: temp.path().display().to_string(),
+                    parent_components: Vec::new(),
+                    destination_name: "fixture.txt".to_string(),
                     content: String::from("runtime-replace"),
                 }),
             },
@@ -6930,7 +7275,13 @@ mod tests {
         let output = Command::new(&binary)
             .output()
             .expect("run replace file binary");
-        assert_eq!(output.status.code(), Some(0));
+        assert_eq!(
+            output.status.code(),
+            Some(0),
+            "stdout={} stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
         assert_eq!(
             fs::read_to_string(&fixture).expect("read runtime replace fixture"),
             "runtime-replace"
@@ -6938,6 +7289,54 @@ mod tests {
         assert!(
             !temp_fixture.exists(),
             "runtime replace should not leave the temp fixture"
+        );
+    }
+
+    #[test]
+    fn links_i64_exit_program_with_replace_file_rejects_temp_collision() {
+        if std::env::var_os("AXIOM_SKIP_CRANELIFT_LINK_TEST").is_some() {
+            return;
+        }
+        if Command::new("cc").arg("--version").output().is_err() {
+            eprintln!("skipping cranelift link test because cc is unavailable");
+            return;
+        }
+        let temp = tempfile::tempdir().expect("tempdir");
+        let fixture = temp.path().join("fixture.txt");
+        let collision = temp.path().join(".axiom-replace-0000000000001234");
+        fs::write(&fixture, "base").expect("write replace base fixture");
+        fs::write(&collision, "collision").expect("plant colliding temp fixture");
+        let object = temp.path().join("i64-exit-replace-collision.o");
+        let binary = temp.path().join("i64-exit-replace-collision");
+        compile_i64_exit_program(
+            I64ExitProgram {
+                functions: Vec::new(),
+                locals: Vec::new(),
+                stmts: Vec::new(),
+                body: I64ExitBody::Return(I64Expr::ReplaceFile {
+                    root: temp.path().display().to_string(),
+                    parent_components: Vec::new(),
+                    destination_name: "fixture.txt".to_string(),
+                    content: String::from("runtime-replace"),
+                }),
+            },
+            &object,
+            &binary,
+        )
+        .expect("compile i64 replace collision exit program");
+
+        let output = Command::new(&binary)
+            .env("AXIOM_TEST_RANDOM_U64", "4660")
+            .output()
+            .expect("run replace collision binary");
+        assert_eq!(output.status.code(), Some(255));
+        assert_eq!(
+            fs::read_to_string(&fixture).expect("read unchanged replace fixture"),
+            "base"
+        );
+        assert_eq!(
+            fs::read_to_string(&collision).expect("read colliding temp fixture"),
+            "collision"
         );
     }
 

--- a/stage1/crates/axiomc-backend-cranelift/src/lib.rs
+++ b/stage1/crates/axiomc-backend-cranelift/src/lib.rs
@@ -6,7 +6,7 @@ use cranelift_codegen::isa;
 use cranelift_codegen::isa::CallConv;
 use cranelift_codegen::settings::{self, Configurable};
 use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext, Variable};
-use cranelift_module::{DataDescription, FuncId, Linkage, Module, default_libcall_names};
+use cranelift_module::{default_libcall_names, DataDescription, FuncId, Linkage, Module};
 use cranelift_object::{ObjectBuilder, ObjectModule};
 
 // Socket option constants (SOL_SOCKET / SO_REUSEADDR) differ between Linux and
@@ -252,6 +252,9 @@ pub enum I64Expr {
     FileLen {
         path: String,
         max_bytes: u64,
+    },
+    FileStat {
+        path: String,
     },
     AuditFs {
         intrinsic: String,
@@ -3490,6 +3493,7 @@ fn emit_i64_expr(
         I64Expr::FileLen { path, max_bytes } => {
             emit_i64_file_len_expr(builder, runtime_refs, path, *max_bytes)
         }
+        I64Expr::FileStat { path } => emit_i64_file_stat_expr(builder, runtime_refs, path),
         I64Expr::AuditFs {
             intrinsic,
             package,
@@ -5041,6 +5045,122 @@ fn emit_i64_file_len_expr(
 
     builder.switch_to_block(present_block);
     builder.seal_block(present_block);
+    builder.ins().jump(merge_block, &[BlockArg::Value(length)]);
+
+    builder.switch_to_block(missing_block);
+    builder.seal_block(missing_block);
+    let missing_result = builder.ins().iconst(types::I64, -1);
+    builder
+        .ins()
+        .jump(merge_block, &[BlockArg::Value(missing_result)]);
+
+    builder.switch_to_block(merge_block);
+    builder.seal_block(merge_block);
+    Ok(builder.block_params(merge_block)[0])
+}
+
+fn emit_i64_file_stat_expr(
+    builder: &mut FunctionBuilder<'_>,
+    runtime_refs: I64RuntimeRefs,
+    path: &str,
+) -> Result<cranelift_codegen::ir::Value, CraneliftBackendError> {
+    if path.as_bytes().contains(&0) {
+        return Err(CraneliftBackendError::new(
+            "filesystem path contains an interior null byte",
+        ));
+    }
+    let path_len = u32::try_from(path.len() + 1)
+        .map_err(|_| CraneliftBackendError::new("filesystem path is too large"))?;
+    let path_slot = builder.create_sized_stack_slot(StackSlotData::new(
+        StackSlotKind::ExplicitSlot,
+        path_len,
+        0,
+    ));
+    for (offset, byte) in path.bytes().chain(std::iter::once(0)).enumerate() {
+        let byte_value = builder.ins().iconst(types::I8, i64::from(byte));
+        builder
+            .ins()
+            .stack_store(byte_value, path_slot, offset as i32);
+    }
+
+    let byte_slot =
+        builder.create_sized_stack_slot(StackSlotData::new(StackSlotKind::ExplicitSlot, 1, 0));
+    let path_ptr = builder.ins().stack_addr(types::I64, path_slot, 0);
+    let byte_ptr = builder.ins().stack_addr(types::I64, byte_slot, 0);
+    let open_flags = builder.ins().iconst(types::I32, 0);
+    let open_call = builder
+        .ins()
+        .call(runtime_refs.open, &[path_ptr, open_flags]);
+    let fd = builder.inst_results(open_call)[0];
+
+    let missing_block = builder.create_block();
+    let probe_block = builder.create_block();
+    let seek_block = builder.create_block();
+    let present_block = builder.create_block();
+    let merge_block = builder.create_block();
+    builder.append_block_param(probe_block, types::I32);
+    builder.append_block_param(seek_block, types::I32);
+    builder.append_block_param(present_block, types::I64);
+    builder.append_block_param(merge_block, types::I64);
+
+    let open_failed = builder.ins().icmp_imm(IntCC::SignedLessThan, fd, 0);
+    builder.ins().brif(
+        open_failed,
+        missing_block,
+        &[],
+        probe_block,
+        &[BlockArg::Value(fd)],
+    );
+
+    builder.switch_to_block(probe_block);
+    builder.seal_block(probe_block);
+    let fd = builder.block_params(probe_block)[0];
+    let requested = builder.ins().iconst(types::I64, 1);
+    let probe_call = builder
+        .ins()
+        .call(runtime_refs.read, &[fd, byte_ptr, requested]);
+    let probe_result = builder.inst_results(probe_call)[0];
+    let probe_failed = builder
+        .ins()
+        .icmp_imm(IntCC::SignedLessThan, probe_result, 0);
+    let probe_failed_block = builder.create_block();
+    builder.append_block_param(probe_failed_block, types::I32);
+    builder.ins().brif(
+        probe_failed,
+        probe_failed_block,
+        &[BlockArg::Value(fd)],
+        seek_block,
+        &[BlockArg::Value(fd)],
+    );
+
+    builder.switch_to_block(probe_failed_block);
+    builder.seal_block(probe_failed_block);
+    let failed_fd = builder.block_params(probe_failed_block)[0];
+    builder.ins().call(runtime_refs.close, &[failed_fd]);
+    builder.ins().jump(missing_block, &[]);
+
+    builder.switch_to_block(seek_block);
+    builder.seal_block(seek_block);
+    let fd = builder.block_params(seek_block)[0];
+    let zero = builder.ins().iconst(types::I64, 0);
+    let seek_end = builder.ins().iconst(types::I32, 2);
+    let seek_call = builder
+        .ins()
+        .call(runtime_refs.lseek, &[fd, zero, seek_end]);
+    let length = builder.inst_results(seek_call)[0];
+    builder.ins().call(runtime_refs.close, &[fd]);
+    let seek_failed = builder.ins().icmp_imm(IntCC::SignedLessThan, length, 0);
+    builder.ins().brif(
+        seek_failed,
+        missing_block,
+        &[],
+        present_block,
+        &[BlockArg::Value(length)],
+    );
+
+    builder.switch_to_block(present_block);
+    builder.seal_block(present_block);
+    let length = builder.block_params(present_block)[0];
     builder.ins().jump(merge_block, &[BlockArg::Value(length)]);
 
     builder.switch_to_block(missing_block);
@@ -7145,6 +7265,111 @@ mod tests {
             .output()
             .expect("run missing file len binary");
         assert_eq!(output.status.code(), Some(255));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn links_i64_exit_program_with_file_stat_edges() {
+        if std::env::var_os("AXIOM_SKIP_CRANELIFT_LINK_TEST").is_some() {
+            return;
+        }
+        if Command::new("cc").arg("--version").output().is_err() {
+            eprintln!("skipping cranelift file stat link test because cc is unavailable");
+            return;
+        }
+        let temp = tempfile::tempdir().expect("tempdir");
+        let empty = temp.path().join("empty.txt");
+        let target = temp.path().join("target.txt");
+        let directory = temp.path().join("directory");
+        let link = temp.path().join("link.txt");
+        let large = temp.path().join("large.txt");
+        fs::write(&empty, "").expect("write empty file");
+        fs::write(&target, "target").expect("write target file");
+        fs::create_dir(&directory).expect("create directory");
+        std::os::unix::fs::symlink(&target, &link).expect("create file symlink");
+        fs::write(&large, vec![b'x'; 64 * 1024 * 1024 + 1]).expect("write large file");
+
+        let compile_and_run = |body: I64Expr, name: &str| {
+            let object = temp.path().join(format!("{name}.o"));
+            let binary = temp.path().join(name);
+            compile_i64_exit_program(
+                I64ExitProgram {
+                    functions: Vec::new(),
+                    locals: Vec::new(),
+                    stmts: Vec::new(),
+                    body: I64ExitBody::Return(body),
+                },
+                &object,
+                &binary,
+            )
+            .expect("compile file stat edge program");
+            Command::new(binary)
+                .output()
+                .expect("run file stat edge program")
+                .status
+                .code()
+                .expect("file stat edge exit code")
+        };
+        assert_eq!(
+            compile_and_run(
+                I64Expr::FileStat {
+                    path: empty.display().to_string(),
+                },
+                "file-stat-empty",
+            ),
+            0
+        );
+        assert_eq!(
+            compile_and_run(
+                I64Expr::Select {
+                    cond: Box::new(I64Condition::Compare(I64Compare {
+                        op: I64CompareOp::Eq,
+                        lhs: I64Expr::FileStat {
+                            path: directory.display().to_string(),
+                        },
+                        rhs: I64Expr::Literal(-1),
+                    })),
+                    then_result: Box::new(I64Expr::Literal(42)),
+                    else_result: Box::new(I64Expr::Literal(41)),
+                },
+                "file-stat-directory",
+            ),
+            42
+        );
+        assert_eq!(
+            compile_and_run(
+                I64Expr::Select {
+                    cond: Box::new(I64Condition::Compare(I64Compare {
+                        op: I64CompareOp::Eq,
+                        lhs: I64Expr::FileStat {
+                            path: link.display().to_string(),
+                        },
+                        rhs: I64Expr::Literal(6),
+                    })),
+                    then_result: Box::new(I64Expr::Literal(42)),
+                    else_result: Box::new(I64Expr::Literal(41)),
+                },
+                "file-stat-symlink",
+            ),
+            42
+        );
+        assert_eq!(
+            compile_and_run(
+                I64Expr::Select {
+                    cond: Box::new(I64Condition::Compare(I64Compare {
+                        op: I64CompareOp::Ge,
+                        lhs: I64Expr::FileStat {
+                            path: large.display().to_string(),
+                        },
+                        rhs: I64Expr::Literal(64 * 1024 * 1024 + 1),
+                    })),
+                    then_result: Box::new(I64Expr::Literal(42)),
+                    else_result: Box::new(I64Expr::Literal(41)),
+                },
+                "file-stat-large",
+            ),
+            42
+        );
     }
 
     #[test]

--- a/stage1/crates/axiomc-backend-cranelift/src/lib.rs
+++ b/stage1/crates/axiomc-backend-cranelift/src/lib.rs
@@ -1,5 +1,5 @@
 use cranelift_codegen::ir::{
-    AbiParam, ArgumentPurpose, BlockArg, FuncRef, InstBuilder, MemFlags, StackSlotData,
+    AbiParam, ArgumentPurpose, Block, BlockArg, FuncRef, InstBuilder, MemFlags, StackSlotData,
     StackSlotKind, TrapCode, Value, condcodes::IntCC, types,
 };
 use cranelift_codegen::isa;
@@ -507,6 +507,8 @@ pub enum I64Stmt {
         cond: I64Condition,
         body: Vec<I64Stmt>,
     },
+    Break,
+    Continue,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1287,6 +1289,7 @@ fn emit_i64_exit_object(
             write_ref,
             &output_data_ids,
             &program.stmts,
+            None,
         )?;
         emit_i64_exit_body(
             &mut module,
@@ -1386,7 +1389,10 @@ fn collect_i64_output_lines(stmts: &[I64Stmt], lines: &mut Vec<(OutputStream, St
                 collect_i64_output_lines(else_body, lines);
             }
             I64Stmt::While { body, .. } => collect_i64_output_lines(body, lines),
-            I64Stmt::Assign(_) | I64Stmt::CallAssign { .. } => {}
+            I64Stmt::Assign(_)
+            | I64Stmt::CallAssign { .. }
+            | I64Stmt::Break
+            | I64Stmt::Continue => {}
         }
     }
 }
@@ -1688,6 +1694,7 @@ fn define_i64_function(
             write_ref,
             output_data_ids,
             &function.stmts,
+            None,
         )?;
         emit_i64_value_body(
             module,
@@ -1726,6 +1733,12 @@ fn i64_function_refs(
         .collect()
 }
 
+#[derive(Clone, Copy)]
+struct I64LoopTargets {
+    break_block: Block,
+    continue_block: Block,
+}
+
 fn emit_i64_stmts(
     module: &mut ObjectModule,
     builder: &mut FunctionBuilder<'_>,
@@ -1736,8 +1749,13 @@ fn emit_i64_stmts(
     write_ref: FuncRef,
     output_data_ids: &[I64OutputData],
     stmts: &[I64Stmt],
-) -> Result<(), CraneliftBackendError> {
+    loop_targets: Option<I64LoopTargets>,
+) -> Result<bool, CraneliftBackendError> {
+    let mut reachable = true;
     for stmt in stmts {
+        if !reachable {
+            break;
+        }
         emit_i64_stmt(
             module,
             builder,
@@ -1748,9 +1766,27 @@ fn emit_i64_stmts(
             write_ref,
             output_data_ids,
             stmt,
+            loop_targets,
         )?;
+        reachable = i64_stmt_can_fall_through(stmt);
     }
-    Ok(())
+    Ok(reachable)
+}
+
+fn i64_stmt_can_fall_through(stmt: &I64Stmt) -> bool {
+    match stmt {
+        I64Stmt::Break | I64Stmt::Continue => false,
+        I64Stmt::If {
+            then_body,
+            else_body,
+            ..
+        } => {
+            then_body.last().is_none_or(i64_stmt_can_fall_through)
+                || else_body.last().is_none_or(i64_stmt_can_fall_through)
+        }
+        I64Stmt::While { .. } => true,
+        _ => true,
+    }
 }
 
 fn emit_i64_stmt(
@@ -1763,6 +1799,7 @@ fn emit_i64_stmt(
     write_ref: FuncRef,
     output_data_ids: &[I64OutputData],
     stmt: &I64Stmt,
+    loop_targets: Option<I64LoopTargets>,
 ) -> Result<(), CraneliftBackendError> {
     match stmt {
         I64Stmt::Assign(assign) => {
@@ -1908,7 +1945,7 @@ fn emit_i64_stmt(
 
             builder.switch_to_block(then_block);
             builder.seal_block(then_block);
-            emit_i64_stmts(
+            let then_reachable = emit_i64_stmts(
                 module,
                 builder,
                 locals,
@@ -1918,12 +1955,15 @@ fn emit_i64_stmt(
                 write_ref,
                 output_data_ids,
                 then_body,
+                loop_targets,
             )?;
-            builder.ins().jump(after_if, &[]);
+            if then_reachable {
+                builder.ins().jump(after_if, &[]);
+            }
 
             builder.switch_to_block(else_block);
             builder.seal_block(else_block);
-            emit_i64_stmts(
+            let else_reachable = emit_i64_stmts(
                 module,
                 builder,
                 locals,
@@ -1933,8 +1973,11 @@ fn emit_i64_stmt(
                 write_ref,
                 output_data_ids,
                 else_body,
+                loop_targets,
             )?;
-            builder.ins().jump(after_if, &[]);
+            if else_reachable {
+                builder.ins().jump(after_if, &[]);
+            }
 
             builder.switch_to_block(after_if);
             builder.seal_block(after_if);
@@ -1954,7 +1997,7 @@ fn emit_i64_stmt(
 
             builder.switch_to_block(loop_body);
             builder.seal_block(loop_body);
-            emit_i64_stmts(
+            let body_reachable = emit_i64_stmts(
                 module,
                 builder,
                 locals,
@@ -1964,12 +2007,30 @@ fn emit_i64_stmt(
                 write_ref,
                 output_data_ids,
                 body,
+                Some(I64LoopTargets {
+                    break_block: after_loop,
+                    continue_block: loop_header,
+                }),
             )?;
-            builder.ins().jump(loop_header, &[]);
+            if body_reachable {
+                builder.ins().jump(loop_header, &[]);
+            }
             builder.seal_block(loop_header);
 
             builder.switch_to_block(after_loop);
             builder.seal_block(after_loop);
+            Ok(())
+        }
+        I64Stmt::Break => {
+            let targets = loop_targets
+                .ok_or_else(|| CraneliftBackendError::new("break is outside a loop"))?;
+            builder.ins().jump(targets.break_block, &[]);
+            Ok(())
+        }
+        I64Stmt::Continue => {
+            let targets = loop_targets
+                .ok_or_else(|| CraneliftBackendError::new("continue is outside a loop"))?;
+            builder.ins().jump(targets.continue_block, &[]);
             Ok(())
         }
     }
@@ -2769,6 +2830,7 @@ fn emit_i64_exit_body(
                 write_ref,
                 output_data_ids,
                 &block.stmts,
+                None,
             )?;
             emit_i64_return(builder, locals, function_refs, runtime_refs, &block.result)
         }
@@ -2820,6 +2882,7 @@ fn emit_i64_exit_body(
                 write_ref,
                 output_data_ids,
                 &then_block.stmts,
+                None,
             )?;
             emit_i64_return(
                 builder,
@@ -2841,6 +2904,7 @@ fn emit_i64_exit_body(
                 write_ref,
                 output_data_ids,
                 &else_block.stmts,
+                None,
             )?;
             emit_i64_return(
                 builder,
@@ -2887,6 +2951,7 @@ fn emit_i64_value_body(
                 write_ref,
                 output_data_ids,
                 &block.stmts,
+                None,
             )?;
             emit_i64_value_return(
                 builder,
@@ -2962,6 +3027,7 @@ fn emit_i64_value_body(
                 write_ref,
                 output_data_ids,
                 &then_block.stmts,
+                None,
             )?;
             emit_i64_value_return(
                 builder,
@@ -2985,6 +3051,7 @@ fn emit_i64_value_body(
                 write_ref,
                 output_data_ids,
                 &else_block.stmts,
+                None,
             )?;
             emit_i64_value_return(
                 builder,
@@ -4318,7 +4385,9 @@ fn emit_i64_env_len_expr(
     builder.seal_block(present_block);
     let call = builder.ins().call(strlen_ref, &[value_ptr]);
     let length = builder.inst_results(call)[0];
-    builder.ins().jump(merge_block, &[BlockArg::Value(length)]);
+    builder
+        .ins()
+        .jump(merge_block, &[BlockArg::Value(length)]);
 
     builder.switch_to_block(merge_block);
     builder.seal_block(merge_block);
@@ -4362,9 +4431,7 @@ fn emit_i64_cwd_len_expr(
     builder.seal_block(present_block);
     let call = builder.ins().call(strlen_ref, &[value_ptr]);
     let length = builder.inst_results(call)[0];
-    builder
-        .ins()
-        .jump(merge_block, &[BlockArg::Value(length)]);
+    builder.ins().jump(merge_block, &[BlockArg::Value(length)]);
 
     builder.switch_to_block(merge_block);
     builder.seal_block(merge_block);

--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -5229,6 +5229,7 @@ unsafe extern "C" {
         debug,
         &[],
         &main_mutable_locals,
+        None,
     );
     out.push_str("    });\n");
     out.push_str("    match result {\n");
@@ -6053,6 +6054,7 @@ fn render_function(
             debug,
             &[],
             &mutable_locals,
+            None,
         );
         out.push_str("    })\n");
     } else {
@@ -6066,6 +6068,7 @@ fn render_function(
             debug,
             &[],
             &mutable_locals,
+            None,
         );
     }
     out.push_str("}\n");
@@ -6360,6 +6363,7 @@ fn render_stmt_block(
     debug: bool,
     active_defers: &[(String, SourceSpan)],
     mutable_locals: &HashSet<String>,
+    loop_defer_floor: Option<usize>,
 ) {
     let mut local_defers: Vec<(String, SourceSpan)> = Vec::new();
     for stmt in stmts {
@@ -6373,6 +6377,7 @@ fn render_stmt_block(
             debug,
             active_defers,
             mutable_locals,
+            loop_defer_floor,
             &mut local_defers,
         );
     }
@@ -6406,6 +6411,7 @@ fn render_stmt(
     debug: bool,
     active_defers: &[(String, SourceSpan)],
     mutable_locals: &HashSet<String>,
+    loop_defer_floor: Option<usize>,
     local_defers: &mut Vec<(String, SourceSpan)>,
 ) {
     let pad = "    ".repeat(indent);
@@ -6502,6 +6508,7 @@ fn render_stmt(
                 debug,
                 &scoped_defers,
                 mutable_locals,
+                loop_defer_floor,
             );
             if let Some(else_block) = else_block {
                 out.push_str(&format!(
@@ -6518,6 +6525,7 @@ fn render_stmt(
                     debug,
                     &scoped_defers,
                     mutable_locals,
+                    loop_defer_floor,
                 );
                 out.push_str(&format!(
                     "{pad}}}
@@ -6539,6 +6547,7 @@ fn render_stmt(
 ",
                 render_expr(cond)
             ));
+            let loop_defer_floor = Some(scoped_defers.len());
             render_stmt_block(
                 body,
                 type_context,
@@ -6549,6 +6558,7 @@ fn render_stmt(
                 debug,
                 &scoped_defers,
                 mutable_locals,
+                loop_defer_floor,
             );
             out.push_str(&format!(
                 "{pad}}}
@@ -6558,13 +6568,19 @@ fn render_stmt(
         Stmt::Break { span } => {
             render_source_marker(source_path, *span, out, indent, debug);
             render_deferred_exprs(out, indent, source_path, debug, local_defers);
-            render_deferred_exprs(out, indent, source_path, debug, active_defers);
+            let loop_defers = loop_defer_floor
+                .and_then(|floor| active_defers.get(floor..))
+                .unwrap_or(&[]);
+            render_deferred_exprs(out, indent, source_path, debug, loop_defers);
             out.push_str(&format!("{pad}break;\n"));
         }
         Stmt::Continue { span } => {
             render_source_marker(source_path, *span, out, indent, debug);
             render_deferred_exprs(out, indent, source_path, debug, local_defers);
-            render_deferred_exprs(out, indent, source_path, debug, active_defers);
+            let loop_defers = loop_defer_floor
+                .and_then(|floor| active_defers.get(floor..))
+                .unwrap_or(&[]);
+            render_deferred_exprs(out, indent, source_path, debug, loop_defers);
             out.push_str(&format!("{pad}continue;\n"));
         }
         Stmt::Match { expr, arms, span } => {
@@ -6587,6 +6603,7 @@ fn render_stmt(
                     debug,
                     &scoped_defers,
                     mutable_locals,
+                    loop_defer_floor,
                 );
             }
             if arms.iter().all(|arm| arm.enum_name.is_empty()) {
@@ -6643,6 +6660,7 @@ fn render_match_arm(
     debug: bool,
     active_defers: &[(String, SourceSpan)],
     mutable_locals: &HashSet<String>,
+    loop_defer_floor: Option<usize>,
 ) {
     let pad = "    ".repeat(indent);
     if arm.enum_name.is_empty() {
@@ -6657,6 +6675,7 @@ fn render_match_arm(
             debug,
             active_defers,
             mutable_locals,
+            loop_defer_floor,
         );
         out.push_str(&format!("{pad}}},\n"));
         return;
@@ -6695,6 +6714,7 @@ fn render_match_arm(
         debug,
         active_defers,
         mutable_locals,
+        loop_defer_floor,
     );
     out.push_str(&format!("{pad}}},\n"));
 }

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -4391,6 +4391,8 @@ fn lower_i64_runtime_stmt(
                 allow_stdio_effects,
             )?,
         }),
+        Stmt::Break { .. } => Some(CraneliftI64Stmt::Break),
+        Stmt::Continue { .. } => Some(CraneliftI64Stmt::Continue),
         _ => None,
     }
 }

--- a/stage1/crates/axiomc/src/cranelift_backend/host_fs.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend/host_fs.rs
@@ -501,10 +501,11 @@ pub(crate) fn lower_i64_fs_write_intrinsic_expr(
                 static_bindings,
             );
         };
-        let temp_path = parent.join(format!(
-            ".{}.axiom-replace.tmp",
-            file_name.to_string_lossy()
-        ));
+        let relative_parent = parent.strip_prefix(fs_root).ok()?.to_path_buf();
+        let parent_components = relative_parent
+            .components()
+            .map(|component| component.as_os_str().to_string_lossy().into_owned())
+            .collect();
         return i64_audited_fs_expr(
             name,
             path_len,
@@ -514,8 +515,9 @@ pub(crate) fn lower_i64_fs_write_intrinsic_expr(
                 &candidate,
                 parent,
                 CraneliftI64Expr::ReplaceFile {
-                    path: candidate.display().to_string(),
-                    temp_path: temp_path.display().to_string(),
+                    root: fs_root.display().to_string(),
+                    parent_components,
+                    destination_name: file_name.to_string_lossy().into_owned(),
                     content,
                 },
             )?,

--- a/stage1/crates/axiomc/src/cranelift_backend/host_fs.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend/host_fs.rs
@@ -22,18 +22,7 @@ pub(crate) fn i64_fs_read_path(
     let Expr::Call { name, args, .. } = expr else {
         return None;
     };
-    if !matches!(
-        name.as_str(),
-        "fs_read"
-            | "read_file"
-            | "std_fs_read_file"
-            | "fs_file_exists"
-            | "file_exists"
-            | "std_fs_file_exists"
-            | "fs_file_size"
-            | "file_size"
-            | "std_fs_file_size"
-    )
+    if !matches!(name.as_str(), "fs_read" | "read_file" | "std_fs_read_file")
         && !static_bindings.fs_read_wrappers.contains(name)
     {
         return None;
@@ -108,9 +97,6 @@ pub(crate) fn lower_i64_fs_metadata_expr(
     ) {
         return None;
     }
-    if static_bindings.has_fs_write_calls {
-        return None;
-    }
     let path = i64_fs_path(args, static_bindings)?;
     let package_root = static_bindings.package_root.as_deref()?;
     let fs_root = static_bindings.fs_root.as_deref()?;
@@ -125,19 +111,49 @@ pub(crate) fn lower_i64_fs_metadata_expr(
     } else {
         "fs_file_size"
     };
-    let file_len =
-        i64_fs_file_len_expr(intrinsic, &candidate.display().to_string(), path.len(), static_bindings)?;
+    let file_stat = i64_fs_file_stat_expr(
+        intrinsic,
+        &candidate.display().to_string(),
+        path.len(),
+        static_bindings,
+    )?;
     if intrinsic == "fs_file_exists" {
         Some(CraneliftI64Expr::ConditionValue(Box::new(
             CraneliftI64Condition::Compare(CraneliftI64Compare {
                 op: CraneliftI64CompareOp::Ge,
-                lhs: file_len,
+                lhs: file_stat,
                 rhs: CraneliftI64Expr::Literal(0),
             }),
         )))
     } else {
-        Some(file_len)
+        Some(file_stat)
     }
+}
+
+fn i64_fs_file_stat_expr(
+    intrinsic: &str,
+    path: &str,
+    path_len: usize,
+    static_bindings: &I64StaticBindings,
+) -> Option<CraneliftI64Expr> {
+    let fs_root = static_bindings.fs_root.as_deref()?;
+    let path = Path::new(path);
+    let guarded = i64_runtime_fs_guard_expr(
+        fs_root,
+        path,
+        i64_fs_runtime_parent_fallback(path)?.as_path(),
+        CraneliftI64Expr::FileStat {
+            path: path.display().to_string(),
+        },
+    )?;
+    i64_audited_fs_expr_with_success(
+        intrinsic,
+        path_len,
+        None,
+        guarded,
+        static_bindings,
+        CraneliftI64AuditSuccess::NonNegative,
+    )
 }
 
 pub(crate) fn i64_stmts_have_fs_write_call(
@@ -296,18 +312,7 @@ pub(crate) fn i64_expr_has_fs_write_call(expr: &Expr, static_bindings: &I64Stati
 pub(crate) fn i64_expr_has_fs_read_call(expr: &Expr, static_bindings: &I64StaticBindings) -> bool {
     match expr {
         Expr::Call { name, args, .. } => {
-            matches!(
-                name.as_str(),
-                "fs_read"
-                    | "read_file"
-                    | "std_fs_read_file"
-                    | "fs_file_exists"
-                    | "file_exists"
-                    | "std_fs_file_exists"
-                    | "fs_file_size"
-                    | "file_size"
-                    | "std_fs_file_size"
-            )
+            matches!(name.as_str(), "fs_read" | "read_file" | "std_fs_read_file")
                 || static_bindings.fs_read_wrappers.contains(name)
                 || args
                     .iter()

--- a/stage1/crates/axiomc/src/hir.rs
+++ b/stage1/crates/axiomc/src/hir.rs
@@ -40,6 +40,7 @@ use self::const_arrays::{
     validate_const_array_lengths_in_program,
 };
 use self::const_functions::validate_const_function_body;
+use self::control_flow::ControlFlow;
 use self::definitions::{
     VariantInfo, collect_enum_definitions, collect_struct_definitions, collect_trait_definitions,
     collect_type_names, validate_recursive_type_cycles, validate_trait_bounds_in_program,
@@ -120,6 +121,12 @@ struct LowerContext<'a> {
     current_property: bool,
     current_borrow_return_params: HashSet<String>,
     loop_depth: usize,
+}
+
+#[derive(Default)]
+struct LoopFlow {
+    break_states: Vec<HashMap<String, Binding>>,
+    continue_states: Vec<HashMap<String, Binding>>,
 }
 
 const OWNERSHIP_CLOSURE_MOVE_CAPTURED_NON_COPY: &str = "closure_move_captured_non_copy";
@@ -266,11 +273,11 @@ fn lower_with_capabilities_impl(
     let mut env = HashMap::new();
     let stmts = if recover {
         let (stmts, mut block_diagnostics, _) =
-            lower_block_recovering(&program.stmts, &mut env, &ctx);
+            lower_block_recovering(&program.stmts, &mut env, &ctx, None);
         diagnostics.append(&mut block_diagnostics);
         stmts
     } else {
-        lower_block(&program.stmts, &mut env, &ctx)
+        lower_block(&program.stmts, &mut env, &ctx, None)
             .map_err(single_diagnostic)?
             .0
     };
@@ -568,17 +575,17 @@ fn lower_function(
             .collect(),
         loop_depth: 0,
     };
-    let (body, _, guaranteed_return) = if function.is_extern {
-        (Vec::new(), env.clone(), true)
+    let (body, _, flow) = if function.is_extern {
+        (Vec::new(), env.clone(), ControlFlow::return_value())
     } else {
         let (body, diagnostics, guaranteed_return) =
-            lower_block_recovering(&function.body, &mut env, &ctx);
+            lower_block_recovering(&function.body, &mut env, &ctx, None);
         if !diagnostics.is_empty() {
             return Err(primary_diagnostic(diagnostics));
         }
         (body, env.clone(), guaranteed_return)
     };
-    if !guaranteed_return {
+    if !flow.always_returns() {
         return Err(Diagnostic::new(
             "control",
             format!(
@@ -616,38 +623,47 @@ fn lower_block(
     block: &[syntax::Stmt],
     env: &mut HashMap<String, Binding>,
     ctx: &LowerContext<'_>,
-) -> Result<(Vec<Stmt>, HashMap<String, Binding>, bool), Diagnostic> {
+    mut loop_flow: Option<&mut LoopFlow>,
+) -> Result<(Vec<Stmt>, HashMap<String, Binding>, ControlFlow), Diagnostic> {
     let scope_names = env.keys().cloned().collect::<HashSet<_>>();
     let mut lowered = Vec::new();
-    let mut guaranteed_return = false;
+    let mut flow = ControlFlow::fallthrough();
     for stmt in block {
-        if guaranteed_return {
+        if !flow.fallthrough {
             return Err(Diagnostic::new(
                 "control",
                 "unreachable statements after a terminating control-flow statement are not yet supported in stage1",
             )
             .with_span(stmt.line(), stmt.column()));
         }
-        let lowered_stmt = lower_stmt(stmt, env, ctx)?;
-        guaranteed_return = lowered_stmt.always_returns();
+        let lowered_stmt = lower_stmt(stmt, env, ctx, loop_flow.as_deref_mut())?;
+        let stmt_flow = lowered_stmt.control_flow();
+        flow = ControlFlow {
+            fallthrough: false,
+            returns: flow.returns,
+            breaks: flow.breaks,
+            continues: flow.continues,
+        }
+        .union(stmt_flow);
         lowered.push(lowered_stmt);
     }
     let mut after = env.clone();
     release_scope_borrows(&mut after, &scope_names);
-    Ok((lowered, after, guaranteed_return))
+    Ok((lowered, after, flow))
 }
 
 fn lower_block_recovering(
     block: &[syntax::Stmt],
     env: &mut HashMap<String, Binding>,
     ctx: &LowerContext<'_>,
-) -> (Vec<Stmt>, Vec<Diagnostic>, bool) {
+    mut loop_flow: Option<&mut LoopFlow>,
+) -> (Vec<Stmt>, Vec<Diagnostic>, ControlFlow) {
     let scope_names = env.keys().cloned().collect::<HashSet<_>>();
     let mut lowered = Vec::new();
     let mut diagnostics = Vec::new();
-    let mut guaranteed_return = false;
+    let mut flow = ControlFlow::fallthrough();
     for stmt in block {
-        if guaranteed_return {
+        if !flow.fallthrough {
             diagnostics.push(
                 Diagnostic::new(
                     "control",
@@ -658,9 +674,16 @@ fn lower_block_recovering(
             continue;
         }
         let mut candidate_env = env.clone();
-        match lower_stmt(stmt, &mut candidate_env, ctx) {
+        match lower_stmt(stmt, &mut candidate_env, ctx, loop_flow.as_deref_mut()) {
             Ok(lowered_stmt) => {
-                guaranteed_return = lowered_stmt.always_returns();
+                let stmt_flow = lowered_stmt.control_flow();
+                flow = ControlFlow {
+                    fallthrough: false,
+                    returns: flow.returns,
+                    breaks: flow.breaks,
+                    continues: flow.continues,
+                }
+                .union(stmt_flow);
                 *env = candidate_env;
                 lowered.push(lowered_stmt);
             }
@@ -671,7 +694,7 @@ fn lower_block_recovering(
         }
     }
     release_scope_borrows(env, &scope_names);
-    (lowered, diagnostics, guaranteed_return)
+    (lowered, diagnostics, flow)
 }
 
 fn insert_type_error_binding_for_failed_stmt(
@@ -761,6 +784,7 @@ fn lower_stmt(
     stmt: &syntax::Stmt,
     env: &mut HashMap<String, Binding>,
     ctx: &LowerContext<'_>,
+    mut loop_flow: Option<&mut LoopFlow>,
 ) -> Result<Stmt, Diagnostic> {
     match stmt {
         syntax::Stmt::Let {
@@ -987,7 +1011,8 @@ fn lower_stmt(
             if let Some(known_cond) = static_bool_value(&lowered_cond) {
                 if known_cond {
                     let mut then_env = env.clone();
-                    let (then_block, then_after, _) = lower_block(then_block, &mut then_env, ctx)?;
+                    let (then_block, then_after, _) =
+                        lower_block(then_block, &mut then_env, ctx, loop_flow.as_deref_mut())?;
                     *env = then_after;
                     return Ok(Stmt::If {
                         cond: lowered_cond,
@@ -998,7 +1023,8 @@ fn lower_stmt(
                 }
                 if let Some(else_block) = else_block {
                     let mut else_env = env.clone();
-                    let (block, after, _) = lower_block(else_block, &mut else_env, ctx)?;
+                    let (block, after, _) =
+                        lower_block(else_block, &mut else_env, ctx, loop_flow.as_deref_mut())?;
                     *env = after;
                     return Ok(Stmt::If {
                         cond: lowered_cond,
@@ -1016,22 +1042,23 @@ fn lower_stmt(
             }
             let before = env.clone();
             let mut then_env = before.clone();
-            let (then_block, then_after, then_returns) =
-                lower_block(then_block, &mut then_env, ctx)?;
-            let (else_block, else_after, else_returns) = if let Some(else_block) = else_block {
+            let (then_block, then_after, then_flow) =
+                lower_block(then_block, &mut then_env, ctx, loop_flow.as_deref_mut())?;
+            let (else_block, else_after, else_flow) = if let Some(else_block) = else_block {
                 let mut else_env = before.clone();
-                let (block, after, returns) = lower_block(else_block, &mut else_env, ctx)?;
-                (Some(block), Some(after), returns)
+                let (block, after, flow) =
+                    lower_block(else_block, &mut else_env, ctx, loop_flow.as_deref_mut())?;
+                (Some(block), Some(after), flow)
             } else {
-                (None, None, false)
+                (None, None, ControlFlow::fallthrough())
             };
             merge_branch_state(
                 env,
                 &before,
                 &then_after,
-                then_returns,
+                then_flow,
                 else_after.as_ref(),
-                else_returns,
+                else_flow,
             );
             Ok(Stmt::If {
                 cond: lowered_cond,
@@ -1065,35 +1092,49 @@ fn lower_stmt(
             let mut body_env = before.clone();
             let mut loop_ctx = ctx.clone();
             loop_ctx.loop_depth += 1;
-            let (body, body_after, body_returns) =
-                lower_block(body, &mut body_env, &loop_ctx)?;
+            let mut inner_loop_flow = LoopFlow::default();
+            let (body, body_after, body_flow) =
+                lower_block(body, &mut body_env, &loop_ctx, Some(&mut inner_loop_flow))?;
             // AG1.1: reject moves of outer non-Copy variables inside the loop
             // body — on subsequent iterations the value would not be available.
-            if !body_returns {
+            if body_flow.fallthrough || !inner_loop_flow.continue_states.is_empty() {
+                let mut loop_backedge_states = Vec::new();
+                if body_flow.fallthrough {
+                    loop_backedge_states.push(&body_after);
+                }
+                loop_backedge_states.extend(inner_loop_flow.continue_states.iter());
                 for (name, pre_binding) in &before {
                     if pre_binding.moved || pre_binding.ty.is_copy() {
                         continue;
                     }
-                    if let Some(post_binding) = body_after.get(name) {
-                        let moved_projection_in_body = post_binding
-                            .moved_projections
-                            .iter()
-                            .any(|projection| !pre_binding.moved_projections.contains(projection));
-                        if post_binding.moved || moved_projection_in_body {
-                            return Err(ownership_error(
-                                OWNERSHIP_LOOP_MOVE_OUTER_NON_COPY,
-                                format!(
-                                    "cannot move non-copy value `{}` inside loop body — \
-                                     value would not be available on subsequent iterations",
-                                    name
-                                ),
-                            )
-                            .with_span(*line, *column));
-                        }
+                    if loop_backedge_states.iter().any(|state| {
+                        state.get(name).is_some_and(|post_binding| {
+                            let moved_projection_in_body =
+                                post_binding.moved_projections.iter().any(|projection| {
+                                    !pre_binding.moved_projections.contains(projection)
+                                });
+                            post_binding.moved || moved_projection_in_body
+                        })
+                    }) {
+                        return Err(ownership_error(
+                            OWNERSHIP_LOOP_MOVE_OUTER_NON_COPY,
+                            format!(
+                                "cannot move non-copy value `{}` inside loop body — \
+                                 value would not be available on subsequent iterations",
+                                name
+                            ),
+                        )
+                        .with_span(*line, *column));
                     }
                 }
             }
-            merge_loop_state(env, &before, &body_after, body_returns);
+            merge_loop_state(
+                env,
+                &before,
+                &body_after,
+                body_flow,
+                &inner_loop_flow.break_states,
+            );
             Ok(Stmt::While {
                 cond: lowered_cond,
                 body,
@@ -1197,7 +1238,15 @@ fn lower_stmt(
                     });
                 }
             }
-            lower_match_stmt(expr, arms, *line, *column, env, ctx)
+            lower_match_stmt(
+                expr,
+                arms,
+                *line,
+                *column,
+                env,
+                ctx,
+                loop_flow.as_deref_mut(),
+            )
         }
         syntax::Stmt::Match {
             expr,
@@ -1206,7 +1255,15 @@ fn lower_stmt(
             column,
         } => {
             let arms = arms.iter().map(MatchArmInput::from).collect();
-            lower_match_stmt(expr, arms, *line, *column, env, ctx)
+            lower_match_stmt(
+                expr,
+                arms,
+                *line,
+                *column,
+                env,
+                ctx,
+                loop_flow.as_deref_mut(),
+            )
         }
         syntax::Stmt::Defer { expr, line, column } => {
             let lowered_expr = lower_expr(expr, env, ctx)?;
@@ -1225,6 +1282,9 @@ fn lower_stmt(
                         .with_span(*line, *column),
                 );
             }
+            if let Some(loop_flow) = loop_flow.as_deref_mut() {
+                loop_flow.break_states.push(env.clone());
+            }
             Ok(Stmt::Break {
                 span: SourceSpan::point(*line, *column),
             })
@@ -1235,6 +1295,9 @@ fn lower_stmt(
                     Diagnostic::new("control", "continue is only valid inside a while loop")
                         .with_span(*line, *column),
                 );
+            }
+            if let Some(loop_flow) = loop_flow.as_deref_mut() {
+                loop_flow.continue_states.push(env.clone());
             }
             Ok(Stmt::Continue {
                 span: SourceSpan::point(*line, *column),
@@ -1294,26 +1357,26 @@ fn merge_branch_state(
     env: &mut HashMap<String, Binding>,
     before: &HashMap<String, Binding>,
     then_after: &HashMap<String, Binding>,
-    then_returns: bool,
+    then_flow: ControlFlow,
     else_after: Option<&HashMap<String, Binding>>,
-    else_returns: bool,
+    else_flow: ControlFlow,
 ) {
     env.clear();
     for (name, binding) in before {
-        let then_moved = if then_returns {
-            binding.moved
-        } else {
+        let then_moved = if then_flow.fallthrough {
             then_after
                 .get(name)
                 .map(|entry| entry.moved)
                 .unwrap_or(binding.moved)
-        };
-        let else_moved = if else_returns {
-            binding.moved
         } else {
+            binding.moved
+        };
+        let else_moved = if else_flow.fallthrough {
             else_after
                 .and_then(|branch| branch.get(name).map(|entry| entry.moved))
                 .unwrap_or(binding.moved)
+        } else {
+            binding.moved
         };
         env.insert(
             name.clone(),
@@ -1323,9 +1386,9 @@ fn merge_branch_state(
                 moved_projections: merge_projection_sets(
                     binding,
                     then_after.get(name),
-                    then_returns,
+                    then_flow,
                     else_after.and_then(|branch| branch.get(name)),
-                    else_returns,
+                    else_flow,
                 ),
                 borrow_kind: binding.borrow_kind,
                 borrow_origin: binding.borrow_origin.clone(),
@@ -1333,19 +1396,19 @@ fn merge_branch_state(
                 borrowed_owners: binding.borrowed_owners.clone(),
                 active_borrow_count: merge_borrow_count(
                     binding.active_borrow_count,
-                    then_returns,
+                    !then_flow.fallthrough,
                     then_after.get(name).map(|entry| entry.active_borrow_count),
-                    else_returns,
+                    !else_flow.fallthrough,
                     else_after
                         .and_then(|branch| branch.get(name).map(|entry| entry.active_borrow_count)),
                 ),
                 active_mut_borrow_count: merge_borrow_count(
                     binding.active_mut_borrow_count,
-                    then_returns,
+                    !then_flow.fallthrough,
                     then_after
                         .get(name)
                         .map(|entry| entry.active_mut_borrow_count),
-                    else_returns,
+                    !else_flow.fallthrough,
                     else_after.and_then(|branch| {
                         branch.get(name).map(|entry| entry.active_mut_borrow_count)
                     }),
@@ -1359,17 +1422,17 @@ fn merge_branch_state(
 fn merge_projection_sets(
     before: &Binding,
     then_after: Option<&Binding>,
-    then_returns: bool,
+    then_flow: ControlFlow,
     else_after: Option<&Binding>,
-    else_returns: bool,
+    else_flow: ControlFlow,
 ) -> HashSet<ProjectionPath> {
     let mut moved = before.moved_projections.clone();
-    if !then_returns {
+    if then_flow.fallthrough {
         if let Some(binding) = then_after {
             moved.extend(binding.moved_projections.iter().cloned());
         }
     }
-    if !else_returns {
+    if else_flow.fallthrough {
         if let Some(binding) = else_after {
             moved.extend(binding.moved_projections.iter().cloned());
         }
@@ -1381,44 +1444,69 @@ fn merge_loop_state(
     env: &mut HashMap<String, Binding>,
     before: &HashMap<String, Binding>,
     body_after: &HashMap<String, Binding>,
-    body_returns: bool,
+    body_flow: ControlFlow,
+    break_states: &[HashMap<String, Binding>],
 ) {
     // AG1.1: the loop body may execute zero times, so post-loop ownership
-    // state preserves the pre-loop moved flags.  Moves of outer non-Copy
-    // values inside the body are rejected earlier (before this function is
-    // called), so the only moved-state change that can reach here is for
-    // values that were already moved before the loop.  Borrow counts still
-    // take the max of pre-loop and body-after to stay conservative.
+    // state preserves the pre-loop moved flags.  Moves on a break edge are
+    // visible after the loop, while moves on a backedge are rejected earlier.
     env.clear();
     for (name, binding) in before {
+        let exit_bindings = break_states.iter().filter_map(|state| state.get(name));
+        let moved_on_break = exit_bindings.clone().any(|entry| entry.moved);
+        let moved_projections_on_break = exit_bindings
+            .flat_map(|entry| entry.moved_projections.iter().cloned())
+            .collect::<HashSet<_>>();
+        let body_borrow_count = if body_flow.fallthrough {
+            body_after
+                .get(name)
+                .map(|entry| entry.active_borrow_count)
+                .unwrap_or(binding.active_borrow_count)
+        } else {
+            binding.active_borrow_count
+        };
+        let body_mut_borrow_count = if body_flow.fallthrough {
+            body_after
+                .get(name)
+                .map(|entry| entry.active_mut_borrow_count)
+                .unwrap_or(binding.active_mut_borrow_count)
+        } else {
+            binding.active_mut_borrow_count
+        };
+        let break_borrow_count = break_states
+            .iter()
+            .filter_map(|state| state.get(name))
+            .map(|entry| entry.active_borrow_count)
+            .max()
+            .unwrap_or(binding.active_borrow_count);
+        let break_mut_borrow_count = break_states
+            .iter()
+            .filter_map(|state| state.get(name))
+            .map(|entry| entry.active_mut_borrow_count)
+            .max()
+            .unwrap_or(binding.active_mut_borrow_count);
         env.insert(
             name.clone(),
             Binding {
                 ty: binding.ty.clone(),
-                moved: binding.moved,
-                moved_projections: binding.moved_projections.clone(),
+                moved: binding.moved || moved_on_break,
+                moved_projections: binding
+                    .moved_projections
+                    .union(&moved_projections_on_break)
+                    .cloned()
+                    .collect(),
                 borrow_kind: binding.borrow_kind,
                 borrow_origin: binding.borrow_origin.clone(),
                 net_origin: binding.net_origin.clone(),
                 borrowed_owners: binding.borrowed_owners.clone(),
-                active_borrow_count: if body_returns {
-                    binding.active_borrow_count
-                } else {
-                    let body_count = body_after
-                        .get(name)
-                        .map(|entry| entry.active_borrow_count)
-                        .unwrap_or(binding.active_borrow_count);
-                    binding.active_borrow_count.max(body_count)
-                },
-                active_mut_borrow_count: if body_returns {
-                    binding.active_mut_borrow_count
-                } else {
-                    let body_count = body_after
-                        .get(name)
-                        .map(|entry| entry.active_mut_borrow_count)
-                        .unwrap_or(binding.active_mut_borrow_count);
-                    binding.active_mut_borrow_count.max(body_count)
-                },
+                active_borrow_count: binding
+                    .active_borrow_count
+                    .max(body_borrow_count)
+                    .max(break_borrow_count),
+                active_mut_borrow_count: binding
+                    .active_mut_borrow_count
+                    .max(body_mut_borrow_count)
+                    .max(break_mut_borrow_count),
                 active_borrows: binding.active_borrows.clone(),
             },
         );
@@ -1428,18 +1516,18 @@ fn merge_loop_state(
 fn merge_match_state(
     env: &mut HashMap<String, Binding>,
     before: &HashMap<String, Binding>,
-    arm_states: &[(HashMap<String, Binding>, bool)],
+    arm_states: &[(HashMap<String, Binding>, ControlFlow)],
 ) {
     env.clear();
     for (name, binding) in before {
-        let moved = arm_states.iter().any(|(after, returns)| {
-            if *returns {
-                binding.moved
-            } else {
+        let moved = arm_states.iter().any(|(after, flow)| {
+            if flow.fallthrough {
                 after
                     .get(name)
                     .map(|entry| entry.moved)
                     .unwrap_or(binding.moved)
+            } else {
+                binding.moved
             }
         });
         env.insert(
@@ -1454,22 +1542,22 @@ fn merge_match_state(
                 borrowed_owners: binding.borrowed_owners.clone(),
                 active_borrow_count: arm_states
                     .iter()
-                    .filter_map(|(after, returns)| {
-                        if *returns {
-                            Some(binding.active_borrow_count)
-                        } else {
+                    .filter_map(|(after, flow)| {
+                        if flow.fallthrough {
                             after.get(name).map(|entry| entry.active_borrow_count)
+                        } else {
+                            Some(binding.active_borrow_count)
                         }
                     })
                     .max()
                     .unwrap_or(binding.active_borrow_count),
                 active_mut_borrow_count: arm_states
                     .iter()
-                    .filter_map(|(after, returns)| {
-                        if *returns {
-                            Some(binding.active_mut_borrow_count)
-                        } else {
+                    .filter_map(|(after, flow)| {
+                        if flow.fallthrough {
                             after.get(name).map(|entry| entry.active_mut_borrow_count)
+                        } else {
+                            Some(binding.active_mut_borrow_count)
                         }
                     })
                     .max()
@@ -1483,11 +1571,11 @@ fn merge_match_state(
 fn merge_match_projection_sets(
     before: &Binding,
     name: &str,
-    arm_states: &[(HashMap<String, Binding>, bool)],
+    arm_states: &[(HashMap<String, Binding>, ControlFlow)],
 ) -> HashSet<ProjectionPath> {
     let mut moved = before.moved_projections.clone();
-    for (after, returns) in arm_states {
-        if *returns {
+    for (after, flow) in arm_states {
+        if !flow.fallthrough {
             continue;
         }
         if let Some(binding) = after.get(name) {

--- a/stage1/crates/axiomc/src/hir/control_flow.rs
+++ b/stage1/crates/axiomc/src/hir/control_flow.rs
@@ -1,37 +1,114 @@
 use super::Stmt;
 use super::expressions::static_bool_value;
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(super) struct ControlFlow {
+    pub(super) fallthrough: bool,
+    pub(super) returns: bool,
+    pub(super) breaks: bool,
+    pub(super) continues: bool,
+}
+
+impl ControlFlow {
+    pub(super) const fn fallthrough() -> Self {
+        Self {
+            fallthrough: true,
+            returns: false,
+            breaks: false,
+            continues: false,
+        }
+    }
+
+    pub(super) const fn return_value() -> Self {
+        Self {
+            fallthrough: false,
+            returns: true,
+            breaks: false,
+            continues: false,
+        }
+    }
+
+    pub(super) const fn break_value() -> Self {
+        Self {
+            fallthrough: false,
+            returns: false,
+            breaks: true,
+            continues: false,
+        }
+    }
+
+    pub(super) const fn continue_value() -> Self {
+        Self {
+            fallthrough: false,
+            returns: false,
+            breaks: false,
+            continues: true,
+        }
+    }
+
+    pub(super) const fn union(self, other: Self) -> Self {
+        Self {
+            fallthrough: self.fallthrough || other.fallthrough,
+            returns: self.returns || other.returns,
+            breaks: self.breaks || other.breaks,
+            continues: self.continues || other.continues,
+        }
+    }
+
+    pub(super) const fn always_returns(self) -> bool {
+        self.returns && !self.fallthrough && !self.breaks && !self.continues
+    }
+}
+
 impl Stmt {
-    pub(super) fn always_returns(&self) -> bool {
+    pub(super) fn control_flow(&self) -> ControlFlow {
         match self {
-            Stmt::Return { .. } | Stmt::Panic { .. } => true,
-            Stmt::Defer { .. } | Stmt::Assign { .. } => false,
-            Stmt::Break { .. } | Stmt::Continue { .. } => true,
+            Stmt::Return { .. } | Stmt::Panic { .. } => ControlFlow::return_value(),
+            Stmt::Defer { .. } | Stmt::Assign { .. } => ControlFlow::fallthrough(),
+            Stmt::Break { .. } => ControlFlow::break_value(),
+            Stmt::Continue { .. } => ControlFlow::continue_value(),
             Stmt::If {
                 cond,
                 then_block,
                 else_block: Some(else_block),
                 ..
             } => match static_bool_value(cond) {
-                Some(true) => block_always_returns(then_block),
-                Some(false) => block_always_returns(else_block),
-                None => block_always_returns(then_block) && block_always_returns(else_block),
+                Some(true) => block_control_flow(then_block),
+                Some(false) => block_control_flow(else_block),
+                None => block_control_flow(then_block).union(block_control_flow(else_block)),
             },
             Stmt::If {
                 cond,
                 then_block,
                 else_block: None,
                 ..
-            } => {
-                static_bool_value(cond).is_some_and(|value| value)
-                    && block_always_returns(then_block)
-            }
-            Stmt::Match { arms, .. } => arms.iter().all(|arm| block_always_returns(&arm.body)),
-            _ => false,
+            } => match static_bool_value(cond) {
+                Some(true) => block_control_flow(then_block),
+                _ => ControlFlow::fallthrough(),
+            },
+            Stmt::While { .. } => ControlFlow::fallthrough(),
+            Stmt::Match { arms, .. } => arms
+                .iter()
+                .map(|arm| block_control_flow(&arm.body))
+                .fold(ControlFlow::default(), ControlFlow::union),
+            _ => ControlFlow::fallthrough(),
         }
     }
 }
 
-fn block_always_returns(block: &[Stmt]) -> bool {
-    block.last().is_some_and(Stmt::always_returns)
+fn block_control_flow(block: &[Stmt]) -> ControlFlow {
+    let mut flow = ControlFlow::fallthrough();
+    for stmt in block {
+        if !flow.fallthrough {
+            break;
+        }
+        flow = ControlFlow {
+            fallthrough: false,
+            returns: flow.returns,
+            breaks: flow.breaks,
+            continues: flow.continues,
+        }
+        .union(stmt.control_flow());
+    }
+    flow
 }

--- a/stage1/crates/axiomc/src/hir/matches.rs
+++ b/stage1/crates/axiomc/src/hir/matches.rs
@@ -55,6 +55,7 @@ pub(super) fn lower_match_stmt(
     column: usize,
     env: &mut HashMap<String, Binding>,
     ctx: &LowerContext<'_>,
+    mut loop_flow: Option<&mut LoopFlow>,
 ) -> Result<Stmt, Diagnostic> {
     let lowered_expr = lower_expr(expr, env, ctx)?;
     let match_borrowed_owners = expr_borrowed_owners(&lowered_expr, env, ctx);
@@ -80,14 +81,13 @@ pub(super) fn lower_match_stmt(
             match_borrow_kind,
             match_borrowed_owners,
             reuse_existing_match_binding,
+            loop_flow,
         );
     };
     let before = env.clone();
     let mut seen = HashMap::new();
     let mut lowered_arms = Vec::new();
     let mut arm_states = Vec::new();
-    let mut ignored_body_cache: HashMap<String, (Vec<Stmt>, HashMap<String, Binding>, bool)> =
-        HashMap::new();
     for arm in arms {
         let variant_def = variant_defs
             .iter()
@@ -272,18 +272,8 @@ pub(super) fn lower_match_stmt(
                 },
             );
         }
-        let (body, after, returns) = if arm.ignore_payloads && arm.bindings.is_empty() {
-            let cache_key = format!("{:?}", arm.body);
-            if let Some((body, after, returns)) = ignored_body_cache.get(&cache_key) {
-                (body.clone(), after.clone(), *returns)
-            } else {
-                let lowered = lower_block(&arm.body, &mut arm_env, ctx)?;
-                ignored_body_cache.insert(cache_key, lowered.clone());
-                lowered
-            }
-        } else {
-            lower_block(&arm.body, &mut arm_env, ctx)?
-        };
+        let (body, after, flow) =
+            lower_block(&arm.body, &mut arm_env, ctx, loop_flow.as_deref_mut())?;
         lowered_arms.push(MatchArm {
             enum_name: enum_name.clone(),
             variant: arm.variant.clone(),
@@ -293,7 +283,7 @@ pub(super) fn lower_match_stmt(
             borrow_region_facts: arm_borrow_region_facts,
             body,
         });
-        arm_states.push((after, returns));
+        arm_states.push((after, flow));
     }
     let missing = variant_defs
         .iter()
@@ -334,6 +324,7 @@ fn lower_const_match_stmt(
     match_borrow_kind: Option<BorrowKind>,
     match_borrowed_owners: HashSet<BorrowedOwner>,
     reuse_existing_match_binding: bool,
+    mut loop_flow: Option<&mut LoopFlow>,
 ) -> Result<Stmt, Diagnostic> {
     if lowered_expr.ty() != &Type::Int {
         return Err(Diagnostic::new(
@@ -368,7 +359,8 @@ fn lower_const_match_stmt(
             );
         }
         let mut arm_env = before.clone();
-        let (body, after, returns) = lower_block(&arm.body, &mut arm_env, ctx)?;
+        let (body, after, flow) =
+            lower_block(&arm.body, &mut arm_env, ctx, loop_flow.as_deref_mut())?;
         lowered_arms.push(MatchArm {
             enum_name: String::new(),
             variant: value.to_string(),
@@ -378,7 +370,7 @@ fn lower_const_match_stmt(
             borrow_region_facts: Vec::new(),
             body,
         });
-        arm_states.push((after, returns));
+        arm_states.push((after, flow));
     }
     merge_match_state(env, &before, &arm_states);
     if let Some(borrow_kind) = match_borrow_kind
@@ -541,7 +533,7 @@ pub(super) fn lower_match_expr(
             is_named: arm.is_named,
             expr: lowered_arm_expr,
         });
-        arm_states.push((arm_env, false));
+        arm_states.push((arm_env, ControlFlow::fallthrough()));
     }
     let missing = variant_defs
         .iter()

--- a/stage1/crates/axiomc/src/package_store.rs
+++ b/stage1/crates/axiomc/src/package_store.rs
@@ -25,7 +25,6 @@ const TRANSACTION_MARKER_NAME: &str = ".axiom-transaction";
 const MAX_EVIDENCE_BYTES: usize = 16 * 1024 * 1024;
 const MAX_VENDOR_PACKAGES: usize = 4_096;
 const MAX_VENDOR_BYTES: u64 = 512 * 1024 * 1024;
-const MAX_TRANSACTION_SCAN_ENTRIES: usize = 1_024;
 const STALE_TRANSACTION_AGE_NANOS: u128 = 24 * 60 * 60 * 1_000_000_000;
 const EVIDENCE_NAMES: [&str; 6] = [
     "integrity.json",
@@ -1633,23 +1632,10 @@ fn reap_stale_transactions(parent: &Path, now: u128) -> Result<(), StoreError> {
             ),
         )
     })?;
-    let mut bounded_entries = Vec::with_capacity(MAX_TRANSACTION_SCAN_ENTRIES);
     for entry in entries {
-        if bounded_entries.len() == MAX_TRANSACTION_SCAN_ENTRIES {
-            return Err(StoreError::new(
-                "store_transaction_scan_exceeded",
-                format!(
-                    "{} contains more than {} transaction entries",
-                    parent.display(),
-                    MAX_TRANSACTION_SCAN_ENTRIES
-                ),
-            ));
-        }
-        bounded_entries.push(entry.map_err(|error| {
+        let entry = entry.map_err(|error| {
             StoreError::new("store_transaction_cleanup_failed", error.to_string())
-        })?);
-    }
-    for entry in bounded_entries {
+        })?;
         let Ok(name) = entry.file_name().into_string() else {
             continue;
         };
@@ -2367,23 +2353,26 @@ mod tests {
     }
 
     #[test]
-    fn stale_transaction_scan_has_a_deterministic_cardinality_bound() {
+    fn stale_transaction_scan_streams_beyond_previous_cardinality_limit() {
         let temp = tempfile::tempdir().unwrap();
         let store = PackageStore::open(&temp.path().join("cache")).unwrap();
         let transactions = store.root().join(".transactions");
-        for index in 0..=MAX_TRANSACTION_SCAN_ENTRIES {
+        for index in 0..=1_024 {
             fs::write(transactions.join(format!("unowned-{index:04}")), b"x").unwrap();
         }
-        let error =
-            reap_stale_transactions(&transactions, unix_epoch_nanos().unwrap()).unwrap_err();
-        assert_eq!(error.code, "store_transaction_scan_exceeded");
-        assert_eq!(
-            error.message,
-            format!(
-                "{} contains more than {} transaction entries",
-                transactions.display(),
-                MAX_TRANSACTION_SCAN_ENTRIES
-            )
+        let stale_pid = 2_000_000_000u32;
+        let stale = transactions.join(format!(".vendor-{stale_pid}-0-9"));
+        fs::create_dir(&stale).unwrap();
+        write_new_file(
+            &stale.join(TRANSACTION_MARKER_NAME),
+            &transaction_marker_bytes(stale_pid, 0, 9),
+        )
+        .unwrap();
+
+        reap_stale_transactions(&transactions, unix_epoch_nanos().unwrap()).unwrap();
+        assert!(
+            !stale.exists(),
+            "stale entries must be reclaimed past the old limit"
         );
     }
 

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -83,6 +83,113 @@ fn cranelift_backend_builds_hello_binary() {
 
 #[cfg(not(windows))]
 #[test]
+fn cranelift_backend_lowers_nested_break_and_continue() {
+    if which::which("cc").is_err() {
+        eprintln!("skipping cranelift loop-control test because cc is unavailable");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("loop-control");
+    fs::create_dir_all(project.join("src")).expect("create project src");
+    fs::write(
+        project.join("axiom.toml"),
+        r#"[package]
+name = "cranelift-loop-control"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[[tests]]
+name = "loop-control"
+entry = "src/main_test.ax"
+stdout = "src/main_test.stdout"
+kind = "unit"
+"#,
+    )
+    .expect("write manifest");
+    fs::write(
+        project.join("axiom.lock"),
+        r#"version = 1
+
+[[package]]
+name = "cranelift-loop-control"
+version = "0.1.0"
+source = "path"
+"#,
+    )
+    .expect("write lockfile");
+    fs::write(
+        project.join("src/main.ax"),
+        r#"let outer: int = 0
+while outer < 2 {
+let inner: int = 0
+while inner < 3 {
+inner = inner + 1
+if inner == 1 {
+continue
+}
+break
+}
+outer = outer + 1
+}
+print outer
+"#,
+    )
+    .expect("write source");
+    fs::write(
+        project.join("src/main_test.ax"),
+        "let value: int = 0\nwhile value < 1 {\nvalue = value + 1\ncontinue\n}\nprint value\n",
+    )
+    .expect("write test source");
+    fs::write(project.join("src/main_test.stdout"), "1\n").expect("write test golden");
+
+    let check = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args(["check", project.to_str().expect("project path"), "--json"])
+        .output()
+        .expect("run default axiomc check");
+    assert!(
+        check.status.success(),
+        "default Cranelift check failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&check.stdout),
+        String::from_utf8_lossy(&check.stderr)
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args(["build", project.to_str().expect("project path"), "--json"])
+        .output()
+        .expect("run default axiomc build");
+    assert!(
+        output.status.success(),
+        "default Cranelift build failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
+    assert_eq!(payload["backend"], "cranelift");
+    let binary = payload["binary"].as_str().expect("binary path");
+    let run = Command::new(binary)
+        .output()
+        .expect("run loop-control binary");
+    assert!(run.status.success(), "loop-control binary failed: {run:?}");
+    assert_eq!(String::from_utf8_lossy(&run.stdout), "2\n");
+
+    let test = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args(["test", project.to_str().expect("project path"), "--json"])
+        .output()
+        .expect("run default axiomc test");
+    assert!(
+        test.status.success(),
+        "default Cranelift test failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&test.stdout),
+        String::from_utf8_lossy(&test.stderr)
+    );
+}
+
+#[cfg(not(windows))]
+#[test]
 fn cranelift_backend_pure_artifact_is_invariant_to_build_env_and_stdin() {
     if which::which("cc").is_err() {
         eprintln!("skipping cranelift backend smoke test because cc is unavailable");
@@ -8602,7 +8709,10 @@ fn cranelift_backend_builds_once_and_reads_cwd_at_each_run() {
         .output()
         .expect("run binary from first cwd");
     assert!(first.status.success());
-    assert_eq!(String::from_utf8_lossy(&first.stdout), format!("{}\n", first_cwd.display()));
+    assert_eq!(
+        String::from_utf8_lossy(&first.stdout),
+        format!("{}\n", first_cwd.display())
+    );
 
     let second = Command::new(binary)
         .current_dir(&second_cwd)

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -4559,7 +4559,7 @@ fn cranelift_backend_lowers_fs_write_to_runtime_exit_code() {
     let runtime_file = project.join("scratch/data.txt");
     let append_file = project.join("scratch/append.txt");
     let replace_file = project.join("scratch/replace.txt");
-    let replace_temp_file = project.join("scratch/.replace.txt.axiom-replace.tmp");
+    let replace_temp_file = project.join("scratch/.replace.txt.axiom-replace-XXXXXX");
     let removed_file = project.join("scratch/remove.txt");
     let created_file = project.join("scratch/created.txt");
     let runtime_dir = project.join("scratch/native-dir");
@@ -4602,6 +4602,19 @@ fn cranelift_backend_lowers_fs_write_to_runtime_exit_code() {
         !audit_log.exists(),
         "build should not create the native fs audit log"
     );
+    #[cfg(unix)]
+    let replace_sentinel = project
+        .parent()
+        .expect("project parent")
+        .join("replace-sentinel.txt");
+    #[cfg(unix)]
+    let planted_temp = project.join("scratch/.replace.txt.axiom-replace.tmp");
+    #[cfg(unix)]
+    {
+        fs::write(&replace_sentinel, "sentinel-safe").expect("write replace sentinel");
+        std::os::unix::fs::symlink(&replace_sentinel, &planted_temp)
+            .expect("plant legacy replace temp symlink");
+    }
     let run = Command::new(binary)
         .env("AXIOM_HOST_AUDIT_LOG", &audit_log)
         .output()
@@ -4619,6 +4632,19 @@ fn cranelift_backend_lowers_fs_write_to_runtime_exit_code() {
     assert_eq!(
         fs::read_to_string(&replace_file).expect("read fs_replace runtime fixture"),
         "runtime-replace"
+    );
+    #[cfg(unix)]
+    assert_eq!(
+        fs::read_to_string(&replace_sentinel).expect("read replace sentinel"),
+        "sentinel-safe"
+    );
+    #[cfg(unix)]
+    assert!(
+        fs::symlink_metadata(&planted_temp)
+            .expect("stat planted replace temp")
+            .file_type()
+            .is_symlink(),
+        "a preplanted legacy temp symlink must never be followed"
     );
     assert!(
         !removed_file.exists(),

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -4422,9 +4422,6 @@ fn cranelift_backend_reports_scoped_file_metadata_at_runtime() {
     let temp = tempfile::tempdir().expect("tempdir");
     let project = temp.path().join("fs-file-metadata");
     write_fs_file_metadata_project(&project);
-    let runtime_content = "runtime-metadata\n";
-    fs::write(project.join("src/metadata.txt"), runtime_content)
-        .expect("rewrite metadata fixture for runtime");
 
     let output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
         .args([
@@ -4447,6 +4444,7 @@ fn cranelift_backend_reports_scoped_file_metadata_at_runtime() {
     assert_eq!(payload["backend"], "cranelift");
     assert_eq!(payload["generated_rust"], Value::Null);
     let binary = payload["binary"].as_str().expect("binary path");
+    let runtime_content = "runtime-metadata\n";
     let audit_log = project.join("native-fs-metadata-audit.jsonl");
     assert!(
         !audit_log.exists(),
@@ -4457,14 +4455,15 @@ fn cranelift_backend_reports_scoped_file_metadata_at_runtime() {
         .env("AXIOM_HOST_AUDIT_LOG", &audit_log)
         .output()
         .expect("run cranelift file metadata binary");
+    let audit = fs::read_to_string(&audit_log).expect("read native fs metadata audit log");
     assert_eq!(
         run.status.code(),
         Some(runtime_content.len() as i32),
-        "runtime metadata should determine the exit code: stdout={} stderr={}",
+        "runtime metadata should determine the exit code: stdout={} stderr={} audit={}",
         String::from_utf8_lossy(&run.stdout),
-        String::from_utf8_lossy(&run.stderr)
+        String::from_utf8_lossy(&run.stderr),
+        audit
     );
-    let audit = fs::read_to_string(&audit_log).expect("read native fs metadata audit log");
     assert!(audit.contains("\"intrinsic\":\"fs_file_exists\""));
     assert!(audit.contains("\"intrinsic\":\"fs_file_size\""));
     assert!(audit.contains("\"outcome\":\"ok\""));
@@ -4976,12 +4975,10 @@ fn cranelift_backend_debug_build_emits_sidecars_without_axiom_dwarf() {
     assert_eq!(manifest["native_debug"]["debuginfo"], 0);
     assert_eq!(manifest["native_debug"]["opt_level"], 0);
     assert_eq!(manifest["native_debug"]["axiom_dwarf"], false);
-    assert!(
-        manifest["native_debug"]["native_debug_info"]
-            .as_str()
-            .expect("native debug info")
-            .contains("does not emit native Axiom DWARF yet")
-    );
+    assert!(manifest["native_debug"]["native_debug_info"]
+        .as_str()
+        .expect("native debug info")
+        .contains("does not emit native Axiom DWARF yet"));
     assert!(
         manifest.get("rustc").is_none(),
         "cranelift debug manifests should not claim rustc debug settings"
@@ -16033,6 +16030,7 @@ out_dir = "dist"
 
 [capabilities]
 fs = true
+"fs:write" = true
 net = false
 process = false
 env = false
@@ -16113,6 +16111,7 @@ out_dir = "dist"
 
 [capabilities]
 fs = true
+"fs:write" = true
 net = false
 process = false
 env = false
@@ -16138,15 +16137,13 @@ source = "path"
         project.join("src/main.ax"),
         r#"import "std/fs.ax"
 
-static METADATA_PATH: string = "src/metadata.txt"
-
 fn main(): int {
-let exists: bool = file_exists(METADATA_PATH)
-let missing: bool = file_exists("src/missing.txt")
-let size: int = file_size(METADATA_PATH)
+let wrote: int = write_file("src/metadata.txt", "runtime-metadata\n")
+let replaced: int = replace_file("src/metadata.txt", "runtime-replaced\n")
+let exists: bool = file_exists("src/metadata.txt")
 let missing_size: int = file_size("src/missing.txt")
-if exists == true && missing == false && size > 0 && missing_size == -1 {
-return size
+if wrote == 0 && replaced == 0 && exists == true && missing_size == -1 {
+return file_size("src/metadata.txt")
 } else {
 return 1
 }

--- a/stage1/crates/axiomc/tests/support/hir_unit.rs
+++ b/stage1/crates/axiomc/tests/support/hir_unit.rs
@@ -5,6 +5,61 @@ fn parse(source: &str) -> syntax::Program {
     syntax::parse_program(source, Path::new("main.ax")).expect("parse fixture")
 }
 
+#[test]
+fn hir_propagates_move_state_from_break_edges() {
+    let parsed = parse(
+        r#"
+fn main(): int {
+let value: string = "owned"
+while true {
+let moved: string = value
+break
+}
+print value
+return 0
+}
+"#,
+    );
+
+    let error = lower(&parsed).expect_err("break exit must preserve moved state");
+    assert!(error.message.contains("use of moved value \"value\""));
+}
+
+#[test]
+fn hir_rejects_move_on_continue_backedge_and_unreachable_statements() {
+    let parsed = parse(
+        r#"
+fn main(): int {
+let value: string = "owned"
+while true {
+let moved: string = value
+continue
+print 1
+}
+return 0
+}
+"#,
+    );
+
+    let error = lower(&parsed).expect_err("continue backedge must not reuse a moved value");
+    assert!(error.message.contains("unreachable statements"));
+
+    let parsed = parse(
+        r#"
+fn main(): int {
+let value: string = "owned"
+while true {
+let moved: string = value
+continue
+}
+return 0
+}
+"#,
+    );
+    let error = lower(&parsed).expect_err("continue backedge must reject the move");
+    assert!(error.message.contains("cannot move non-copy value"));
+}
+
 fn collect_borrow_region_facts(stmts: &[Stmt]) -> Vec<BorrowRegionFact> {
     let mut facts = Vec::new();
     for stmt in stmts {

--- a/stage1/crates/axiomc/tests/support/lib_unit.rs
+++ b/stage1/crates/axiomc/tests/support/lib_unit.rs
@@ -1055,6 +1055,54 @@ print demo()
 }
 
 #[test]
+fn generated_rust_unwinds_only_the_loop_scope_on_control_edges() {
+    let source = r#"fn trace(label: string): int {
+print label
+return 0
+}
+
+fn demo(): int {
+defer trace("outer")
+let index: int = 0
+while index < 2 {
+defer trace("loop")
+index = index + 1
+if index == 1 {
+continue
+}
+break
+}
+return 0
+}
+
+print demo()
+"#;
+    let parsed = parse_program(source, Path::new("main.ax")).expect("parse");
+    let hir = hir::lower(&parsed).expect("lower");
+    let mir = mir::lower(&hir);
+    let rendered = render_rust(&mir);
+    let demo_pos = rendered.find("fn demo").expect("demo rendered");
+    let continue_pos = rendered[demo_pos..]
+        .find("continue;")
+        .map(|offset| demo_pos + offset)
+        .expect("continue rendered");
+    let break_pos = rendered[demo_pos..]
+        .find("break;")
+        .map(|offset| demo_pos + offset)
+        .expect("break rendered");
+    let outer_pos = rendered
+        .rfind("let _ = trace(String::from(\"outer\"));")
+        .expect("outer defer rendered");
+    assert!(rendered[..continue_pos].contains("let _ = trace(String::from(\"loop\"));"));
+    assert!(rendered[..break_pos].contains("let _ = trace(String::from(\"loop\"));"));
+    assert!(!rendered[continue_pos..break_pos].contains("trace(String::from(\"outer\"))"));
+    assert!(
+        outer_pos > break_pos,
+        "outer defer must remain at function exit"
+    );
+}
+
+#[test]
 fn run_project_executes_defer_on_return_panic_and_nested_scope() {
     let dir = tempdir().expect("tempdir");
     fs::write(dir.path().join("axiom.toml"), render_manifest("defer-demo"))


### PR DESCRIPTION
## Summary

- Isolate Fast Checks and Full Lib Suite Cargo targets per workflow run and attempt.
- Ensure Fast Checks reads PR-head data through `AXIOM_CHECKOUT_PATH` while retaining base-pinned trusted scripts.
- Add workflow and checker regressions covering checkout and target-directory isolation.

## Issue linkage

Closes #1560

## Validation

- Workflow contract test
- Provider ABI, stdlib, Semantic MIR, Runtime Lifecycle, Compatibility, and autonomy regression suites
- Fresh-target `cranelift_backend` Cargo test build
- Python compilation and `git diff --check`

## Risk and blockers

This prevents persistent self-hosted runners from reusing Rust artifacts across PR checkouts or workflow attempts. External autoreview was unavailable because the reviewer API connection failed.
