### PR TITLE
Wire inspect evidence command

### DIFF
--- a/scripts/ci/run-fast-checks.sh
+++ b/scripts/ci/run-fast-checks.sh
@@ -5,7 +5,12 @@ script_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 repo_root="${AXIOM_CHECKOUT_PATH:-$script_repo_root}"
 cd "$repo_root"
 
-target_dir="${CARGO_TARGET_DIR:-${RUNNER_TEMP:-/tmp}/axiom-fast-ci-target}"
+if [[ -n "${CARGO_TARGET_DIR:-}" ]]; then
+  target_dir="$CARGO_TARGET_DIR"
+else
+  checkout_head="$(git rev-parse --verify HEAD)"
+  target_dir="${RUNNER_TEMP:-/tmp}/axiom-fast-ci-target-${checkout_head:0:12}"
+fi
 mkdir -p "$target_dir"
 export CARGO_TARGET_DIR="$target_dir"
 

--- a/scripts/ci/run-fast-checks.sh
+++ b/scripts/ci/run-fast-checks.sh
@@ -74,7 +74,7 @@ bash "$script_repo_root/scripts/ci/test-propose-stage1-crap-thresholds.sh"
 python3 "$script_repo_root/scripts/ci/test-run-toolchain-qualification.py"
 python3 "$script_repo_root/scripts/ci/test-report-toolchain-qualification.py"
 cargo test --manifest-path "$repo_root/stage1/Cargo.toml" -p axiomc \
-  --test schema_metadata --locked
+  --bin axiomc --test schema_metadata --locked
 cargo test --manifest-path "$repo_root/stage1/Cargo.toml" -p axiomc \
   --test migration_plan_cli --locked
 python3 "$script_repo_root/scripts/ci/check-capability-ledger.py" \

--- a/scripts/ci/test-pr-fast-ci-workflow.sh
+++ b/scripts/ci/test-pr-fast-ci-workflow.sh
@@ -67,6 +67,7 @@ fast_checks_trusted_base_ref=$(awk '
 benchmark_gate_reference=$(grep -nE 'check-stage1-benchmarks\.py|stage1-comparison-report\.json' "$workflow" || true)
 runtime_abi_status_check=$(grep -nF 'scripts/ci/render-direct-native-runtime-abi-status.py' "$fast_checks_script" || true)
 runtime_abi_coverage_check=$(grep -nF -- '--coverage-matrix' "$fast_checks_script" || true)
+schema_metadata_bin_check=$(grep -nA1 -F 'cargo test --manifest-path "$repo_root/stage1/Cargo.toml" -p axiomc \' "$fast_checks_script" | grep -F -- '--bin axiomc --test schema_metadata --locked' || true)
 full_lib_triage_check=$(grep -nF 'scripts/ci/check-stage1-full-lib-triage.py' "$fast_checks_script" || true)
 full_lib_suite_job=$(grep -nF 'full-lib-suite:' "$workflow" || true)
 full_lib_suite_run=$(grep -nF 'cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib --features run-native-tests' "$workflow" || true)
@@ -188,6 +189,11 @@ fi
 
 if [[ -z "$runtime_abi_coverage_check" ]]; then
   echo "run-fast-checks must validate the direct-native runtime ABI coverage matrix" >&2
+  exit 1
+fi
+
+if [[ -z "$schema_metadata_bin_check" ]]; then
+  echo "run-fast-checks must select the axiomc binary for schema metadata CLI tests (#1195)" >&2
   exit 1
 fi
 

--- a/stage1/compatibility/cli-surface-v1.json
+++ b/stage1/compatibility/cli-surface-v1.json
@@ -22,6 +22,7 @@
     "inspect",
     "inspect artifacts",
     "inspect effects",
+    "inspect evidence",
     "inspect graph",
     "inspect intent",
     "inspect symbols",

--- a/stage1/compatibility/fixtures/current/contract.json
+++ b/stage1/compatibility/fixtures/current/contract.json
@@ -77,13 +77,13 @@
       "migration": {
         "action": "Existing command invocations require no changes. To adopt registry dependencies, run axiomc pkg fetch to create the v2 lock and verified cache, use axiomc pkg update for explicit re-resolution, and run axiomc pkg vendor before cache-independent locked offline builds. Package Trust v1 remains available through axiomc pkg verify with exact artifact and trust metadata paths plus --json."
       },
-      "signature": "commands=bench,build,caps,caps diff,check,dap,doc,doctor,evidence,explain,fmt,generate,generate openapi,generate policy,generate runbook,generate sql,generate terraform,inspect,inspect artifacts,inspect effects,inspect graph,inspect intent,inspect symbols,lsp,migrate,mutation-report,new,parse,pkg,pkg fetch,pkg graph,pkg update,pkg vendor,pkg verify,publish,registry-index,registry-serve,registry-validate,repair-plan,repl,run,semantic-diff,task-contract,test,trace,verification-plan,verify; command_semantic_digest=af506b3fccca2c0b539655a6966fe364eaf25c9d486d30f3930ed5be963754ed; flags_status=experimental_partial; flags=--json is the versioned machine envelope opt-in where the command publishes JSON; command-specific optional flags remain additive.; exit=0 means the requested operation completed successfully; nonzero means diagnostics or an operational failure.; json=axiom.stage1.v1 for governed stage1 command payloads; command-specific schemas retain their own AxiOM schema IDs.",
+      "signature": "commands=bench,build,caps,caps diff,check,dap,doc,doctor,evidence,explain,fmt,generate,generate openapi,generate policy,generate runbook,generate sql,generate terraform,inspect,inspect artifacts,inspect effects,inspect evidence,inspect graph,inspect intent,inspect symbols,lsp,migrate,mutation-report,new,parse,pkg,pkg fetch,pkg graph,pkg update,pkg vendor,pkg verify,publish,registry-index,registry-serve,registry-validate,repair-plan,repl,run,semantic-diff,task-contract,test,trace,verification-plan,verify; command_semantic_digest=9a6558998fdbbf2ec144668a5f042790e18a2aa827360e5f64192908baebe102; flags_status=experimental_partial; flags=--json is the versioned machine envelope opt-in where the command publishes JSON; command-specific optional flags remain additive.; exit=0 means the requested operation completed successfully; nonzero means diagnostics or an operational failure.; json=axiom.stage1.v1 for governed stage1 command payloads; command-specific schemas retain their own AxiOM schema IDs.",
       "sources": [
         {
           "path": "stage1/compatibility/cli-surface-v1.json",
           "role": "cli_public_surface",
           "selector": "command_paths,flags,exit_status,migration",
-          "sha256": "07bbb71adee957f8137ffa45e8a76ed13cfb06e5bbe26d7e5bd245b414bd6409"
+          "sha256": "a742f334a6eae8bdf958e3d8b757873b7639160ffcd57af0cbc53b8b17c88be5"
         },
         {
           "path": "stage1/compiler-contracts/schemas/axiom.stage1.command.schema.json",
@@ -101,7 +101,7 @@
           "path": "stage1/crates/axiomc/src/main.rs",
           "role": "cli_command_graph_parity",
           "selector": "Command and nested command variant names",
-          "sha256": "bc45caf55899c1dc1457ea48ac8bcca0e7722c7b8bfb350a917be115f34bd73b"
+          "sha256": "af763dd424e4642a9a469ad0607b5b8eb255eebb4af570c2e7690f9182322667"
         }
       ],
       "stability": "experimental",

--- a/stage1/crates/axiomc/src/main.rs
+++ b/stage1/crates/axiomc/src/main.rs
@@ -485,6 +485,7 @@ enum InspectCommand {
         #[arg(long)]
         json: bool,
     },
+    Evidence { path: PathBuf, #[arg(long)] json: bool },
     /// Emit planned and generated artifact records for a package.
     Artifacts {
         path: PathBuf,
@@ -1157,6 +1158,9 @@ fn main() {
                 }
                 Err(error) => print_error("inspect effects", error, json),
             },
+            InspectCommand::Evidence { path, json } => match inspect_evidence(&path) {
+                Ok(report) => if json { print_json("inspect evidence", &report) } else { for item in &report.evidence { println!("{} {} {} {}", item.kind, item.name, item.path, item.status); } 0 },
+                Err(error) => print_error("inspect evidence", error, json), },
             InspectCommand::Artifacts { path, json } => match inspect_artifacts(&path) {
                 Ok(report) => {
                     if json {
@@ -8284,8 +8288,6 @@ fn collect_program_type_refs(program: &axiomc::syntax::Program) -> Vec<String> {
     }
     refs.into_iter().collect()
 }
-
-#[cfg(test)]
 #[derive(Debug, Clone, Serialize)]
 struct InspectEvidenceReport {
     schema_version: &'static str,
@@ -8296,7 +8298,6 @@ struct InspectEvidenceReport {
     evidence: Vec<EvidenceNode>,
 }
 
-#[cfg(test)]
 #[derive(Debug, Clone, Serialize)]
 struct EvidenceNode {
     kind: &'static str,
@@ -8306,7 +8307,6 @@ struct EvidenceNode {
     status: String,
 }
 
-#[cfg(test)]
 fn inspect_evidence(project: &Path) -> Result<InspectEvidenceReport, Diagnostic> {
     let manifest = load_manifest(project)?;
     let lockfile_status = match validate_lockfile(project, &manifest) {

--- a/stage1/crates/axiomc/tests/schema_metadata.rs
+++ b/stage1/crates/axiomc/tests/schema_metadata.rs
@@ -9,6 +9,7 @@ use jsonschema::Validator;
 use serde_json::Value;
 use std::fs;
 use std::path::Path;
+use std::process::Command;
 
 fn schema_dir() -> std::path::PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -1016,6 +1017,51 @@ fn editor_metadata_schemas_are_parseable_and_current() {
             "compiler schema capability descriptors include {capability}"
         );
     }
+}
+
+#[test]
+fn inspect_evidence_cli_is_wired_for_text_and_json_output() {
+    let temp = tempfile::tempdir().expect("create inspect evidence tempdir");
+    let project = temp.path().join("inspect-evidence-app");
+    let project_arg = project.to_str().expect("project path");
+    let created = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args(["new", project_arg, "--name", "inspect-evidence-app"])
+        .output()
+        .expect("run axiomc new");
+    assert!(created.status.success(), "new failed: {:?}", created);
+
+    let json_output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args(["inspect", "evidence", project_arg, "--json"])
+        .output()
+        .expect("run inspect evidence json");
+    assert!(
+        json_output.status.success(),
+        "inspect evidence json failed: {:?}",
+        json_output
+    );
+    let payload: Value = serde_json::from_slice(&json_output.stdout).expect("evidence JSON");
+    assert_eq!(payload["command"], "inspect evidence");
+    assert!(payload["evidence"].is_array());
+    let schema: Value = serde_json::from_str(
+        &fs::read_to_string(schema_dir().join("axiom-inspect-v0.schema.json"))
+            .expect("read inspect schema"),
+    )
+    .expect("inspect schema JSON");
+    compile_validator(&schema)
+        .validate(&payload)
+        .expect("inspect evidence JSON validates against inspect schema");
+
+    let text_output = Command::new(env!("CARGO_BIN_EXE_axiomc"))
+        .args(["inspect", "evidence", project_arg])
+        .output()
+        .expect("run inspect evidence text");
+    assert!(
+        text_output.status.success(),
+        "inspect evidence text failed: {:?}",
+        text_output
+    );
+    let text = String::from_utf8(text_output.stdout).expect("evidence text UTF-8");
+    assert!(text.contains("lockfile axiom.lock"), "text output: {text}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Wire the existing `inspect_evidence` implementation into the production `axiomc inspect evidence` command.
- Support both human-readable evidence rows and the published `axiom.stage1.v1` JSON envelope.
- Add CLI text/JSON execution coverage, schema validation, and command-graph/public-contract parity updates.

## Governing Issue

Refs #1195

## Validation

- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test schema_metadata -- --nocapture` — 17 passed
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc --bin axiomc inspect_effects_evidence_and_artifacts_report_agent_shapes -- --nocapture` — passed
- [x] `python3 scripts/ci/extract-public-contract-v1.py --check`
- [x] `bash scripts/ci/run-fast-checks.sh`
- [x] `git diff --check`

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] No real secrets, runtime auth, or machine-local env files are committed
- [x] Auto-merge will be enabled after publication

## Flow Contract

- Owner lane: Stage 1 compiler/tooling command surface
- Repair owner: inspect evidence CLI wiring and contract parity
- Autonomy class: low-risk implementation with local validation; independent review required
- Risk class: low — additive command dispatch and governed evidence output

## Flow Merge Readiness

- [x] Every known blocker has a next actor and next action
- [ ] Non-author approval is present when required
- [ ] Required GitHub checks and review gate are pending after publication

## Merge Automation

- Auto-merge will be enabled with `gh pr merge --auto --squash`.

## Notes

- The published inspect schema already advertised this command; this change restores production parity and removes the dead-code-only path.
- The repository's external `autoreview` workflow could not run because private-diff review authorization was not available; this PR requires independent review.
