### PR TITLE
Bound LSP and DAP frame reads

### DIFF
--- a/stage1/crates/axiomc/src/dap.rs
+++ b/stage1/crates/axiomc/src/dap.rs
@@ -1,4 +1,5 @@
 use crate::diagnostics::Diagnostic;
+use crate::framed_protocol;
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
 use std::fs;
@@ -13,7 +14,7 @@ where
     W: Write,
 {
     let mut session = DapSession::default();
-    while let Some(message) = read_message(&mut input)? {
+    while let Some(message) = framed_protocol::read_message(&mut input, "dap")? {
         let response = session.handle_message(&message)?;
         for payload in response.messages {
             write_message(&mut output, &payload)?;
@@ -404,43 +405,6 @@ fn collect_static_locals(source: &str) -> Vec<Variable> {
             })
         })
         .collect()
-}
-
-fn read_message<R>(input: &mut R) -> Result<Option<String>, Diagnostic>
-where
-    R: BufRead,
-{
-    let mut content_length = None;
-    loop {
-        let mut line = String::new();
-        let bytes = input
-            .read_line(&mut line)
-            .map_err(|err| Diagnostic::new("dap", format!("failed to read DAP header: {err}")))?;
-        if bytes == 0 {
-            return Ok(None);
-        }
-        let trimmed = line.trim_end_matches(['\r', '\n']);
-        if trimmed.is_empty() {
-            break;
-        }
-        if let Some((name, value)) = trimmed.split_once(':') {
-            if name.trim().eq_ignore_ascii_case("Content-Length") {
-                content_length = Some(value.trim().parse::<usize>().map_err(|err| {
-                    Diagnostic::new("dap", format!("invalid Content-Length header: {err}"))
-                })?);
-            }
-        }
-    }
-
-    let length = content_length
-        .ok_or_else(|| Diagnostic::new("dap", "missing Content-Length header in DAP message"))?;
-    let mut body = vec![0; length];
-    input
-        .read_exact(&mut body)
-        .map_err(|err| Diagnostic::new("dap", format!("failed to read DAP body: {err}")))?;
-    String::from_utf8(body)
-        .map(Some)
-        .map_err(|err| Diagnostic::new("dap", format!("DAP body is not UTF-8: {err}")))
 }
 
 fn write_message<W>(output: &mut W, payload: &Value) -> Result<(), Diagnostic>

--- a/stage1/crates/axiomc/src/framed_protocol.rs
+++ b/stage1/crates/axiomc/src/framed_protocol.rs
@@ -1,0 +1,268 @@
+use crate::diagnostics::Diagnostic;
+use std::io::BufRead;
+
+pub(crate) const MAX_HEADER_BYTES: usize = 64 * 1024;
+pub(crate) const MAX_HEADER_LINE_BYTES: usize = 8 * 1024;
+pub(crate) const MAX_HEADER_COUNT: usize = 64;
+pub(crate) const MAX_BODY_BYTES: usize = 16 * 1024 * 1024;
+
+pub(crate) fn read_message<R>(input: &mut R, protocol: &str) -> Result<Option<String>, Diagnostic>
+where
+    R: BufRead,
+{
+    let Some(first_line) = read_header_line(input, protocol)? else {
+        return Ok(None);
+    };
+    let mut header_bytes = first_line.len();
+    let mut header_count = 0usize;
+    let mut content_length = None;
+
+    let mut line = Some(first_line);
+    while let Some(raw_line) = line.take() {
+        if header_bytes > MAX_HEADER_BYTES {
+            return Err(frame_error(
+                protocol,
+                "headers_oversized",
+                format!("{protocol} headers exceed the {MAX_HEADER_BYTES}-byte limit"),
+            ));
+        }
+        let trimmed = trim_header_line(&raw_line, protocol)?;
+        if trimmed.is_empty() {
+            break;
+        }
+        header_count = header_count.saturating_add(1);
+        if header_count > MAX_HEADER_COUNT {
+            return Err(frame_error(
+                protocol,
+                "too_many_headers",
+                format!("{protocol} message exceeds the {MAX_HEADER_COUNT}-header limit"),
+            ));
+        }
+        let (name, value) = trimmed.split_once(':').ok_or_else(|| {
+            frame_error(
+                protocol,
+                "malformed_header",
+                format!("malformed {protocol} header"),
+            )
+        })?;
+        if name.trim().is_empty() {
+            return Err(frame_error(
+                protocol,
+                "malformed_header",
+                format!("malformed {protocol} header name"),
+            ));
+        }
+        if name.trim().eq_ignore_ascii_case("Content-Length") {
+            if content_length.is_some() {
+                return Err(frame_error(
+                    protocol,
+                    "duplicate_content_length",
+                    format!("duplicate Content-Length header in {protocol} message"),
+                ));
+            }
+            let value = value.trim();
+            let length = value.parse::<u64>().map_err(|_| {
+                frame_error(
+                    protocol,
+                    "invalid_content_length",
+                    format!("invalid Content-Length header in {protocol} message"),
+                )
+            })?;
+            if length > MAX_BODY_BYTES as u64 {
+                return Err(frame_error(
+                    protocol,
+                    "body_oversized",
+                    format!("{protocol} body exceeds the {MAX_BODY_BYTES}-byte limit"),
+                ));
+            }
+            content_length = Some(length as usize);
+        }
+
+        line = read_header_line(input, protocol)?;
+        let Some(next_line) = line.as_ref() else {
+            return Err(frame_error(
+                protocol,
+                "truncated_headers",
+                format!("truncated {protocol} header block"),
+            ));
+        };
+        header_bytes = header_bytes.saturating_add(next_line.len());
+        if header_bytes > MAX_HEADER_BYTES {
+            return Err(frame_error(
+                protocol,
+                "headers_oversized",
+                format!("{protocol} headers exceed the {MAX_HEADER_BYTES}-byte limit"),
+            ));
+        }
+    }
+
+    let length = content_length.ok_or_else(|| {
+        frame_error(
+            protocol,
+            "missing_content_length",
+            format!("missing Content-Length header in {protocol} message"),
+        )
+    })?;
+    let mut body = Vec::new();
+    body.try_reserve_exact(length).map_err(|_| {
+        frame_error(
+            protocol,
+            "body_allocation_failed",
+            format!("unable to reserve {length} bytes for {protocol} body"),
+        )
+    })?;
+    body.resize(length, 0);
+    input.read_exact(&mut body).map_err(|err| {
+        frame_error(
+            protocol,
+            "truncated_body",
+            format!("failed to read {protocol} body: {err}"),
+        )
+    })?;
+    String::from_utf8(body).map(Some).map_err(|err| {
+        frame_error(
+            protocol,
+            "invalid_utf8",
+            format!("{protocol} body is not UTF-8: {err}"),
+        )
+    })
+}
+
+fn read_header_line<R>(input: &mut R, protocol: &str) -> Result<Option<Vec<u8>>, Diagnostic>
+where
+    R: BufRead,
+{
+    let mut line = Vec::new();
+    loop {
+        let buffer = input.fill_buf().map_err(|err| {
+            frame_error(
+                protocol,
+                "header_read",
+                format!("failed to read {protocol} header: {err}"),
+            )
+        })?;
+        if buffer.is_empty() {
+            if line.is_empty() {
+                return Ok(None);
+            }
+            return Err(frame_error(
+                protocol,
+                "truncated_header",
+                format!("truncated {protocol} header line"),
+            ));
+        }
+        let newline = buffer.iter().position(|byte| *byte == b'\n');
+        let take = newline.map_or(buffer.len(), |index| index + 1);
+        if line.len().saturating_add(take) > MAX_HEADER_LINE_BYTES {
+            return Err(frame_error(
+                protocol,
+                "header_line_oversized",
+                format!("{protocol} header line exceeds the {MAX_HEADER_LINE_BYTES}-byte limit"),
+            ));
+        }
+        line.extend_from_slice(&buffer[..take]);
+        input.consume(take);
+        if newline.is_some() {
+            return Ok(Some(line));
+        }
+    }
+}
+
+fn trim_header_line<'a>(line: &'a [u8], protocol: &str) -> Result<&'a str, Diagnostic> {
+    let line = line.strip_suffix(b"\n").unwrap_or(line);
+    let line = line.strip_suffix(b"\r").unwrap_or(line);
+    std::str::from_utf8(line).map_err(|err| {
+        frame_error(
+            protocol,
+            "invalid_header",
+            format!("{protocol} header is not UTF-8: {err}"),
+        )
+    })
+}
+
+fn frame_error(protocol: &str, code: &str, message: String) -> Diagnostic {
+    Diagnostic::new(protocol, message).with_code(format!("{protocol}.frame.{code}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    fn read(input: &str, protocol: &str) -> Result<Option<String>, Diagnostic> {
+        read_message(&mut Cursor::new(input.as_bytes()), protocol)
+    }
+
+    #[test]
+    fn accepts_valid_lsp_and_dap_frames() {
+        for protocol in ["lsp", "dap"] {
+            let body = "{\"jsonrpc\":\"2.0\"}";
+            let input = format!("X-Test: ok\r\nContent-Length: {}\r\n\r\n{body}", body.len());
+            assert_eq!(read(&input, protocol).unwrap(), Some(body.to_owned()));
+        }
+    }
+
+    #[test]
+    fn rejects_duplicate_missing_malformed_and_overflow_lengths() {
+        for (input, code) in [
+            (
+                "Content-Length: 1\r\nContent-Length: 1\r\n\r\na",
+                "duplicate_content_length",
+            ),
+            ("X-Test: ok\r\n\r\n", "missing_content_length"),
+            ("Content-Length: nope\r\n\r\n", "invalid_content_length"),
+            (
+                "Content-Length: 18446744073709551616\r\n\r\n",
+                "invalid_content_length",
+            ),
+            ("Content-Length: 1\r\n\r\n", "truncated_body"),
+        ] {
+            let error = read(input, "lsp").expect_err("invalid frame must fail");
+            assert_eq!(
+                error.code.as_deref(),
+                Some(format!("lsp.frame.{code}").as_str())
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_malformed_oversized_and_truncated_frames_before_body_allocation() {
+        for protocol in ["lsp", "dap"] {
+            let malformed = read("not-a-header\r\n\r\n", protocol)
+                .expect_err("malformed header");
+            assert_eq!(
+                malformed.code.as_deref(),
+                Some(format!("{protocol}.frame.malformed_header").as_str())
+            );
+
+            let huge = format!("Content-Length: {}\r\n\r\n", MAX_BODY_BYTES + 1);
+            let huge = read(&huge, protocol).expect_err("oversized body");
+            assert_eq!(
+                huge.code.as_deref(),
+                Some(format!("{protocol}.frame.body_oversized").as_str())
+            );
+        }
+
+        let mut many_headers = String::new();
+        for index in 0..=MAX_HEADER_COUNT {
+            many_headers.push_str(&format!("X-Test-{index}: ok\r\n"));
+        }
+        many_headers.push_str("Content-Length: 0\r\n\r\n");
+        let many_headers = read(&many_headers, "dap").expect_err("too many headers");
+        assert_eq!(
+            many_headers.code.as_deref(),
+            Some("dap.frame.too_many_headers")
+        );
+
+        let long_header = format!("{}\r\n", "x".repeat(MAX_HEADER_LINE_BYTES));
+        let long_header = read(&long_header, "lsp").expect_err("oversized header line");
+        assert_eq!(
+            long_header.code.as_deref(),
+            Some("lsp.frame.header_line_oversized")
+        );
+
+        let body = "Content-Length: 4\r\n\r\nabc";
+        let truncated = read(body, "lsp").expect_err("truncated body");
+        assert_eq!(truncated.code.as_deref(), Some("lsp.frame.truncated_body"));
+    }
+}

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -5,7 +5,7 @@ pub mod bounded_executor;
 pub mod build_contract;
 pub mod codegen;
 pub(crate) mod cranelift_backend;
-pub mod dap;
+pub mod dap; pub(crate) mod framed_protocol;
 pub mod diagnostic_catalog;
 pub mod diagnostics;
 pub mod doctor;

--- a/stage1/crates/axiomc/src/lsp.rs
+++ b/stage1/crates/axiomc/src/lsp.rs
@@ -1,4 +1,5 @@
 use crate::diagnostics::Diagnostic;
+use crate::framed_protocol;
 use crate::hir;
 use crate::manifest::load_manifest;
 use crate::mir;
@@ -606,7 +607,7 @@ where
     W: Write,
 {
     let mut server = LspServer::default();
-    while let Some(message) = read_message(&mut input)? {
+    while let Some(message) = framed_protocol::read_message(&mut input, "lsp")? {
         let response = server.handle_message(&message)?;
         for payload in response.messages {
             write_message(&mut output, &payload)?;
@@ -1088,44 +1089,6 @@ fn word_occurrences(source: &str, word: &str) -> Vec<(usize, usize)> {
 
 fn is_identifier_byte(byte: u8) -> bool {
     byte.is_ascii_alphanumeric() || byte == b'_'
-}
-
-fn read_message<R>(input: &mut R) -> Result<Option<String>, Diagnostic>
-where
-    R: BufRead,
-{
-    let mut content_length = None;
-    loop {
-        let mut line = String::new();
-        let bytes = input
-            .read_line(&mut line)
-            .map_err(|err| Diagnostic::new("lsp", format!("failed to read LSP header: {err}")))?;
-        if bytes == 0 {
-            return Ok(None);
-        }
-        let trimmed = line.trim_end_matches(['\r', '\n']);
-        if trimmed.is_empty() {
-            break;
-        }
-        if let Some((name, value)) = trimmed.split_once(':') {
-            if !name.trim().eq_ignore_ascii_case("Content-Length") {
-                continue;
-            }
-            content_length = Some(value.trim().parse::<usize>().map_err(|err| {
-                Diagnostic::new("lsp", format!("invalid Content-Length header: {err}"))
-            })?);
-        }
-    }
-
-    let length = content_length
-        .ok_or_else(|| Diagnostic::new("lsp", "missing Content-Length header in LSP message"))?;
-    let mut body = vec![0; length];
-    input
-        .read_exact(&mut body)
-        .map_err(|err| Diagnostic::new("lsp", format!("failed to read LSP body: {err}")))?;
-    String::from_utf8(body)
-        .map(Some)
-        .map_err(|err| Diagnostic::new("lsp", format!("LSP body is not UTF-8: {err}")))
 }
 
 fn write_message<W>(output: &mut W, payload: &Value) -> Result<(), Diagnostic>


### PR DESCRIPTION
## Summary

- Add one bounded framed-reader implementation shared by LSP and DAP stdio.
- Bound header bytes, header line length, header count, Content-Length, and body allocation; reject malformed, duplicate, overflowing, oversized, and truncated frames with stable protocol error codes.
- Add endpoint-symmetric malformed/oversized framing tests and preserve valid framing/shutdown behavior.

## Governing Issue

Refs #1573

## Validation

- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc framed_protocol --lib -- --nocapture`
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc lsp --lib -- --nocapture`
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc dap --lib -- --nocapture`
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test lsp_stdio -- --nocapture`
- [x] `make stage1-command-lsp-boundary-test`
- [x] `bash scripts/ci/run-fast-checks.sh`
- [x] `git diff --check`

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] No real secrets, runtime auth, or machine-local env files are committed
- [x] Auto-merge will be enabled after publication

## Flow Contract

- Owner lane: protocol and security boundaries
- Repair owner: bounded LSP/DAP framing
- Autonomy class: implementation with local validation; independent review required
- Risk class: high — malformed input and allocation behavior at protocol boundaries

## Flow Merge Readiness

- [x] Every known blocker has a next actor and next action
- [ ] Non-author approval is present when required
- [ ] Required GitHub checks and review gate are still pending after publication

## Merge Automation

- Auto-merge will be enabled with `gh pr merge --auto --squash`.

## Notes

- The repository's external `autoreview` workflow could not run because private-diff review authorization was not available; this PR requires independent GitHub review.
