### PR TITLE
Remove rustc dependency from native target selection

### DIFF
--- a/stage1/crates/axiomc/src/doctor.rs
+++ b/stage1/crates/axiomc/src/doctor.rs
@@ -80,7 +80,7 @@ struct DoctorPackage {
 pub fn doctor_report(project: &Path, command_count: usize) -> DoctorReport {
     let rustc = probe_tool("rustc", &["-vV"]);
     let cargo = probe_tool("cargo", &["--version"]);
-    let target_triple = rustc.version.as_deref().and_then(parse_rustc_host_target);
+    let target_triple = target_support::host_target();
     let target_support = target_support_report(target_triple.clone());
     let check = check_project_with_options(project, &CheckOptions::default());
     let (ok, lockfile_status, capabilities, workspace_graph, error) = match check {
@@ -191,10 +191,6 @@ fn probe_tool(program: &str, args: &[&str]) -> ToolProbe {
     }
 }
 
-fn parse_rustc_host_target(version: &str) -> Option<String> {
-    target_support::parse_rustc_host_target(version)
-}
-
 pub fn doctor_text(report: &DoctorReport) -> String {
     let mut lines = vec![
         format!("project: {}", report.project),
@@ -247,7 +243,7 @@ fn tool_text(tool: &ToolProbe) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{CheckedCapabilityLedger, doctor_report, parse_rustc_host_target};
+    use super::{CheckedCapabilityLedger, doctor_report};
     use crate::json_contract;
     use crate::new_project::{WorkloadTemplate, create_project_with_template};
 
@@ -333,12 +329,4 @@ mod tests {
         );
     }
 
-    #[test]
-    fn rustc_host_target_parser_reads_verbose_version_output() {
-        let version = "rustc 1.90.0\nhost: aarch64-apple-darwin\nrelease: 1.90.0\n";
-        assert_eq!(
-            parse_rustc_host_target(version).as_deref(),
-            Some("aarch64-apple-darwin")
-        );
-    }
 }

--- a/stage1/crates/axiomc/src/target_support.rs
+++ b/stage1/crates/axiomc/src/target_support.rs
@@ -6,7 +6,6 @@
 
 use crate::diagnostics::Diagnostic;
 use serde::Serialize;
-use std::process::Command;
 
 pub const TARGET_SUPPORT_SCHEMA_VERSION: &str = "axiom.target_support.v1";
 pub const SUPPORTED_NATIVE_BACKEND: &str = "cranelift";
@@ -56,14 +55,29 @@ pub fn supported_targets() -> Vec<SupportedTarget> {
 }
 
 pub fn host_target() -> Option<String> {
-    let output = Command::new("rustc").args(["-vV"]).output().ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    parse_rustc_host_target(&String::from_utf8_lossy(&output.stdout))
+    compiled_host_target().map(str::to_owned)
 }
 
-pub fn parse_rustc_host_target(version: &str) -> Option<String> {
+#[cfg(all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"))]
+fn compiled_host_target() -> Option<&'static str> {
+    Some("x86_64-unknown-linux-gnu")
+}
+
+#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+fn compiled_host_target() -> Option<&'static str> {
+    Some("aarch64-apple-darwin")
+}
+
+#[cfg(not(any(
+    all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"),
+    all(target_arch = "aarch64", target_os = "macos")
+)))]
+fn compiled_host_target() -> Option<&'static str> {
+    None
+}
+
+#[cfg(test)]
+fn parse_rustc_host_target(version: &str) -> Option<String> {
     version
         .lines()
         .find_map(|line| line.strip_prefix("host: "))
@@ -71,7 +85,9 @@ pub fn parse_rustc_host_target(version: &str) -> Option<String> {
 }
 
 pub fn is_known_supported_target(target: &str) -> bool {
-    matches!(target, "x86_64-unknown-linux-gnu" | "aarch64-apple-darwin")
+    supported_targets()
+        .iter()
+        .any(|supported| supported.target == target)
 }
 
 pub fn is_host_target(target: &str) -> bool {
@@ -79,22 +95,20 @@ pub fn is_host_target(target: &str) -> bool {
 }
 
 pub fn resolve_requested_target(target: Option<&str>) -> Result<Option<String>, Diagnostic> {
-    let Some(target) = target else {
-        return Ok(None);
-    };
+    let host = host_target().ok_or_else(|| {
+        Diagnostic::new(
+            "target",
+            "the compiler host is not one of the supported direct-native targets",
+        )
+        .with_code("target.unsupported")
+        .with_help("use a prebuilt compiler for a supported Linux x86_64 or macOS arm64 host")
+    })?;
+    let target = target.unwrap_or(&host);
     let target = match target {
         "wasm32" | "wasm32-wasi" => "wasm32-wasip1",
         target => target,
     };
-    let host = host_target().ok_or_else(|| {
-        Diagnostic::new(
-            "target",
-            "cannot resolve the Rust host target for direct-native compilation",
-        )
-        .with_code("target.host_unavailable")
-        .with_help("install a usable rustc toolchain, or omit --target")
-    })?;
-    if target != host {
+    if !is_known_supported_target(target) || target != host {
         return Err(Diagnostic::new(
             "target",
             format!(
@@ -173,6 +187,13 @@ mod tests {
     }
 
     #[test]
+    fn compiled_host_identity_matches_the_supported_catalog() {
+        let host = host_target().expect("test target must be a supported host");
+        assert!(is_known_supported_target(&host));
+        assert_eq!(report(Some(host.clone())).host_target, Some(host));
+    }
+
+    #[test]
     fn unknown_hosts_are_not_reported_as_supported() {
         assert!(!is_known_supported_target("x86_64-unknown-linux-musl"));
         assert!(!report(Some(String::from("x86_64-unknown-linux-musl"))).host_supported);
@@ -181,10 +202,14 @@ mod tests {
     #[test]
     fn explicit_host_target_is_accepted_and_non_host_target_fails_closed() {
         let host = host_target().expect("test environment must expose a rustc host target");
+        assert_eq!(resolve_requested_target(None), Ok(Some(host.clone())));
         assert_eq!(resolve_requested_target(Some(&host)), Ok(Some(host)));
         let error = resolve_requested_target(Some("wasm32"))
             .expect_err("non-host targets must not silently use host codegen");
         assert_eq!(error.code.as_deref(), Some("target.unsupported"));
+        let malformed = resolve_requested_target(Some("not-a-target"))
+            .expect_err("malformed targets must fail closed");
+        assert_eq!(malformed.code.as_deref(), Some("target.unsupported"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Derive the native compiler host identity from the compiled target instead of shelling out to `rustc -vV`.
- Use the supported-target catalog as the single source for host validation and fail closed with stable `target.unsupported` diagnostics.
- Make omitted and explicit native targets resolve identically, and expose the same target provenance through `doctor --json`.

## Governing Issue

Refs #1578

## Validation

- [x] Relevant local checks passed
- [ ] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Commands and evidence:

- `cargo test --manifest-path stage1/Cargo.toml -p axiomc target_support --lib -- --nocapture` — 6 passed.
- `cargo build --manifest-path stage1/Cargo.toml -p axiomc` — passed.
- `bash scripts/ci/run-fast-checks.sh` — completed the fast contract checks and direct-native proof workloads on this branch.
- `git diff --check` — passed.
- With `PATH=/usr/bin:/bin`, `axiomc doctor ... --json` reported `rustc.available: false`, `cargo.available: false`, and still reported `target_triple` / `target_support.host_target` as `aarch64-apple-darwin`.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] PR author enabled auto-merge where GitHub allows it, or GitHub plan-limit evidence/unavailable reason is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Flow Contract

- Owner lane: compiler/runtime target policy
- Repair owner: target support and doctor reporting
- Autonomy class: bounded implementation
- Risk class: medium — target identity and diagnostics change, backend support remains host-only

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] PR author enabled auto-merge where GitHub allows it

## Merge Automation

- [x] PR author enabled auto-merge with `gh pr merge --auto --squash`.

## Notes

- This slice removes the target-selection dependency on a discoverable Rust toolchain. Native linking/runtime prerequisites remain host-specific and are intentionally unchanged.
- `autoreview` was not run because private-diff external-review authorization is not available in this session.
