### PR TITLE
Repair stale Extended Validation assertions

### DIFF
--- a/scripts/ci/run-extended-stage1-checks.sh
+++ b/scripts/ci/run-extended-stage1-checks.sh
@@ -34,9 +34,11 @@ import json
 import sys
 
 payload = json.load(open(sys.argv[1], encoding="utf-8"))
-message = payload.get("error", {}).get("message", "")
 if payload.get("ok") is not False:
     raise SystemExit("targeted build failure must return ok=false")
-if "cranelift backend spike currently supports only the host target" not in message:
-    raise SystemExit(f"unexpected targeted build failure: {message}")
+error = payload.get("error")
+if not isinstance(error, dict):
+    raise SystemExit(f"targeted build failure omitted structured error evidence: {payload}")
+if error.get("kind") != "target" or error.get("code") != "target.unsupported":
+    raise SystemExit(f"unexpected targeted build error evidence: {error}")
 PY

--- a/scripts/ci/run-stage1-stdlib-smoke.sh
+++ b/scripts/ci/run-stage1-stdlib-smoke.sh
@@ -117,6 +117,72 @@ run_stdlib_project() {
   cargo run --manifest-path stage1/Cargo.toml -p axiomc -- run "$project" --backend cranelift
 }
 
+run_stdlib_env_project() {
+  local project="stage1/examples/stdlib_env"
+  local build_report check_report runtime_binary first_output second_output
+
+  check_report="$(mktemp "${TMPDIR:-/tmp}/axiom-stdlib-env-check.XXXXXX")"
+  temp_reports+=("$check_report")
+  capture_report "$check_report" \
+    cargo run --manifest-path stage1/Cargo.toml -p axiomc -- check "$project" --json
+  assert_ok_report "$check_report" "check" "$project"
+
+  build_report="$(mktemp "${TMPDIR:-/tmp}/axiom-stdlib-env-build-cranelift.XXXXXX")"
+  temp_reports+=("$build_report")
+  capture_report "$build_report" \
+    cargo run --manifest-path stage1/Cargo.toml -p axiomc -- build "$project" --backend cranelift --json
+  assert_cranelift_report "$build_report" "build" "$project" "direct-native"
+
+  runtime_binary="$(python3 - "$build_report" <<'PY'
+import json
+import sys
+
+payload = json.load(open(sys.argv[1], encoding="utf-8"))
+if payload.get("generated_rust") is not None:
+    raise SystemExit("stdlib_env emitted generated Rust")
+lowering = payload.get("lowering")
+if not isinstance(lowering, dict):
+    raise SystemExit("stdlib_env omitted lowering evidence")
+if lowering.get("execution_mode") != "direct_native_runtime":
+    raise SystemExit(f"stdlib_env did not use direct-native runtime: {lowering}")
+if lowering.get("direct_native_runtime") is not True:
+    raise SystemExit(f"stdlib_env did not prove direct-native runtime: {lowering}")
+if lowering.get("known_value_static_folds") is not False:
+    raise SystemExit(f"stdlib_env used static-value folding: {lowering}")
+if lowering.get("legacy_fallback_attempted") is not False:
+    raise SystemExit(f"stdlib_env attempted a legacy fallback: {lowering}")
+binary = payload.get("binary")
+if not isinstance(binary, str) or not binary:
+    raise SystemExit(f"stdlib_env omitted runtime binary: {payload}")
+print(binary)
+PY
+)"
+
+  first_output="$(mktemp "${TMPDIR:-/tmp}/axiom-stdlib-env-first-run.XXXXXX")"
+  temp_reports+=("$first_output")
+  capture_report "$first_output" \
+    env "__AXIOM_STAGE1_MISSING__=first-runtime-value" "$runtime_binary"
+
+  second_output="$(mktemp "${TMPDIR:-/tmp}/axiom-stdlib-env-second-run.XXXXXX")"
+  temp_reports+=("$second_output")
+  capture_report "$second_output" \
+    env "__AXIOM_STAGE1_MISSING__=second-runtime-value" "$runtime_binary"
+
+  python3 - "$first_output" "$second_output" <<'PY'
+from pathlib import Path
+import sys
+
+first, second = (Path(path).read_text(encoding="utf-8") for path in sys.argv[1:])
+if first != "first-runtime-value\n" or second != "second-runtime-value\n":
+    raise SystemExit(
+        "stdlib_env did not produce runtime-sensitive output: "
+        f"first={first!r}, second={second!r}"
+    )
+if first == second:
+    raise SystemExit("stdlib_env output did not change with the runtime environment")
+PY
+}
+
 run_stdlib_test() {
   local example="$1"
   shift
@@ -178,8 +244,9 @@ for example in \
   run_stdlib_project "$example" "bounded-static"
 done
 
+run_stdlib_env_project
+
 for example in \
-  stdlib_env \
   stdlib_fs \
   stdlib_net \
   stdlib_process \

--- a/scripts/ci/test-run-extended-stage1-checks.sh
+++ b/scripts/ci/test-run-extended-stage1-checks.sh
@@ -29,4 +29,14 @@ grep -Fq 'default targeted builds must not silently fall back to generated Rust'
   exit 1
 }
 
+grep -Fq 'error.get("code") != "target.unsupported"' "$script" || {
+  echo "extended stage1 checks must assert the structured unsupported-target code" >&2
+  exit 1
+}
+
+if grep -Fq 'cranelift backend spike currently supports only the host target' "$script"; then
+  echo "extended stage1 checks must not depend on unsupported-target message text" >&2
+  exit 1
+fi
+
 echo "run-extended-stage1-checks regression cases passed"

--- a/scripts/ci/test-run-stage1-stdlib-smoke.sh
+++ b/scripts/ci/test-run-stage1-stdlib-smoke.sh
@@ -14,6 +14,14 @@ required = (
     "capture_expected_failure_report",
     "validate-stage1-smoke-report.py",
     '--expect "$expectation"',
+    "run_stdlib_env_project",
+    '__AXIOM_STAGE1_MISSING__=first-runtime-value',
+    '__AXIOM_STAGE1_MISSING__=second-runtime-value',
+    '"execution_mode") != "direct_native_runtime"',
+    '"direct_native_runtime") is not True',
+    '"known_value_static_folds") is not False',
+    '"generated_rust") is not None',
+    "stdlib_env did not produce runtime-sensitive output",
     '"bounded-static"',
     "--expect blocked",
     "run_fail_closed_stdlib_project",
@@ -33,7 +41,6 @@ if missing:
     )
 
 fail_closed = {
-    "stdlib_env",
     "stdlib_fs",
     "stdlib_net",
     "stdlib_process",


### PR DESCRIPTION
## Summary

- Match unsupported wasm targets by structured `target.unsupported` evidence rather than message text.
- Prove `stdlib_env` is direct-native runtime behavior with two distinct runtime values.
- Preserve `generated_rust: null`, direct-native mode, no static folding, and no fallback assertions.
- Update Extended Validation and stdlib smoke contract tests.

## Issue linkage

Closes #1563

## Validation

- Extended-stage1 checks
- Full stdlib smoke
- Focused Rust runtime and target-support tests
- Shell syntax checks
- 8 smoke-report validator tests
- `git diff --check`

## Risk and blockers

The fail-closed behavior remains for unsupported/non-runtime-lowerable cases; only the proven `stdlib_env` case changes expectation. External autoreview remains unavailable for the private diff.
