### PR TITLE
Add structured JSON parse errors

### DIFF
--- a/stage1/compiler-contracts/snapshots/capability-ledger.json
+++ b/stage1/compiler-contracts/snapshots/capability-ledger.json
@@ -1766,6 +1766,8 @@
         "is_null",
         "object_field",
         "parse_error_message",
+        "parse_error_offset",
+        "parse_error_path",
         "stringify",
         "text_field",
         "to_json",

--- a/stage1/compiler-contracts/snapshots/stdlib-catalog.json
+++ b/stage1/compiler-contracts/snapshots/stdlib-catalog.json
@@ -3012,7 +3012,7 @@
       "module_loading": {
         "kind": "embedded_source",
         "source_path": "stage1/crates/axiomc/src/stdlib.rs",
-        "source_digest": "e8441e2f4c63b0a97e1526e155d09a26dc3c834b2de2f5f7634789158132265f"
+        "source_digest": "6dd3815e1cec4d96ac1b7f37d8b4b9a99765f0179639b4e56166ca77f3f741f8"
       },
       "capabilities": [],
       "symbols": [
@@ -3189,6 +3189,28 @@
           "binding_kind": "provider_contract",
           "provider": {
             "id": "axiom://provider/stage1-v1/serdes/parse_error_message",
+            "kind": "declared_provider"
+          }
+        },
+        {
+          "name": "parse_error_offset",
+          "signature": "fn parse_error_offset(error: ParseError): int",
+          "effect": "pure",
+          "binding": "axiom://provider/stage1-v1/serdes/parse_error_offset",
+          "binding_kind": "provider_contract",
+          "provider": {
+            "id": "axiom://provider/stage1-v1/serdes/parse_error_offset",
+            "kind": "declared_provider"
+          }
+        },
+        {
+          "name": "parse_error_path",
+          "signature": "fn parse_error_path(error: ParseError): string",
+          "effect": "pure",
+          "binding": "axiom://provider/stage1-v1/serdes/parse_error_path",
+          "binding_kind": "provider_contract",
+          "provider": {
+            "id": "axiom://provider/stage1-v1/serdes/parse_error_path",
             "kind": "declared_provider"
           }
         },
@@ -3796,7 +3818,7 @@
       "symbols": []
     }
   ],
-  "release_digest": "fb6f4db3b4c664f2b001edee117ffedae64d07af40eb05563e4ade7a2804758c",
+  "release_digest": "d2630d3390704132289b99a86d47f03ea77a11893aaff913e4149d01149a60c8",
   "rollback_boundary": "stage1/crates/axiomc/src/stdlib.rs remains the bootstrap loader until #1436 qualifies a catalog consumer.",
   "acceptance_boundary": {
     "status": "pending",

--- a/stage1/crates/axiomc/src/codegen.rs
+++ b/stage1/crates/axiomc/src/codegen.rs
@@ -149,7 +149,7 @@ mod tests {
         assert!(rendered.contains("AXIOM_JSON_MAX_DEPTH: usize = 128"));
         assert!(rendered.contains("AXIOM_JSON_MAX_COLLECTION_ITEMS: usize = 100_000"));
         assert!(rendered.contains("AXIOM_JSON_MAX_NUMBER_DIGITS: usize = 1_024"));
-        assert!(rendered.contains("fn parse_value(&mut self, depth: usize)"));
+        assert!(rendered.contains("fn parse_value("));
         assert!(rendered.contains("JSON collection exceeds"));
     }
 
@@ -5328,6 +5328,43 @@ fn axiom_json_serdes_to_json_object(values: HashMap<String, std_serdes_Value>) -
 }
 
 #[allow(dead_code)]
+#[derive(Clone, Debug)]
+struct AxiomJsonSerdesError {
+    message: String,
+    offset: usize,
+    path: String,
+}
+
+#[allow(dead_code)]
+fn axiom_json_serdes_error(message: impl Into<String>, offset: usize, path: &str) -> AxiomJsonSerdesError {
+    AxiomJsonSerdesError {
+        message: message.into(),
+        offset,
+        path: path.to_string(),
+    }
+}
+
+#[allow(dead_code)]
+fn axiom_json_serdes_field_path(path: &str, key: &str) -> String {
+    if !key.is_empty()
+        && key.chars().enumerate().all(|(index, ch)| {
+            ch == '_'
+                || ch.is_ascii_alphanumeric()
+                    && (index > 0 || ch.is_ascii_alphabetic() || ch == '_')
+        })
+    {
+        format!("{path}.{key}")
+    } else {
+        format!("{path}[{}]", axiom_json_serdes_string_to_json(key.to_string()))
+    }
+}
+
+#[allow(dead_code)]
+fn axiom_json_serdes_index_path(path: &str, index: usize) -> String {
+    format!("{path}[{index}]")
+}
+
+#[allow(dead_code)]
 struct AxiomJsonSerdesParser<'a> {
     text: &'a str,
     index: usize,
@@ -5368,29 +5405,42 @@ impl<'a> AxiomJsonSerdesParser<'a> {
         }
     }
 
-    fn parse_value(&mut self, depth: usize) -> Result<std_serdes_Value, String> {
+    fn parse_value(
+        &mut self,
+        depth: usize,
+        path: &str,
+    ) -> Result<std_serdes_Value, AxiomJsonSerdesError> {
         self.skip_ws();
         match self.peek_byte() {
             Some(b'n') if self.consume_literal("null") => Ok(std_serdes_Value::Null),
             Some(b't') if self.consume_literal("true") => Ok(std_serdes_Value::Bool(true)),
             Some(b'f') if self.consume_literal("false") => Ok(std_serdes_Value::Bool(false)),
-            Some(b'"') => Ok(std_serdes_Value::Text(self.parse_string()?)),
-            Some(b'[') => self.parse_array(depth),
-            Some(b'{') => self.parse_object(depth),
-            Some(b'-' | b'0'..=b'9') => self.parse_number(),
-            Some(_) => Err(String::from("unexpected JSON token")),
-            None => Err(String::from("empty JSON input")),
+            Some(b'"') => Ok(std_serdes_Value::Text(self.parse_string(path)?)),
+            Some(b'[') => self.parse_array(depth, path),
+            Some(b'{') => self.parse_object(depth, path),
+            Some(b'-' | b'0'..=b'9') => self.parse_number(path),
+            Some(_) => Err(axiom_json_serdes_error(
+                "unexpected JSON token",
+                self.index,
+                path,
+            )),
+            None => Err(axiom_json_serdes_error("empty JSON input", self.index, path)),
         }
     }
 
-    fn parse_array(&mut self, depth: usize) -> Result<std_serdes_Value, String> {
+    fn parse_array(
+        &mut self,
+        depth: usize,
+        path: &str,
+    ) -> Result<std_serdes_Value, AxiomJsonSerdesError> {
         if depth >= AXIOM_JSON_MAX_DEPTH {
-            return Err(format!(
-                "JSON nesting exceeds {} level limit",
-                AXIOM_JSON_MAX_DEPTH
+            return Err(axiom_json_serdes_error(
+                format!("JSON nesting exceeds {} level limit", AXIOM_JSON_MAX_DEPTH),
+                self.index,
+                path,
             ));
         }
-        self.expect_byte(b'[', "array")?;
+        self.expect_byte(b'[', "array", path)?;
         self.skip_ws();
         let mut values = Vec::new();
         if self.peek_byte() == Some(b']') {
@@ -5399,31 +5449,47 @@ impl<'a> AxiomJsonSerdesParser<'a> {
         }
         loop {
             if values.len() >= AXIOM_JSON_MAX_COLLECTION_ITEMS {
-                return Err(format!(
-                    "JSON collection exceeds {} item limit",
-                    AXIOM_JSON_MAX_COLLECTION_ITEMS
+                return Err(axiom_json_serdes_error(
+                    format!(
+                        "JSON collection exceeds {} item limit",
+                        AXIOM_JSON_MAX_COLLECTION_ITEMS
+                    ),
+                    self.index,
+                    path,
                 ));
             }
-            values.push(self.parse_value(depth + 1)?);
+            let value_path = axiom_json_serdes_index_path(path, values.len());
+            values.push(self.parse_value(depth + 1, &value_path)?);
             self.skip_ws();
             match self.next_byte() {
                 Some(b',') => {
                     self.skip_ws();
                 }
                 Some(b']') => return Ok(std_serdes_Value::Array(values)),
-                _ => return Err(String::from("array expects ',' or ']'")),
+                _ => {
+                    return Err(axiom_json_serdes_error(
+                        "array expects ',' or ']'",
+                        self.index.saturating_sub(1),
+                        path,
+                    ));
+                }
             }
         }
     }
 
-    fn parse_object(&mut self, depth: usize) -> Result<std_serdes_Value, String> {
+    fn parse_object(
+        &mut self,
+        depth: usize,
+        path: &str,
+    ) -> Result<std_serdes_Value, AxiomJsonSerdesError> {
         if depth >= AXIOM_JSON_MAX_DEPTH {
-            return Err(format!(
-                "JSON nesting exceeds {} level limit",
-                AXIOM_JSON_MAX_DEPTH
+            return Err(axiom_json_serdes_error(
+                format!("JSON nesting exceeds {} level limit", AXIOM_JSON_MAX_DEPTH),
+                self.index,
+                path,
             ));
         }
-        self.expect_byte(b'{', "object")?;
+        self.expect_byte(b'{', "object", path)?;
         self.skip_ws();
         let mut values = HashMap::new();
         if self.peek_byte() == Some(b'}') {
@@ -5432,16 +5498,21 @@ impl<'a> AxiomJsonSerdesParser<'a> {
         }
         loop {
             if values.len() >= AXIOM_JSON_MAX_COLLECTION_ITEMS {
-                return Err(format!(
-                    "JSON collection exceeds {} item limit",
-                    AXIOM_JSON_MAX_COLLECTION_ITEMS
+                return Err(axiom_json_serdes_error(
+                    format!(
+                        "JSON collection exceeds {} item limit",
+                        AXIOM_JSON_MAX_COLLECTION_ITEMS
+                    ),
+                    self.index,
+                    path,
                 ));
             }
             self.skip_ws();
-            let key = self.parse_string()?;
+            let key = self.parse_string(path)?;
+            let value_path = axiom_json_serdes_field_path(path, &key);
             self.skip_ws();
-            self.expect_byte(b':', "object field")?;
-            let value = self.parse_value(depth + 1)?;
+            self.expect_byte(b':', "object field", &value_path)?;
+            let value = self.parse_value(depth + 1, &value_path)?;
             values.insert(key, value);
             self.skip_ws();
             match self.next_byte() {
@@ -5449,12 +5520,21 @@ impl<'a> AxiomJsonSerdesParser<'a> {
                     self.skip_ws();
                 }
                 Some(b'}') => return Ok(std_serdes_Value::Object(values)),
-                _ => return Err(String::from("object expects ',' or '}'")),
+                _ => {
+                    return Err(axiom_json_serdes_error(
+                        "object expects ',' or '}'",
+                        self.index.saturating_sub(1),
+                        path,
+                    ));
+                }
             }
         }
     }
 
-    fn parse_number(&mut self) -> Result<std_serdes_Value, String> {
+    fn parse_number(
+        &mut self,
+        path: &str,
+    ) -> Result<std_serdes_Value, AxiomJsonSerdesError> {
         let start = self.index;
         if self.peek_byte() == Some(b'-') {
             self.index += 1;
@@ -5467,14 +5547,14 @@ impl<'a> AxiomJsonSerdesParser<'a> {
                 self.index += 1;
                 self.consume_digits();
             }
-            _ => return Err(String::from("invalid JSON number")),
+            _ => return Err(axiom_json_serdes_error("invalid JSON number", start, path)),
         }
         let mut is_float = false;
         if self.peek_byte() == Some(b'.') {
             is_float = true;
             self.index += 1;
             if self.consume_digits() == 0 {
-                return Err(String::from("invalid JSON fraction"));
+                return Err(axiom_json_serdes_error("invalid JSON fraction", start, path));
             }
         }
         if matches!(self.peek_byte(), Some(b'e' | b'E')) {
@@ -5484,49 +5564,67 @@ impl<'a> AxiomJsonSerdesParser<'a> {
                 self.index += 1;
             }
             if self.consume_digits() == 0 {
-                return Err(String::from("invalid JSON exponent"));
+                return Err(axiom_json_serdes_error("invalid JSON exponent", start, path));
             }
         }
         let raw = &self.text[start..self.index];
         if raw.bytes().filter(u8::is_ascii_digit).count() > AXIOM_JSON_MAX_NUMBER_DIGITS {
-            return Err(format!(
-                "JSON number exceeds {} digit limit",
-                AXIOM_JSON_MAX_NUMBER_DIGITS
+            return Err(axiom_json_serdes_error(
+                format!(
+                    "JSON number exceeds {} digit limit",
+                    AXIOM_JSON_MAX_NUMBER_DIGITS
+                ),
+                start,
+                path,
             ));
         }
         if is_float {
             let value = raw
                 .parse::<f64>()
-                .map_err(|_| String::from("invalid JSON float"))?;
+                .map_err(|_| axiom_json_serdes_error("invalid JSON float", start, path))?;
             if !value.is_finite() {
-                return Err(String::from("non-finite JSON float"));
+                return Err(axiom_json_serdes_error("non-finite JSON float", start, path));
             }
             Ok(std_serdes_Value::Float(value))
         } else {
             raw.parse::<i64>()
                 .map(std_serdes_Value::Int)
-                .map_err(|_| String::from("invalid JSON int"))
+                .map_err(|_| axiom_json_serdes_error("invalid JSON int", start, path))
         }
     }
 
-    fn parse_string(&mut self) -> Result<String, String> {
-        self.expect_byte(b'"', "string")?;
+    fn parse_string(&mut self, path: &str) -> Result<String, AxiomJsonSerdesError> {
+        self.expect_byte(b'"', "string", path)?;
         let mut value = String::new();
         loop {
             let Some(ch) = self.text[self.index..].chars().next() else {
-                return Err(String::from("unterminated JSON string"));
+                return Err(axiom_json_serdes_error(
+                    "unterminated JSON string",
+                    self.index,
+                    path,
+                ));
             };
             self.index += ch.len_utf8();
             match ch {
                 '"' => return Ok(value),
-                '\\' => self.parse_escape(&mut value)?,
-                ch if ch <= '\u{1f}' => return Err(String::from("control character in JSON string")),
+                '\\' => self.parse_escape(&mut value, path)?,
+                ch if ch <= '\u{1f}' => {
+                    return Err(axiom_json_serdes_error(
+                        "control character in JSON string",
+                        self.index.saturating_sub(ch.len_utf8()),
+                        path,
+                    ));
+                }
                 ch => value.push(ch),
             }
         }
     }
 
-    fn parse_escape(&mut self, value: &mut String) -> Result<(), String> {
+    fn parse_escape(
+        &mut self,
+        value: &mut String,
+        path: &str,
+    ) -> Result<(), AxiomJsonSerdesError> {
         match self.next_byte() {
             Some(b'"') => value.push('"'),
             Some(b'\\') => value.push('\\'),
@@ -5537,51 +5635,73 @@ impl<'a> AxiomJsonSerdesParser<'a> {
             Some(b'r') => value.push('\r'),
             Some(b't') => value.push('\t'),
             Some(b'u') => {
-                let high = self.parse_hex4()?;
+                let high = self.parse_hex4(path)?;
                 if (0xD800..=0xDBFF).contains(&high) {
                     if self.next_byte() != Some(b'\\') || self.next_byte() != Some(b'u') {
-                        return Err(String::from("missing low surrogate escape"));
+                        return Err(axiom_json_serdes_error(
+                            "missing low surrogate escape",
+                            self.index,
+                            path,
+                        ));
                     }
-                    let low = self.parse_hex4()?;
+                    let low = self.parse_hex4(path)?;
                     if !(0xDC00..=0xDFFF).contains(&low) {
-                        return Err(String::from("invalid low surrogate escape"));
+                        return Err(axiom_json_serdes_error(
+                            "invalid low surrogate escape",
+                            self.index,
+                            path,
+                        ));
                     }
                     let scalar =
                         0x10000 + (((high as u32) - 0xD800) << 10) + ((low as u32) - 0xDC00);
                     value.push(
                         char::from_u32(scalar)
-                            .ok_or_else(|| String::from("invalid unicode scalar"))?,
+                            .ok_or_else(|| axiom_json_serdes_error("invalid unicode scalar", self.index, path))?,
                     );
                 } else if (0xDC00..=0xDFFF).contains(&high) {
-                    return Err(String::from("unpaired low surrogate escape"));
+                    return Err(axiom_json_serdes_error(
+                        "unpaired low surrogate escape",
+                        self.index,
+                        path,
+                    ));
                 } else {
                     value.push(
                         char::from_u32(high as u32)
-                            .ok_or_else(|| String::from("invalid unicode escape"))?,
+                            .ok_or_else(|| axiom_json_serdes_error("invalid unicode escape", self.index, path))?,
                     );
                 }
             }
-            _ => return Err(String::from("invalid JSON string escape")),
+            _ => return Err(axiom_json_serdes_error("invalid JSON string escape", self.index, path)),
         }
         Ok(())
     }
 
-    fn parse_hex4(&mut self) -> Result<u16, String> {
+    fn parse_hex4(&mut self, path: &str) -> Result<u16, AxiomJsonSerdesError> {
         let mut value = 0u16;
         for _ in 0..4 {
             let digit = self
                 .next_byte()
                 .and_then(|byte| (byte as char).to_digit(16))
-                .ok_or_else(|| String::from("invalid unicode escape"))?;
+                .ok_or_else(|| axiom_json_serdes_error("invalid unicode escape", self.index, path))?;
             value = (value << 4) + digit as u16;
         }
         Ok(value)
     }
 
-    fn expect_byte(&mut self, expected: u8, context: &str) -> Result<(), String> {
+    fn expect_byte(
+        &mut self,
+        expected: u8,
+        context: &str,
+        path: &str,
+    ) -> Result<(), AxiomJsonSerdesError> {
+        let offset = self.index;
         match self.next_byte() {
             Some(actual) if actual == expected => Ok(()),
-            _ => Err(format!("{context} expects '{}'", expected as char)),
+            _ => Err(axiom_json_serdes_error(
+                format!("{context} expects '{}'", expected as char),
+                offset,
+                path,
+            )),
         }
     }
 
@@ -5607,10 +5727,12 @@ fn axiom_json_serdes_parse_str(text: &str) -> Result<std_serdes_Value, std_serde
                 "JSON document exceeds {} byte limit",
                 AXIOM_JSON_MAX_DOCUMENT_BYTES
             ),
+            offset: AXIOM_JSON_MAX_DOCUMENT_BYTES as i64,
+            path: String::from("$"),
         });
     }
     let mut parser = AxiomJsonSerdesParser::new(text);
-    match parser.parse_value(0) {
+    match parser.parse_value(0, "$") {
         Ok(value) => {
             parser.skip_ws();
             if parser.is_end() {
@@ -5618,10 +5740,16 @@ fn axiom_json_serdes_parse_str(text: &str) -> Result<std_serdes_Value, std_serde
             } else {
                 Err(std_serdes_ParseError {
                     message: String::from("trailing characters after JSON value"),
+                    offset: parser.index as i64,
+                    path: String::from("$"),
                 })
             }
         }
-        Err(message) => Err(std_serdes_ParseError { message }),
+        Err(error) => Err(std_serdes_ParseError {
+            message: error.message,
+            offset: error.offset as i64,
+            path: error.path,
+        }),
     }
 }
 

--- a/stage1/crates/axiomc/src/cranelift_backend.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend.rs
@@ -17664,7 +17664,8 @@ fn json_serdes_parse_value(
     text: &str,
     index: usize,
     depth: usize,
-) -> Result<(SpikeValue, usize), String> {
+    path: &str,
+) -> Result<(SpikeValue, usize), JsonSerdesError> {
     let index = json_skip_ws(text, index);
     match text.as_bytes().get(index).copied() {
         Some(b'n') if text[index..].starts_with("null") => {
@@ -17680,19 +17681,19 @@ fn json_serdes_parse_value(
         )),
         Some(b'"') => {
             let end = json_scan_string_end(text, index)
-                .ok_or_else(|| String::from("unterminated JSON string"))?;
+                .ok_or_else(|| json_serdes_error("unterminated JSON string", index, path))?;
             let value = json_parse_string(&text[index..end])
-                .ok_or_else(|| String::from("invalid JSON string"))?;
+                .ok_or_else(|| json_serdes_error("invalid JSON string", index, path))?;
             Ok((
                 json_serdes_value_variant("Text", vec![SpikeValue::Text(value)]),
                 end,
             ))
         }
-        Some(b'[') => json_serdes_parse_array(text, index, depth),
-        Some(b'{') => json_serdes_parse_object(text, index, depth),
-        Some(b'-' | b'0'..=b'9') => json_serdes_parse_number(text, index),
-        Some(_) => Err(String::from("unexpected JSON token")),
-        None => Err(String::from("empty JSON input")),
+        Some(b'[') => json_serdes_parse_array(text, index, depth, path),
+        Some(b'{') => json_serdes_parse_object(text, index, depth, path),
+        Some(b'-' | b'0'..=b'9') => json_serdes_parse_number(text, index, path),
+        Some(_) => Err(json_serdes_error("unexpected JSON token", index, path)),
+        None => Err(json_serdes_error("empty JSON input", index, path)),
     }
 }
 
@@ -17700,11 +17701,13 @@ fn json_serdes_parse_array(
     text: &str,
     index: usize,
     depth: usize,
-) -> Result<(SpikeValue, usize), String> {
+    path: &str,
+) -> Result<(SpikeValue, usize), JsonSerdesError> {
     if depth >= JSON_MAX_DEPTH {
-        return Err(format!(
-            "JSON nesting exceeds {} level limit",
-            JSON_MAX_DEPTH
+        return Err(json_serdes_error(
+            format!("JSON nesting exceeds {} level limit", JSON_MAX_DEPTH),
+            index,
+            path,
         ));
     }
     let mut index = index + 1;
@@ -17720,12 +17723,18 @@ fn json_serdes_parse_array(
             }
             Some(_) => {
                 if values.len() >= JSON_MAX_COLLECTION_ITEMS {
-                    return Err(format!(
-                        "JSON collection exceeds {} item limit",
-                        JSON_MAX_COLLECTION_ITEMS
+                    return Err(json_serdes_error(
+                        format!(
+                            "JSON collection exceeds {} item limit",
+                            JSON_MAX_COLLECTION_ITEMS
+                        ),
+                        index,
+                        path,
                     ));
                 }
-                let (value, next) = json_serdes_parse_value(text, index, depth + 1)?;
+                let value_path = json_serdes_index_path(path, values.len());
+                let (value, next) =
+                    json_serdes_parse_value(text, index, depth + 1, &value_path)?;
                 values.push(value);
                 index = json_skip_ws(text, next);
                 match text.as_bytes().get(index).copied() {
@@ -17736,10 +17745,16 @@ fn json_serdes_parse_array(
                             index + 1,
                         ));
                     }
-                    _ => return Err(String::from("array expects ',' or ']'")),
+                    _ => {
+                        return Err(json_serdes_error(
+                            "array expects ',' or ']'",
+                            index,
+                            path,
+                        ));
+                    }
                 }
             }
-            None => return Err(String::from("unterminated JSON array")),
+            None => return Err(json_serdes_error("unterminated JSON array", index, path)),
         }
     }
 }
@@ -17748,11 +17763,13 @@ fn json_serdes_parse_object(
     text: &str,
     index: usize,
     depth: usize,
-) -> Result<(SpikeValue, usize), String> {
+    path: &str,
+) -> Result<(SpikeValue, usize), JsonSerdesError> {
     if depth >= JSON_MAX_DEPTH {
-        return Err(format!(
-            "JSON nesting exceeds {} level limit",
-            JSON_MAX_DEPTH
+        return Err(json_serdes_error(
+            format!("JSON nesting exceeds {} level limit", JSON_MAX_DEPTH),
+            index,
+            path,
         ));
     }
     let mut index = index + 1;
@@ -17768,22 +17785,32 @@ fn json_serdes_parse_object(
             }
             Some(b'"') => {
                 if entries.len() >= JSON_MAX_COLLECTION_ITEMS {
-                    return Err(format!(
-                        "JSON collection exceeds {} item limit",
-                        JSON_MAX_COLLECTION_ITEMS
+                    return Err(json_serdes_error(
+                        format!(
+                            "JSON collection exceeds {} item limit",
+                            JSON_MAX_COLLECTION_ITEMS
+                        ),
+                        index,
+                        path,
                     ));
                 }
                 let key_end = json_scan_string_end(text, index)
-                    .ok_or_else(|| String::from("unterminated JSON object key"))?;
+                    .ok_or_else(|| json_serdes_error("unterminated JSON object key", index, path))?;
                 let key = json_parse_string(&text[index..key_end])
-                    .ok_or_else(|| String::from("invalid JSON object key"))?;
+                    .ok_or_else(|| json_serdes_error("invalid JSON object key", index, path))?;
+                let value_path = json_serdes_field_path(path, &key);
                 index = json_skip_ws(text, key_end);
                 if text.as_bytes().get(index).copied() != Some(b':') {
-                    return Err(String::from("object field expects ':'"));
+                    return Err(json_serdes_error(
+                        "object field expects ':'",
+                        index,
+                        &value_path,
+                    ));
                 }
-                let (value, next) = json_serdes_parse_value(text, index + 1, depth + 1)?;
+                let (value, next) =
+                    json_serdes_parse_value(text, index + 1, depth + 1, &value_path)?;
                 insert_map_entry(&mut entries, SpikeValue::Text(key), value)
-                    .map_err(|err| err.message)?;
+                    .map_err(|err| json_serdes_error(err.message, index, path))?;
                 index = json_skip_ws(text, next);
                 match text.as_bytes().get(index).copied() {
                     Some(b',') => index += 1,
@@ -17793,16 +17820,26 @@ fn json_serdes_parse_object(
                             index + 1,
                         ));
                     }
-                    _ => return Err(String::from("object expects ',' or '}'")),
+                    _ => {
+                        return Err(json_serdes_error(
+                            "object expects ',' or '}'",
+                            index,
+                            path,
+                        ));
+                    }
                 }
             }
-            Some(_) => return Err(String::from("object expects string keys")),
-            None => return Err(String::from("unterminated JSON object")),
+            Some(_) => return Err(json_serdes_error("object expects string keys", index, path)),
+            None => return Err(json_serdes_error("unterminated JSON object", index, path)),
         }
     }
 }
 
-fn json_serdes_parse_number(text: &str, index: usize) -> Result<(SpikeValue, usize), String> {
+fn json_serdes_parse_number(
+    text: &str,
+    index: usize,
+    path: &str,
+) -> Result<(SpikeValue, usize), JsonSerdesError> {
     let start = index;
     let bytes = text.as_bytes();
     let mut index = index;
@@ -17817,7 +17854,7 @@ fn json_serdes_parse_number(text: &str, index: usize) -> Result<(SpikeValue, usi
                 index += 1;
             }
         }
-        _ => return Err(String::from("invalid JSON number")),
+        _ => return Err(json_serdes_error("invalid JSON number", start, path)),
     }
     let mut is_float = false;
     if bytes.get(index).copied() == Some(b'.') {
@@ -17828,7 +17865,7 @@ fn json_serdes_parse_number(text: &str, index: usize) -> Result<(SpikeValue, usi
             index += 1;
         }
         if index == fraction_start {
-            return Err(String::from("invalid JSON fraction"));
+            return Err(json_serdes_error("invalid JSON fraction", start, path));
         }
     }
     if matches!(bytes.get(index).copied(), Some(b'e' | b'E')) {
@@ -17842,22 +17879,23 @@ fn json_serdes_parse_number(text: &str, index: usize) -> Result<(SpikeValue, usi
             index += 1;
         }
         if index == exponent_start {
-            return Err(String::from("invalid JSON exponent"));
+            return Err(json_serdes_error("invalid JSON exponent", start, path));
         }
     }
     let raw = &text[start..index];
     if raw.bytes().filter(u8::is_ascii_digit).count() > JSON_MAX_NUMBER_DIGITS {
-        return Err(format!(
-            "JSON number exceeds {} digit limit",
-            JSON_MAX_NUMBER_DIGITS
+        return Err(json_serdes_error(
+            format!("JSON number exceeds {} digit limit", JSON_MAX_NUMBER_DIGITS),
+            start,
+            path,
         ));
     }
     if is_float {
         let value = raw
             .parse::<f64>()
-            .map_err(|_| String::from("invalid JSON float"))?;
+            .map_err(|_| json_serdes_error("invalid JSON float", start, path))?;
         if !value.is_finite() {
-            return Err(String::from("non-finite JSON float"));
+            return Err(json_serdes_error("non-finite JSON float", start, path));
         }
         Ok((
             json_serdes_value_variant("Float", vec![SpikeValue::Float(value)]),
@@ -17871,7 +17909,7 @@ fn json_serdes_parse_number(text: &str, index: usize) -> Result<(SpikeValue, usi
                     index,
                 )
             })
-            .map_err(|_| String::from("invalid JSON int"))
+            .map_err(|_| json_serdes_error("invalid JSON int", start, path))
     }
 }
 

--- a/stage1/crates/axiomc/src/cranelift_backend/evaluator.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend/evaluator.rs
@@ -4268,6 +4268,15 @@ mod json_limit_tests {
     }
 
     #[test]
+    fn rejects_control_characters_inside_json_strings() {
+        let error = json_serdes_parse_document("\"line\nbreak\"")
+            .expect_err("raw control character in JSON string");
+        assert_eq!(error.message, "invalid JSON string");
+        assert_eq!(error.offset, 0);
+        assert_eq!(error.path, "$");
+    }
+
+    #[test]
     fn reports_structured_nested_json_error_location() {
         let error = json_serdes_parse_document("{\"outer\":[true,}")
             .expect_err("malformed nested JSON");

--- a/stage1/crates/axiomc/src/cranelift_backend/evaluator.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend/evaluator.rs
@@ -2098,7 +2098,44 @@ pub(crate) fn std_serdes_as_object_value(value: &SpikeValue) -> Result<Option<Sp
     })
 }
 
-pub(crate) fn json_serdes_result(value: Result<SpikeValue, String>) -> SpikeValue {
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct JsonSerdesError {
+    pub(crate) message: String,
+    pub(crate) offset: usize,
+    pub(crate) path: String,
+}
+
+pub(crate) fn json_serdes_error(
+    message: impl Into<String>,
+    offset: usize,
+    path: &str,
+) -> JsonSerdesError {
+    JsonSerdesError {
+        message: message.into(),
+        offset,
+        path: path.to_string(),
+    }
+}
+
+pub(crate) fn json_serdes_field_path(path: &str, key: &str) -> String {
+    if !key.is_empty()
+        && key.chars().enumerate().all(|(index, ch)| {
+            ch == '_'
+                || ch.is_ascii_alphanumeric()
+                    && (index > 0 || ch.is_ascii_alphabetic() || ch == '_')
+        })
+    {
+        format!("{path}.{key}")
+    } else {
+        format!("{path}[{}]", json_serdes_escape_string(key))
+    }
+}
+
+pub(crate) fn json_serdes_index_path(path: &str, index: usize) -> String {
+    format!("{path}[{index}]")
+}
+
+pub(crate) fn json_serdes_result(value: Result<SpikeValue, JsonSerdesError>) -> SpikeValue {
     match value {
         Ok(value) => SpikeValue::Enum {
             enum_name: String::from("Result"),
@@ -2106,30 +2143,39 @@ pub(crate) fn json_serdes_result(value: Result<SpikeValue, String>) -> SpikeValu
             field_names: Vec::new(),
             payloads: vec![value],
         },
-        Err(message) => SpikeValue::Enum {
+        Err(error) => SpikeValue::Enum {
             enum_name: String::from("Result"),
             variant: String::from("Err"),
             field_names: Vec::new(),
             payloads: vec![SpikeValue::Struct {
                 name: String::from("std_serdes_ParseError"),
-                fields: vec![(String::from("message"), SpikeValue::Text(message))],
+                fields: vec![
+                    (String::from("message"), SpikeValue::Text(error.message)),
+                    (String::from("offset"), SpikeValue::Int(error.offset as i64)),
+                    (String::from("path"), SpikeValue::Text(error.path)),
+                ],
             }],
         },
     }
 }
 
-pub(crate) fn json_serdes_parse_document(text: &str) -> Result<SpikeValue, String> {
+pub(crate) fn json_serdes_parse_document(text: &str) -> Result<SpikeValue, JsonSerdesError> {
     if text.len() > JSON_MAX_DOCUMENT_BYTES {
-        return Err(format!(
-            "JSON document exceeds {} byte limit",
-            JSON_MAX_DOCUMENT_BYTES
+        return Err(json_serdes_error(
+            format!("JSON document exceeds {} byte limit", JSON_MAX_DOCUMENT_BYTES),
+            JSON_MAX_DOCUMENT_BYTES,
+            "$",
         ));
     }
-    let (value, index) = json_serdes_parse_value(text, json_skip_ws(text, 0), 0)?;
+    let (value, index) = json_serdes_parse_value(text, json_skip_ws(text, 0), 0, "$")?;
     if json_skip_ws(text, index) == text.len() {
         Ok(value)
     } else {
-        Err(String::from("trailing characters after JSON value"))
+        Err(json_serdes_error(
+            "trailing characters after JSON value",
+            json_skip_ws(text, index),
+            "$",
+        ))
     }
 }
 
@@ -4222,17 +4268,30 @@ mod json_limit_tests {
     }
 
     #[test]
+    fn reports_structured_nested_json_error_location() {
+        let error = json_serdes_parse_document("{\"outer\":[true,}")
+            .expect_err("malformed nested JSON");
+        assert_eq!(error.path, "$.outer[1]");
+        assert_eq!(error.offset, 15);
+        assert_eq!(error.message, "unexpected JSON token");
+    }
+
+    #[test]
     fn rejects_documents_over_byte_limit() {
         let document = "x".repeat(JSON_MAX_DOCUMENT_BYTES + 1);
         let error = json_serdes_parse_document(&document).expect_err("oversized JSON");
-        assert!(error.contains("byte limit"));
+        assert!(error.message.contains("byte limit"));
+        assert_eq!(error.path, "$");
+        assert_eq!(error.offset, JSON_MAX_DOCUMENT_BYTES);
     }
 
     #[test]
     fn rejects_excessive_nesting() {
         let document = "[".repeat(JSON_MAX_DEPTH + 1) + &"]".repeat(JSON_MAX_DEPTH + 1);
         let error = json_serdes_parse_document(&document).expect_err("deep JSON");
-        assert!(error.contains("level limit"));
+        assert!(error.message.contains("level limit"));
+        assert!(error.path.starts_with("$[0]"));
+        assert!(error.offset > 0);
     }
 
     #[test]
@@ -4244,14 +4303,16 @@ mod json_limit_tests {
                 .join(",")
         );
         let error = json_serdes_parse_document(&document).expect_err("large JSON array");
-        assert!(error.contains("item limit"));
+        assert!(error.message.contains("item limit"));
+        assert_eq!(error.path, "$");
     }
 
     #[test]
     fn rejects_excessive_number_digits() {
         let document = "1".repeat(JSON_MAX_NUMBER_DIGITS + 1);
         let error = json_serdes_parse_document(&document).expect_err("large JSON number");
-        assert!(error.contains("digit limit"));
+        assert!(error.message.contains("digit limit"));
+        assert_eq!(error.path, "$");
     }
 }
 

--- a/stage1/crates/axiomc/src/cranelift_backend/intrinsics.rs
+++ b/stage1/crates/axiomc/src/cranelift_backend/intrinsics.rs
@@ -90,6 +90,9 @@ pub(crate) fn json_parse_string(text: &str) -> Option<String> {
     let mut chars = text[1..text.len() - 1].chars();
     while let Some(ch) = chars.next() {
         if ch != '\\' {
+            if ch <= '\u{001f}' {
+                return None;
+            }
             out.push(ch);
             continue;
         }

--- a/stage1/stdlib/std/serdes.ax
+++ b/stage1/stdlib/std/serdes.ax
@@ -2,6 +2,8 @@ import "std/collections.ax"
 
 pub struct ParseError {
 message: string
+offset: int
+path: string
 }
 
 pub enum Value {
@@ -32,6 +34,14 @@ return json_serdes_parse_str(text)
 
 pub fn parse_error_message(error: ParseError): string {
 return error.message
+}
+
+pub fn parse_error_offset(error: ParseError): int {
+return error.offset
+}
+
+pub fn parse_error_path(error: ParseError): string {
+return error.path
 }
 
 pub fn is_null(value: Value): bool {


### PR DESCRIPTION
## Summary

- Carry deterministic byte offsets and JSON paths through the generated and Cranelift SerDes parsers.
- Expose `ParseError.offset` and `ParseError.path` through `std/serdes.ax` and refresh the capability/catalog snapshots.
- Keep parser limits and existing error messages intact while making nested failures machine-readable.

## Governing Issue

Refs #1450

This is the structured error-contract slice of #1450. The broader issue remains dependency-gated by the self-hosting and provider work tracked in its dependency chain.

## Validation

- [x] Relevant local checks passed
- [ ] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Passed locally:

- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib --locked` — 913 passed, 21 ignored with loopback access
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib json_limit_tests --locked`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib generated_rust_json_serdes_emits_bounded_parser_contract --locked`
- `cargo test --manifest-path stage1/Cargo.toml -p axiomc --test cranelift_backend cranelift_backend_lowers_std_serdes_known_json_to_runtime_exit_code --locked`
- `make stage1-stdlib-test`

Known local blockers:

- `bash scripts/ci/run-stage1-stdlib-smoke.sh` reaches the existing `stdlib_env` fail-closed expectation, but the command succeeds from a clean generated-artifact directory; this is outside the changed SerDes path.
- `bash scripts/ci/run-fast-checks.sh` reaches the existing compiler-source ratchet gate: `summary.top_file_lines` is 71370 over 71278, `codegen.rs` is 8148 over 8020, and `evaluator.rs` is 4321 over 4260.
- The live PR Fast Checks run also fails the pre-existing `schema_metadata` inspect-evidence contract because `main` lacks the `inspect evidence` CLI routing supplied by prerequisite PR #1617.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] PR author enabled auto-merge where GitHub allows it
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Flow Contract

- Owner lane: compiler / stdlib
- Repair owner: PR author
- Autonomy class: bounded issue-backed implementation
- Risk class: parser contract and generated-runtime compatibility

## Flow Merge Readiness

- [ ] Every blocker has a next actor and next action
- [ ] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] PR author enabled auto-merge where GitHub allows it

## Merge Automation

- [x] PR author enabled auto-merge with `gh pr merge --auto --squash`

## Notes

- External autoreview was unavailable because private-diff authorization was not granted; no external review result is represented as approval.
