### PR TITLE
Print actionable redacted validation summaries

### DIFF
--- a/.github/workflows/extended-validation.yml
+++ b/.github/workflows/extended-validation.yml
@@ -137,6 +137,13 @@ jobs:
           --target '${{ runner.os }}-${{ runner.arch }}'
           --trigger '${{ github.event_name }}'
 
+      - name: Summarize qualification evidence
+        if: always()
+        run: >-
+          python3 scripts/ci/report-toolchain-qualification.py
+          --evidence artifacts/toolchain-qualification/toolchain-qualification.json
+          --expected-head-sha '${{ github.sha }}'
+
       - name: Upload qualification evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4 pinned 2026-04-19

--- a/scripts/ci/report-toolchain-qualification.py
+++ b/scripts/ci/report-toolchain-qualification.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Print a metadata-only summary of toolchain qualification evidence."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+SCHEMA = "axiom.toolchain_qualification.v0"
+SHA_PATTERN = re.compile(r"[0-9a-f]{40}\Z")
+MAX_ARTIFACT_LENGTH = 200
+
+
+def load_validator(repo_root: Path):
+    runner = repo_root / "scripts/ci/run-toolchain-qualification.py"
+    spec = importlib.util.spec_from_file_location("toolchain_qualification", runner)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("qualification validator is unavailable")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return (
+        module.validate_qualification_evidence,
+        repo_root / "stage1/schemas/axiom-toolchain-qualification-v0.schema.json",
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--evidence", type=Path, required=True)
+    parser.add_argument("--expected-head-sha", required=True)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    return parser.parse_args()
+
+
+def safe_path(path: Path) -> str:
+    value = str(path)
+    if any(ord(char) < 32 or ord(char) == 127 for char in value):
+        raise ValueError("evidence path contains control characters")
+    return value
+
+
+def safe_artifacts(value: Any) -> str:
+    if not isinstance(value, list) or not value:
+        raise ValueError("artifacts must be a non-empty array")
+    names: list[str] = []
+    for artifact in value:
+        if (
+            not isinstance(artifact, str)
+            or not artifact
+            or len(artifact) > MAX_ARTIFACT_LENGTH
+            or any(ord(char) < 32 or ord(char) == 127 for char in artifact)
+        ):
+            raise ValueError(
+                "artifact names must be bounded strings without control characters"
+            )
+        names.append(artifact)
+    return ",".join(names)
+
+
+def print_harness_failure(evidence_path: str) -> None:
+    print(
+        "qualification summary: "
+        "status=harness_failure failure_class=harness_failure "
+        "error=malformed_or_unverifiable_evidence "
+        f"evidence={evidence_path}"
+    )
+
+
+def main() -> int:
+    options = parse_args()
+    evidence_path = options.evidence.resolve()
+    evidence_display = "<unavailable>"
+    try:
+        evidence_display = safe_path(evidence_path)
+        if not SHA_PATTERN.fullmatch(options.expected_head_sha):
+            raise ValueError("expected head SHA is not an exact lowercase commit")
+        payload = json.loads(evidence_path.read_text(encoding="utf-8"))
+        validate, schema_path = load_validator(options.repo_root.resolve())
+        evidence = validate(payload, schema_path)
+        if evidence["headSha"] != options.expected_head_sha:
+            raise ValueError("evidence head SHA does not match expected head SHA")
+        for check in evidence["checks"]:
+            safe_artifacts(check["artifacts"])
+    except (OSError, UnicodeError, json.JSONDecodeError, RuntimeError, ValueError):
+        print_harness_failure(evidence_display)
+        return 1
+
+    counts = {
+        status: sum(check["status"] == status for check in evidence["checks"])
+        for status in ("passed", "skipped", "failed")
+    }
+    print(
+        "qualification summary: "
+        f"status={evidence['status']} failure_class={evidence['failureClass']} "
+        f"passed={counts['passed']} skipped={counts['skipped']} failed={counts['failed']} "
+        f"head_sha={evidence['headSha']} evidence={evidence_display}"
+    )
+    for check in evidence["checks"]:
+        if check["status"] == "failed":
+            print(
+                "qualification failure: "
+                f"id={check['id']} status={check['status']} "
+                f"failure_class={check['failureClass']} exit_code={check['exitCode']} "
+                f"artifacts={safe_artifacts(check['artifacts'])}"
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/run-fast-checks.sh
+++ b/scripts/ci/run-fast-checks.sh
@@ -72,6 +72,7 @@ bash "$script_repo_root/scripts/ci/test-check-package-trust-contract.sh"
 python3 "$script_repo_root/scripts/ci/test-run-stage1-quality-gate.py"
 bash "$script_repo_root/scripts/ci/test-propose-stage1-crap-thresholds.sh"
 python3 "$script_repo_root/scripts/ci/test-run-toolchain-qualification.py"
+python3 "$script_repo_root/scripts/ci/test-report-toolchain-qualification.py"
 cargo test --manifest-path "$repo_root/stage1/Cargo.toml" -p axiomc \
   --test schema_metadata --locked
 cargo test --manifest-path "$repo_root/stage1/Cargo.toml" -p axiomc \

--- a/scripts/ci/run-toolchain-qualification.py
+++ b/scripts/ci/run-toolchain-qualification.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any
 
 SCHEMA = "axiom.toolchain_qualification.v0"
+SUMMARY_ARTIFACT = "toolchain-qualification-summary.txt"
 
 DEFAULT_CHECKS = [
     {"id": "full_crate_integration", "command": "RUST_MIN_STACK=8388608 cargo test --manifest-path stage1/Cargo.toml --workspace --all-targets --features run-native-tests --locked -- --test-threads=1"},
@@ -286,6 +287,59 @@ def classify(returncode: int, command: str) -> tuple[str, str]:
     return "failed", "product_failure"
 
 
+def render_summary(
+    *,
+    records: list[dict[str, Any]],
+    status: str,
+    failure_class: str,
+    evidence_name: str,
+    head: str,
+) -> str:
+    counts = {
+        check_status: sum(record["status"] == check_status for record in records)
+        for check_status in ("passed", "skipped", "failed")
+    }
+    if status == "failed":
+        result = "valid_red"
+    elif status == "skipped":
+        result = "skipped"
+    else:
+        result = "passed"
+    lines = [
+        (
+            "qualification summary: "
+            f"result={result} status={status} failureClass={failure_class} "
+            f"passed={counts['passed']} skipped={counts['skipped']} "
+            f"failed={counts['failed']} evidenceArtifact={evidence_name} headSha={head}"
+        )
+    ]
+    for record in records:
+        if record["status"] != "failed":
+            continue
+        lines.append(
+            "FAILED "
+            f"id={record['id']} status={record['status']} "
+            f"failureClass={record['failureClass']} exitCode={record['exitCode']} "
+            f"artifactPath={record['artifacts'][0]}"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def render_harness_summary(*, evidence_name: str, head: str) -> str:
+    return (
+        "qualification summary: "
+        "result=harness_failure failureClass=schema_failure "
+        f"evidenceArtifact={evidence_name} headSha={head}\n"
+    )
+
+
+def artifact_identity(path: Path, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.name
+
+
 def file_fingerprint(path: Path) -> tuple[int, int, int, int] | None:
     if not path.is_file():
         return None
@@ -309,6 +363,7 @@ def main() -> int:
     checks = load_plan(options.plan)
     reserved_artifact_names = {
         "toolchain-qualification.json",
+        SUMMARY_ARTIFACT,
         *(f"{check['id']}.log" for check in checks),
     }
     artifact_destinations: dict[str, str] = {}
@@ -512,17 +567,37 @@ def main() -> int:
         "artifactPaths": artifact_paths,
         "checks": records,
     }
+    summary_path = output / SUMMARY_ARTIFACT
+    evidence_identity = artifact_identity(evidence_path, root)
+    summary = render_summary(
+        records=records,
+        status=evidence["status"],
+        failure_class=overall_failure,
+        evidence_name=evidence_identity,
+        head=head,
+    )
+    evidence["artifactPaths"].insert(-1, summary_path.name)
+    summary_path.write_text(summary, encoding="utf-8")
     schema_path = root / "stage1/schemas/axiom-toolchain-qualification-v0.schema.json"
     try:
         validate_qualification_evidence(evidence, schema_path)
-    except ValueError as error:
-        print(f"toolchain qualification evidence schema validation failed: {error}", file=sys.stderr)
+    except ValueError:
+        harness_summary = render_harness_summary(
+            evidence_name=evidence_identity,
+            head=head,
+        )
+        summary_path.write_text(harness_summary, encoding="utf-8")
+        print(
+            "toolchain qualification harness failure: schema validation failed",
+            file=sys.stderr,
+        )
+        print(harness_summary, end="")
         return 1
     encoded = json.dumps(evidence, indent=2, sort_keys=True) + "\n"
     temporary_evidence_path = evidence_path.with_suffix(".json.tmp")
     temporary_evidence_path.write_text(encoded, encoding="utf-8")
     temporary_evidence_path.replace(evidence_path)
-    print(evidence_path)
+    print(summary, end="")
     return 1 if failures or overall_failure == "infrastructure_skip" else 0
 
 

--- a/scripts/ci/test-extended-validation-workflow.sh
+++ b/scripts/ci/test-extended-validation-workflow.sh
@@ -91,6 +91,18 @@ if "needs.changes.outputs.extended == 'true'" not in extended_job:
     errors.append("extended-checks must consume the extended selection output")
 if "bash scripts/ci/run-extended-validation.sh" not in extended_job:
     errors.append("extended-checks must invoke the extended validation entrypoint")
+if "- name: Summarize qualification evidence" not in extended_job:
+    errors.append("extended-checks must summarize qualification evidence")
+if "scripts/ci/report-toolchain-qualification.py" not in extended_job:
+    errors.append("extended-checks must invoke the metadata-only qualification reporter")
+if "--expected-head-sha '${{ github.sha }}'" not in extended_job:
+    errors.append("extended-checks must bind the qualification summary to the workflow head")
+summary_marker = "- name: Summarize qualification evidence"
+qualification_upload_marker = "- name: Upload qualification evidence"
+summary_index = extended_job.find(summary_marker)
+upload_index = extended_job.find(qualification_upload_marker)
+if summary_index < 0 or upload_index < 0 or summary_index > upload_index:
+    errors.append("extended-checks must summarize qualification evidence before uploading artifacts")
 job_preamble = extended_job.split("\n    steps:\n", 1)[0]
 if re.search(r"\$\{\{\s*runner\s*(?:\.|\[)", job_preamble):
     errors.append("extended-checks must not use the runner context before step execution")

--- a/scripts/ci/test-report-toolchain-qualification.py
+++ b/scripts/ci/test-report-toolchain-qualification.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+REPORTER = ROOT / "scripts/ci/report-toolchain-qualification.py"
+SHA = "0123456789abcdef0123456789abcdef01234567"
+
+
+def evidence(checks, status="failed", failure_class="product_failure"):
+    return {
+        "schema": "axiom.toolchain_qualification.v0",
+        "trigger": "fixture",
+        "headSha": SHA,
+        "target": "fixture-target",
+        "status": status,
+        "durationMs": 7,
+        "failureClass": failure_class,
+        "artifactPaths": [
+            artifact for check in checks for artifact in check["artifacts"]
+        ]
+        + ["toolchain-qualification.json"],
+        "checks": checks,
+    }
+
+
+def check(check_id, status, failure_class, exit_code, artifact):
+    return {
+        "id": check_id,
+        "command": "printf 'CAPTURED_VALUE=do-not-print'",
+        "target": "fixture-target",
+        "required": True,
+        "status": status,
+        "durationMs": 7,
+        "failureClass": failure_class,
+        "exitCode": exit_code,
+        "artifacts": [artifact],
+    }
+
+
+class QualificationReportTests(unittest.TestCase):
+    def run_report(self, payload, expected_sha=SHA):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            evidence_path = root / "toolchain-qualification.json"
+            evidence_path.write_text(json.dumps(payload), encoding="utf-8")
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPORTER),
+                    "--evidence",
+                    str(evidence_path),
+                    "--expected-head-sha",
+                    expected_sha,
+                    "--repo-root",
+                    str(ROOT),
+                ],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            return result
+
+    def test_single_and_multiple_failures_are_metadata_only(self):
+        payload = evidence(
+            [
+                check("build_purity", "failed", "product_failure", 3, "build_purity.log"),
+                check(
+                    "proof_smoke",
+                    "failed",
+                    "infrastructure_failure",
+                    127,
+                    "proof_smoke.log",
+                ),
+            ]
+        )
+        result = self.run_report(payload)
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("status=failed", result.stdout)
+        self.assertIn("passed=0 skipped=0 failed=2", result.stdout)
+        self.assertIn("id=build_purity", result.stdout)
+        self.assertIn("id=proof_smoke", result.stdout)
+        self.assertIn("failure_class=product_failure exit_code=3", result.stdout)
+        self.assertIn("failure_class=infrastructure_failure exit_code=127", result.stdout)
+        self.assertIn(SHA, result.stdout)
+        self.assertIn("toolchain-qualification.json", result.stdout)
+        self.assertNotIn("CAPTURED_VALUE", result.stdout)
+        self.assertNotIn("CAPTURED_VALUE", result.stderr)
+
+    def test_pass_and_skip_counts_are_reported_without_failure_rows(self):
+        passed = check("conformance", "passed", "none", 0, "conformance.log")
+        skipped = check(
+            "supply_chain", "skipped", "infrastructure_skip", 0, "supply_chain.log"
+        )
+        result = self.run_report(
+            evidence(
+                [passed, skipped],
+                status="skipped",
+                failure_class="infrastructure_skip",
+            )
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("passed=1 skipped=1 failed=0", result.stdout)
+        self.assertNotIn("qualification failure:", result.stdout)
+
+    def test_malformed_or_stale_evidence_is_a_harness_failure(self):
+        payload = evidence(
+            [check("conformance", "passed", "none", 0, "conformance.log")],
+            status="passed",
+            failure_class="none",
+        )
+        result = self.run_report(
+            payload, expected_sha="fedcba9876543210fedcba9876543210fedcba98"
+        )
+        self.assertEqual(1, result.returncode)
+        self.assertIn("status=harness_failure", result.stdout)
+        self.assertIn("failure_class=harness_failure", result.stdout)
+        self.assertNotIn("CAPTURED_VALUE", result.stdout)
+
+    def test_malformed_json_is_a_harness_failure(self):
+        with tempfile.TemporaryDirectory() as directory:
+            evidence_path = Path(directory) / "toolchain-qualification.json"
+            evidence_path.write_text("not-json\n", encoding="utf-8")
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPORTER),
+                    "--evidence",
+                    str(evidence_path),
+                    "--expected-head-sha",
+                    SHA,
+                    "--repo-root",
+                    str(ROOT),
+                ],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+        self.assertEqual(1, result.returncode)
+        self.assertIn("status=harness_failure", result.stdout)
+
+    def test_secret_like_log_content_is_never_read_or_printed(self):
+        payload = evidence(
+            [check("conformance", "failed", "product_failure", 1, "conformance.log")]
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            evidence_path = root / "toolchain-qualification.json"
+            evidence_path.write_text(json.dumps(payload), encoding="utf-8")
+            (root / "conformance.log").write_text(
+                "TOKEN=secret-value\nENV=ENV_VALUE_SHOULD_NOT_PRINT\n",
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPORTER),
+                    "--evidence",
+                    str(evidence_path),
+                    "--expected-head-sha",
+                    SHA,
+                    "--repo-root",
+                    str(ROOT),
+                ],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertNotIn("secret-value", result.stdout + result.stderr)
+        self.assertNotIn("ENV_VALUE_SHOULD_NOT_PRINT", result.stdout + result.stderr)
+
+    def test_control_character_in_artifact_name_fails_closed(self):
+        payload = evidence(
+            [check("conformance", "failed", "product_failure", 1, "bad\nname.log")]
+        )
+        result = self.run_report(payload)
+        self.assertEqual(1, result.returncode)
+        self.assertIn("status=harness_failure", result.stdout)
+        self.assertNotIn("bad\nname", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/test-run-extended-validation.sh
+++ b/scripts/ci/test-run-extended-validation.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 runner="$repo_root/scripts/ci/run-toolchain-qualification.py"
+fast_checks="$repo_root/scripts/ci/run-fast-checks.sh"
 
 for required in full_crate_integration conformance build_purity proof_smoke schemas_protocol lsp_protocol_smoke direct_native_abi runtime_sensitivity benchmark_comparison stage1_quality_gate mutation_quality_smoke supply_chain readiness_self_tests; do
   grep -Fq "\"id\": \"$required\"" "$runner" || {
@@ -10,5 +11,10 @@ for required in full_crate_integration conformance build_purity proof_smoke sche
     exit 1
   }
 done
+
+grep -Fq 'test-report-toolchain-qualification.py' "$fast_checks" || {
+  echo "fast checks must run the qualification evidence reporter self-test" >&2
+  exit 1
+}
 
 python3 "$repo_root/scripts/ci/test-run-toolchain-qualification.py"


### PR DESCRIPTION
## Summary

- Add metadata-only Extended Validation failure summaries with stable check ID, status, failure class, exit code, and artifact identity.
- Preserve and upload structured qualification artifacts on failure.
- Distinguish harness/schema failures from valid-red qualification results.
- Add redaction, malformed, pass/skip, multi-failure, workflow, and shell-safety coverage.

## Issue linkage

Closes #1580

## Validation

- 6 reporter tests
- 21 qualification-runner tests
- Workflow and PR fast-CI contract tests
- `bash -n`, `shellcheck`, Python compilation
- Simulated multi-failure run with preserved artifacts and redacted output
- `git diff --check`

## Risk and blockers

The reporter never emits captured log bodies, environment values, tokens, or policy decisions. Blocking/page/report-only policy remains human-gated in #1561. External autoreview was unavailable for the private diff.
