### PR TITLE
Reconcile roadmap and readiness issue contracts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test smoke supply-chain capability-ledger capability-ledger-test compatibility-v1 compatibility-v1-test docs-python-exit docs-python-exit-test python-exit-readiness python-exit-readiness-github rust-exit-readiness rust-exit-readiness-github rust-exit-readiness-test rust-exit-command-surface-coverage rust-exit-command-surface-coverage-test self-hosting-language-readiness self-hosting-language-readiness-github self-hosting-language-readiness-test production-language-readiness production-language-readiness-github production-language-readiness-validate production-language-readiness-test snapshot-bootstrap-readiness snapshot-bootstrap-readiness-test self-hosting-spike-parity stage1-compiler-source-monoliths stage1-compiler-source-monoliths-test stage1-full-lib-triage stage1-full-lib-triage-test stage1-direct-native-runtime-abi stage1-direct-native-runtime-abi-coverage stage1-direct-native-runtime-abi-evidence stage1-direct-native-runtime-abi-test stage1-direct-native-example-smoke stage1-direct-native-example-smoke-test stage1-axiom-dwarf-readiness-test stage1-package-graph-boundary stage1-package-graph-boundary-test stage1-package-trust-contract stage1-package-trust-contract-test stage1-diagnostics-syntax-boundary stage1-diagnostics-syntax-boundary-test stage1-hir-boundary stage1-hir-boundary-test stage1-mir-backend-boundary stage1-mir-backend-boundary-test stage1-runtime-lifecycle-v1 stage1-test stage1-proof-test stage1-stdlib-test stage1-basic-smoke stage1-stdlib-smoke stage1-compiler-property-test stage1-conformance stage1-smoke stage1-bench stage1-bench-update-baseline stage1-bench-gate stage1-quality-gate stage1-quality-gate-test stage1-crap-proposal stage1-crap-thresholds stage1-crap-thresholds-test mutation-rust-smoke mutation-rust-gate mutation-survivor-report stage1-run
+.PHONY: test smoke supply-chain capability-ledger capability-ledger-test compatibility-v1 compatibility-v1-test docs-python-exit docs-python-exit-test python-exit-readiness python-exit-readiness-github rust-exit-readiness rust-exit-readiness-github rust-exit-readiness-test rust-exit-command-surface-coverage rust-exit-command-surface-coverage-test self-hosting-language-readiness self-hosting-language-readiness-github self-hosting-language-readiness-live self-hosting-language-readiness-test production-language-readiness production-language-readiness-github production-language-readiness-live production-language-readiness-validate production-language-readiness-test snapshot-bootstrap-readiness snapshot-bootstrap-readiness-test self-hosting-spike-parity stage1-compiler-source-monoliths stage1-compiler-source-monoliths-test stage1-full-lib-triage stage1-full-lib-triage-test stage1-direct-native-runtime-abi stage1-direct-native-runtime-abi-coverage stage1-direct-native-runtime-abi-evidence stage1-direct-native-runtime-abi-test stage1-direct-native-example-smoke stage1-direct-native-example-smoke-test stage1-axiom-dwarf-readiness-test stage1-package-graph-boundary stage1-package-graph-boundary-test stage1-package-trust-contract stage1-package-trust-contract-test stage1-diagnostics-syntax-boundary stage1-diagnostics-syntax-boundary-test stage1-hir-boundary stage1-hir-boundary-test stage1-mir-backend-boundary stage1-mir-backend-boundary-test stage1-runtime-lifecycle-v1 stage1-test stage1-proof-test stage1-stdlib-test stage1-basic-smoke stage1-stdlib-smoke stage1-compiler-property-test stage1-conformance stage1-smoke stage1-bench stage1-bench-update-baseline stage1-bench-gate stage1-quality-gate stage1-quality-gate-test stage1-crap-proposal stage1-crap-thresholds stage1-crap-thresholds-test mutation-rust-smoke mutation-rust-gate mutation-survivor-report stage1-run
 
 capability-ledger:
 	python3 scripts/ci/check-capability-ledger.py --check-docs --json
@@ -56,7 +56,10 @@ self-hosting-language-readiness:
 	python3 scripts/ci/check-self-hosting-language-readiness.py --json
 
 self-hosting-language-readiness-github:
-	python3 scripts/ci/check-self-hosting-language-readiness.py --json --require-issue-states
+	python3 scripts/ci/check-self-hosting-language-readiness.py --json --validate-live-issue-states
+
+self-hosting-language-readiness-live:
+	python3 scripts/ci/check-self-hosting-language-readiness.py --json --validate-live-issue-states
 
 self-hosting-language-readiness-test:
 	bash scripts/ci/test-check-self-hosting-language-readiness.sh
@@ -65,7 +68,10 @@ production-language-readiness:
 	python3 scripts/ci/check-production-language-readiness.py --json
 
 production-language-readiness-github:
-	python3 scripts/ci/check-production-language-readiness.py --json --require-issue-states
+	python3 scripts/ci/check-production-language-readiness.py --json --validate-live-issue-states
+
+production-language-readiness-live:
+	python3 scripts/ci/check-production-language-readiness.py --json --validate-live-issue-states
 
 production-language-readiness-validate:
 	python3 scripts/ci/check-production-language-readiness.py --json --validate-only

--- a/docs/production-language-readiness.json
+++ b/docs/production-language-readiness.json
@@ -41,13 +41,13 @@
       "targetTier": "runtime_complete",
       "currentTier": "static_spike",
       "status": "blocked",
-      "governingIssue": 1434,
-      "blockerIssues": [1434],
+      "governingIssue": 1436,
+      "blockerIssues": [1436],
       "dependencies": [],
-      "evidence": ["stage1/crates/axiomc/src/cranelift_backend.rs", "stage1/crates/axiomc/src/cranelift_backend/evaluator.rs", "stage1/examples/proof_cli/axiom.toml"],
-      "validatingCommand": "make stage1-direct-native-runtime-abi-test",
+      "evidence": ["docs/repository-audit-2026-08.md", "stage1/crates/axiomc/src/cranelift_backend.rs", "stage1/crates/axiomc/src/cranelift_backend/static_output_purity.rs", "stage1/examples/proof_cli/axiom.toml"],
+      "validatingCommand": "cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib static_output_purity -- --nocapture && make stage1-direct-native-runtime-abi-test",
       "rustCaptureRisk": "high",
-      "agentInspectionImpact": "Build JSON must expose lowering mode, runtime support, and fail-closed diagnostics."
+      "agentInspectionImpact": "Build JSON must expose lowering mode, runtime support, and fail-closed diagnostics; #1485 supplies the guard while #1436-#1440 supply runtime completeness."
     },
     {
       "id": "executable_mir",
@@ -58,7 +58,7 @@
       "currentTier": "syntax_only",
       "status": "blocked",
       "governingIssue": 1436,
-      "blockerIssues": [1436, 1437],
+      "blockerIssues": [1436],
       "dependencies": [1434, 1437],
       "evidence": ["docs/compiler-mir-backend-packages.md", "stage1/crates/axiomc/src/mir.rs"],
       "validatingCommand": "make stage1-mir-backend-boundary",

--- a/docs/production-language-roadmap.md
+++ b/docs/production-language-roadmap.md
@@ -41,7 +41,8 @@ Therefore:
 
 - `generated_rust: null` proves only that generated Rust was bypassed;
 - a green static or known-input spike does not prove runtime execution;
-- #1434 is the first product and self-hosting blocker;
+- #1434's effect-purity correction shipped in #1485; runtime completeness now
+  routes through the open executable-MIR and lifecycle leaves;
 - #1427 cannot certify a compiler-scale workload until one built binary
   processes different runtime source inputs without rebuilding.
 
@@ -68,12 +69,18 @@ make production-language-readiness
 ```
 
 The command is expected to report `ready: false` until the required rows have
-real evidence. Release or final-gate work may additionally require live issue
+real evidence. Release or final-gate work may additionally validate live issue
 state:
 
 ```bash
 make production-language-readiness-github
 ```
+
+The live mode requires every referenced issue state to be available. It treats
+`blockerIssues` as active execution contracts that must remain `OPEN`; closed
+governing or historical dependency references are allowed. A structurally
+valid but not-ready ledger remains a report, not a live-state validation
+failure.
 
 ## Current Baseline
 
@@ -117,21 +124,21 @@ make production-language-readiness-github
 | Issue | Outcome | Dispatch rule |
 | --- | --- | --- |
 | #1433 | Checked roadmap, manifest, schema, and validator | This roadmap PR. |
-| #1434 | Builds are effect-pure; unsupported runtime lowering fails closed | First implementation task; blocks all higher runtime claims. |
-| #1435 | Generated capability ledger and documentation drift gate | May proceed in parallel with #1434. |
-| #1437 | Axiom-neutral executable MIR v1 contract | Human design approval before implementation. |
-| #1436 | First HIR → MIR → native runtime-complete vertical slice | After #1437 and #1434. |
+| #1434 | Builds are effect-pure; unsupported runtime lowering fails closed | Completed by #1485; retain as historical proof, not an active dispatch target. |
+| #1435 | Generated capability ledger and documentation drift gate | Reconcile the completed #1434/#1437 contracts with the active leaf work. |
+| #1437 | Axiom-neutral executable MIR v1 contract | Completed; its contract is the design input for #1436 and #1438-#1440. |
+| #1436 | First HIR → MIR → native runtime-complete vertical slice | Open implementation path after the #1437 contract and #1485 purity guard. |
 
 ### Wave 1 — native value and ownership foundation
 
 | Issue | Outcome | Dependencies |
 | --- | --- | --- |
 | #1438 | Allocation, ownership, drop, and resource lifecycle ABI | MIR design; human approval. |
-| #1425 | Runtime-sized sequence/vector allocation and growth | #1434, #1437, #1438. |
-| #1426 | Runtime string and slice calls, returns, aliases, and cleanup | #1434, #1437, #1438, coordinated with #1425. |
+| #1425 | Runtime-sized sequence/vector allocation and growth | #1436, #1438. |
+| #1426 | Runtime string and slice calls, returns, aliases, and cleanup | #1436, #1438, coordinated with #1425. |
 | #1439 | Dynamic non-Copy aggregates across calls, returns, and storage | #1438, #1425, #1426, #1436. |
-| #1440 | Dedicated MIR move, borrow, drop, and resource analysis | #1437-#1439. |
-| #1476 | Runtime maps/sets, equality/hashing, deterministic iteration, and collision bounds | Lifecycle, sequences, and ownership; human collection-contract approval. |
+| #1440 | Dedicated MIR move, borrow, drop, and resource analysis | #1436, #1438, #1439. |
+| #1476 | Runtime maps/sets, equality/hashing, deterministic iteration, and collision bounds | #1438, #1425, #1440; human collection-contract approval. |
 
 ### Wave 2 — serious CLI and worker runtime
 
@@ -199,10 +206,10 @@ make production-language-readiness-github
 
 The safe first queue is:
 
-1. #1434 — effect-pure builds and fail-closed runtime lowering;
-2. #1435 — canonical capability truth and documentation reconciliation;
-3. #1437 — Pheidon-led MIR v1 design;
-4. #1438 — Pheidon-led lifecycle ABI design;
+1. #1436 — first executable-MIR to native runtime-complete vertical slice;
+2. #1438 — lifecycle ABI implementation after the completed #1437 contract;
+3. #1425 and #1426 — runtime collections and string/slice ABI;
+4. #1439 and #1440 — dynamic aggregates and ownership analysis;
 5. #1454 — extended validation design after #1430;
 6. #1460 and #1463 — bounded tooling/quality work that does not claim runtime
    readiness.

--- a/docs/roadmap-agent-native-ledger.md
+++ b/docs/roadmap-agent-native-ledger.md
@@ -23,9 +23,9 @@ canonical issue has already shipped or has an active PR.
 
 | Family | Canonical issue | Duplicate / related issues | Disposition | Agent instruction |
 |---|---:|---|---|---|
-| Direct native backend | #1124 | #105, #627-#630, #652-#656, #691-#694, #927-#929, #1191, #1255, #1434 | structurally shipped; runtime-truth correction active | Keep generated Rust outside the CLI and execute the compile-time replay correction from #1434. Existing green ABI rows do not supersede it. |
+| Direct native backend | #1124 | #105, #627-#630, #652-#656, #691-#694, #927-#929, #1191, #1255, #1434 | structurally shipped; runtime-completeness active | #1485 shipped the #1434 compile-time replay correction. Keep generated Rust outside the CLI and route remaining runtime proof through #1436 and #1438-#1440. |
 | Production language readiness | #1432 | #1433-#1467, #1476-#1477, #1481 | active dependency-ordered program | Dispatch from the leaf order in `docs/production-language-roadmap.md`; require the row's evidence tier before closure. |
-| Rust bootstrap removal / self-hosting | #721 | #565, #1254, #1366, #1425-#1428, #1434, #1436-#1440, #1468-#1475, #1478-#1479 | active final gate | Execute from the leaf issues. Runtime truth, compiler-source ownership, and snapshot evidence are all required. |
+| Rust bootstrap removal / self-hosting | #721 | #565, #1254, #1366, #1425-#1428, #1436, #1438-#1440, #1468-#1475, #1478-#1479 | active final gate | Execute from the leaf issues. Runtime truth, compiler-source ownership, and snapshot evidence are all required. |
 | Property testing | #715 | #560, #561, #637, #639, #640, #641, #642, #672, #676, #678, #679, #680, #706, #711, #712, #714 | shipped as the Phase-I property gate | #715, #714, and #712 are the shipped property-gate record. Close older Phase-I duplicate trackers such as #561 against this evidence when explicitly assigned; route remaining Cargo/Rust-bootstrap removal to #719 and #721. |
 | Doc/LSP self-hosting | #731 | #563, #564, #646, #647, #648, #649, #651, #689, #723, #725, #727, #728 | #731 is closed; use it as the completed doc/LSP-owned readiness proof and treat #563/#564 as historical slices | Do not infer full self-hosting completion from doc/LSP readiness. Final compiler-source migration and snapshot bootstrap remain with #721. |
 | Numeric tower | #716 | #681, #683, #685, #686, #688, #690, #718, #720, #722, #724, #726 | closed historical family | Open a source-grounded leaf for any missing numeric behavior; do not revive the duplicate phase stack. |
@@ -74,9 +74,9 @@ phase scheme in #565 where they disagree.
 - **Backend-exit** — make `rustc`/Cargo unnecessary to build *user programs* by
   defaulting to the direct-native Cranelift backend and removing the
   generated-Rust backend. The structural track is shipped, but runtime
-  completeness is not: unsupported programs can still fall into compiler-side
-  evaluation and replay. #1434 must close before treating backend exit as a
-  semantic execution proof.
+  completeness is not: the unsupported-program evaluation and replay path was
+  closed by #1485. Treat #1436 and #1438-#1440 as the remaining semantic
+  execution proof path.
   Note: Cranelift is itself a Rust crate linked into `axiomc`, so backend-exit
   removes the `rustc` *step*, not Rust from the toolchain.
 - **Host-exit (self-hosting)** — rewrite `axiomc` itself in AxiOM and prove a
@@ -84,7 +84,7 @@ phase scheme in #565 where they disagree.
   This is #565's thesis ("Rust is not the product"). It is active but early:
   existing AxiOM compiler spikes prove static/bootstrap shapes, while the
   compiler remains roughly 90k lines of hand-written Rust source. The leaf path
-  is #1254, #1425-#1428, #1434, #1436-#1440, and #1468-#1479, with #721 as the
+  is #1254, #1425-#1428, #1436, #1438-#1440, and #1468-#1479, with #721 as the
   final policy gate.
 
 | Concern | Canonical issue | Disposition | Agent instruction |
@@ -92,9 +92,9 @@ phase scheme in #565 where they disagree.
 | Self-hosting master thesis | #565 | keep open; **historical phase scheme — do not execute from its checkboxes** | #565's Phase-G checkboxes are stale (conformance corpus and `check --properties` shipped) and its phase letters collide with the active `phase-j`/`phase-l` labels. Treat #565 as intent narrative; take execution gates from this ledger. |
 | Feasibility and design | #1253 | closed as completed | The diagnostics spikes and snapshot-chain design shipped; execute from the leaf issues below. |
 | Monolith decomposition | #1254 | keep open | Prerequisite for package-by-package porting. #930/#936–#940 closed the *boundary contracts* (snapshot fixtures + validators), **not** source migration — do not infer decomposition is done from their closed state. |
-| Self-hosting language readiness | #1366 | keep open | Defer to `docs/self-hosting-language-readiness.json`: build purity #1434, executable MIR/lifecycle/ownership #1436-#1440, runtime sequences/text #1425-#1426, maps/sets #1476, program host ABI #1477, runtime crypto #1481, and compiler proof #1427 remain before migration entry. |
-| Effect-pure compilation | #1434 | first implementation task | Reject unsupported runtime lowering; no environment, filesystem, process, network, clock, randomness, or other runtime effect may execute during build. |
-| Executable MIR and lifecycle | #1436-#1440 | design then implementation | Establish backend-neutral control/value/effect/lifecycle semantics before expanding native shapes. |
+| Self-hosting language readiness | #1366 | keep open | Defer to `docs/self-hosting-language-readiness.json`: the #1485 purity guard is complete; executable MIR/lifecycle/ownership #1436 and #1438-#1440, runtime sequences/text #1425-#1426, maps/sets #1476, program host ABI #1477, runtime crypto #1481, and compiler proof #1427 remain before migration entry. |
+| Effect-pure compilation | #1434 | shipped in #1485 | Preserve fail-closed unsupported lowering and treat #1434 as historical proof, not an active dependency. |
+| Executable MIR and lifecycle | #1436-#1440 | design complete; implementation active | The #1437 contract is complete; establish backend-neutral control/value/effect/lifecycle semantics in #1436 and #1438-#1440 before expanding native shapes. |
 | Runtime-sized compiler collections | #1425 | ready for planning | Land Axiom-neutral language/stdlib/backend contracts with conformance and runtime evidence. |
 | String and slice parameter ABI | #1426 | ready for planning | Prove owned/borrowed values and mutable write-through across direct-native function boundaries. |
 | Compiler-scale AxiOM proof | #1427 | ready after runtime foundation | Build once, run with different runtime inputs, and prove output/effects change without compiler-side execution. |

--- a/docs/roadmap-status.md
+++ b/docs/roadmap-status.md
@@ -23,9 +23,10 @@ define completion.
 - Direct-native Cranelift is the supported user-program backend; generated Rust
   is not a supported CLI backend.
 - The direct-native ABI and Rust-exit reports are structurally green for their
-  declared rows, but the backend can execute unsupported programs in the
-  compiler process and emit replay binaries. #1434 therefore blocks any broad
-  runtime-complete, production, or self-hosting claim.
+  declared rows. #1485 closed the unsupported-program evaluator/replay path;
+  broad runtime-complete, production, and self-hosting claims remain blocked by
+  the open executable-MIR, lifecycle, value, aggregate, and ownership leaves
+  (#1436 and #1438-#1440).
 - The production-language ledger currently has 52 capability rows: 3 of 39
   production-required rows meet their target evidence tier. The remaining
   rows are intentionally `partial` or `blocked`, not missing from the plan.
@@ -48,11 +49,11 @@ define completion.
 | Family | Canonical issues | Status | Execution rule |
 | --- | --- | --- | --- |
 | Production language umbrella | #1432-#1467, #1476-#1477, #1481 | Active, dependency ordered | Execute from `docs/production-language-roadmap.md`; do not skip evidence tiers or dependency/human gates. |
-| Runtime truth and executable semantics | #1434, #1436-#1440 | First critical path | Remove effectful compile-time replay, then land MIR, lifecycle, runtime values, aggregates, and ownership evidence. |
-| Backend exit for user programs | #1124, #1191, #1255, #731 | Structurally shipped; runtime-truth correction open | Keep generated Rust outside the supported CLI while #1434 closes the evaluator/replay hole. |
+| Runtime truth and executable semantics | #1436, #1438-#1440 | First critical path | The #1434 purity correction and #1437 MIR contract are complete; land the executable runtime, lifecycle, values, aggregates, and ownership evidence. |
+| Backend exit for user programs | #1124, #1191, #1255, #731 | Structurally shipped; runtime-completeness open | Keep generated Rust outside the supported CLI; runtime-complete claims now route through #1436 and #1438-#1440. |
 | Host exit / self-hosting | #565, #721 | Active, early | Treat #565 as the thesis and #721 as the final Class 3 gate. |
 | Compiler source decomposition | #1254 | Active | Continue shrinking Rust monoliths along AxiOM package boundaries under the enforced ratchet. |
-| Self-hosting language/backend gaps | #1366, #1425-#1427, #1434, #1436-#1440, #1476-#1477 | Blocked on runtime foundation | Require build-once/run-many evidence with runtime-origin values and effects. |
+| Self-hosting language/backend gaps | #1366, #1425-#1427, #1436, #1438-#1440, #1476-#1477 | Blocked on runtime foundation | Require build-once/run-many evidence with runtime-origin values and effects. |
 | Compiler source migration | #1468-#1475, #1478-#1479 | Blocked on compiler-scale proof | Port by accepted package boundaries with Rust coexistence and rollback; never infer migration from boundary fixtures. |
 | Compiler-scale AxiOM proof | #1427 | Blocked on runtime foundation | One emitted binary must process distinct runtime inputs without rebuild or compile-time effects. |
 | Snapshot bootstrap | #1428 | Human-gated release work | Pin the genesis snapshot and prove offline build/test, no Cargo after genesis, and fixpoint evidence. |
@@ -84,7 +85,8 @@ Expected current outcomes:
   locked-offline, vendor, trust-tamper/replay, and graph-inspection fixtures pass
   the resolver target;
 - direct-native ABI, command surface, Rust exit, and monolith ratchet:
-  structurally green, but not a substitute for #1434 runtime truth;
+  structurally green, but not a substitute for the open runtime-completeness
+  leaves;
 - self-hosting language entry readiness: red until the runtime foundation,
   #1425-#1427, #1476-#1477, and #1481 are executable; compiler-source ownership
   is a subsequent migration/final-host-exit gate, not an entry prerequisite;

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -43,14 +43,15 @@ implementation surfaces; see
   repair plans, provenance, semantic diff, decision records, target contracts,
   and OpenAPI/policy/SQL/OpenTofu/runbook generators.
 - Direct-native object emission and Rust-exit command-surface structure for
-  user programs; generated Rust is no longer a supported CLI backend. Runtime
-  truth beyond the supported native lowering subset remains gated by #1434.
+  user programs; generated Rust is no longer a supported CLI backend. The
+  #1434 effect-purity correction shipped in #1485; runtime truth beyond the
+  supported native lowering subset remains gated by #1436 and #1438-#1440.
 
 ## Current Focus
 
-- Restore runtime truth first: prohibit effectful compile-time replay and fail
-  closed on unsupported native lowering (#1434), define executable MIR (#1437),
-  and establish the runtime lifecycle ABI (#1438).
+- Restore runtime truth first: implement the executable-MIR vertical slice
+  (#1436), then establish lifecycle, value, aggregate, and ownership semantics
+  (#1438-#1440) on the completed #1437 contract and #1485 purity guard.
 - Execute the [Production Language Roadmap](production-language-roadmap.md)
   (#1432) in dependency waves from runtime values and ownership through serious
   CLI/worker/service capabilities, productized tooling, and final workloads.

--- a/docs/rust-exit-readiness.md
+++ b/docs/rust-exit-readiness.md
@@ -10,14 +10,14 @@ compiler, while generated Rust is no longer a supported backend path. Full
 **host exit** additionally requires AxiOM-owned compiler sources and a
 Cargo-free snapshot bootstrap chain; that work is tracked separately by
 `make self-hosting-language-readiness`, `make snapshot-bootstrap-readiness`,
-#1254, #1425-#1428, #1434, #1436-#1440, #1476-#1477, #1468-#1475,
+#1254, #1425-#1428, #1436, #1438-#1440, #1476-#1477, #1468-#1475,
 #1478-#1479, and the final #721 decision.
 
 The backend-exit report currently proves that generated Rust is absent from the
 supported command path. It does **not** yet prove runtime-complete execution for
-every accepted package. The Cranelift fallback can evaluate unsupported AxiOM
-programs inside the compiler and emit a binary that replays captured output.
-That semantic and security blocker is #1434.
+every accepted package. The Cranelift fallback's unsupported-program evaluation
+and replay path was closed by #1485; remaining runtime-complete proof is the
+open #1436 and #1438-#1440 path.
 
 Final Rust bootstrap issue: [#721](https://github.com/OMT-Global/axiomlang/issues/721)
 
@@ -68,11 +68,11 @@ sufficient to author the compiler.
 
 | Surface | Required state | Current disposition | Governing issue |
 | --- | --- | --- | --- |
-| Direct native parity matrix | Every supported stage1 surface has a direct-native status row and linked blocker when incomplete. | The declared matrix is green, but its coverage does not currently distinguish native runtime lowering from compiler-side evaluation/replay. Runtime truth is blocked by #1434. | [#927](https://github.com/OMT-Global/axiomlang/issues/927), [#1434](https://github.com/OMT-Global/axiomlang/issues/1434) |
-| Direct native runtime ABI | Supported values, ownership shapes, stdlib calls, and capability host calls lower through backend-neutral direct-native runtime entrypoints. | Implemented only for the explicitly supported native subset. General effects, dynamic values, and lifecycle remain blocked by #1434 and #1436-#1440. | [#1124](https://github.com/OMT-Global/axiomlang/issues/1124), [#1434](https://github.com/OMT-Global/axiomlang/issues/1434) |
+| Direct native parity matrix | Every supported stage1 surface has a direct-native status row and linked blocker when incomplete. | The declared matrix is green for its supported subset; runtime-complete coverage remains on #1436 and #1438-#1440 after the #1485 purity correction. | [#927](https://github.com/OMT-Global/axiomlang/issues/927), [#1436](https://github.com/OMT-Global/axiomlang/issues/1436) |
+| Direct native runtime ABI | Supported values, ownership shapes, stdlib calls, and capability host calls lower through backend-neutral direct-native runtime entrypoints. | Implemented only for the explicitly supported native subset. General effects, dynamic values, and lifecycle remain blocked by #1436 and #1438-#1440. | [#1124](https://github.com/OMT-Global/axiomlang/issues/1124), [#1436](https://github.com/OMT-Global/axiomlang/issues/1436) |
 | Direct native diagnostics and evidence | Direct native builds preserve source diagnostics, provenance, debug manifests, and operator evidence without generated Rust. | Implemented for the Cranelift direct-native spike; broader coverage remains gated by default-backend blockers. | [#929](https://github.com/OMT-Global/axiomlang/issues/929) |
 | Full lib-suite and backend parity gate | The full `axiomc --lib --features run-native-tests` suite is triaged, environment-gated cases are separated, direct-native failures are repaired or explicitly linked to blockers, and parity evidence is green before final Rust removal. | Ready on the current Rust-exit stack: the full lib suite is a PR CI Gate dependency, `make stage1-full-lib-triage` reports zero open rows, and generated Rust is already removed as a supported backend oracle. Ongoing parity evidence is the direct-native ABI matrix plus the blocking full-suite lane. | [#1255](https://github.com/OMT-Global/axiomlang/issues/1255) |
-| Default backend | `axiomc build` defaults to direct native output and no longer invokes `rustc` for supported broad builds. | Builds report Cranelift with `generated_rust: null`, but unsupported runtime behavior can still be captured by the evaluator. #1434 must make this path fail closed. | [#1191](https://github.com/OMT-Global/axiomlang/issues/1191), [#1434](https://github.com/OMT-Global/axiomlang/issues/1434) |
+| Default backend | `axiomc build` defaults to direct native output and no longer invokes `rustc` for supported broad builds. | Builds report Cranelift with `generated_rust: null`; unsupported runtime lowering now fails closed through #1485, while runtime completeness remains open. | [#1191](https://github.com/OMT-Global/axiomlang/issues/1191), [#1436](https://github.com/OMT-Global/axiomlang/issues/1436) |
 | Generated-Rust removal | The generated-Rust backend and `--backend rust` compatibility path are removed after a release with direct native as default. | Completed for the supported toolchain in #1191. The CLI parser no longer accepts `--backend generated-rust` or the old `--backend rust` transition alias, targeted builds fail closed instead of using generated Rust, and command/schema fixtures no longer model generated Rust as supported output. | [#1191](https://github.com/OMT-Global/axiomlang/issues/1191) |
 
 ## Host-Exit Companion Matrix
@@ -83,11 +83,11 @@ self-hosting evidence exists.
 
 | Surface | Required state | Current disposition | Governing issue |
 | --- | --- | --- | --- |
-| Build/runtime effect boundary | Compilation cannot exercise runtime authority or freeze runtime-origin values into a replay binary. | Blocked; the evaluator fallback can perform effectful work during compilation. | [#1434](https://github.com/OMT-Global/axiomlang/issues/1434) |
-| Executable MIR and lifecycle | Backend-neutral MIR drives runtime control, values, effects, ownership, allocation, and cleanup. | Blocked on the MIR and lifecycle foundation. | [#1436](https://github.com/OMT-Global/axiomlang/issues/1436), [#1437](https://github.com/OMT-Global/axiomlang/issues/1437), [#1438](https://github.com/OMT-Global/axiomlang/issues/1438) |
+| Build/runtime effect boundary | Compilation cannot exercise runtime authority or freeze runtime-origin values into a replay binary. | The fail-closed guard shipped in #1485; runtime-origin execution proof remains blocked on #1436. | [#1485](https://github.com/OMT-Global/axiomlang/issues/1485), [#1436](https://github.com/OMT-Global/axiomlang/issues/1436) |
+| Executable MIR and lifecycle | Backend-neutral MIR drives runtime control, values, effects, ownership, allocation, and cleanup. | Blocked on the first executable slice and lifecycle foundation; the #1437 contract is complete. | [#1436](https://github.com/OMT-Global/axiomlang/issues/1436), [#1438](https://github.com/OMT-Global/axiomlang/issues/1438) |
 | AxiOM compiler source layout | Parser, checker, lowering, MIR, backend selection, diagnostics, packages, manifests, lockfiles, and command dispatch have AxiOM package boundaries and AxiOM-owned implementations. | Boundary contracts are implemented; source migration has not begun. | [#1254](https://github.com/OMT-Global/axiomlang/issues/1254), [#1468](https://github.com/OMT-Global/axiomlang/issues/1468) |
 | Snapshot bootstrap | A previously shipped `axiomc` snapshot builds the next working `axiomc` binary without invoking Cargo after genesis. | Blocked; the manifest contains no pinned snapshot. | [#1428](https://github.com/OMT-Global/axiomlang/issues/1428) |
-| Compiler-scale language readiness | A real multi-package compiler workload runs through the supported AxiOM/direct-native surface. | Blocked on effect-pure builds, executable MIR/lifecycle, runtime sequences/maps/sets, program host ABI, ownership, and executable compiler-scale proof. | [#1434](https://github.com/OMT-Global/axiomlang/issues/1434), [#1436](https://github.com/OMT-Global/axiomlang/issues/1436), [#1425](https://github.com/OMT-Global/axiomlang/issues/1425), [#1426](https://github.com/OMT-Global/axiomlang/issues/1426), [#1476](https://github.com/OMT-Global/axiomlang/issues/1476), [#1477](https://github.com/OMT-Global/axiomlang/issues/1477), [#1427](https://github.com/OMT-Global/axiomlang/issues/1427) |
+| Compiler-scale language readiness | A real multi-package compiler workload runs through the supported AxiOM/direct-native surface. | Blocked on executable MIR/lifecycle, runtime sequences/maps/sets, program host ABI, ownership, and executable compiler-scale proof. | [#1436](https://github.com/OMT-Global/axiomlang/issues/1436), [#1425](https://github.com/OMT-Global/axiomlang/issues/1425), [#1426](https://github.com/OMT-Global/axiomlang/issues/1426), [#1476](https://github.com/OMT-Global/axiomlang/issues/1476), [#1477](https://github.com/OMT-Global/axiomlang/issues/1477), [#1427](https://github.com/OMT-Global/axiomlang/issues/1427) |
 | Compiler verification | Compiler-internal coverage is expressed and executable through AxiOM-owned property/evidence surfaces. | Property foundations are shipped; final compiler-source ownership proof belongs to #1427. | [#1427](https://github.com/OMT-Global/axiomlang/issues/1427) |
 | Final host-exit gate | Language readiness, source ownership, snapshot chain, release, provenance, and live review evidence are all green for one candidate. | Blocked and human-gated. | [#721](https://github.com/OMT-Global/axiomlang/issues/721) |
 

--- a/docs/self-hosting-language-readiness.json
+++ b/docs/self-hosting-language-readiness.json
@@ -8,17 +8,19 @@
       "id": "build_effect_purity",
       "group": "semantic truth",
       "requirement": "Compilation never executes runtime effects or freezes runtime inputs into replay output.",
-      "governingIssue": 1434,
+      "governingIssue": 1436,
       "status": "blocked",
       "directNativeStatus": "blocked",
-      "blockerIssues": [1434],
+      "blockerIssues": [1436],
       "evidence": [
+        "docs/repository-audit-2026-08.md",
         "docs/production-language-roadmap.md",
         "stage1/crates/axiomc/src/cranelift_backend.rs",
-        "stage1/crates/axiomc/src/cranelift_backend/evaluator.rs"
+        "stage1/crates/axiomc/src/cranelift_backend/static_output_purity.rs",
+        "stage1/crates/axiomc/tests/cranelift_backend.rs"
       ],
-      "validatingCommand": "cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend build_never_executes_runtime_effects -- --nocapture && make stage1-direct-native-runtime-abi-test",
-      "notes": "Unsupported runtime lowering currently reaches compiler-side evaluation; #1434 must replace that behavior with fail-closed diagnostics and runtime-sensitive evidence."
+      "validatingCommand": "cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib static_output_purity -- --nocapture && make stage1-direct-native-runtime-abi-test",
+      "notes": "#1485 closed the effectful evaluator path for unsupported native lowering. Runtime-complete compiler workloads remain blocked on the executable MIR and native runtime slices tracked by #1436-#1440."
     },
     {
       "id": "executable_mir_runtime",
@@ -27,7 +29,7 @@
       "governingIssue": 1436,
       "status": "blocked",
       "directNativeStatus": "blocked",
-      "blockerIssues": [1436, 1437],
+      "blockerIssues": [1436],
       "evidence": [
         "docs/compiler-mir-backend-packages.md",
         "stage1/crates/axiomc/src/mir.rs"
@@ -176,7 +178,7 @@
       "governingIssue": 1251,
       "status": "blocked",
       "directNativeStatus": "blocked",
-      "blockerIssues": [1434, 1443, 1444, 1477, 1481],
+      "blockerIssues": [1443, 1444, 1477, 1481],
       "evidence": [
         "stage1/examples/stdlib_fs/axiom.toml",
         "stage1/examples/stdlib_env/axiom.toml",
@@ -190,7 +192,7 @@
         "stage1/conformance/fail/stdlib_net_tcp_without_capability/axiom.toml"
       ],
       "validatingCommand": "make stage1-stdlib-smoke && make stage1-conformance",
-      "notes": "Capability declarations and denial checks exist, but runtime effects cannot count as direct-native proof while the compiler-side evaluator fallback remains reachable."
+      "notes": "Capability declarations and denial checks exist, but runtime-origin host effects remain incomplete across the open host ABI and provider issues; the compiler-side evaluator fallback was closed by #1485."
     },
     {
       "id": "program_host_abi",

--- a/docs/self-hosting-language-readiness.md
+++ b/docs/self-hosting-language-readiness.md
@@ -20,12 +20,16 @@ make self-hosting-language-readiness
 
 It emits `axiom.self_hosting.language_readiness.v0` JSON and fails while any
 required row is not `implemented` or while row evidence is missing. For release
-or rewrite-decision PRs, require live issue state so open blocker issues also
-keep the gate red:
+or rewrite-decision PRs, validate live issue state so active blocker issues are
+still open while ordinary not-ready status remains a report:
 
 ```bash
 make self-hosting-language-readiness-github
 ```
+
+The live mode requires every referenced issue state to be available. It treats
+`blockerIssues` as active execution contracts that must remain `OPEN`; closed
+governing or historical evidence issues are allowed.
 
 The self-hosting gate is a prerequisite for the Rust bootstrap exit in
 [#721](https://github.com/OMT-Global/axiomlang/issues/721) and the broader
@@ -37,8 +41,8 @@ language and backend surface are adequate to start the compiler rewrite.
 
 | Row | Required surface | Current status | Governing issue |
 | --- | --- | --- | --- |
-| `build_effect_purity` | Compilation never executes runtime effects or freezes runtime inputs into emitted replay output. | Blocked; effectful evaluator fallback remains reachable. | [#1434](https://github.com/OMT-Global/axiomlang/issues/1434) |
-| `executable_mir_runtime` | Backend-neutral MIR drives runtime control, values, effects, ownership, and provenance. | Blocked on MIR contract and first vertical slice. | [#1436](https://github.com/OMT-Global/axiomlang/issues/1436), [#1437](https://github.com/OMT-Global/axiomlang/issues/1437) |
+| `build_effect_purity` | Compilation never executes runtime effects or freezes runtime inputs into emitted replay output. | Purity guard shipped in #1485; runtime-complete proof remains blocked on the executable vertical slice. | [#1436](https://github.com/OMT-Global/axiomlang/issues/1436) |
+| `executable_mir_runtime` | Backend-neutral MIR drives runtime control, values, effects, ownership, and provenance. | Blocked on the first executable vertical slice; the #1437 contract is complete. | [#1436](https://github.com/OMT-Global/axiomlang/issues/1436) |
 | `runtime_lifecycle` | Allocations, owned values, borrows, drops, and resource handles have deterministic runtime semantics. | Blocked on the lifecycle ABI. | [#1438](https://github.com/OMT-Global/axiomlang/issues/1438) |
 | `error_handling_try` | Option/Result propagation and diagnostics for recoverable compiler errors. | Implemented for current stage1 and direct-native evidence. | [#1256](https://github.com/OMT-Global/axiomlang/issues/1256) |
 | `compiler_data_shapes` | Scalars, tuples, arrays, maps, structs, enums, `Option`, `Result`, and ownership-sensitive aggregate movement. | Partial; static shapes work, but dynamic non-Copy aggregate ABI/lifecycle and runtime map/set proof are open. | [#1439](https://github.com/OMT-Global/axiomlang/issues/1439), [#1476](https://github.com/OMT-Global/axiomlang/issues/1476) |
@@ -47,7 +51,7 @@ language and backend surface are adequate to start the compiler rewrite.
 | `runtime_string_slice_parameter_abi` | Runtime strings and immutable/mutable slices cross function boundaries with defined ownership, length, aliasing, and write-through behavior. | Partial locally; blocked across direct-native calls. | [#1426](https://github.com/OMT-Global/axiomlang/issues/1426) |
 | `generics_traits_static_dispatch` | Explicit generics and static trait-bounded dispatch for reusable typed helpers. | Implemented for static dispatch; dynamic dispatch is intentionally not required by this row. | [#216](https://github.com/OMT-Global/axiomlang/issues/216) |
 | `strings_diagnostics_and_text` | String building, byte inspection, substring search, JSON, regex, logging, and deterministic text processing for lexer/parser/diagnostics work. | Partial; bootstrap helpers exist, but runtime-origin text and dynamic codec behavior are not complete. | [#1426](https://github.com/OMT-Global/axiomlang/issues/1426), [#1441](https://github.com/OMT-Global/axiomlang/issues/1441) |
-| `host_io_capabilities` | Scoped filesystem, environment, clock, process, networking, crypto, JSON, and regex surfaces through capability-gated stdlib modules. | Blocked as runtime proof because effectful fallback remains and runtime-origin crypto is incomplete. | [#1434](https://github.com/OMT-Global/axiomlang/issues/1434), [#1443](https://github.com/OMT-Global/axiomlang/issues/1443), [#1444](https://github.com/OMT-Global/axiomlang/issues/1444), [#1481](https://github.com/OMT-Global/axiomlang/issues/1481) |
+| `host_io_capabilities` | Scoped filesystem, environment, clock, process, networking, crypto, JSON, and regex surfaces through capability-gated stdlib modules. | Blocked as runtime proof because runtime-origin host ABI and crypto remain incomplete; the effectful fallback was closed by #1485. | [#1443](https://github.com/OMT-Global/axiomlang/issues/1443), [#1444](https://github.com/OMT-Global/axiomlang/issues/1444), [#1477](https://github.com/OMT-Global/axiomlang/issues/1477), [#1481](https://github.com/OMT-Global/axiomlang/issues/1481) |
 | `program_host_abi` | The running compiler receives argv, scoped environment, stdin/cwd, separate output streams, exit status, and cleanup at runtime. | Partial shapes exist; build-once/run-many host ABI proof is blocked. | [#1477](https://github.com/OMT-Global/axiomlang/issues/1477) |
 | `packages_modules_and_workspace` | Package-local modules, local dependencies, workspaces, and deterministic lockfile validation. | Implemented as a language/package surface; source migration remains separate. | [#721](https://github.com/OMT-Global/axiomlang/issues/721) |
 | `compiler_command_surface` | AxiOM-owned check/build/run/test/doc/LSP-facing command packages. | Blocked until the compiler-scale proof owns the command surface. | [#1427](https://github.com/OMT-Global/axiomlang/issues/1427) |

--- a/scripts/ci/check-production-language-readiness.py
+++ b/scripts/ci/check-production-language-readiness.py
@@ -68,10 +68,19 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--issue-state-file", help="file containing '<issue> <state>' rows"
     )
-    parser.add_argument(
+    issue_state_group = parser.add_mutually_exclusive_group()
+    issue_state_group.add_argument(
         "--require-issue-states",
         action="store_true",
-        help="load blocker issue state from GitHub and fail when unavailable",
+        help="load all referenced issue states from GitHub and require them closed",
+    )
+    issue_state_group.add_argument(
+        "--validate-live-issue-states",
+        action="store_true",
+        help=(
+            "validate live issue availability and require active blockerIssues "
+            "to remain open; readiness remains report-only"
+        ),
     )
     return parser.parse_args()
 
@@ -640,6 +649,17 @@ def main() -> int:
             )
 
     issue_states: dict[int, str] = {}
+    active_blocker_issues: set[int] = set()
+    for row in rows:
+        if row.get("required_for_production") is not True:
+            continue
+        blockers = row.get("blocker_issues", [])
+        if isinstance(blockers, list):
+            active_blocker_issues.update(
+                issue
+                for issue in blockers
+                if isinstance(issue, int) and not isinstance(issue, bool) and issue > 0
+            )
     issue_source = "not required"
     if args.issue_state_file:
         issue_path = Path(args.issue_state_file)
@@ -662,13 +682,13 @@ def main() -> int:
                     f"issue state file does not exist: {issue_path}",
                 )
             )
-    elif args.require_issue_states:
+    elif args.require_issue_states or args.validate_live_issue_states:
         issue_source = "GitHub"
         checks.append(
             check(
                 "production_readiness_issue_state_source",
                 "pass",
-                "blocker issue states requested from GitHub",
+                "referenced issue states requested from GitHub",
             )
         )
     else:
@@ -680,12 +700,23 @@ def main() -> int:
             )
         )
 
-    if args.issue_state_file or args.require_issue_states:
+    live_state_failures = False
+    if (
+        args.issue_state_file
+        or args.require_issue_states
+        or args.validate_live_issue_states
+    ):
         for issue in sorted(required_issues):
             state = issue_states.get(issue)
-            if state is None and args.require_issue_states and not args.issue_state_file:
+            if (
+                state is None
+                and (args.require_issue_states or args.validate_live_issue_states)
+                and not args.issue_state_file
+            ):
                 state = issue_state_from_github(issue)
             if state is None:
+                if args.validate_live_issue_states:
+                    live_state_failures = True
                 checks.append(
                     check(
                         f"production_readiness_issue_{issue}_closed",
@@ -694,11 +725,20 @@ def main() -> int:
                     )
                 )
             else:
+                state_ok = state == "CLOSED"
+                if args.validate_live_issue_states:
+                    state_ok = issue not in active_blocker_issues or state == "OPEN"
+                    if not state_ok:
+                        live_state_failures = True
                 checks.append(
                     check(
                         f"production_readiness_issue_{issue}_closed",
-                        "pass" if state == "CLOSED" else "fail",
-                        f"issue #{issue} is {state}",
+                        "pass" if state_ok else "fail",
+                        (
+                            f"issue #{issue} is {state}; active blocker state is valid"
+                            if args.validate_live_issue_states and state_ok
+                            else f"issue #{issue} is {state}"
+                        ),
                     )
                 )
 
@@ -738,7 +778,7 @@ def main() -> int:
         if item["name"] != "production_readiness_required_rows"
         and not re.fullmatch(r"production_readiness_issue_\d+_closed", item["name"])
     ]
-    valid = all(item["status"] == "pass" for item in validation_checks)
+    valid = all(item["status"] == "pass" for item in validation_checks) and not live_state_failures
     ready = all(check_item["status"] == "pass" for check_item in checks)
     summary = {
         "total": len(rows),
@@ -778,7 +818,7 @@ def main() -> int:
         )
         for failed in (item for item in checks if item["status"] == "fail"):
             print(f"- {failed['name']}: {failed['detail']}", file=sys.stderr)
-    return 0 if (valid if args.validate_only else ready) else 1
+    return 0 if (valid if args.validate_only or args.validate_live_issue_states else ready) else 1
 
 
 if __name__ == "__main__":

--- a/scripts/ci/check-self-hosting-language-readiness.py
+++ b/scripts/ci/check-self-hosting-language-readiness.py
@@ -133,7 +133,8 @@ def blocker_issue_states(
         )
 
     issue_states_available = True
-    for issue in sorted(issues):
+    issues_to_check = issues if validate_live_issue_states else active_blockers
+    for issue in sorted(issues_to_check):
         state = file_states.get(issue)
         if state is None and (
             require_issue_states or validate_live_issue_states or issue_state_file

--- a/scripts/ci/check-self-hosting-language-readiness.py
+++ b/scripts/ci/check-self-hosting-language-readiness.py
@@ -24,10 +24,19 @@ def parse_args() -> argparse.Namespace:
         help="path to the readiness documentation",
     )
     parser.add_argument("--issue-state-file", help="file containing '<issue> <state>' rows")
-    parser.add_argument(
+    issue_state_group = parser.add_mutually_exclusive_group()
+    issue_state_group.add_argument(
         "--require-issue-states",
         action="store_true",
-        help="fail when blocker issue state cannot be read",
+        help="fail when blocker issue state cannot be read and require blockers closed",
+    )
+    issue_state_group.add_argument(
+        "--validate-live-issue-states",
+        action="store_true",
+        help=(
+            "validate all referenced issue states and require active blockerIssues "
+            "to remain open; readiness remains report-only"
+        ),
     )
     return parser.parse_args()
 
@@ -84,7 +93,11 @@ def issue_state_from_github(issue: int) -> str | None:
 
 
 def blocker_issue_states(
-    issues: set[int], issue_state_file: str | None, require_issue_states: bool
+    issues: set[int],
+    active_blockers: set[int],
+    issue_state_file: str | None,
+    require_issue_states: bool,
+    validate_live_issue_states: bool,
 ) -> tuple[list[dict], bool]:
     checks: list[dict] = []
     file_states = read_issue_states(issue_state_file)
@@ -101,13 +114,13 @@ def blocker_issue_states(
                 else f"issue state file does not exist: {issue_state_file}",
             )
         )
-    elif require_issue_states:
+    elif require_issue_states or validate_live_issue_states:
         source = "GitHub"
         checks.append(
             check(
                 "language_readiness_issue_state_source",
                 "pass",
-                "issue states loaded from GitHub",
+                "referenced issue states loaded from GitHub",
             )
         )
     else:
@@ -115,17 +128,19 @@ def blocker_issue_states(
             check(
                 "language_readiness_issue_state_source",
                 "pass",
-                "issue states not required; pass --require-issue-states for rewrite decision PRs",
+                "issue states not required; pass --validate-live-issue-states for live contract validation",
             )
         )
 
     issue_states_available = True
     for issue in sorted(issues):
         state = file_states.get(issue)
-        if state is None and (require_issue_states or issue_state_file):
+        if state is None and (
+            require_issue_states or validate_live_issue_states or issue_state_file
+        ):
             state = issue_state_from_github(issue) if not issue_state_file else None
         if state is None:
-            if require_issue_states or issue_state_file:
+            if require_issue_states or validate_live_issue_states or issue_state_file:
                 issue_states_available = False
                 checks.append(
                     check(
@@ -135,11 +150,23 @@ def blocker_issue_states(
                     )
                 )
             continue
+        state_ok = state == "CLOSED"
+        detail = f"issue #{issue} is {state}"
+        if validate_live_issue_states:
+            state_ok = (
+                (issue in active_blockers and state == "OPEN")
+                or issue not in active_blockers
+            )
+            detail = (
+                f"issue #{issue} is {state}; active blocker state is valid"
+                if state_ok
+                else f"active blocker issue #{issue} is {state}; expected OPEN"
+            )
         checks.append(
             check(
                 f"language_readiness_issue_{issue}_closed",
-                "pass" if state == "CLOSED" else "fail",
-                f"issue #{issue} is {state}",
+                "pass" if state_ok else "fail",
+                detail,
             )
         )
     return checks, issue_states_available
@@ -164,6 +191,7 @@ def main() -> int:
     checks: list[dict] = []
     rows: list[dict] = []
     blocker_issues: set[int] = set()
+    referenced_issues: set[int] = set()
 
     checks.append(
         check(
@@ -264,8 +292,11 @@ def main() -> int:
             row_checks.append("missing group")
         if not row.get("requirement"):
             row_checks.append("missing requirement")
-        if not isinstance(row.get("governingIssue"), int):
+        governing_issue = row.get("governingIssue")
+        if not isinstance(governing_issue, int) or isinstance(governing_issue, bool):
             row_checks.append("missing numeric governingIssue")
+        else:
+            referenced_issues.add(governing_issue)
         if not row.get("validatingCommand"):
             row_checks.append("missing validatingCommand")
 
@@ -325,14 +356,26 @@ def main() -> int:
             )
         )
 
-    issue_checks, _ = blocker_issue_states(
-        blocker_issues, args.issue_state_file, args.require_issue_states
+    referenced_issues.update(blocker_issues)
+    issue_checks, issue_states_available = blocker_issue_states(
+        referenced_issues,
+        blocker_issues,
+        args.issue_state_file,
+        args.require_issue_states,
+        args.validate_live_issue_states,
     )
     checks.extend(issue_checks)
 
     ready = all(item["status"] == "pass" for item in checks)
+    validation_checks = [
+        item for item in checks if item["name"] != "language_readiness_rows_implemented"
+    ]
+    valid = all(item["status"] == "pass" for item in validation_checks) and (
+        issue_states_available if args.validate_live_issue_states else True
+    )
     report = {
         "schema": SCHEMA,
+        "valid": valid,
         "ready": ready,
         "manifest": str(manifest_path),
         "document": str(doc_path),
@@ -357,7 +400,7 @@ def main() -> int:
         for item in checks:
             print(f"{item['status']} {item['name']}: {item['detail']}")
 
-    return 0 if ready else 1
+    return 0 if (valid if args.validate_live_issue_states else ready) else 1
 
 
 if __name__ == "__main__":

--- a/scripts/ci/test-check-production-language-readiness.sh
+++ b/scripts/ci/test-check-production-language-readiness.sh
@@ -255,6 +255,37 @@ fi
 grep -Fq 'dependencies must be an array' "$tmpdir/null-dependencies.json"
 
 write_blocked_manifest
+python3 "$checker" --json --validate-live-issue-states --manifest "$manifest" --doc "$doc" \
+  --schema-file "$schema" --issue-state-file "$issues_open" > "$tmpdir/live-blocked.json"
+python3 - "$tmpdir/live-blocked.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    payload = json.load(handle)
+
+assert payload["valid"] is True
+assert payload["ready"] is False
+statuses = {item["name"]: item["status"] for item in payload["checks"]}
+assert statuses["production_readiness_issue_1434_closed"] == "pass"
+assert statuses["production_readiness_required_rows"] == "fail"
+PY
+
+if python3 "$checker" --json --validate-live-issue-states --manifest "$manifest" --doc "$doc" \
+  --schema-file "$schema" --issue-state-file "$issues_closed" > "$tmpdir/live-closed-blocker.json"; then
+  echo "expected live validation to reject a closed active blocker" >&2
+  exit 1
+fi
+grep -Fq 'active blocker' "$tmpdir/live-closed-blocker.json"
+
+if python3 "$checker" --json --validate-live-issue-states --manifest "$manifest" --doc "$doc" \
+  --schema-file "$schema" --issue-state-file "$tmpdir/missing-live.txt" > "$tmpdir/live-missing-issue.json"; then
+  echo "expected live validation to reject unavailable issue state" >&2
+  exit 1
+fi
+grep -Fq 'state is unavailable' "$tmpdir/live-missing-issue.json"
+
+write_blocked_manifest
 python3 - "$manifest" <<'PY'
 import json
 import sys

--- a/scripts/ci/test-check-self-hosting-language-readiness.sh
+++ b/scripts/ci/test-check-self-hosting-language-readiness.sh
@@ -44,10 +44,12 @@ cat > "$manifest" <<JSON
 JSON
 
 cat > "$issues_open" <<'STATES'
+1256 CLOSED
 721 OPEN
 STATES
 
 cat > "$issues_closed" <<'STATES'
+1256 CLOSED
 721 CLOSED
 STATES
 
@@ -152,5 +154,53 @@ if python3 scripts/ci/check-self-hosting-language-readiness.py \
 fi
 
 grep -Fq "missing evidence: missing.ax" "$tmpdir/missing-evidence.json"
+
+python3 - "$manifest" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, encoding="utf-8") as handle:
+    payload = json.load(handle)
+
+payload["rows"][0]["evidence"] = payload["rows"][1]["evidence"]
+payload["rows"][0]["blockerIssues"] = [721]
+payload["rows"][0]["status"] = "blocked"
+payload["rows"][0]["directNativeStatus"] = "partial"
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(payload, handle)
+PY
+
+python3 scripts/ci/check-self-hosting-language-readiness.py \
+  --json \
+  --validate-live-issue-states \
+  --manifest "$manifest" \
+  --doc "$doc" \
+  --issue-state-file "$issues_open" > "$tmpdir/live-blocked.json"
+
+python3 - "$tmpdir/live-blocked.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    payload = json.load(handle)
+
+assert payload["valid"] is True
+assert payload["ready"] is False
+statuses = {check["name"]: check["status"] for check in payload["checks"]}
+assert statuses["language_readiness_issue_721_closed"] == "pass"
+assert statuses["language_readiness_rows_implemented"] == "fail"
+PY
+
+if python3 scripts/ci/check-self-hosting-language-readiness.py \
+  --json \
+  --validate-live-issue-states \
+  --manifest "$manifest" \
+  --doc "$doc" \
+  --issue-state-file "$issues_closed" > "$tmpdir/live-closed-blocker.json"; then
+  echo "expected live validation to reject a closed active blocker" >&2
+  exit 1
+fi
+grep -Fq "expected OPEN" "$tmpdir/live-closed-blocker.json"
 
 echo "check-self-hosting-language-readiness regression cases passed"


### PR DESCRIPTION
## Summary

- Reconcile roadmap and readiness contracts after completed issues #1434 and #1437.
- Route active runtime work through open #1436 and #1438-#1440; remove closed issues from active blocker lists and refresh effect-purity evidence.
- Add validation-only live issue-state modes for production and self-hosting readiness: active `blockerIssues` must be open, historical references may be closed, and unavailable state fails validation while ordinary not-ready status remains report-only.

## Governing Issue

Refs #1568

## Validation

- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib static_output_purity -- --nocapture` (4 passed)
- `bash scripts/ci/test-check-production-language-readiness.sh`
- `bash scripts/ci/test-check-self-hosting-language-readiness.sh`
- `make production-language-readiness-validate` (valid; readiness intentionally `3/39`)
- Python compilation, JSON parsing, shell syntax, and `git diff --check`
- Required PR checks are expected to satisfy `CI Gate`.

## Bootstrap Governance

- [x] Changes are scoped to #1568.
- [x] No real secrets, runtime auth, or machine-local env files are committed.
- [ ] Auto-merge will be enabled after the PR is created, if GitHub permits it.

## Flow Contract

- Owner lane: roadmap/readiness governance
- Repair owner: Codex
- Autonomy class: implementation with live-state validation
- Risk class: medium; changes are fail-closed validation and documentation routing.

## Flow Merge Readiness

- [ ] Independent review and required checks remain pending after publication.
- Every live-state failure has a next action: refresh issue state or route the manifest to an open leaf issue.

## Merge Automation

- Auto-merge will be requested with `gh pr merge --auto --squash` after PR creation.

## Notes

- The private-diff external autoreview service was unavailable under the current authorization boundary; focused local review and tests were completed instead.
- The readiness reports remain honestly red; this PR does not claim runtime or self-hosting completion.
