### PR TITLE
Validate command failure envelopes

### DIFF
--- a/stage1/compatibility/fixtures/current/contract.json
+++ b/stage1/compatibility/fixtures/current/contract.json
@@ -89,7 +89,7 @@
           "path": "stage1/compiler-contracts/schemas/axiom.stage1.command.schema.json",
           "role": "cli_json_envelope",
           "selector": "$id,oneOf",
-          "sha256": "7cc009c7e11ec2396416169ebef3bfd50a78163613614465436c1f2b427408ec"
+          "sha256": "354bce11a99ea5bf7c3e15e132e67d1c96fcb78a6dcd71e437c3ea9624b7eecb"
         },
         {
           "path": "stage1/compiler-contracts/snapshots/capability-ledger.json",
@@ -1061,13 +1061,13 @@
       "migration": {
         "action": "Update consumers to understand the new diagnostic and lowering fields before consuming axiom.stage1.command envelopes."
       },
-      "signature": "published schema id=https://omt-global.github.io/axiom/schemas/axiom.stage1.command.schema.json; semantic_digest=aa49a0885cba0e06e4f0bf79ca00a8f0b3c58bf16f6148a8c72af070ea701239",
+      "signature": "published schema id=https://omt-global.github.io/axiom/schemas/axiom.stage1.command.schema.json; semantic_digest=85982718206cb1659a92d4bc8fd6a6c8eae416ad56982c2dde545efd76bd1fa1",
       "sources": [
         {
           "path": "stage1/compiler-contracts/schemas/axiom.stage1.command.schema.json",
           "role": "published_schema",
           "selector": "$id,properties.schema_version.const",
-          "sha256": "7cc009c7e11ec2396416169ebef3bfd50a78163613614465436c1f2b427408ec"
+          "sha256": "354bce11a99ea5bf7c3e15e132e67d1c96fcb78a6dcd71e437c3ea9624b7eecb"
         }
       ],
       "stability": "experimental",

--- a/stage1/compiler-contracts/schemas/axiom.stage1.command.schema.json
+++ b/stage1/compiler-contracts/schemas/axiom.stage1.command.schema.json
@@ -21,6 +21,9 @@
     },
     {
       "$ref": "#/$defs/mutationReport"
+    },
+    {
+      "$ref": "#/$defs/commandFailure"
     }
   ],
   "$defs": {
@@ -34,6 +37,92 @@
     "durationMs": {
       "type": "integer",
       "minimum": 0
+    },
+    "failureEnvelope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version",
+        "ok",
+        "command",
+        "error"
+      ],
+      "properties": {
+        "schema_version": {
+          "$ref": "#/$defs/schemaVersion"
+        },
+        "ok": {
+          "const": false
+        },
+        "command": {
+          "type": "string",
+          "minLength": 1
+        },
+        "error": {
+          "$ref": "#/$defs/diagnostic"
+        },
+        "lowering": {
+          "$ref": "#/$defs/buildLoweringEvidence"
+        }
+      }
+    },
+    "commandFailure": {
+      "oneOf": [
+        {
+          "allOf": [
+            { "$ref": "#/$defs/failureEnvelope" },
+            { "properties": { "command": { "const": "check" } } }
+          ]
+        },
+        {
+          "allOf": [
+            { "$ref": "#/$defs/failureEnvelope" },
+            { "properties": { "command": { "const": "build" } } }
+          ]
+        },
+        {
+          "allOf": [
+            { "$ref": "#/$defs/failureEnvelope" },
+            { "properties": { "command": { "const": "run" } } }
+          ]
+        },
+        {
+          "allOf": [
+            { "$ref": "#/$defs/failureEnvelope" },
+            { "properties": { "command": { "const": "test" } } }
+          ]
+        },
+        {
+          "allOf": [
+            { "$ref": "#/$defs/failureEnvelope" },
+            { "properties": { "command": { "const": "caps" } } }
+          ]
+        },
+        {
+          "allOf": [
+            { "$ref": "#/$defs/failureEnvelope" },
+            { "properties": { "command": { "const": "mutation-report" } } }
+          ]
+        },
+        {
+          "allOf": [
+            { "$ref": "#/$defs/failureEnvelope" },
+            { "properties": { "command": { "const": "parse" } } }
+          ]
+        },
+        {
+          "allOf": [
+            { "$ref": "#/$defs/failureEnvelope" },
+            { "properties": { "command": { "const": "doc" } } }
+          ]
+        },
+        {
+          "allOf": [
+            { "$ref": "#/$defs/failureEnvelope" },
+            { "properties": { "command": { "const": "lsp" } } }
+          ]
+        }
+      ]
     },
     "diagnosticRepair": {
       "type": "object",
@@ -59,10 +148,7 @@
       "additionalProperties": false,
       "required": [
         "kind",
-        "message",
-        "path",
-        "line",
-        "column"
+        "message"
       ],
       "properties": {
         "kind": {

--- a/stage1/crates/axiomc/tests/json_contract_snapshots.rs
+++ b/stage1/crates/axiomc/tests/json_contract_snapshots.rs
@@ -1,5 +1,6 @@
+use axiomc::{diagnostics::Diagnostic, json_contract};
 use jsonschema::Validator;
-use serde_json::{json, Map, Value};
+use serde_json::{Map, Value, json};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -47,6 +48,68 @@ fn cli_json_outputs_match_checked_in_contract_snapshots() {
         let snapshot = read_json(&contracts.join(format!("snapshots/{command}.json")));
         assert_eq!(normalized, snapshot, "{command} JSON contract drifted");
     }
+}
+
+#[test]
+fn command_failure_envelopes_validate_against_the_published_schema() {
+    let schema = read_json(&contract_root().join("schemas/axiom.stage1.command.schema.json"));
+    let validator = jsonschema::validator_for(&schema).expect("compile JSON contract schema");
+    let diagnostic = Diagnostic::new("manifest", "fixture failure");
+
+    for command in [
+        "check",
+        "build",
+        "run",
+        "test",
+        "caps",
+        "mutation-report",
+        "parse",
+        "doc",
+        "lsp",
+    ] {
+        let payload = json_contract::error(command, &diagnostic);
+        validator
+            .validate(&payload)
+            .unwrap_or_else(|error| panic!("{command} failure envelope must validate: {error}"));
+    }
+
+    for (group, name) in [
+        ("check", "parse-error.json"),
+        ("build", "runtime-lowering-required.json"),
+        ("doc", "failure.json"),
+    ] {
+        let payload = read_json(
+            &contract_root()
+                .parent()
+                .expect("stage1 root")
+                .join("json-fixtures")
+                .join(group)
+                .join(name),
+        );
+        validator
+            .validate(&payload)
+            .unwrap_or_else(|error| panic!("{group}/{name} must validate: {error}"));
+    }
+}
+
+#[test]
+fn command_failure_envelopes_reject_unrelated_commands_and_fields() {
+    let schema = read_json(&contract_root().join("schemas/axiom.stage1.command.schema.json"));
+    let validator = jsonschema::validator_for(&schema).expect("compile JSON contract schema");
+    let diagnostic = Diagnostic::new("manifest", "fixture failure");
+
+    let mut unrelated = json_contract::error("doctor", &diagnostic);
+    assert!(
+        !validator.is_valid(&unrelated),
+        "failure envelope must reject commands outside the published command branches"
+    );
+
+    unrelated["command"] = serde_json::json!("check");
+    unrelated["unexpected"] = serde_json::json!(true);
+    assert!(
+        !validator.is_valid(&unrelated),
+        "failure envelope must reject unrelated fields"
+    );
 }
 
 #[cfg(not(windows))]


### PR DESCRIPTION
## Summary

- Add closed `ok: false` command-failure branches to the published stage1 command schema.
- Cover check, build, run, test, caps, mutation-report, parse, doc, and lsp failure command identities.
- Keep diagnostic source locations optional so setup/backend failures without source spans validate, while preserving stable kind/message/error fields and rejecting unknown top-level fields.
- Validate real checked-in check, build, and doc failure envelopes and regenerate the public compatibility fixture for the schema digest change.

## Governing Issue

Refs #1577

## Validation

- [x] Relevant local checks passed
- [ ] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Commands and evidence:

- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test json_contract_snapshots -- --nocapture` — 17 passed.
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test json_command_fixtures -- --nocapture` — 6 passed.
- `python3 scripts/ci/extract-public-contract-v1.py --check` — passed.
- `bash scripts/ci/run-fast-checks.sh` — passed, including command/schema metadata and direct-native proof workloads.
- `python3 -m json.tool stage1/compiler-contracts/schemas/axiom.stage1.command.schema.json` — passed.
- `git diff --check` — passed.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] PR author enabled auto-merge where GitHub allows it, or GitHub plan-limit evidence/unavailable reason is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Flow Contract

- Owner lane: compiler/tooling contract parity
- Repair owner: command JSON schema and failure-envelope fixtures
- Autonomy class: bounded implementation
- Risk class: high — published failure shapes affect downstream command consumers

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [x] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] PR author enabled auto-merge where GitHub allows it

## Merge Automation

- [x] PR author enabled auto-merge with `gh pr merge --auto --squash`.

## Notes

- Existing report-shaped run/test successes and failures remain unchanged; this adds the generic top-level diagnostic envelope currently emitted by command setup/validation failures.
- `autoreview` was not run because private-diff external-review authorization is not available in this session.
