### PR TITLE
Fix direct-native filesystem metadata

### DIFF
--- a/stage1/crates/axiomc-backend-cranelift/src/lib.rs
+++ b/stage1/crates/axiomc-backend-cranelift/src/lib.rs
@@ -80,6 +80,8 @@ struct I64RuntimeRefs {
     open: FuncRef,
     creat: FuncRef,
     lseek: FuncRef,
+    #[cfg(not(windows))]
+    fstat: FuncRef,
     close: FuncRef,
     access: FuncRef,
     #[cfg(windows)]
@@ -242,6 +244,11 @@ pub enum I64Expr {
     FileLen {
         path: String,
         max_bytes: u64,
+    },
+    /// Runtime file metadata length. Unlike `FileLen`, this is a stat-style
+    /// probe: it never reads file contents and has no read-size cap.
+    FileMetadataLen {
+        path: String,
     },
     AuditFs {
         intrinsic: String,
@@ -798,6 +805,20 @@ fn emit_i64_exit_object(
         .map_err(|message| {
             CraneliftBackendError::new(format!("declare lseek import: {message}"))
         })?;
+    #[cfg(not(windows))]
+    let mut fstat_sig = module.make_signature();
+    #[cfg(not(windows))]
+    fstat_sig.params.push(AbiParam::new(types::I32));
+    #[cfg(not(windows))]
+    fstat_sig.params.push(AbiParam::new(pointer_type));
+    #[cfg(not(windows))]
+    fstat_sig.returns.push(AbiParam::new(types::I32));
+    #[cfg(not(windows))]
+    let fstat_id = module
+        .declare_function("fstat", Linkage::Import, &fstat_sig)
+        .map_err(|message| {
+            CraneliftBackendError::new(format!("declare fstat import: {message}"))
+        })?;
     let mut close_sig = module.make_signature();
     close_sig.params.push(AbiParam::new(types::I32));
     close_sig.returns.push(AbiParam::new(types::I32));
@@ -1059,6 +1080,7 @@ fn emit_i64_exit_object(
                 open_id,
                 creat_id,
                 lseek_id,
+                fstat_id,
                 close_id,
                 access_id,
                 fork_id,
@@ -1161,6 +1183,8 @@ fn emit_i64_exit_object(
         let open_ref = module.declare_func_in_func(open_id, builder.func);
         let creat_ref = module.declare_func_in_func(creat_id, builder.func);
         let lseek_ref = module.declare_func_in_func(lseek_id, builder.func);
+        #[cfg(not(windows))]
+        let fstat_ref = module.declare_func_in_func(fstat_id, builder.func);
         let close_ref = module.declare_func_in_func(close_id, builder.func);
         let access_ref = module.declare_func_in_func(access_id, builder.func);
         #[cfg(windows)]
@@ -1209,6 +1233,8 @@ fn emit_i64_exit_object(
             open: open_ref,
             creat: creat_ref,
             lseek: lseek_ref,
+            #[cfg(not(windows))]
+            fstat: fstat_ref,
             close: close_ref,
             access: access_ref,
             #[cfg(windows)]
@@ -1477,6 +1503,7 @@ fn define_i64_function(
     open_id: FuncId,
     creat_id: FuncId,
     lseek_id: FuncId,
+    #[cfg(not(windows))] fstat_id: FuncId,
     close_id: FuncId,
     access_id: FuncId,
     #[cfg(windows)] system_id: FuncId,
@@ -1547,6 +1574,8 @@ fn define_i64_function(
         let open_ref = module.declare_func_in_func(open_id, builder.func);
         let creat_ref = module.declare_func_in_func(creat_id, builder.func);
         let lseek_ref = module.declare_func_in_func(lseek_id, builder.func);
+        #[cfg(not(windows))]
+        let fstat_ref = module.declare_func_in_func(fstat_id, builder.func);
         let close_ref = module.declare_func_in_func(close_id, builder.func);
         let access_ref = module.declare_func_in_func(access_id, builder.func);
         #[cfg(windows)]
@@ -1595,6 +1624,8 @@ fn define_i64_function(
             open: open_ref,
             creat: creat_ref,
             lseek: lseek_ref,
+            #[cfg(not(windows))]
+            fstat: fstat_ref,
             close: close_ref,
             access: access_ref,
             #[cfg(windows)]
@@ -3293,6 +3324,16 @@ fn emit_i64_expr(
         I64Expr::FileLen { path, max_bytes } => {
             emit_i64_file_len_expr(builder, runtime_refs, path, *max_bytes)
         }
+        I64Expr::FileMetadataLen { path } => {
+            #[cfg(not(windows))]
+            {
+                emit_i64_file_metadata_len_expr(builder, runtime_refs, path)
+            }
+            #[cfg(windows)]
+            {
+                emit_i64_file_len_expr(builder, runtime_refs, path, i64::MAX as u64)
+            }
+        }
         I64Expr::AuditFs {
             intrinsic,
             package,
@@ -4833,6 +4874,105 @@ fn emit_i64_file_len_expr(
     builder
         .ins()
         .jump(merge_block, &[BlockArg::Value(missing_result)]);
+
+    builder.switch_to_block(present_block);
+    builder.seal_block(present_block);
+    builder.ins().jump(merge_block, &[BlockArg::Value(length)]);
+
+    builder.switch_to_block(missing_block);
+    builder.seal_block(missing_block);
+    let missing_result = builder.ins().iconst(types::I64, -1);
+    builder
+        .ins()
+        .jump(merge_block, &[BlockArg::Value(missing_result)]);
+
+    builder.switch_to_block(merge_block);
+    builder.seal_block(merge_block);
+    Ok(builder.block_params(merge_block)[0])
+}
+
+#[cfg(not(windows))]
+fn emit_i64_file_metadata_len_expr(
+    builder: &mut FunctionBuilder<'_>,
+    runtime_refs: I64RuntimeRefs,
+    path: &str,
+) -> Result<cranelift_codegen::ir::Value, CraneliftBackendError> {
+    if path.as_bytes().contains(&0) {
+        return Err(CraneliftBackendError::new(
+            "filesystem path contains an interior null byte",
+        ));
+    }
+    let path_ptr = emit_i64_path_ptr(builder, path)?;
+    let stat_slot =
+        builder.create_sized_stack_slot(StackSlotData::new(StackSlotKind::ExplicitSlot, 512, 0));
+    let stat_ptr = builder.ins().stack_addr(types::I64, stat_slot, 0);
+    let open_flags = builder.ins().iconst(types::I32, 0);
+    let open_call = builder
+        .ins()
+        .call(runtime_refs.open, &[path_ptr, open_flags]);
+    let fd = builder.inst_results(open_call)[0];
+
+    let missing_block = builder.create_block();
+    let stat_block = builder.create_block();
+    let fstat_block = builder.create_block();
+    let stat_failed_block = builder.create_block();
+    let directory_block = builder.create_block();
+    let seek_block = builder.create_block();
+    let merge_block = builder.create_block();
+    builder.append_block_param(merge_block, types::I64);
+
+    let open_failed = builder.ins().icmp_imm(IntCC::SignedLessThan, fd, 0);
+    builder
+        .ins()
+        .brif(open_failed, missing_block, &[], stat_block, &[]);
+
+    builder.switch_to_block(stat_block);
+    builder.seal_block(stat_block);
+    let directory_call = builder.ins().call(runtime_refs.opendir, &[path_ptr]);
+    let directory_handle = builder.inst_results(directory_call)[0];
+    let directory_present = builder.ins().icmp_imm(IntCC::NotEqual, directory_handle, 0);
+    builder
+        .ins()
+        .brif(directory_present, directory_block, &[], fstat_block, &[]);
+
+    builder.switch_to_block(fstat_block);
+    builder.seal_block(fstat_block);
+    let stat_call = builder.ins().call(runtime_refs.fstat, &[fd, stat_ptr]);
+    let stat_status = builder.inst_results(stat_call)[0];
+    let stat_failed = builder
+        .ins()
+        .icmp_imm(IntCC::SignedLessThan, stat_status, 0);
+    builder
+        .ins()
+        .brif(stat_failed, stat_failed_block, &[], seek_block, &[]);
+
+    builder.switch_to_block(stat_failed_block);
+    builder.seal_block(stat_failed_block);
+    builder.ins().call(runtime_refs.close, &[fd]);
+    builder.ins().jump(missing_block, &[]);
+
+    builder.switch_to_block(directory_block);
+    builder.seal_block(directory_block);
+    builder
+        .ins()
+        .call(runtime_refs.closedir, &[directory_handle]);
+    builder.ins().call(runtime_refs.close, &[fd]);
+    builder.ins().jump(missing_block, &[]);
+
+    builder.switch_to_block(seek_block);
+    builder.seal_block(seek_block);
+    let zero = builder.ins().iconst(types::I64, 0);
+    let seek_end = builder.ins().iconst(types::I32, 2);
+    let seek_call = builder
+        .ins()
+        .call(runtime_refs.lseek, &[fd, zero, seek_end]);
+    let length = builder.inst_results(seek_call)[0];
+    builder.ins().call(runtime_refs.close, &[fd]);
+    let seek_failed = builder.ins().icmp_imm(IntCC::SignedLessThan, length, 0);
+    let present_block = builder.create_block();
+    builder
+        .ins()
+        .brif(seek_failed, missing_block, &[], present_block, &[]);
 
     builder.switch_to_block(present_block);
     builder.seal_block(present_block);

--- a/stage1/crates/axiomc/src/cranelift_backend/host_fs.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend/host_fs.rs
@@ -92,6 +92,32 @@ fn i64_fs_file_len_expr(
     )
 }
 
+fn i64_fs_metadata_len_expr(
+    intrinsic: &str,
+    path: &str,
+    path_len: usize,
+    static_bindings: &I64StaticBindings,
+) -> Option<CraneliftI64Expr> {
+    let fs_root = static_bindings.fs_root.as_deref()?;
+    let path = Path::new(path);
+    let guarded = i64_runtime_fs_guard_expr(
+        fs_root,
+        path,
+        i64_fs_runtime_parent_fallback(path)?.as_path(),
+        CraneliftI64Expr::FileMetadataLen {
+            path: path.display().to_string(),
+        },
+    )?;
+    i64_audited_fs_expr_with_success(
+        intrinsic,
+        path_len,
+        None,
+        guarded,
+        static_bindings,
+        CraneliftI64AuditSuccess::NonNegative,
+    )
+}
+
 pub(crate) fn lower_i64_fs_metadata_expr(
     name: &str,
     args: &[Expr],
@@ -108,9 +134,6 @@ pub(crate) fn lower_i64_fs_metadata_expr(
     ) {
         return None;
     }
-    if static_bindings.has_fs_write_calls {
-        return None;
-    }
     let path = i64_fs_path(args, static_bindings)?;
     let package_root = static_bindings.package_root.as_deref()?;
     let fs_root = static_bindings.fs_root.as_deref()?;
@@ -125,8 +148,12 @@ pub(crate) fn lower_i64_fs_metadata_expr(
     } else {
         "fs_file_size"
     };
-    let file_len =
-        i64_fs_file_len_expr(intrinsic, &candidate.display().to_string(), path.len(), static_bindings)?;
+    let file_len = i64_fs_metadata_len_expr(
+        intrinsic,
+        &candidate.display().to_string(),
+        path.len(),
+        static_bindings,
+    )?;
     if intrinsic == "fs_file_exists" {
         Some(CraneliftI64Expr::ConditionValue(Box::new(
             CraneliftI64Condition::Compare(CraneliftI64Compare {

--- a/stage1/crates/axiomc/tests/cranelift_backend.rs
+++ b/stage1/crates/axiomc/tests/cranelift_backend.rs
@@ -1,5 +1,5 @@
 use serde_json::Value;
-use std::fs;
+use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::Path;
 use std::process::{Command, Output, Stdio};
@@ -4339,7 +4339,21 @@ fn cranelift_backend_reports_scoped_file_metadata_at_runtime() {
     let payload: Value = serde_json::from_slice(&output.stdout).expect("parse build JSON");
     assert_eq!(payload["backend"], "cranelift");
     assert_eq!(payload["generated_rust"], Value::Null);
+    assert_eq!(payload["lowering"]["execution_mode"], "direct_native_runtime");
+    assert_eq!(payload["lowering"]["direct_native_runtime"], true);
     let binary = payload["binary"].as_str().expect("binary path");
+    let large_file = project.join("src/large.txt");
+    let large_len = 64 * 1024 * 1024 + 1;
+    OpenOptions::new()
+        .write(true)
+        .open(&large_file)
+        .expect("open large metadata fixture")
+        .set_len(large_len)
+        .expect("expand large metadata fixture");
+    let outside = temp.path().join("metadata-outside.txt");
+    fs::write(&outside, "outside-metadata").expect("write metadata symlink target");
+    std::os::unix::fs::symlink(&outside, project.join("src/escape.txt"))
+        .expect("create metadata symlink escape");
     let audit_log = project.join("native-fs-metadata-audit.jsonl");
     assert!(
         !audit_log.exists(),
@@ -4352,7 +4366,7 @@ fn cranelift_backend_reports_scoped_file_metadata_at_runtime() {
         .expect("run cranelift file metadata binary");
     assert_eq!(
         run.status.code(),
-        Some(runtime_content.len() as i32),
+        Some(42),
         "runtime metadata should determine the exit code: stdout={} stderr={}",
         String::from_utf8_lossy(&run.stdout),
         String::from_utf8_lossy(&run.stderr)
@@ -15965,6 +15979,7 @@ return 1
 
 fn write_fs_file_metadata_project(project: &Path) {
     fs::create_dir_all(project.join("src")).expect("create fs metadata project src");
+    fs::create_dir(project.join("src/metadata-dir")).expect("create metadata directory fixture");
     fs::write(
         project.join("axiom.toml"),
         r#"[package]
@@ -15977,6 +15992,7 @@ out_dir = "dist"
 
 [capabilities]
 fs = true
+"fs:write" = true
 net = false
 process = false
 env = false
@@ -15998,19 +16014,33 @@ source = "path"
     .expect("write fs metadata lockfile");
     fs::write(project.join("src/metadata.txt"), "compile-time\n")
         .expect("write fs metadata fixture");
+    fs::write(project.join("src/zero.txt"), "").expect("write zero-byte metadata fixture");
+    fs::write(project.join("src/large.txt"), "seed").expect("write large metadata fixture");
     fs::write(
         project.join("src/main.ax"),
         r#"import "std/fs.ax"
 
 static METADATA_PATH: string = "src/metadata.txt"
+static ZERO_PATH: string = "src/zero.txt"
+static DIRECTORY_PATH: string = "src/metadata-dir"
+static LARGE_PATH: string = "src/large.txt"
+static ESCAPE_PATH: string = "src/escape.txt"
 
 fn main(): int {
+let write_status: int = fs_write(METADATA_PATH, "runtime-metadata\\n")
+let replace_status: int = replace_file(METADATA_PATH, "runtime-metadata\\n")
 let exists: bool = file_exists(METADATA_PATH)
 let missing: bool = file_exists("src/missing.txt")
 let size: int = file_size(METADATA_PATH)
 let missing_size: int = file_size("src/missing.txt")
-if exists == true && missing == false && size > 0 && missing_size == -1 {
-return size
+let zero_exists: bool = file_exists(ZERO_PATH)
+let zero_size: int = file_size(ZERO_PATH)
+let directory_exists: bool = file_exists(DIRECTORY_PATH)
+let directory_size: int = file_size(DIRECTORY_PATH)
+let large_size: int = file_size(LARGE_PATH)
+let escape_exists: bool = file_exists(ESCAPE_PATH)
+if write_status == 0 && replace_status == 0 && exists == true && missing == false && size == 18 && missing_size == -1 && zero_exists == true && zero_size == 0 && directory_exists == false && directory_size == -1 && large_size == 67108865 && escape_exists == false {
+return 42
 } else {
 return 1
 }


### PR DESCRIPTION
## Summary

- Separate direct-native filesystem metadata lowering from capped content reads.
- Allow `file_exists` and `file_size` after `fs_write` and `replace_file` in the same program.
- Add Unix `fstat`-backed metadata probing with directory classification and preserve the existing filesystem scope/symlink guard.
- Extend native integration coverage for zero-byte files, directories, missing paths, external symlinks, and a sparse file of 64 MiB + 1 byte.

## Governing Issue

Refs #1582

## Validation

- [x] Relevant local checks passed
- [ ] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Local validation:

- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend cranelift_backend_reports_scoped_file_metadata_at_runtime -- --nocapture`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend cranelift_backend_lowers_fs_write_to_runtime_exit_code -- --nocapture`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend cranelift_backend_denies_fs_read_symlink_escape_at_runtime -- --nocapture`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc-backend-cranelift --lib links_i64_exit_program_with_file_len -- --nocapture`
- `bash scripts/ci/run-fast-checks.sh`
- `git diff --check`

All listed checks passed. The optional external autoreview was not run because this is a private diff and separate authorization to transmit it externally was not available.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [ ] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] PR author enabled auto-merge where GitHub allows it, or GitHub plan-limit evidence/unavailable reason is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Flow Contract

- Owner lane: Pheidon / stage1 native backend
- Repair owner: Codex
- Autonomy class: assisted implementation with native runtime validation
- Risk class: high; filesystem capability and ABI boundary

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [ ] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] PR author enabled auto-merge where GitHub allows it, or recorded why it is unavailable/unsafe

## Merge Automation

- [x] PR author enabled auto-merge with `gh pr merge --auto --squash`, or the reason it is unavailable/unsafe is noted below

## Notes

- The native integration asserts `generated_rust` is null and `lowering.direct_native_runtime` is true.
- Runtime metadata reporting is not constrained by the 64 MiB content-read cap.
