### PR TITLE
Align manifest schema with parser contract

### DIFF
--- a/stage1/compatibility/fixtures/current/contract.json
+++ b/stage1/compatibility/fixtures/current/contract.json
@@ -149,7 +149,7 @@
       "migration": {
         "action": "Existing path dependencies remain valid. Registry consumers add one root [registry] table with index, trust_roots, and expectation paths, then use the closed registry dependency form with registry, namespace, package, and an exact or caret version requirement before running axiomc pkg fetch."
       },
-      "signature": "axiom.toml schema=https://axiom.omt.global/schemas/axiom.toml.schema.json; semantic_digest=fe45690ed5f1217eb0a3461e106573f13d1159d2d694843f9be3c08ba0099b6d; fields=build,capabilities,dependencies,package,publish,registry,runtime,tests,workspace; edition_selector=unavailable",
+      "signature": "axiom.toml schema=https://axiom.omt.global/schemas/axiom.toml.schema.json; semantic_digest=941dcc92a0484a8b14960502af2a2aa27df2367252b1fc0232b3be7e304858a6; fields=build,capabilities,dependencies,package,publish,registry,runtime,tests,workspace; edition_selector=unavailable",
       "sources": [
         {
           "path": "stage1/compatibility/manifest-parser-contract-v1.json",
@@ -167,7 +167,7 @@
           "path": "stage1/schemas/axiom.toml.schema.json",
           "role": "package_manifest_schema",
           "selector": "$id,properties",
-          "sha256": "de567ce7d89ae36558c21922ea61d661f9f372ccd194365bfba5d7d4b756147f"
+          "sha256": "8815aafc6b07b4260eca826fbce765f6cddf07a0efb3d4cd6db9b116add0ace9"
         }
       ],
       "stability": "experimental",
@@ -1097,13 +1097,13 @@
       "migration": {
         "action": "Existing path-only manifests remain valid. To adopt registry dependencies, add the root registry configuration and use the closed registry dependency object documented by the 0.2 schema, then run axiomc pkg fetch to create axiom.lock version 2."
       },
-      "signature": "published schema id=https://axiom.omt.global/schemas/axiom.toml.schema.json; semantic_digest=e0d385251a6ba1c8aae6ff2641e89cb5e29d8ceba0d724f07bf7ba2f7a621e8a",
+      "signature": "published schema id=https://axiom.omt.global/schemas/axiom.toml.schema.json; semantic_digest=31e399ea9f093d4ec55bd645d0b34a328d312d9095e3f499993ff449c61c7042",
       "sources": [
         {
           "path": "stage1/schemas/axiom.toml.schema.json",
           "role": "published_schema",
           "selector": "$id,properties.schema_version.const",
-          "sha256": "de567ce7d89ae36558c21922ea61d661f9f372ccd194365bfba5d7d4b756147f"
+          "sha256": "8815aafc6b07b4260eca826fbce765f6cddf07a0efb3d4cd6db9b116add0ace9"
         }
       ],
       "stability": "experimental",

--- a/stage1/crates/axiomc/tests/schema_metadata.rs
+++ b/stage1/crates/axiomc/tests/schema_metadata.rs
@@ -2,7 +2,7 @@ use axiomc::{
     json_contract,
     manifest::{
         DEPENDENCY_VERSION_PATTERN, KNOWN_CAPABILITIES, PER_TEST_CAPABILITIES_SUPPORTED,
-        TEST_KIND_NAMES,
+        TEST_KIND_NAMES, load_manifest,
     },
 };
 use jsonschema::Validator;
@@ -905,6 +905,75 @@ fn editor_metadata_schemas_are_parseable_and_current() {
     }
 
     let manifest_validator = compile_validator(&manifest_schema);
+
+    for fixture in [
+        r#"
+[package]
+name = "defaults"
+version = "0.1.0"
+"#,
+        r#"
+[package]
+name = "explicit-build"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+"#,
+        r#"
+[workspace]
+"#,
+        r#"
+[package]
+name = "path-dependency"
+version = "0.1.0"
+
+[dependencies]
+dep = "../dep"
+"#,
+    ] {
+        let decoded: toml::Value = toml::from_str(fixture).expect("fixture is valid TOML");
+        let json = serde_json::to_value(decoded).expect("fixture converts to JSON");
+        manifest_validator
+            .validate(&json)
+            .expect("parser-valid manifest fixture matches the published schema");
+        let dir = tempfile::tempdir().expect("create manifest fixture directory");
+        fs::write(dir.path().join("axiom.toml"), fixture).expect("write manifest fixture");
+        load_manifest(dir.path()).expect("schema-valid manifest fixture parses");
+    }
+
+    for fixture in [
+        r#"
+[package]
+name = "partial-build"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+"#,
+        r#"
+[package]
+name = "empty-dependency"
+version = "0.1.0"
+
+[dependencies]
+dep = ""
+"#,
+        r#"
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+"#,
+    ] {
+        let decoded: toml::Value = toml::from_str(fixture).expect("fixture is valid TOML");
+        let json = serde_json::to_value(decoded).expect("fixture converts to JSON");
+        assert!(
+            !manifest_validator.is_valid(&json),
+            "schema must reject parser-invalid manifest fixture"
+        );
+    }
+
     let parser_parity_manifest = serde_json::json!({
         "package": {"name": "parity", "version": "0.1.0"},
         "dependencies": {

--- a/stage1/schemas/axiom.toml.schema.json
+++ b/stage1/schemas/axiom.toml.schema.json
@@ -25,9 +25,6 @@
     },
     "workspace": {
       "type": "object",
-      "required": [
-        "members"
-      ],
       "properties": {
         "members": {
           "type": "array",
@@ -42,6 +39,10 @@
     },
     "build": {
       "type": "object",
+      "required": [
+        "entry",
+        "out_dir"
+      ],
       "properties": {
         "entry": {
           "type": "string",
@@ -105,7 +106,8 @@
       "additionalProperties": {
         "oneOf": [
           {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           },
           {
             "type": "object",
@@ -462,6 +464,20 @@
       "additionalProperties": false
     }
   },
+  "allOf": [
+    {
+      "if": {
+        "required": [
+          "build"
+        ]
+      },
+      "then": {
+        "required": [
+          "package"
+        ]
+      }
+    }
+  ],
   "anyOf": [
     {
       "required": [


### PR DESCRIPTION
## Summary

- Align the published `axiom.toml` schema with the parser's requiredness and default contract.
- Permit workspace manifests to omit `members`, require `entry` and `out_dir` when `[build]` is present, and reject empty dependency shorthand.
- Add bidirectional schema/parser fixtures for defaults, workspace-only manifests, explicit builds, path dependencies, and invalid partial/empty forms.
- Regenerate the public compatibility contract fixture for the schema digest change.

## Governing Issue

Refs #1576

## Validation

- [x] Relevant local checks passed
- [ ] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Commands and evidence:

- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test schema_metadata editor_metadata_schemas_are_parseable_and_current -- --nocapture` — passed.
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc manifest --lib -- --nocapture` — 63 passed.
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test schema_metadata -- --nocapture` — 16 passed in the fast gate.
- `bash scripts/ci/test-check-compatibility-v1.sh` — passed.
- `python3 scripts/ci/extract-public-contract-v1.py --check` — passed.
- `bash scripts/ci/run-fast-checks.sh` — passed, including compatibility, schema metadata, and direct-native proof workloads.
- `rustfmt --edition 2024 --check stage1/crates/axiomc/tests/schema_metadata.rs` — passed.
- `git diff --check` — passed.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] PR author enabled auto-merge where GitHub allows it, or GitHub plan-limit evidence/unavailable reason is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Flow Contract

- Owner lane: compiler/tooling contract parity
- Repair owner: manifest schema and compatibility fixture
- Autonomy class: bounded implementation
- Risk class: medium — editor validation becomes stricter where the parser already rejects input

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] PR author enabled auto-merge where GitHub allows it

## Merge Automation

- [x] PR author enabled auto-merge with `gh pr merge --auto --squash`.

## Notes

- The parser remains the source of truth for the aligned cases; this PR does not broaden parser acceptance or introduce a new diagnostic-code contract.
- `autoreview` was not run because private-diff external-review authorization is not available in this session.
