### PR TITLE
Add executable MIR inspection slice

### DIFF
--- a/docs/compiler-source-decomposition-plan.md
+++ b/docs/compiler-source-decomposition-plan.md
@@ -108,6 +108,11 @@ before this ratchet merged; the ceilings below reflect that post-merge snapshot
 so future backend growth must be paid down or accompanied by an explicit
 ratchet update.
 
+The executable MIR v0 inspection slice adds a backend-neutral model and a
+read-only project projection while production backend routing remains on the
+compatibility path; its bounded `project.rs` and `lib.rs` growth is recorded in
+the ceilings below.
+
 The cranelift intrinsics extraction then moved the pure runtime-intrinsic
 implementations (JSON scalar parse/stringify, the stage1-safe regex engine,
 percent encoding, and the crypto primitives) into
@@ -235,13 +240,13 @@ the final measured increase recorded here.
 
 ## Current Top Files
 
-Snapshot updated 2026-07-29 after the Package Resolver v1 security review:
+Snapshot updated 2026-08-10 after the executable MIR v0 inspection slice:
 
 | Rank | Current Rust file | Lines | Target package boundary | First extraction slice |
 | ---: | --- | ---: | --- | --- |
 | 1 | `stage1/crates/axiomc/src/cranelift_backend.rs` | 20,076 | `compiler.backend.native` | Runtime-intrinsic implementations live in `.../cranelift_backend/intrinsics.rs`, the compile-time evaluator in `.../cranelift_backend/evaluator.rs`, host-capability lowering in the `host_*` siblings, and static-output eligibility in `.../cranelift_backend/static_output_purity.rs`; the remaining work is sub-partitioning the mutually-recursive value/control core by value shape. |
 
-| 2 | `stage1/crates/axiomc/src/project.rs` | 13,493 | `compiler.package_graph`, `compiler.commands`, `compiler.evidence` | Build lowering evidence now lives in `stage1/crates/axiomc/src/project/build_contract.rs`; Documentation v1 now derives public symbols here; Package Resolver v1 now consumes authenticated registry manifests and sources from a bounded in-memory archive view. Continue splitting manifest/workspace loading, command orchestration, provenance/debug records, artifact planning, and the future `compiler.docs` semantic projection along package ownership. |
+| 2 | `stage1/crates/axiomc/src/project.rs` | 13,691 | `compiler.package_graph`, `compiler.commands`, `compiler.evidence` | Build lowering evidence now lives in `stage1/crates/axiomc/src/project/build_contract.rs`; Documentation v1 now derives public symbols here; Package Resolver v1 now consumes authenticated registry manifests and sources from a bounded in-memory archive view; executable MIR v0 is exposed through a read-only inspection API. Continue splitting manifest/workspace loading, command orchestration, provenance/debug records, artifact planning, and the future `compiler.docs` semantic projection along package ownership. |
 | 3 | `stage1/crates/axiomc/src/main.rs` | 11,917 | `compiler.commands` | Formatter reporting and edit planning now live in `stage1/crates/axiomc/src/formatter.rs`; Documentation v1 owns deterministic rendering, HTML/Markdown link validation, search, and doctest orchestration here; Package Trust v1 adds package verification and signed-registry command dispatch, while Package Resolver v1 adds bounded fetch/update/vendor parsing, structured failure evidence, and dispatch. Continue moving command parsing, JSON envelope construction, check/build/run/test/doc/trace orchestration, and package-management dispatch behind package-owned APIs. |
 | 4 | `stage1/crates/axiomc/src/codegen.rs` | 7,919 | `compiler.backend.generated_rust`, `compiler.backend.contracts` | Isolate generated-Rust compatibility emission from backend target selection and unsupported-feature contracts. |
 | 5 | `stage1/crates/axiomc/src/syntax.rs` | 6,370 | `compiler.syntax`, `compiler.diagnostics` | Split lexer/parser, parse recovery, source spans, macros, and syntax diagnostics behind the syntax boundary. |
@@ -259,7 +264,7 @@ matching ceiling in this table in the same PR.
 | Tracked item | Ceiling |
 | --- | ---: |
 | `summary.top_file_line_share` | 0.5767 |
-| `summary.top_file_lines` | 71278 |
+| `summary.top_file_lines` | 71331 |
 | `stage1/crates/axiomc/src/cranelift_backend.rs` | 20120 |
 | `stage1/crates/axiomc/src/cranelift_backend/static_output_purity.rs` | 282 |
 | `stage1/crates/axiomc/src/cranelift_backend/host_env_proc_clock.rs` | 620 |
@@ -270,7 +275,7 @@ matching ceiling in this table in the same PR.
 | `stage1/crates/axiomc/src/cranelift_backend/host_crypto.rs` | 783 |
 | `stage1/crates/axiomc/src/cranelift_backend/host_net_http.rs` | 1121 |
 | `stage1/crates/axiomc/src/hir.rs` | 5904 |
-| `stage1/crates/axiomc/src/project.rs` | 13564 |
+| `stage1/crates/axiomc/src/project.rs` | 13691 |
 | `stage1/crates/axiomc/src/project/build_contract.rs` | 118 |
 | `stage1/crates/axiomc/src/main.rs` | 11917 |
 | `stage1/crates/axiomc/src/formatter.rs` | 191 |
@@ -299,7 +304,7 @@ matching ceiling in this table in the same PR.
 | `stage1/crates/axiomc/src/hir/variants.rs` | 188 |
 | `stage1/crates/axiomc/src/package_trust.rs` | 5410 |
 | `stage1/crates/axiomc/src/registry.rs` | 4319 |
-| `stage1/crates/axiomc/src/lib.rs` | 36 |
+| `stage1/crates/axiomc/src/lib.rs` | 37 |
 
 ## Extraction Order
 

--- a/docs/executable-mir-v0.md
+++ b/docs/executable-mir-v0.md
@@ -1,0 +1,24 @@
+# Executable MIR v0 inspection slice
+
+`axiomc::project::executable_mir_packages` exposes the first explicit,
+backend-neutral executable MIR boundary for inspected packages.  The model is
+deliberately small while the existing Cranelift compatibility lowering remains
+the production build path.
+
+The v0 slice represents:
+
+- scalar `int` and `bool` values;
+- scalar parameters, locals, assignments, arithmetic, comparisons, and logic;
+- direct scalar function calls;
+- runtime stdin length through `read_to_string()`;
+- basic blocks with terminal returns and conditional branches; and
+- source spans on functions, blocks, instructions, and terminators.
+
+Callers receive `executable_mir.unsupported` when a package is outside this
+slice.  The API never returns a partial program and does not alter normal build
+output.  This makes the model suitable for snapshots and backend migration
+work while preserving the existing compatibility path.
+
+The next implementation slice can make Cranelift consume this model directly
+after the explicit block and effect contracts have independent backend
+coverage.

--- a/stage1/crates/axiomc/src/executable_mir.rs
+++ b/stage1/crates/axiomc/src/executable_mir.rs
@@ -1,0 +1,515 @@
+//! A small, backend-neutral executable MIR for the first runtime vertical slice.
+//!
+//! This is intentionally narrower than the full Semantic MIR contract.  It
+//! captures scalar values, runtime stdin length, direct calls, arithmetic,
+//! comparisons, conditions, and terminal control-flow blocks.  Unsupported
+//! source shapes return `None` so the existing broader lowering can continue
+//! serving compatibility fixtures while this boundary grows deliberately.
+
+use crate::mir;
+use std::collections::{HashMap, HashSet};
+
+pub type BlockId = usize;
+pub type ValueId = usize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+pub enum ScalarType {
+    Int,
+    Bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct Program {
+    pub schema_version: &'static str,
+    pub entrypoint: String,
+    pub functions: Vec<Function>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct Function {
+    pub name: String,
+    pub params: Vec<Param>,
+    pub return_type: ScalarType,
+    pub entry_block: BlockId,
+    pub blocks: Vec<BasicBlock>,
+    pub span: mir::SourceSpan,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct Param {
+    pub name: String,
+    pub value: ValueId,
+    pub ty: ScalarType,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct BasicBlock {
+    pub id: BlockId,
+    pub instructions: Vec<Instruction>,
+    pub terminator: Terminator,
+    pub span: mir::SourceSpan,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub enum Instruction {
+    Parameter {
+        result: ValueId,
+        index: usize,
+        ty: ScalarType,
+        span: mir::SourceSpan,
+    },
+    Const {
+        result: ValueId,
+        value: i64,
+        ty: ScalarType,
+        span: mir::SourceSpan,
+    },
+    ReadStdin {
+        result: ValueId,
+        max_bytes: u32,
+        effects: Vec<String>,
+        span: mir::SourceSpan,
+    },
+    Binary {
+        result: ValueId,
+        op: mir::ArithmeticOp,
+        lhs: ValueId,
+        rhs: ValueId,
+        span: mir::SourceSpan,
+    },
+    Compare {
+        result: ValueId,
+        op: mir::CompareOp,
+        lhs: ValueId,
+        rhs: ValueId,
+        span: mir::SourceSpan,
+    },
+    Logic {
+        result: ValueId,
+        op: mir::LogicOp,
+        lhs: ValueId,
+        rhs: ValueId,
+        span: mir::SourceSpan,
+    },
+    Call {
+        result: ValueId,
+        function: String,
+        args: Vec<ValueId>,
+        effects: Vec<String>,
+        span: mir::SourceSpan,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub enum Terminator {
+    Return {
+        value: ValueId,
+        span: mir::SourceSpan,
+    },
+    Branch {
+        condition: ValueId,
+        then_block: BlockId,
+        else_block: BlockId,
+        span: mir::SourceSpan,
+    },
+    Unreachable,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ValueInfo {
+    id: ValueId,
+    ty: ScalarType,
+}
+
+struct FunctionLowerer<'a> {
+    function: &'a mir::Function,
+    known_functions: &'a HashSet<String>,
+    next_value: ValueId,
+    blocks: Vec<BasicBlock>,
+    variables: HashMap<String, ValueInfo>,
+}
+
+impl<'a> FunctionLowerer<'a> {
+    fn new(function: &'a mir::Function, known_functions: &'a HashSet<String>) -> Option<Self> {
+        scalar_type(&function.return_ty)?;
+        if function.is_property || function.is_async || function.is_extern {
+            return None;
+        }
+        let mut lowerer = Self {
+            function,
+            known_functions,
+            next_value: 0,
+            blocks: vec![BasicBlock {
+                id: 0,
+                instructions: Vec::new(),
+                terminator: Terminator::Unreachable,
+                span: mir::SourceSpan {
+                    line: function.line,
+                    column: function.column,
+                },
+            }],
+            variables: HashMap::new(),
+        };
+        for (index, param) in function.params.iter().enumerate() {
+            let ty = scalar_type(&param.ty)?;
+            let value = lowerer.fresh_value();
+            lowerer
+                .variables
+                .insert(param.name.clone(), ValueInfo { id: value, ty });
+            let span = lowerer.blocks[0].span;
+            lowerer.blocks[0].instructions.push(Instruction::Parameter {
+                result: value,
+                index,
+                ty,
+                span,
+            });
+        }
+        Some(lowerer)
+    }
+
+    fn fresh_value(&mut self) -> ValueId {
+        let value = self.next_value;
+        self.next_value += 1;
+        value
+    }
+
+    fn lower(mut self) -> Option<Function> {
+        let entry_variables = self.variables.clone();
+        let body = self.function.body.clone();
+        self.lower_statements(0, &body, entry_variables)?;
+        let params = self
+            .function
+            .params
+            .iter()
+            .enumerate()
+            .map(|(index, param)| {
+                Some(Param {
+                    name: param.name.clone(),
+                    value: self.blocks[0].instructions.iter().find_map(|instruction| {
+                        match instruction {
+                            Instruction::Parameter {
+                                result,
+                                index: found,
+                                ..
+                            } if *found == index => Some(*result),
+                            _ => None,
+                        }
+                    })?,
+                    ty: scalar_type(&param.ty)?,
+                })
+            })
+            .collect::<Option<Vec<_>>>()?;
+        Some(Function {
+            name: self.function.name.clone(),
+            params,
+            return_type: scalar_type(&self.function.return_ty)?,
+            entry_block: 0,
+            blocks: self.blocks,
+            span: mir::SourceSpan {
+                line: self.function.line,
+                column: self.function.column,
+            },
+        })
+    }
+
+    fn lower_statements(
+        &mut self,
+        block_id: BlockId,
+        statements: &[mir::Stmt],
+        mut variables: HashMap<String, ValueInfo>,
+    ) -> Option<()> {
+        for (index, statement) in statements.iter().enumerate() {
+            match statement {
+                mir::Stmt::Let {
+                    name,
+                    ty,
+                    expr,
+                    span,
+                } => {
+                    let expected = scalar_type(ty)?;
+                    let value = self.lower_expr(block_id, expr, &variables, *span)?;
+                    if value.ty != expected {
+                        return None;
+                    }
+                    variables.insert(name.clone(), value);
+                }
+                mir::Stmt::Assign { target, expr, span } => {
+                    let mir::Expr::VarRef { name, ty } = target else {
+                        return None;
+                    };
+                    let expected = scalar_type(ty)?;
+                    let value = self.lower_expr(block_id, expr, &variables, *span)?;
+                    if value.ty != expected {
+                        return None;
+                    }
+                    variables.insert(name.clone(), value);
+                }
+                mir::Stmt::Return { expr, span } => {
+                    let value = self.lower_expr(block_id, expr, &variables, *span)?;
+                    if value.ty != scalar_type(&self.function.return_ty)? {
+                        return None;
+                    }
+                    self.blocks[block_id].terminator = Terminator::Return {
+                        value: value.id,
+                        span: *span,
+                    };
+                    return (index + 1 == statements.len()).then_some(());
+                }
+                mir::Stmt::If {
+                    cond,
+                    then_block,
+                    else_block: Some(else_block),
+                    span,
+                } => {
+                    if index + 1 != statements.len() {
+                        return None;
+                    }
+                    let condition = self.lower_expr(block_id, cond, &variables, *span)?;
+                    if condition.ty != ScalarType::Bool {
+                        return None;
+                    }
+                    let then_id = self.new_block(*span);
+                    let else_id = self.new_block(*span);
+                    self.blocks[block_id].terminator = Terminator::Branch {
+                        condition: condition.id,
+                        then_block: then_id,
+                        else_block: else_id,
+                        span: *span,
+                    };
+                    self.lower_statements(then_id, then_block, variables.clone())?;
+                    self.lower_statements(else_id, else_block, variables)?;
+                    return Some(());
+                }
+                _ => return None,
+            }
+        }
+        None
+    }
+
+    fn new_block(&mut self, span: mir::SourceSpan) -> BlockId {
+        let id = self.blocks.len();
+        self.blocks.push(BasicBlock {
+            id,
+            instructions: Vec::new(),
+            terminator: Terminator::Unreachable,
+            span,
+        });
+        id
+    }
+
+    fn lower_expr(
+        &mut self,
+        block_id: BlockId,
+        expr: &mir::Expr,
+        variables: &HashMap<String, ValueInfo>,
+        span: mir::SourceSpan,
+    ) -> Option<ValueInfo> {
+        let ty = scalar_type(&expr.ty())?;
+        let result = self.fresh_value();
+        let instruction = match expr {
+            mir::Expr::Literal(mir::LiteralValue::Int(value)) => Instruction::Const {
+                result,
+                value: *value,
+                ty,
+                span,
+            },
+            mir::Expr::Literal(mir::LiteralValue::Bool(value)) => Instruction::Const {
+                result,
+                value: i64::from(*value),
+                ty,
+                span,
+            },
+            mir::Expr::VarRef { name, .. } => return variables.get(name).copied(),
+            mir::Expr::Call { name, args, .. }
+                if name == "len"
+                    && args.len() == 1
+                    && matches!(
+                        &args[0],
+                        mir::Expr::Call { name, args, .. }
+                            if matches!(name.as_str(), "io_read_to_string" | "std_io_read_to_string")
+                                && args.is_empty()
+                    ) =>
+            {
+                Instruction::ReadStdin {
+                    result,
+                    max_bytes: axiomc_backend_cranelift::I64_STDIN_BUFFER_BYTES,
+                    effects: vec![String::from("stdin.read")],
+                    span,
+                }
+            }
+            mir::Expr::Call { name, args, .. } => {
+                if !self.known_functions.contains(name) {
+                    return None;
+                }
+                let args = args
+                    .iter()
+                    .map(|arg| {
+                        self.lower_expr(block_id, arg, variables, span)
+                            .map(|value| value.id)
+                    })
+                    .collect::<Option<Vec<_>>>()?;
+                Instruction::Call {
+                    result,
+                    function: name.clone(),
+                    args,
+                    effects: Vec::new(),
+                    span,
+                }
+            }
+            mir::Expr::BinaryAdd { op, lhs, rhs, .. } => Instruction::Binary {
+                result,
+                op: *op,
+                lhs: self.lower_expr(block_id, lhs, variables, span)?.id,
+                rhs: self.lower_expr(block_id, rhs, variables, span)?.id,
+                span,
+            },
+            mir::Expr::BinaryCompare { op, lhs, rhs, .. } => Instruction::Compare {
+                result,
+                op: *op,
+                lhs: self.lower_expr(block_id, lhs, variables, span)?.id,
+                rhs: self.lower_expr(block_id, rhs, variables, span)?.id,
+                span,
+            },
+            mir::Expr::BinaryLogic { op, lhs, rhs, .. } => Instruction::Logic {
+                result,
+                op: *op,
+                lhs: self.lower_expr(block_id, lhs, variables, span)?.id,
+                rhs: self.lower_expr(block_id, rhs, variables, span)?.id,
+                span,
+            },
+            _ => return None,
+        };
+        self.blocks[block_id].instructions.push(instruction);
+        Some(ValueInfo { id: result, ty })
+    }
+}
+
+pub fn lower_scalar_program(source: &mir::Program) -> Option<Program> {
+    if !source.stmts.is_empty() {
+        return None;
+    }
+    let user_functions = source
+        .functions
+        .iter()
+        .filter(|function| !function.path.starts_with("<stdlib>"))
+        .filter(|function| !function.is_property && !function.is_async && !function.is_extern)
+        .collect::<Vec<_>>();
+    let main = user_functions.iter().find(|function| {
+        function.source_name == "main"
+            && function.params.is_empty()
+            && scalar_type(&function.return_ty).is_some()
+    })?;
+    let mut known_functions = user_functions
+        .iter()
+        .filter(|function| {
+            scalar_type(&function.return_ty).is_some()
+                && function
+                    .params
+                    .iter()
+                    .all(|param| scalar_type(&param.ty).is_some())
+        })
+        .map(|function| function.name.clone())
+        .collect::<HashSet<_>>();
+    known_functions.remove(&main.name);
+
+    let mut lowered = user_functions
+        .iter()
+        .filter(|function| function.name != main.name)
+        .filter_map(|function| {
+            FunctionLowerer::new(function, &known_functions).and_then(FunctionLowerer::lower)
+        })
+        .collect::<Vec<_>>();
+    let main = FunctionLowerer::new(main, &known_functions)?.lower()?;
+    let lowered_names = lowered
+        .iter()
+        .map(|function| function.name.clone())
+        .collect::<HashSet<_>>();
+    if !calls_are_resolved(&main, &lowered_names)
+        || lowered
+            .iter()
+            .any(|function| !calls_are_resolved(function, &lowered_names))
+    {
+        return None;
+    }
+    lowered.insert(0, main);
+    Some(Program {
+        schema_version: "axiom.executable_mir.v0",
+        entrypoint: String::from("main"),
+        functions: lowered,
+    })
+}
+
+fn calls_are_resolved(function: &Function, known_functions: &HashSet<String>) -> bool {
+    function.blocks.iter().all(|block| {
+        block
+            .instructions
+            .iter()
+            .all(|instruction| match instruction {
+                Instruction::Call { function, .. } => known_functions.contains(function),
+                _ => true,
+            })
+    })
+}
+
+fn scalar_type(ty: &mir::Type) -> Option<ScalarType> {
+    match ty {
+        mir::Type::Int => Some(ScalarType::Int),
+        mir::Type::Bool => Some(ScalarType::Bool),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lowers_runtime_scalar_branch_into_explicit_blocks() {
+        let source = mir::Program {
+            path: String::from("main.ax"),
+            structs: Vec::new(),
+            enums: Vec::new(),
+            statics: Vec::new(),
+            functions: vec![mir::Function {
+                name: String::from("main"),
+                source_name: String::from("main"),
+                path: String::from("main.ax"),
+                params: Vec::new(),
+                return_ty: mir::Type::Int,
+                body: vec![mir::Stmt::If {
+                    cond: mir::Expr::BinaryCompare {
+                        op: mir::CompareOp::Gt,
+                        lhs: Box::new(mir::Expr::Literal(mir::LiteralValue::Int(2))),
+                        rhs: Box::new(mir::Expr::Literal(mir::LiteralValue::Int(1))),
+                        ty: mir::Type::Bool,
+                    },
+                    then_block: vec![mir::Stmt::Return {
+                        expr: mir::Expr::Literal(mir::LiteralValue::Int(7)),
+                        span: mir::SourceSpan { line: 2, column: 1 },
+                    }],
+                    else_block: Some(vec![mir::Stmt::Return {
+                        expr: mir::Expr::Literal(mir::LiteralValue::Int(1)),
+                        span: mir::SourceSpan { line: 4, column: 1 },
+                    }]),
+                    span: mir::SourceSpan { line: 1, column: 1 },
+                }],
+                is_property: false,
+                is_async: false,
+                is_extern: false,
+                extern_abi: None,
+                extern_library: None,
+                line: 1,
+                column: 1,
+            }],
+            stmts: Vec::new(),
+        };
+
+        let lowered = lower_scalar_program(&source).expect("scalar MIR should lower");
+        assert_eq!(lowered.schema_version, "axiom.executable_mir.v0");
+        assert_eq!(lowered.functions[0].blocks.len(), 3);
+        assert!(matches!(
+            lowered.functions[0].blocks[0].terminator,
+            Terminator::Branch { .. }
+        ));
+    }
+}

--- a/stage1/crates/axiomc/src/lib.rs
+++ b/stage1/crates/axiomc/src/lib.rs
@@ -9,6 +9,7 @@ pub mod dap;
 pub mod diagnostic_catalog;
 pub mod diagnostics;
 pub mod doctor;
+pub mod executable_mir;
 pub mod hir;
 pub mod intent_ir;
 pub mod json_contract;

--- a/stage1/crates/axiomc/src/project.rs
+++ b/stage1/crates/axiomc/src/project.rs
@@ -4,6 +4,7 @@ use crate::codegen::{
 };
 use crate::cranelift_backend::compile_cranelift_hello_spike;
 use crate::diagnostics::Diagnostic;
+use crate::executable_mir;
 use crate::hir;
 use crate::lockfile::{ParsedLockfile, load_lockfile, validate_lockfile};
 use crate::manifest::{
@@ -191,6 +192,18 @@ pub struct DocumentationSymbol {
     pub effects: Vec<String>,
     #[serde(skip)]
     pub source_path: PathBuf,
+}
+
+/// The first executable-MIR slice is exposed for compiler inspection and
+/// snapshotting before it becomes the production backend input.  Keeping this
+/// boundary read-only lets backend work land independently from the existing
+/// compatibility lowering path.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ExecutableMirPackage {
+    pub package_root: String,
+    pub manifest: String,
+    pub entry: String,
+    pub program: executable_mir::Program,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -625,6 +638,49 @@ pub fn documentation_packages(
         packages.push(documentation_package(&package_root, &analyzed)?);
     }
     packages.sort_by(|left, right| left.id.cmp(&right.id));
+    Ok(packages)
+}
+
+/// Lower the packages in a project to the supported executable-MIR slice.
+///
+/// This is intentionally an inspection API while the Cranelift backend still
+/// consumes the compatibility lowering path.  Unsupported source shapes fail
+/// with a stable diagnostic instead of silently producing a partial program.
+pub fn executable_mir_packages(
+    project_root: &Path,
+) -> Result<Vec<ExecutableMirPackage>, Diagnostic> {
+    let project_root = canonicalize_existing_path(&normalize_path(project_root), "project root")?;
+    let graph = load_package_graph(&project_root)?;
+    validate_workspace_root_lockfile(&graph, &project_root)?;
+    let mut packages = Vec::new();
+    for package_root in workspace_package_roots(&graph, &project_root, None)? {
+        let analyzed = analyze_package_with_macro_limit(
+            &graph,
+            &package_root,
+            syntax::DEFAULT_MACRO_RECURSION_LIMIT,
+        )?;
+        let program = executable_mir::lower_scalar_program(&analyzed.mir).ok_or_else(|| {
+            Diagnostic::new(
+                "codegen",
+                format!(
+                    "package {} is outside the executable MIR v0 slice",
+                    package_root.display()
+                ),
+            )
+            .with_code("executable_mir.unsupported")
+            .with_path(analyzed.entry_path.display().to_string())
+            .with_help(
+                "The current executable MIR slice supports scalar values, direct calls, runtime stdin length, and terminal conditions.",
+            )
+        })?;
+        packages.push(ExecutableMirPackage {
+            package_root: package_root.display().to_string(),
+            manifest: manifest_path(&package_root).display().to_string(),
+            entry: analyzed.entry_path.display().to_string(),
+            program,
+        });
+    }
+    packages.sort_by(|left, right| left.package_root.cmp(&right.package_root));
     Ok(packages)
 }
 
@@ -10953,6 +11009,77 @@ out_dir = "dist"
             direct.packages[0].lockfile.status,
             public.packages[0].lockfile.status
         );
+    }
+
+    #[test]
+    fn executable_mir_inspection_exposes_runtime_stdin_and_branch_blocks() {
+        let dir = tempdir().expect("tempdir");
+        let root = dir.path().join("executable-mir-inspection");
+        fs::create_dir_all(root.join("src")).expect("create source directory");
+        fs::write(
+            root.join("axiom.toml"),
+            r#"[package]
+name = "executable-mir-inspection"
+version = "0.1.0"
+
+[build]
+entry = "src/main.ax"
+out_dir = "dist"
+
+[capabilities]
+fs = false
+net = false
+process = false
+env = false
+clock = false
+crypto = false
+"#,
+        )
+        .expect("write manifest");
+        fs::write(
+            root.join("axiom.lock"),
+            r#"version = 1
+
+[[package]]
+name = "executable-mir-inspection"
+version = "0.1.0"
+source = "path"
+"#,
+        )
+        .expect("write lockfile");
+        fs::write(
+            root.join("src/main.ax"),
+            r#"import "std/io.ax"
+
+fn main(): int {
+if len(read_to_string()) == 13 {
+return 18
+} else {
+return 1
+}
+}
+"#,
+        )
+        .expect("write source");
+
+        let packages = executable_mir_packages(&root).expect("lower executable MIR");
+        assert_eq!(packages.len(), 1);
+        let main = &packages[0].program.functions[0];
+        assert_eq!(packages[0].program.entrypoint, "main");
+        assert_eq!(main.blocks.len(), 3);
+        assert!(main.blocks.iter().any(|block| {
+            block.instructions.iter().any(|instruction| {
+                matches!(instruction, executable_mir::Instruction::ReadStdin { .. })
+            })
+        }));
+        assert!(main
+            .blocks
+            .iter()
+            .any(|block| matches!(block.terminator, executable_mir::Terminator::Branch { .. })));
+
+        fs::write(root.join("src/main.ax"), "print 1\n").expect("write unsupported source");
+        let error = executable_mir_packages(&root).expect_err("unsupported MIR shape");
+        assert_eq!(error.code.as_deref(), Some("executable_mir.unsupported"));
     }
 
     fn write_test_package(root: &Path, name: &str, version: &str) {


### PR DESCRIPTION
## Summary

- Add an explicit backend-neutral executable MIR v0 model for the first scalar runtime vertical slice.
- Preserve source spans, direct calls, runtime stdin effects, and terminal conditional control flow.
- Expose `axiomc::project::executable_mir_packages` for inspection and snapshotting without changing production Cranelift routing.
- Return stable `executable_mir.unsupported` diagnostics for source outside the bounded slice.
- Document the boundary and next backend-consumption step.

## Governing Issue

Refs #1436

## Validation

- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc executable_mir --lib` — 2 passed
- [x] `cargo test --manifest-path stage1/Cargo.toml -p axiomc --lib` — 909 passed, 21 ignored; 5 loopback registry tests were sandbox-blocked
- [x] Host-network rerun of the 5 loopback registry tests — 5 passed
- [x] Host-network rerun of `package_archive_fetch_uses_its_explicit_64_mib_contract_limit` — passed
- [x] `git diff --check`
- [ ] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

The full local library run's five socket failures were environment restrictions, not code failures; the exact tests pass with host networking. Autoreview was attempted but its model endpoint disconnected before producing a review result.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected when applicable — not applicable
- [x] PR author enabled auto-merge where GitHub allows it, or GitHub plan-limit evidence/unavailable reason is recorded
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Flow Contract

- Owner lane: compiler/runtime lowering
- Repair owner: PR author
- Autonomy class: supervised implementation
- Risk class: bounded, inspection-only compiler boundary; production backend unchanged

## Flow Merge Readiness

- [x] Every blocker has a next actor and next action
- [ ] No active blocking requested changes remain
- [ ] Non-author approval is present when required
- [x] PR author enabled auto-merge where GitHub allows it

## Merge Automation

- [x] PR author enabled auto-merge with `gh pr merge --auto --squash`

## Notes

This is a companion slice for #1436. It does not claim full issue completion or switch Cranelift to the new model. The next slice can add independent backend consumption after the explicit block/effect contract has coverage.
